### PR TITLE
chore: add `.prettierrc`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
Defines the current conventions for Prettier formatting used by this project. No files changed from running `npm run format` after this addition, but useful for IDE extensions/plugins that support it (e.g. formatting on file save).