### PR TITLE
feat: add delete-schema tool for Schema Registry

### DIFF
--- a/src/confluent/tools/handlers/schema/delete-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.ts
@@ -1,0 +1,130 @@
+import { ClientManager } from "@src/confluent/client-manager.js";
+import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  ToolConfig,
+} from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { EnvVar } from "@src/env-schema.js";
+import env from "@src/env.js";
+import { logger } from "@src/logger.js";
+import { wrapAsPathBasedClient } from "openapi-fetch";
+import { z } from "zod";
+
+const deleteSchemaArguments = z.object({
+  baseUrl: z
+    .string()
+    .describe("The base URL of the Schema Registry REST API.")
+    .url()
+    .default(() => env.SCHEMA_REGISTRY_ENDPOINT ?? "")
+    .optional(),
+  subject: z.string().describe("Name of the subject to delete.").nonempty(),
+  version: z
+    .string()
+    .describe(
+      'Version of the schema to delete. Valid values are between [1,2^31-1] or the string "latest". If omitted, all versions of the subject are deleted.',
+    )
+    .optional(),
+  permanent: z
+    .boolean()
+    .describe(
+      "Whether to perform a permanent (hard) delete. Default is false (soft delete).",
+    )
+    .default(false)
+    .optional(),
+});
+
+export class DeleteSchemaHandler extends BaseToolHandler {
+  async handle(
+    clientManager: ClientManager,
+    toolArguments: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const { subject, version, permanent, baseUrl } =
+      deleteSchemaArguments.parse(toolArguments);
+
+    logger.debug(
+      { subject, version, permanent },
+      "DeleteSchemaHandler.handle called with arguments",
+    );
+
+    if (baseUrl !== undefined && baseUrl !== "") {
+      clientManager.setConfluentCloudSchemaRegistryEndpoint(baseUrl);
+    }
+
+    const pathBasedClient = wrapAsPathBasedClient(
+      clientManager.getConfluentCloudSchemaRegistryRestClient(),
+    );
+
+    if (version !== undefined) {
+      const { response, error } = await pathBasedClient[
+        "/subjects/{subject}/versions/{version}"
+      ].DELETE({
+        params: {
+          path: { subject, version },
+          query: { permanent },
+        },
+      });
+
+      if (error) {
+        logger.error(
+          { subject, version, error },
+          "Failed to delete schema version",
+        );
+        return this.createResponse(
+          `Failed to delete schema version ${version} for subject "${subject}": ${JSON.stringify(error)}`,
+          true,
+        );
+      }
+
+      logger.info(
+        { subject, version, status: response?.status },
+        "Successfully deleted schema version",
+      );
+      return this.createResponse(
+        `Successfully deleted version ${version} of subject "${subject}". Status: ${response?.status}`,
+      );
+    }
+
+    const { response, error } = await pathBasedClient[
+      "/subjects/{subject}"
+    ].DELETE({
+      params: {
+        path: { subject },
+        query: { permanent },
+      },
+    });
+
+    if (error) {
+      logger.error({ subject, error }, "Failed to delete subject");
+      return this.createResponse(
+        `Failed to delete subject "${subject}": ${JSON.stringify(error)}`,
+        true,
+      );
+    }
+
+    logger.info(
+      { subject, status: response?.status },
+      "Successfully deleted subject",
+    );
+    return this.createResponse(
+      `Successfully deleted subject "${subject}". Status: ${response?.status}`,
+    );
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.DELETE_SCHEMA,
+      description:
+        "Delete a schema subject or a specific version from the Schema Registry. If version is omitted, all versions of the subject are deleted.",
+      inputSchema: deleteSchemaArguments.shape,
+    };
+  }
+
+  getRequiredEnvVars(): EnvVar[] {
+    return [
+      "SCHEMA_REGISTRY_ENDPOINT",
+      "SCHEMA_REGISTRY_API_KEY",
+      "SCHEMA_REGISTRY_API_SECRET",
+    ];
+  }
+}

--- a/src/confluent/tools/tool-factory.ts
+++ b/src/confluent/tools/tool-factory.ts
@@ -31,6 +31,7 @@ import { DeleteTopicsHandler } from "@src/confluent/tools/handlers/kafka/delete-
 import { GetTopicConfigHandler } from "@src/confluent/tools/handlers/kafka/get-topic-config.js";
 import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topics-handler.js";
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
+import { DeleteSchemaHandler } from "@src/confluent/tools/handlers/schema/delete-schema-handler.js";
 import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
 import { SearchTopicsByTagHandler } from "@src/confluent/tools/handlers/search/search-topic-by-tag-handler.js";
 import { SearchTopicsByNameHandler } from "@src/confluent/tools/handlers/search/search-topics-by-name-handler.js";
@@ -83,6 +84,7 @@ export class ToolFactory {
     [ToolName.LIST_ENVIRONMENTS, new ListEnvironmentsHandler()],
     [ToolName.READ_ENVIRONMENT, new ReadEnvironmentHandler()],
     [ToolName.LIST_SCHEMAS, new ListSchemasHandler()],
+    [ToolName.DELETE_SCHEMA, new DeleteSchemaHandler()],
     [ToolName.CONSUME_MESSAGES, new ConsumeKafkaMessagesHandler()],
     [ToolName.GET_TOPIC_CONFIG, new GetTopicConfigHandler()],
     [ToolName.CREATE_TABLEFLOW_TOPIC, new CreateTableFlowTopicHandler()],

--- a/src/confluent/tools/tool-name.ts
+++ b/src/confluent/tools/tool-name.ts
@@ -33,6 +33,7 @@ export enum ToolName {
   LIST_ENVIRONMENTS = "list-environments",
   READ_ENVIRONMENT = "read-environment",
   LIST_SCHEMAS = "list-schemas",
+  DELETE_SCHEMA = "delete-schema",
   GET_TOPIC_CONFIG = "get-topic-config",
   CREATE_TABLEFLOW_TOPIC = "create-tableflow-topic",
   LIST_TABLEFLOW_REGIONS = "list-tableflow-regions",


### PR DESCRIPTION
Adds a single delete-schema tool that supports deleting an entire subject (all versions) or a specific version, with optional permanent (hard) delete.