### PR TITLE
chore: Update Dockerfile to expose port 8080, enhance environment schema with new HTTP and SSE endpoint paths, and add ping health check endpoints for both HTTP and SSE transports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules/
 
 ENV NODE_ENV=production
-EXPOSE 3000
+EXPOSE 8080
 ENTRYPOINT ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start:all": "node dist/index.js --env-file .env --transport http,sse,stdio",
     "help": "node dist/index.js -h",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.+(js|ts|json)\"",
     "build": "tsc && tsc-alias",
     "print:schema": "node dist/print-md-schema.js",

--- a/src/env-schema.ts
+++ b/src/env-schema.ts
@@ -8,11 +8,29 @@ const envSchema = z.object({
     .int()
     .positive()
     .describe("Port to use for HTTP transport")
-    .default(3000),
+    .default(8080),
   HTTP_HOST: z
     .string()
     .describe("Host to bind for HTTP transport")
     .default("localhost"),
+  HTTP_MCP_ENDPOINT_PATH: z
+    .string()
+    .describe(
+      "HTTP endpoint path for MCP transport (e.g., '/mcp', '/invocations')",
+    )
+    .default("/mcp"),
+  SSE_MCP_ENDPOINT_PATH: z
+    .string()
+    .describe(
+      "SSE endpoint path for establishing SSE connections (e.g., '/sse', '/events')",
+    )
+    .default("/sse"),
+  SSE_MCP_MESSAGE_ENDPOINT_PATH: z
+    .string()
+    .describe(
+      "SSE message endpoint path for receiving messages (e.g., '/messages', '/events/messages')",
+    )
+    .default("/messages"),
   LOG_LEVEL: z
     .preprocess(
       (val) => (typeof val === "string" ? val.toLowerCase() : val),

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,9 @@ async function main() {
       cliOptions.transports,
       env.HTTP_PORT,
       env.HTTP_HOST,
+      env.HTTP_MCP_ENDPOINT_PATH,
+      env.SSE_MCP_ENDPOINT_PATH,
+      env.SSE_MCP_MESSAGE_ENDPOINT_PATH,
     );
 
     // Set up cleanup handlers

--- a/src/mcp/transports/manager.ts
+++ b/src/mcp/transports/manager.ts
@@ -16,6 +16,9 @@ export class TransportManager {
     types: TransportType[],
     port?: number,
     host?: string,
+    httpMcpEndpointPath?: string,
+    sseMcpEndpointPath?: string,
+    sseMcpMessageEndpointPath?: string,
   ): Promise<void> {
     try {
       const needsHttpServer = types.some(
@@ -31,7 +34,12 @@ export class TransportManager {
       // Create and connect all transports
       await Promise.all(
         types.map(async (type) => {
-          const transport = await this.createTransport(type);
+          const transport = await this.createTransport(
+            type,
+            httpMcpEndpointPath,
+            sseMcpEndpointPath,
+            sseMcpMessageEndpointPath,
+          );
           this.transports.set(type, transport);
           await transport.connect();
         }),
@@ -83,18 +91,32 @@ export class TransportManager {
     this.httpServer = null;
   }
 
-  private async createTransport(type: TransportType): Promise<Transport> {
+  private async createTransport(
+    type: TransportType,
+    httpMcpEndpointPath?: string,
+    sseMcpEndpointPath?: string,
+    sseMcpMessageEndpointPath?: string,
+  ): Promise<Transport> {
     switch (type) {
       case "http":
         if (!this.httpServer) {
           throw new Error("HTTP server not initialized");
         }
-        return new HttpTransport(this.server, this.httpServer);
+        return new HttpTransport(
+          this.server,
+          this.httpServer,
+          httpMcpEndpointPath,
+        );
       case "sse":
         if (!this.httpServer) {
           throw new Error("HTTP server not initialized");
         }
-        return new SseTransport(this.server, this.httpServer);
+        return new SseTransport(
+          this.server,
+          this.httpServer,
+          sseMcpEndpointPath,
+          sseMcpMessageEndpointPath,
+        );
       case "stdio":
         return new StdioTransport(this.server);
       default:

--- a/src/mcp/transports/ping.ts
+++ b/src/mcp/transports/ping.ts
@@ -1,0 +1,20 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export const pingResponseSchema = {
+  type: "object",
+  properties: {
+    status: { type: "string" },
+    timestamp: { type: "string", format: "date-time" },
+    transport: { type: "string" },
+  },
+};
+
+export function pingHandler(transport: string) {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    reply.send({
+      status: "ok",
+      timestamp: new Date().toISOString(),
+      transport,
+    });
+  };
+}


### PR DESCRIPTION
This pull request introduces several enhancements to the HTTP and SSE transports, updates environment configurations, and adds health check endpoints. The changes improve flexibility in configuring endpoint paths, streamline transport setup, and introduce standardized health checks for monitoring.

### Endpoint Configuration Updates:
* [`src/env-schema.ts`](diffhunk://#diff-9b3ab2a485c1456d3f200654ad6a791dfe001b2613540105c336cd57478c4f4aL11-R33): Added new environment variables (`HTTP_MCP_ENDPOINT_PATH`, `SSE_MCP_ENDPOINT_PATH`, `SSE_MCP_MESSAGE_ENDPOINT_PATH`) to allow configurable paths for HTTP and SSE endpoints. Defaults are set to `/mcp`, `/sse`, and `/messages`, respectively.
* [`src/mcp/transports/http.ts`](diffhunk://#diff-fabec5f200ca33c96e195b935e6b1d4c1387344f08f201eb2cff5256232afc1fR34-R42): Updated the `HttpTransport` class to use the configurable `httpMcpEndpointPath` for all HTTP endpoints (`GET`, `POST`, `DELETE`). [[1]](diffhunk://#diff-fabec5f200ca33c96e195b935e6b1d4c1387344f08f201eb2cff5256232afc1fR34-R42) [[2]](diffhunk://#diff-fabec5f200ca33c96e195b935e6b1d4c1387344f08f201eb2cff5256232afc1fL83-R85) [[3]](diffhunk://#diff-fabec5f200ca33c96e195b935e6b1d4c1387344f08f201eb2cff5256232afc1fL118-R120)
* [`src/mcp/transports/sse.ts`](diffhunk://#diff-959d9c7d9320562096cab8b4c429cffc41479011998d3dca84a7fea80856a36aR29-R38): Modified the `SseTransport` class to use configurable paths for SSE connection (`sseMcpEndpointPath`) and message handling (`sseMcpMessageEndpointPath`). [[1]](diffhunk://#diff-959d9c7d9320562096cab8b4c429cffc41479011998d3dca84a7fea80856a36aR29-R38) [[2]](diffhunk://#diff-959d9c7d9320562096cab8b4c429cffc41479011998d3dca84a7fea80856a36aL48-R54) [[3]](diffhunk://#diff-959d9c7d9320562096cab8b4c429cffc41479011998d3dca84a7fea80856a36aL84-R90)

### Health Check Endpoints:
* [`src/mcp/transports/ping.ts`](diffhunk://#diff-13cac66cf40a6a16939e56ef6fc0e99d27786091b083e3025ee391fd15cf921eR1-R20): Introduced a reusable `pingHandler` function and `pingResponseSchema` for health check endpoints. These endpoints return a status, timestamp, and transport type.
* `src/mcp/transports/http.ts` and `src/mcp/transports/sse.ts`: Added `GET` and `POST` `/ping` endpoints for health checks in both HTTP and SSE transports. [[1]](diffhunk://#diff-fabec5f200ca33c96e195b935e6b1d4c1387344f08f201eb2cff5256232afc1fR155-R184) [[2]](diffhunk://#diff-959d9c7d9320562096cab8b4c429cffc41479011998d3dca84a7fea80856a36aR141-R170)

### Transport Manager Enhancements:
* [`src/mcp/transports/manager.ts`](diffhunk://#diff-04df2b5aee786037b78ae7d8c1fbd609511dbef5637f189449c4b7969343cb62R19-R21): Updated the `TransportManager` class to support passing configurable endpoint paths (`httpMcpEndpointPath`, `sseMcpEndpointPath`, `sseMcpMessageEndpointPath`) during transport creation. [[1]](diffhunk://#diff-04df2b5aee786037b78ae7d8c1fbd609511dbef5637f189449c4b7969343cb62R19-R21) [[2]](diffhunk://#diff-04df2b5aee786037b78ae7d8c1fbd609511dbef5637f189449c4b7969343cb62L34-R42) [[3]](diffhunk://#diff-04df2b5aee786037b78ae7d8c1fbd609511dbef5637f189449c4b7969343cb62L86-R119)

### Port Change:
* `Dockerfile` and `src/env-schema.ts`: Changed the default HTTP port from `3000` to `8080` for better alignment with production environments. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L28-R28) [[2]](diffhunk://#diff-9b3ab2a485c1456d3f200654ad6a791dfe001b2613540105c336cd57478c4f4aL11-R33)

### Development Convenience:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R35): Added a new `lint:fix` script to automatically fix linting issues using ESLint.