### PR TITLE
[chore] update the modelcontextprotocol version to 1.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@confluentinc/schemaregistry": "^1.3.1",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.3",
-    "@modelcontextprotocol/sdk": "^1.23.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^14.0.0",
     "dotenv": "^16.5.0",
     "fastify": "^5.4.0",


### PR DESCRIPTION
to use a version gte 1.26.0 to prevent a functional bug in response routing