### PR TITLE
feat - tests + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,3 +552,12 @@ npx openapi-typescript ./openapi.json -o ./src/confluent/openapi-schema.d.ts --e
 ### Contributing
 
 Bug reports and feedback is appreciated in the form of Github Issues. For guidelines on contributing please see [CONTRIBUTING.md](CONTRIBUTING.MD)
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/index.ts
+```

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "openapi-fetch": "^0.13.7",
     "pino": "^9.6.0",
     "properties-file": "^3.5.12",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "mcp-evals": "^1.0.18"
   },
   "files": [
     "dist"

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,0 +1,59 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const CustomToolEval: EvalFunction = {
+    name: "Custom Tool Evaluation",
+    description: "Evaluates the functionality of the custom tool",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "How does this custom tool handle input data with a specific session context?");
+        return JSON.parse(result);
+    }
+};
+
+const ListFlinkStatementsEval: EvalFunction = {
+  name: "ListFlinkStatements Tool Evaluation",
+  description: "Evaluates the correctness and completeness of listing Flink SQL statements with specific parameters",
+  run: async () => {
+    const result = await grade(openai("gpt-4"), "List the Flink SQL statements for organization 123 in environment dev with a label selector of 'type=test' and a page size of 5.");
+    return JSON.parse(result);
+  }
+};
+
+const CreateFlinkStatementHandlerEval: EvalFunction = {
+    name: "CreateFlinkStatementHandlerEval",
+    description: "Evaluates the functionality of the CreateFlinkStatementHandler tool",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Create a Flink statement named 'test_statement' with catalog 'test_catalog', database 'test_db', and the statement 'SELECT * FROM test_table' for a specific compute pool, environment, and organization using the CreateFlinkStatementHandler tool.");
+        return JSON.parse(result);
+    }
+};
+
+const DeleteFlinkStatementHandlerEval: EvalFunction = {
+    name: "DeleteFlinkStatementHandlerEval",
+    description: "Evaluates the functionality of deleting a Flink SQL statement",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please delete the Flink SQL statement named 'test-statement' from environment 'env-123' in organization 'org-456' using the base URL 'https://flink.example.com'.");
+        return JSON.parse(result);
+    }
+};
+
+const readFlinkStatementEval: EvalFunction = {
+    name: "ReadFlinkStatement Tool Evaluation",
+    description: "Evaluates the tool's ability to read a Flink statement and its results",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please read the results of the Flink SQL statement named 'testStatement' from environment 'testEnv' in org 'testOrg'.");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [CustomToolEval, ListFlinkStatementsEval, CreateFlinkStatementHandlerEval, DeleteFlinkStatementHandlerEval, readFlinkStatementEval]
+};
+  
+export default config;
+  
+export const evals = [CustomToolEval, ListFlinkStatementsEval, CreateFlinkStatementHandlerEval, DeleteFlinkStatementHandlerEval, readFlinkStatementEval];


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 