### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server implementation that enables AI assistants to interact with Confluent Cloud REST APIs. This server allows AI tools like Claude Desktop and Goose CLI to manage Kafka topics, connectors, and Flink SQL statements through natural language interactions.
 
+<a href="https://glama.ai/mcp/servers/@confluentinc/mcp-confluent">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@confluentinc/mcp-confluent/badge" alt="mcp-confluent MCP server" />
+</a>
+
 ## Demo
 
 ### Goose CLI


### PR DESCRIPTION
This PR adds a badge for the [mcp-confluent](https://glama.ai/mcp/servers/@confluentinc/mcp-confluent) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@confluentinc/mcp-confluent">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@confluentinc/mcp-confluent/badge" alt="mcp-confluent MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.