### PR TITLE
fix(tool): modify list schema to use SchemaRegistryClient to be accessible for CP 

### DIFF
--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -90,7 +90,7 @@ export class ListSchemasHandler extends BaseToolHandler {
             const versions: number[] = await registry.getAllVersions(subject);
             logger.debug({ subject, versions }, "Fetched all schema versions");
             result[subject] = [];
-            for (const version of versions) {
+            const versionPromises = versions.map(async (version) => {
               try {
                 const schema = await registry.getSchemaMetadata(
                   subject,
@@ -121,7 +121,8 @@ export class ListSchemasHandler extends BaseToolHandler {
                   error: err instanceof Error ? err.message : String(err),
                 });
               }
-            }
+            });
+            await Promise.all(versionPromises);
           } catch (err) {
             logger.warn(
               {

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -1,3 +1,4 @@
+import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -6,7 +7,7 @@ import {
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import env from "@src/env.js";
-import { wrapAsPathBasedClient } from "openapi-fetch";
+import { logger } from "@src/logger.js";
 import { z } from "zod";
 
 const listSchemasArguments = z.object({
@@ -14,7 +15,7 @@ const listSchemasArguments = z.object({
     .string()
     .describe("The base URL of the Schema Registry REST API.")
     .url()
-    .default(env.SCHEMA_REGISTRY_ENDPOINT ?? "")
+    .default(() => env.SCHEMA_REGISTRY_ENDPOINT ?? "")
     .optional(),
   latestOnly: z
     .boolean()
@@ -25,7 +26,11 @@ const listSchemasArguments = z.object({
     .string()
     .describe("The prefix of the subject to list schemas for.")
     .optional(),
-  deleted: z.string().describe("List deleted schemas.").optional(),
+  deleted: z
+    .boolean()
+    .describe("List deleted schemas. (Only used if latestOnly is false)")
+    .default(false)
+    .optional(),
 });
 
 export class ListSchemasHandler extends BaseToolHandler {
@@ -36,33 +41,130 @@ export class ListSchemasHandler extends BaseToolHandler {
     const { baseUrl, latestOnly, subjectPrefix, deleted } =
       listSchemasArguments.parse(toolArguments);
 
+    logger.debug(
+      {
+        baseUrl,
+        latestOnly,
+        subjectPrefix,
+        deleted,
+      },
+      "ListSchemasHandler.handle called with arguments",
+    );
+
     if (baseUrl !== undefined && baseUrl !== "") {
+      logger.info({ baseUrl }, "Setting Schema Registry endpoint");
       clientManager.setConfluentCloudSchemaRegistryEndpoint(baseUrl);
     }
 
-    const pathBasedClient = wrapAsPathBasedClient(
-      clientManager.getConfluentCloudSchemaRegistryRestClient(),
-    );
+    const registry: SchemaRegistryClient =
+      clientManager.getSchemaRegistryClient();
 
-    // First get all schemas
-    const { data: response, error: error } = await pathBasedClient[
-      "/schemas"
-    ].GET({
-      query: {
-        ...(latestOnly ? { latestOnly: true } : {}),
-        ...(subjectPrefix ? { subjectPrefix: subjectPrefix } : {}),
-        ...(deleted ? { deleted: true } : {}),
-      },
-    });
+    try {
+      let subjects: string[] = await registry.getAllSubjects();
+      logger.debug(
+        { subjectsCount: subjects.length },
+        "Fetched all subjects from registry",
+      );
+      if (subjectPrefix) {
+        subjects = subjects.filter((s) => s.startsWith(subjectPrefix));
+        logger.debug(
+          { filteredSubjectsCount: subjects.length, subjectPrefix },
+          "Filtered subjects by prefix",
+        );
+      }
 
-    if (error) {
+      const result: Record<string, unknown> = {};
+      for (const subject of subjects) {
+        if (latestOnly) {
+          try {
+            const latest = await registry.getLatestSchemaMetadata(subject);
+            logger.debug({ subject, latest }, "Fetched latest schema metadata");
+            result[subject] = {
+              version: latest.version,
+              id: latest.id,
+              schemaType: latest.schemaType,
+              schema: latest.schema,
+            };
+          } catch (err) {
+            logger.warn(
+              {
+                subject,
+                error: err instanceof Error ? err.message : String(err),
+              },
+              "Failed to fetch latest schema metadata",
+            );
+            result[subject] = {
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        } else {
+          try {
+            const versions: number[] = await registry.getAllVersions(subject);
+            logger.debug({ subject, versions }, "Fetched all schema versions");
+            result[subject] = [];
+            for (const version of versions) {
+              try {
+                const schema = await registry.getSchemaMetadata(
+                  subject,
+                  version,
+                  deleted,
+                );
+                logger.debug(
+                  { subject, version, schema },
+                  "Fetched schema metadata for version",
+                );
+                (result[subject] as unknown[]).push({
+                  version: schema.version,
+                  id: schema.id,
+                  schemaType: schema.schemaType,
+                  schema: schema.schema,
+                });
+              } catch (err) {
+                logger.warn(
+                  {
+                    subject,
+                    version,
+                    error: err instanceof Error ? err.message : String(err),
+                  },
+                  "Failed to fetch schema metadata for version",
+                );
+                (result[subject] as unknown[]).push({
+                  version,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              }
+            }
+          } catch (err) {
+            logger.warn(
+              {
+                subject,
+                error: err instanceof Error ? err.message : String(err),
+              },
+              "Failed to fetch all versions for subject",
+            );
+            result[subject] = {
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+      }
+      logger.info(
+        { subjects: Object.keys(result).length },
+        "Returning schema listing result",
+      );
+      return this.createResponse(JSON.stringify(result));
+    } catch (error) {
+      logger.error(
+        {
+          error: error instanceof Error ? error.message : JSON.stringify(error),
+        },
+        "Failed to list schemas",
+      );
       return this.createResponse(
-        `Failed to list schemas: ${JSON.stringify(error)}`,
+        `Failed to list schemas: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
         true,
       );
     }
-
-    return this.createResponse(`${JSON.stringify(response)}`);
   }
 
   getToolConfig(): ToolConfig {

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -7,17 +7,10 @@ import {
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { EnvVar } from "@src/env-schema.js";
-import env from "@src/env.js";
 import { logger } from "@src/logger.js";
 import { z } from "zod";
 
 const listSchemasArguments = z.object({
-  baseUrl: z
-    .string()
-    .describe("The base URL of the Schema Registry REST API.")
-    .url()
-    .default(() => env.SCHEMA_REGISTRY_ENDPOINT ?? "")
-    .optional(),
   latestOnly: z
     .boolean()
     .describe("If true, only return the latest version of each schema.")
@@ -39,23 +32,17 @@ export class ListSchemasHandler extends BaseToolHandler {
     clientManager: ClientManager,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const { baseUrl, latestOnly, subjectPrefix, deleted } =
+    const { latestOnly, subjectPrefix, deleted } =
       listSchemasArguments.parse(toolArguments);
 
     logger.debug(
       {
-        baseUrl,
         latestOnly,
         subjectPrefix,
         deleted,
       },
       "ListSchemasHandler.handle called with arguments",
     );
-
-    if (baseUrl !== undefined && baseUrl !== "") {
-      logger.info({ baseUrl }, "Setting Schema Registry endpoint");
-      clientManager.setConfluentCloudSchemaRegistryEndpoint(baseUrl);
-    }
 
     const registry: SchemaRegistryClient =
       clientManager.getSchemaRegistryClient();
@@ -177,6 +164,10 @@ export class ListSchemasHandler extends BaseToolHandler {
   }
 
   getRequiredEnvVars(): EnvVar[] {
-    return ["SCHEMA_REGISTRY_API_KEY", "SCHEMA_REGISTRY_API_SECRET"];
+    return [
+      "SCHEMA_REGISTRY_ENDPOINT",
+      "SCHEMA_REGISTRY_API_KEY",
+      "SCHEMA_REGISTRY_API_SECRET",
+    ];
   }
 }


### PR DESCRIPTION
This pull request refactors the `ListSchemasHandler` to improve its functionality, logging, and error handling. Key updates include replacing the use of `wrapAsPathBasedClient` with the `SchemaRegistryClient`, enhancing logging for better debugging, and restructuring the logic to fetch schemas and their metadata.

### Refactoring and functionality improvements:
* Replaced `wrapAsPathBasedClient` with `SchemaRegistryClient` for interacting with the Schema Registry, allowing more granular control over schema operations. [[1]](diffhunk://#diff-1a4bbae90725108a0073e388dbb94937d853b5a70bc97f54789b3b9f73800e16R1) [[2]](diffhunk://#diff-1a4bbae90725108a0073e388dbb94937d853b5a70bc97f54789b3b9f73800e16R44-L65)
* Updated the `deleted` argument to use a `boolean` type with a default value of `false` for better clarity and type safety.

### Logging enhancements:
* Added detailed `logger.debug`, `logger.info`, and `logger.warn` statements to trace the flow of execution, log key operations, and capture errors during schema fetching and filtering.

### Error handling improvements:
* Enhanced error handling for schema metadata retrieval, including logging specific errors for failed operations and returning error details in the response.

### Minor updates:
* Changed the default value for the `baseUrl` argument to use a function, ensuring it dynamically evaluates the environment variable.