### PR TITLE
chore: add DTX to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/csid-reviewers @confluentinc/matrix
+*	@confluentinc/csid-reviewers @confluentinc/matrix @confluentinc/dtx


### PR DESCRIPTION
This change adds the @confluentinc/dtx team to the list of codeowners.