### PR TITLE
add list-connectors and read-connector tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ FLINK_ENV_NAME=""
 FLINK_DATABASE_NAME=""
 FLINK_API_KEY=""
 FLINK_API_SECRET=""
+FLINK_COMPUTE_POOL_ID="lfcp-..."
+CONFLUENT_CLOUD_API_KEY=""
+CONFLUENT_CLOUD_API_SECRET=""
+KAFKA_CLUSTER_ID=""
+KAFKA_ENV_ID="env-..."
+CONFLUENT_CLOUD_REST_ENDPOINT="https://api.confluent.cloud"
 ```
 
 ### Incremental watch mode of typescript

--- a/src/confluent/handlers.ts
+++ b/src/confluent/handlers.ts
@@ -289,3 +289,76 @@ export async function handleDeleteFlinkStatement(
     `Flink SQL Statement Deletion Status Code: ${response?.status}`,
   );
 }
+
+/**
+ * Lists Confluent Cloud connectors for a given cluster.
+ *
+ * @param confluentCloudRestClient - The Confluent Cloud REST API client instance
+ * @param envId - The Confluent Cloud environment ID
+ * @param clusterId - The Confluent Cloud cluster ID
+ * @returns An object containing a content array with a message listing the active connectors
+ * @throws {Error} if the request to list Confluent Cloud connectors fails
+ */
+export async function handleListConnectors(
+  confluentCloudRestClient: Client<paths, `${string}/${string}`>,
+  envId: string,
+  clusterId: string,
+) {
+  const pathBasedClient = wrapAsPathBasedClient(confluentCloudRestClient);
+  const { data: response, error } = await pathBasedClient[
+    "/connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors"
+  ].GET({
+    params: {
+      path: {
+        environment_id: envId,
+        kafka_cluster_id: clusterId,
+      },
+    },
+  });
+  if (error) {
+    return createResponse(
+      `Failed to list Confluent Cloud connectors for ${clusterId}: ${JSON.stringify(error)}`,
+    );
+  }
+  return createResponse(
+    `Active Connectors: ${JSON.stringify(response?.join(","))}`,
+  );
+}
+
+/**
+ * Gets the configuration details for a given connector
+ *
+ * @param confluentCloudRestClient - The Confluent Cloud REST API client instance
+ * @param envId - The Confluent Cloud environment ID
+ * @param clusterId - The Confluent Cloud cluster ID
+ * @param connectorName - The name of the connector
+ * @returns An object containing the connector details
+ * @throws {Error} if the request to get the connector details fails
+ */
+export async function handleReadConnector(
+  confluentCloudRestClient: Client<paths, `${string}/${string}`>,
+  envId: string,
+  clusterId: string,
+  connectorName: string,
+) {
+  const pathBasedClient = wrapAsPathBasedClient(confluentCloudRestClient);
+  const { data: response, error } = await pathBasedClient[
+    "/connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors/{connector_name}"
+  ].GET({
+    params: {
+      path: {
+        connector_name: connectorName,
+        environment_id: envId,
+        kafka_cluster_id: clusterId,
+      },
+    },
+  });
+  if (error) {
+    return createResponse(
+      `Failed to get information about connector ${connectorName}: ${JSON.stringify(error)}`,
+    );
+  }
+  return createResponse(
+    `Connector Details for ${connectorName}: ${JSON.stringify(response)}`,
+  );
+}

--- a/src/confluent/middleware.ts
+++ b/src/confluent/middleware.ts
@@ -11,11 +11,17 @@ import { Middleware } from "openapi-fetch";
  */
 export const authMiddleware: Middleware = {
   async onRequest({ request }) {
+    // use appropriate api key and api secret from env based on the request url
+    let apiKey = env.FLINK_API_KEY;
+    let apiSecret = env.FLINK_API_SECRET;
+    if (request.url.startsWith(env.CONFLUENT_CLOUD_REST_ENDPOINT)) {
+      apiKey = env.CONFLUENT_CLOUD_API_KEY;
+      apiSecret = env.CONFLUENT_CLOUD_API_SECRET;
+    }
     // add Authorization header to every request
-    // us flink api key and flink api secret from env
     request.headers.set(
       "Authorization",
-      `Basic ${Buffer.from(`${env.FLINK_API_KEY}:${env.FLINK_API_SECRET}`).toString("base64")}`,
+      `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString("base64")}`,
     );
     return request;
   },

--- a/src/confluent/schema.ts
+++ b/src/confluent/schema.ts
@@ -45,6 +45,14 @@ export const DeleteFlinkStatementArgumentsSchema = z.object({
   statementName: z.string().nonempty().max(255),
 });
 
+export const ListConnectorsArgumentsSchema = z.object({
+  // No arguments
+});
+
+export const ReadConnectorArgumentsSchema = z.object({
+  connectorName: z.string().nonempty(),
+});
+
 export const ListTopicsInputSchema = {
   type: "object",
   properties: {},
@@ -153,6 +161,23 @@ export const DeleteFlinkStatementsInputSchema = {
   required: ["statementName"],
 };
 
+export const ListConnectorsInputSchema = {
+  type: "object",
+  properties: {},
+  required: [],
+};
+
+export const ReadConnectorInputSchema = {
+  type: "object",
+  properties: {
+    connectorName: {
+      type: "string",
+      description: "The unique name of the connector.",
+    },
+  },
+  required: ["connectorName"],
+};
+
 // Add type exports for TypeScript
 export type ListTopicsArguments = z.infer<typeof ListTopicsArgumentsSchema>;
 export type CreateTopicsArguments = z.infer<typeof CreateTopicsArgumentsSchema>;
@@ -171,4 +196,10 @@ export type ReadFlinkStatementArguments = z.infer<
 >;
 export type DeleteFlinkStatementArguments = z.infer<
   typeof DeleteFlinkStatementArgumentsSchema
+>;
+export type ListConnectorsArguments = z.infer<
+  typeof ListConnectorsArgumentsSchema
+>;
+export type ReadConnectorArguments = z.infer<
+  typeof ReadConnectorArgumentsSchema
 >;

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,6 +14,11 @@ const envSchema = z.object({
   FLINK_COMPUTE_POOL_ID: z.string().trim().startsWith("lfcp-"),
   FLINK_ENV_NAME: z.string().trim().min(1),
   FLINK_DATABASE_NAME: z.string().trim().min(1),
+  CONFLUENT_CLOUD_API_KEY: z.string().trim().min(1),
+  CONFLUENT_CLOUD_API_SECRET: z.string().trim().min(1),
+  KAFKA_CLUSTER_ID: z.string().trim().min(1),
+  KAFKA_ENV_ID: z.string().trim().startsWith("env-"),
+  CONFLUENT_CLOUD_REST_ENDPOINT: z.string().trim().url(),
 });
 
 // Validate `process.env` against our schema


### PR DESCRIPTION
Added support for Confluent Cloud API with the following initial connector tools: 

:white_check_mark: list-connectors
:white_check_mark: read-connector

Uses the [API for Managed Connectors or Custom Connectors in Confluent Cloud.](https://docs.confluent.io/cloud/current/api.html#tag/Connectors-(connectv1))