### PR TITLE
Wildcard allows (auth.ts)

### DIFF
--- a/src/mcp/transports/auth.ts
+++ b/src/mcp/transports/auth.ts
@@ -62,6 +62,11 @@ function isHostAllowed(
   hostHeader: string | undefined,
   allowedHosts: string[],
 ): boolean {
+  // Wildcard allows all hosts (useful for cloud deployments with dynamic IPs)
+  if (allowedHosts.includes("*")) {
+    return true;
+  }
+
   if (!hostHeader) {
     return false;
   }


### PR DESCRIPTION
Add Wildcard allows all hosts (useful for cloud deployments with dynamic IPs)
In my cloud deployment (koyeb) i can't configure healthcheck for 8080 because getting 403 (not 200)