### PR TITLE
feat(cli): Enhance CLI with package version retrieval and TypeScript …

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,11 +4,20 @@ import { TransportType } from "@src/mcp/transports/types.js";
 import * as dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
+import pkg from "../package.json" with { type: "json" };
 
 // Define the interface for our CLI options
 export interface CLIOptions {
   envFile?: string;
   transports: TransportType[];
+}
+
+/**
+ * Get the package version from package.json
+ * @returns Package version string
+ */
+export function getPackageVersion(): string {
+  return pkg.version;
 }
 
 function parseTransportList(value: string): TransportType[] {
@@ -44,7 +53,7 @@ export function parseCliArgs(): CLIOptions {
     .description(
       "Confluent MCP Server - Model Context Protocol implementation for Confluent Cloud",
     )
-    .version(process.env.npm_package_version ?? "dev")
+    .version(getPackageVersion())
     .option("-e, --env-file <path>", "Load environment variables from file")
     .addOption(
       new Option(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { parseCliArgs } from "@src/cli.js";
+import { getPackageVersion, parseCliArgs } from "@src/cli.js";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolFactory } from "@src/confluent/tools/tool-factory.js";
@@ -101,7 +101,7 @@ async function main() {
 
     const server = new McpServer({
       name: "confluent",
-      version: process.env.npm_package_version ?? "dev",
+      version: getPackageVersion(),
     });
 
     toolHandlers.forEach((handler, name) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     // openapi-typescript generation
     "noImplicitAny": false,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "isolatedModules": true,
     "skipLibCheck": true,
     "baseUrl": "./",


### PR DESCRIPTION
This pull request introduces a utility function to retrieve the package version from `package.json` and replaces hardcoded or environment-based version references with this new function. The changes improve maintainability and ensure consistency in version handling across the application.

### Version Handling Improvements:

* **Added `getPackageVersion` Function**: Introduced the `getPackageVersion` utility function in `src/cli.ts` to fetch the package version from `package.json`. This eliminates the need for directly accessing environment variables or hardcoding the version.
* **Updated CLI Version Handling**: Modified the `.version()` method in the CLI argument parser to use `getPackageVersion` instead of relying on `process.env.npm_package_version`.
* **Updated MCP Server Initialization**: Replaced the `process.env.npm_package_version` reference in the `McpServer` configuration with the `getPackageVersion` function, ensuring consistent version usage.

### Code Import Adjustments:

* **Enhanced Imports in `src/index.ts`**: Updated the import statement to include the new `getPackageVersion` function alongside `parseCliArgs`.