### PR TITLE
feat: add Confluent Cloud metrics API tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or install the [npm package](https://www.npmjs.com/package/@confluentinc/mcp-con
 
 ## Available Tools
 
-The server provides 37+ tools organized by category. Only the tools whose required environment variables are configured will be enabled.
+The server provides 39+ tools organized by category. Only the tools whose required environment variables are configured will be enabled.
 
 | Category                    | Tools                                                                                                                                                                                               | Description                                                       |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -64,6 +64,7 @@ The server provides 37+ tools organized by category. Only the tools whose requir
 | **Environments & Clusters** | `list-environments`, `read-environment`, `list-clusters`                                                                                                                                            | Discover Confluent Cloud resources                                |
 | **Tableflow**               | `create-tableflow-topic`, `list-tableflow-topics`, `read-tableflow-topic`, `update-tableflow-topic`, `delete-tableflow-topic`, `list-tableflow-regions`                                             | Manage Tableflow-enabled topics                                   |
 | **Tableflow Catalog**       | `create-tableflow-catalog-integration`, `list-tableflow-catalog-integrations`, `read-tableflow-catalog-integration`, `update-tableflow-catalog-integration`, `delete-tableflow-catalog-integration` | Manage Tableflow catalog integrations (e.g., AWS Glue)            |
+| **Metrics**                 | `list-available-metrics`, `query-metrics`                                                                                                                                                           | Discover and query Confluent Cloud operational metrics            |
 | **Billing**                 | `list-billing-costs`                                                                                                                                                                                | Query billing and cost data                                       |
 
 You can also list all available tools via the CLI:
@@ -246,6 +247,9 @@ MCP_AUTH_DISABLED=true
 | SCHEMA_REGISTRY_ENDPOINT      | URL endpoint for accessing Schema Registry services to manage data schemas (string)                                                       |                       | No       |
 | TABLEFLOW_API_KEY             | Authentication key for accessing Confluent Cloud's Tableflow services (string (min: 1))                                                   |                       | No       |
 | TABLEFLOW_API_SECRET          | Authentication secret paired with TABLEFLOW_API_KEY for secure Tableflow access (string (min: 1))                                         |                       | No       |
+| TELEMETRY_ENDPOINT            | Base URL for Confluent Cloud Telemetry API (metrics)                                                                                      | "https://api.telemetry.confluent.cloud" | No |
+| TELEMETRY_API_KEY             | Optional API key for telemetry access. Falls back to CONFLUENT_CLOUD_API_KEY if not set.                                                  |                       | No       |
+| TELEMETRY_API_SECRET          | Optional API secret for telemetry access. Falls back to CONFLUENT_CLOUD_API_SECRET if not set.                                            |                       | No       |
 
 ### Usage
 
@@ -697,6 +701,51 @@ Claude: Uses get-flink-statement-profile → gets task-level metrics
 Claude: "The statement has high backpressure on task 'Sink'. Try increasing parallelism..."
 ```
 
+## Metrics Example Workflows
+
+The `list-available-metrics` and `query-metrics` tools work together to let AI assistants monitor your Confluent Cloud resources. The discovery tool ensures the assistant uses valid metric names and filter fields rather than guessing.
+
+#### Kafka Topic Throughput
+
+```
+User: "What's the throughput on topic sensor-readings over the last hour?"
+        ↓
+Claude: Uses list-available-metrics(resource_type: "kafka") → discovers metric names & filters
+        ↓
+Claude: Uses query-metrics(metric: "io.confluent.kafka.server/received_bytes",
+        filter: {"metric.topic": "sensor-readings"}) → gets time-series data
+        ↓
+Claude: "sensor-readings is receiving ~14.3 KB/min steadily over the last hour."
+```
+
+#### Flink Compute Pool Utilization
+
+```
+User: "How many CFUs is my Flink compute pool using?"
+        ↓
+Claude: Uses list-available-metrics(resource_type: "compute_pool") → discovers CFU metrics
+        ↓
+Claude: Uses query-metrics(metric: "io.confluent.flink/compute_pool_utilization/current_cfus",
+        filter: {"resource.compute_pool.id": "lfcp-..."}, granularity: "PT1H",
+        interval: "<7-day range>") → gets usage trend
+        ↓
+Claude: "Your compute pool is using 1 CFU consistently."
+```
+
+#### Consumer Lag Monitoring
+
+```
+User: "Is there any consumer lag on the sensor-readings topic?"
+        ↓
+Claude: Uses query-metrics(metric: "io.confluent.kafka.server/consumer_lag_offsets",
+        filter: {"metric.topic": "sensor-readings"},
+        group_by: ["metric.consumer_group_id"]) → gets lag per consumer group
+        ↓
+Claude: "Consumer group 'analytics' has 1,200 offsets of lag."
+```
+
+> **Note:** Kafka server metrics (e.g., `io.confluent.kafka.server/received_bytes`) require `CONFLUENT_CLOUD_API_KEY` and `CONFLUENT_CLOUD_API_SECRET`. The `KAFKA_CLUSTER_ID` environment variable is auto-injected as a filter when querying Kafka metrics. Flink compute pool metrics report at hourly granularity, so queries may need a wider time window than the default 1 hour.
+
 ## Developer Guide
 
 ### Project Structure
@@ -724,6 +773,7 @@ Claude: "The statement has high backpressure on task 'Sink'. Try increasing para
 │   │           ├── environments/    # Environment tools
 │   │           ├── flink/           # Flink SQL, catalog & diagnostics tools
 │   │           ├── kafka/           # Kafka topic & message tools
+│   │           ├── metrics/         # Telemetry API metrics tools
 │   │           ├── schema/          # Schema Registry tools
 │   │           ├── search/          # Search tools
 │   │           └── tableflow/       # Tableflow topic & catalog tools

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -1,0 +1,269 @@
+import { ClientManager } from "@src/confluent/client-manager.js";
+import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  ToolConfig,
+} from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { EnvVar } from "@src/env-schema.js";
+import { logger } from "@src/logger.js";
+import { z } from "zod";
+
+const listMetricsArguments = z.object({
+  resource_type: z
+    .enum([
+      "kafka",
+      "connector",
+      "compute_pool",
+      "flink_statement",
+      "schema_registry",
+      "ksql",
+    ])
+    .describe(
+      'Filter metrics by resource type. Use "kafka" for Kafka cluster/topic metrics, "connector" for Kafka Connect metrics, "compute_pool" for Flink compute pool metrics, "flink_statement" for Flink statement metrics.',
+    )
+    .optional(),
+});
+
+interface MetricDescriptor {
+  name: string;
+  description: string;
+  type: string;
+  unit: string;
+  lifecycle_stage: string;
+  resources: string[];
+  labels: Array<{ key: string; description: string }>;
+}
+
+interface ResourceDescriptor {
+  type: string;
+  description: string;
+  labels: Array<{ key: string; description: string }>;
+}
+
+interface DescriptorResponse {
+  data?: MetricDescriptor[] | ResourceDescriptor[];
+  errors?: Array<{ detail?: string }>;
+}
+
+/**
+ * Well-known Kafka server metrics that may not appear in the descriptors
+ * endpoint but are queryable via the Telemetry API.
+ */
+const KAFKA_SERVER_METRICS = [
+  {
+    name: "io.confluent.kafka.server/received_bytes",
+    description: "Total bytes received by the cluster from producers",
+    unit: "By",
+    labels: [
+      { key: "topic", description: "Kafka topic name" },
+      { key: "partition", description: "Partition ID" },
+    ],
+  },
+  {
+    name: "io.confluent.kafka.server/sent_bytes",
+    description: "Total bytes sent by the cluster to consumers",
+    unit: "By",
+    labels: [
+      { key: "topic", description: "Kafka topic name" },
+      { key: "partition", description: "Partition ID" },
+    ],
+  },
+  {
+    name: "io.confluent.kafka.server/received_records",
+    description: "Total records received by the cluster from producers",
+    unit: "1",
+    labels: [{ key: "topic", description: "Kafka topic name" }],
+  },
+  {
+    name: "io.confluent.kafka.server/sent_records",
+    description: "Total records sent by the cluster to consumers",
+    unit: "1",
+    labels: [{ key: "topic", description: "Kafka topic name" }],
+  },
+  {
+    name: "io.confluent.kafka.server/retained_bytes",
+    description: "Total bytes retained (stored) by the cluster",
+    unit: "By",
+    labels: [
+      { key: "topic", description: "Kafka topic name" },
+      { key: "partition", description: "Partition ID" },
+    ],
+  },
+  {
+    name: "io.confluent.kafka.server/consumer_lag_offsets",
+    description: "Consumer lag in number of offsets for a consumer group",
+    unit: "1",
+    labels: [
+      { key: "topic", description: "Kafka topic name" },
+      { key: "consumer_group_id", description: "Consumer group ID" },
+      { key: "partition", description: "Partition ID" },
+    ],
+  },
+  {
+    name: "io.confluent.kafka.server/request_count",
+    description: "Total number of requests to the cluster",
+    unit: "1",
+    labels: [{ key: "type", description: "Request type" }],
+  },
+  {
+    name: "io.confluent.kafka.server/request_bytes",
+    description: "Total request bytes sent to the cluster",
+    unit: "By",
+    labels: [{ key: "type", description: "Request type" }],
+  },
+  {
+    name: "io.confluent.kafka.server/response_bytes",
+    description: "Total response bytes received from the cluster",
+    unit: "By",
+    labels: [{ key: "type", description: "Request type" }],
+  },
+  {
+    name: "io.confluent.kafka.server/active_connection_count",
+    description: "Number of active authenticated connections to the cluster",
+    unit: "1",
+    labels: [],
+  },
+  {
+    name: "io.confluent.kafka.server/partition_count",
+    description: "Number of partitions in the cluster",
+    unit: "1",
+    labels: [],
+  },
+  {
+    name: "io.confluent.kafka.server/successful_authentication_count",
+    description: "Number of successful authentications",
+    unit: "1",
+    labels: [],
+  },
+];
+
+export class ListMetricsHandler extends BaseToolHandler {
+  async handle(
+    clientManager: ClientManager,
+    toolArguments: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const { resource_type } = listMetricsArguments.parse(toolArguments);
+
+    try {
+      const telemetryClient =
+        clientManager.getConfluentCloudTelemetryRestClient();
+
+      // Fetch both metrics and resources descriptors
+      const [metricsResponse, resourcesResponse] = await Promise.all([
+        telemetryClient.GET(
+          "/v2/metrics/{dataset}/descriptors/metrics" as never,
+          { params: { path: { dataset: "cloud" } } } as never,
+        ) as Promise<{ data?: DescriptorResponse }>,
+        telemetryClient.GET(
+          "/v2/metrics/{dataset}/descriptors/resources" as never,
+          { params: { path: { dataset: "cloud" } } } as never,
+        ) as Promise<{ data?: DescriptorResponse }>,
+      ]);
+
+      const metrics = (metricsResponse.data as DescriptorResponse)?.data as
+        | MetricDescriptor[]
+        | undefined;
+      const resources = (resourcesResponse.data as DescriptorResponse)?.data as
+        | ResourceDescriptor[]
+        | undefined;
+
+      if (!metrics || metrics.length === 0) {
+        return this.createResponse(
+          "No metrics descriptors available from the Telemetry API.",
+          true,
+        );
+      }
+
+      // Filter by resource type if specified
+      let filteredMetrics = resource_type
+        ? metrics.filter((m) => m.resources.includes(resource_type))
+        : metrics;
+
+      // The descriptors endpoint may not list Kafka server metrics depending
+      // on API key permissions, but they still work when queried directly.
+      // Include well-known Kafka server metrics as a fallback.
+      if (
+        (!resource_type || resource_type === "kafka") &&
+        !filteredMetrics.some((m) =>
+          m.name.startsWith("io.confluent.kafka.server/"),
+        )
+      ) {
+        const kafkaServerMetrics: MetricDescriptor[] = KAFKA_SERVER_METRICS.map(
+          (m) => ({
+            ...m,
+            type: "GAUGE_DOUBLE",
+            unit: m.unit,
+            lifecycle_stage: "GENERAL_AVAILABILITY",
+            resources: ["kafka"],
+          }),
+        );
+        filteredMetrics = [...kafkaServerMetrics, ...filteredMetrics];
+      }
+
+      // Format resources section
+      const lines: string[] = [];
+
+      if (resources && resources.length > 0) {
+        const relevantResources = resource_type
+          ? resources.filter((r) => r.type === resource_type)
+          : resources;
+
+        if (relevantResources.length > 0) {
+          lines.push("Resource Types and Filter Fields:");
+          for (const r of relevantResources) {
+            lines.push(`  ${r.type}: ${r.description}`);
+            for (const label of r.labels) {
+              lines.push(`    resource.${label.key} — ${label.description}`);
+            }
+          }
+          lines.push("");
+        }
+      }
+
+      // Format metrics
+      lines.push(
+        `Available Metrics${resource_type ? ` (${resource_type})` : ""}: ${filteredMetrics.length}`,
+      );
+      lines.push("");
+
+      for (const m of filteredMetrics) {
+        lines.push(`${m.name}`);
+        lines.push(`  ${m.description}`);
+        lines.push(
+          `  Type: ${m.type} | Unit: ${m.unit} | Resources: ${m.resources.join(", ")}`,
+        );
+        if (m.labels.length > 0) {
+          const labelKeys = m.labels.map((l) => `metric.${l.key}`).join(", ");
+          lines.push(`  Filter/group_by labels: ${labelKeys}`);
+        }
+        lines.push("");
+      }
+
+      return this.createResponse(lines.join("\n").trimEnd());
+    } catch (error) {
+      logger.error({ error }, "Error in ListMetricsHandler");
+      return this.createResponse(
+        `Failed to list metrics: ${error instanceof Error ? error.message : String(error)}`,
+        true,
+      );
+    }
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.LIST_METRICS,
+      description:
+        "List available Confluent Cloud metrics and their filter fields from the Telemetry API. Use this tool BEFORE query-metrics to discover valid metric names, resource filter fields, and grouping labels. This avoids guessing metric names.",
+      inputSchema: listMetricsArguments.shape,
+    };
+  }
+
+  getRequiredEnvVars(): EnvVar[] {
+    return ["CONFLUENT_CLOUD_API_KEY", "CONFLUENT_CLOUD_API_SECRET"];
+  }
+
+  isConfluentCloudOnly(): boolean {
+    return true;
+  }
+}

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -1,0 +1,322 @@
+import { ClientManager } from "@src/confluent/client-manager.js";
+import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  ToolConfig,
+} from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { EnvVar } from "@src/env-schema.js";
+import env from "@src/env.js";
+import { logger } from "@src/logger.js";
+import { z } from "zod";
+
+const queryMetricsArguments = z.object({
+  metric: z
+    .string()
+    .describe(
+      'The metric name to query. Common Kafka metrics: "io.confluent.kafka.server/received_bytes", "io.confluent.kafka.server/sent_bytes", "io.confluent.kafka.server/received_records", "io.confluent.kafka.server/sent_records", "io.confluent.kafka.server/retained_bytes", "io.confluent.kafka.server/consumer_lag_offsets", "io.confluent.kafka.server/request_count". Common Flink metrics: "io.confluent.flink/num_records_in", "io.confluent.flink/num_records_out". Common Connector metrics: "io.confluent.kafka.connect/sent_records", "io.confluent.kafka.connect/received_records".',
+    ),
+  dataset: z
+    .enum(["cloud"])
+    .default("cloud")
+    .describe("The metrics dataset to query.")
+    .optional(),
+  aggregation: z
+    .enum(["SUM", "MAX", "AVG", "MIN", "COUNT"])
+    .default("SUM")
+    .describe("Aggregation function to apply to the metric values.")
+    .optional(),
+  filter: z
+    .record(z.string(), z.string())
+    .describe(
+      'Key-value pairs to filter results. Use "resource.kafka.id" for cluster ID (e.g. "lkc-abc123"), "metric.topic" for topic name (e.g. "sensor-readings"), "metric.consumer_group_id" for consumer group, "resource.connector.id" for connector ID, "resource.environment.id" for environment ID, "resource.schema_registry.id" for schema registry ID. For Kafka topic metrics, "resource.kafka.id" is required.',
+    )
+    .optional(),
+  granularity: z
+    .enum(["PT1M", "PT5M", "PT15M", "PT30M", "PT1H", "P1D", "ALL"])
+    .default("PT1M")
+    .describe(
+      "Time granularity for the metric data points. Defaults to PT1M. Use PT1M or PT5M for intervals under a few hours, PT1H for day-scale queries, P1D for multi-day queries.",
+    )
+    .optional(),
+  interval: z
+    .string()
+    .describe(
+      'Time range as two ISO 8601 timestamps separated by "/". Example: "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z". Must include both start and end timestamps. Defaults to the last 1 hour if omitted. Do NOT pass a duration like "PT1H" — always use "start/end" format.',
+    )
+    .optional(),
+  group_by: z
+    .array(z.string())
+    .describe(
+      'Label keys to group results by. Common keys: "resource.kafka.id" (by cluster), "metric.topic" (by topic), "metric.partition" (by partition), "metric.consumer_group_id" (by consumer group), "metric.type" (by request type). Returns separate time series for each group.',
+    )
+    .optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(1000)
+    .default(100)
+    .describe("Maximum number of data points to return (max 1000).")
+    .optional(),
+});
+
+// Response format from the Telemetry API (flat or grouped)
+interface TelemetryResponse {
+  data?: Array<Record<string, unknown>>;
+  errors?: Array<{ detail?: string }>;
+}
+
+export class QueryMetricsHandler extends BaseToolHandler {
+  async handle(
+    clientManager: ClientManager,
+    toolArguments: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const args = queryMetricsArguments.parse(toolArguments);
+    const {
+      metric,
+      dataset = "cloud",
+      aggregation = "SUM",
+      filter,
+      granularity = "PT1M",
+      group_by,
+      limit = 100,
+    } = args;
+
+    // Resolve interval to a proper "start/end" range
+    let interval = args.interval;
+    if (!interval || !interval.includes("/")) {
+      // No interval provided, or a duration like "PT1H" was passed instead of a range
+      const now = new Date();
+      const durationMs = parseDuration(interval) ?? 60 * 60 * 1000; // default 1 hour
+      const start = new Date(now.getTime() - durationMs);
+      interval = `${start.toISOString()}/${now.toISOString()}`;
+    }
+
+    try {
+      const telemetryClient =
+        clientManager.getConfluentCloudTelemetryRestClient();
+
+      // Auto-inject resource.kafka.id for Kafka metrics if not provided
+      const effectiveFilter = { ...filter };
+      if (
+        metric.startsWith("io.confluent.kafka.server/") &&
+        !effectiveFilter["resource.kafka.id"] &&
+        env.KAFKA_CLUSTER_ID
+      ) {
+        effectiveFilter["resource.kafka.id"] = env.KAFKA_CLUSTER_ID;
+      }
+
+      // Build filter object
+      const filters = Object.entries(effectiveFilter).map(([field, value]) => ({
+        field,
+        op: "EQ" as const,
+        value,
+      }));
+
+      const filterObj =
+        filters.length > 0
+          ? filters.length === 1
+            ? filters[0]
+            : { op: "AND" as const, filters }
+          : undefined;
+
+      logger.debug(
+        { metric, filter: effectiveFilter, granularity, interval },
+        "Querying metrics",
+      );
+
+      // Build request body
+      const useGrouped = group_by && group_by.length > 0;
+      const body: Record<string, unknown> = {
+        aggregations: [{ metric, agg: aggregation }],
+        granularity,
+        intervals: [interval],
+        limit,
+      };
+
+      if (filterObj) {
+        body.filter = filterObj;
+      }
+
+      if (useGrouped) {
+        body.group_by = group_by;
+        body.format = "GROUPED";
+      }
+
+      const response = (await telemetryClient.POST(
+        "/v2/metrics/{dataset}/query" as never,
+        {
+          params: { path: { dataset } },
+          body,
+        } as never,
+      )) as { data?: TelemetryResponse; error?: unknown };
+
+      const data = response.data as TelemetryResponse;
+
+      if (data?.errors && data.errors.length > 0) {
+        const errorDetails = data.errors
+          .map((e) => e.detail)
+          .filter(Boolean)
+          .join("; ");
+        return this.createResponse(
+          `Metrics query returned errors: ${errorDetails}`,
+          true,
+        );
+      }
+
+      if (!data?.data || data.data.length === 0) {
+        return this.createResponse(
+          `No data returned for metric "${metric}" in the specified interval.\n\nQuery details:\n  Metric: ${metric}\n  Dataset: ${dataset}\n  Aggregation: ${aggregation}\n  Granularity: ${granularity}\n  Interval: ${interval}\n  Filter: ${JSON.stringify(effectiveFilter)}${group_by ? `\n  Group by: ${group_by.join(", ")}` : ""}`,
+        );
+      }
+
+      // Format the response
+      const output = formatMetricsResponse(
+        data.data,
+        metric,
+        aggregation,
+        granularity,
+        interval,
+        effectiveFilter,
+        group_by,
+      );
+
+      return this.createResponse(output, false, {
+        metric,
+        dataset,
+        aggregation,
+        granularity,
+        interval,
+        result_count: data.data.length,
+      });
+    } catch (error) {
+      logger.error({ error }, "Error in QueryMetricsHandler");
+      return this.createResponse(
+        `Failed to query metrics: ${error instanceof Error ? error.message : String(error)}`,
+        true,
+      );
+    }
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.QUERY_METRICS,
+      description:
+        "Query Confluent Cloud metrics from the Telemetry API. IMPORTANT: Use the list-available-metrics tool first to discover valid metric names and filter fields — do not guess them. Supports Kafka, Flink, Connectors, and Schema Registry metrics with flexible filtering, aggregation, and grouping.",
+      inputSchema: queryMetricsArguments.shape,
+    };
+  }
+
+  getRequiredEnvVars(): EnvVar[] {
+    return ["CONFLUENT_CLOUD_API_KEY", "CONFLUENT_CLOUD_API_SECRET"];
+  }
+
+  isConfluentCloudOnly(): boolean {
+    return true;
+  }
+}
+
+function formatMetricsResponse(
+  data: Array<Record<string, unknown>>,
+  metric: string,
+  aggregation: string,
+  granularity: string,
+  interval: string,
+  filter?: Record<string, string>,
+  groupBy?: string[],
+): string {
+  const lines: string[] = [];
+
+  lines.push(`Metrics Query Results`);
+  lines.push(`  Metric: ${metric}`);
+  lines.push(`  Aggregation: ${aggregation}`);
+  lines.push(`  Granularity: ${granularity}`);
+  lines.push(`  Interval: ${interval}`);
+  if (filter && Object.keys(filter).length > 0) {
+    lines.push(`  Filter: ${JSON.stringify(filter)}`);
+  }
+  if (groupBy && groupBy.length > 0) {
+    lines.push(`  Group by: ${groupBy.join(", ")}`);
+  }
+  lines.push("");
+
+  // Detect format: flat responses have timestamp/value at top level,
+  // grouped responses have a points array
+  const firstItem = data[0];
+  const isFlat =
+    firstItem !== undefined && "timestamp" in firstItem && "value" in firstItem;
+
+  if (isFlat) {
+    lines.push(`Data Points: ${data.length}`);
+    for (const point of data) {
+      const ts = point.timestamp
+        ? new Date(point.timestamp as string).toISOString()
+        : "unknown";
+      const val =
+        point.value !== undefined ? formatValue(point.value as number) : "N/A";
+      lines.push(`  ${ts}: ${val}`);
+    }
+  } else {
+    lines.push(`Groups: ${data.length}`);
+    lines.push("");
+    for (const group of data) {
+      const labels: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(group)) {
+        if (key !== "points") {
+          labels[key] = value;
+        }
+      }
+
+      if (Object.keys(labels).length > 0) {
+        const labelStr = Object.entries(labels)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(", ");
+        lines.push(`Group: ${labelStr}`);
+      }
+
+      const points = group.points as
+        | Array<{ timestamp?: string; value?: number }>
+        | undefined;
+      if (points && points.length > 0) {
+        for (const point of points) {
+          const ts = point.timestamp
+            ? new Date(point.timestamp).toISOString()
+            : "unknown";
+          const val =
+            point.value !== undefined ? formatValue(point.value) : "N/A";
+          lines.push(`  ${ts}: ${val}`);
+        }
+      } else {
+        lines.push("  (no data points)");
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function formatValue(value: number): string {
+  if (Number.isInteger(value)) {
+    return value.toLocaleString();
+  }
+  return value.toFixed(4);
+}
+
+/**
+ * Parse an ISO 8601 duration string (e.g. "PT1H", "PT30M", "P1D") to milliseconds.
+ * Returns undefined if the string is not a recognized duration.
+ */
+function parseDuration(duration: string | undefined): number | undefined {
+  if (!duration) return undefined;
+  const match = duration.match(
+    /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/,
+  );
+  if (!match) return undefined;
+  const days = parseInt(match[1] || "0", 10);
+  const hours = parseInt(match[2] || "0", 10);
+  const minutes = parseInt(match[3] || "0", 10);
+  const seconds = parseInt(match[4] || "0", 10);
+  return ((days * 24 + hours) * 60 + minutes) * 60 * 1000 + seconds * 1000;
+}

--- a/src/confluent/tools/tool-factory.ts
+++ b/src/confluent/tools/tool-factory.ts
@@ -47,6 +47,8 @@ import { ListTableFlowTopicsHandler } from "@src/confluent/tools/handlers/tablef
 import { ReadTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.js";
 import { UpdateTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.js";
 import { ListBillingCostsHandler } from "@src/confluent/tools/handlers/billing/list-billing-costs-handler.js";
+import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
+import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 
 export class ToolFactory {
@@ -114,6 +116,8 @@ export class ToolFactory {
       new DeleteTableFlowCatalogIntegrationHandler(),
     ],
     [ToolName.LIST_BILLING_COSTS, new ListBillingCostsHandler()],
+    [ToolName.QUERY_METRICS, new QueryMetricsHandler()],
+    [ToolName.LIST_METRICS, new ListMetricsHandler()],
   ]);
 
   static createToolHandler(toolName: ToolName): ToolHandler {

--- a/src/confluent/tools/tool-name.ts
+++ b/src/confluent/tools/tool-name.ts
@@ -47,4 +47,6 @@ export enum ToolName {
   UPDATE_TABLEFLOW_CATALOG_INTEGRATION = "update-tableflow-catalog-integration",
   DELETE_TABLEFLOW_CATALOG_INTEGRATION = "delete-tableflow-catalog-integration",
   LIST_BILLING_COSTS = "list-billing-costs",
+  QUERY_METRICS = "query-metrics",
+  LIST_METRICS = "list-available-metrics",
 }


### PR DESCRIPTION
## Summary

- Adds two new MCP tools (`query-metrics` and `list-available-metrics`) that expose Confluent Cloud's Telemetry API for querying operational metrics across Kafka, Flink, Connectors, and Schema Registry
- `list-available-metrics` discovers valid metric names, resource filter fields, and grouping labels — preventing LLMs from hallucinating invalid metric names
- `query-metrics` supports flexible filtering, aggregation, granularity, and grouping with built-in conveniences: auto-injects `resource.kafka.id` from `KAFKA_CLUSTER_ID` env var, converts ISO 8601 duration intervals (e.g. `PT1H`) to proper time ranges, and defaults to `PT1M` granularity
- Includes hardcoded Kafka server metrics (`io.confluent.kafka.server/*`) as a fallback in the discovery tool since the descriptors endpoint may not return them depending on API key permissions
- Updates README with metrics tool documentation, example workflows, environment variable reference, and project structure