### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-confluent
 
-An MCP server implementation that enables AI assistants to interact with Confluent Kafka and Confluent Cloud REST APIs. This server allows AI tools like Claude Desktop and Goose CLI to manage Kafka topics, connectors, and Flink SQL statements through natural language interactions.
+An MCP server implementation that enables AI assistants to interact with Confluent Cloud REST APIs. This server allows AI tools like Claude Desktop and Goose CLI to manage Kafka topics, connectors, and Flink SQL statements through natural language interactions.
 
 ## Demo
 


### PR DESCRIPTION
The README referenced a thing called "Confluent Kafka." Apache Software Foundation trademark guidelines do not allow us to use this phrase. :) 

My proposed modification might be too simple, but I'm not sure what the difference is between our version of Kafka (i.e., what we run in Confluent Cloud), and Confluent Cloud itself, which remains in the suggested version of the README.

