### PR TITLE
set up `SessionRegistry` to support multiple sessions for HTTP transport config

### DIFF
--- a/src/confluent/node-deps.ts
+++ b/src/confluent/node-deps.ts
@@ -1,5 +1,6 @@
 // Wrappers for easier stubbing in tests — ESM live bindings can't be stubbed at runtime,
 // but property access on these namespace objects can be (via `vi.spyOn`).
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Analytics } from "@segment/analytics-node";
 import { TELEMETRY_WRITE_KEY } from "@src/build-config.js";
 import envProxy from "@src/env.js";
@@ -33,3 +34,4 @@ export const nodeOpen = {
     await open(target);
   },
 };
+export const sdkTransports = { StreamableHTTPServerTransport };

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,8 +177,7 @@ async function main() {
       );
     }
 
-    // server construction inputs flow in via start(), keeping transport config and McpServer
-    // config separated on the TransportManager constructor
+    // McpServer construction inputs flow through start(), not the TransportManager constructor
     const transportManager = new TransportManager({
       disableAuth: mcpConfig.server.auth.disabled,
       allowedHosts: mcpConfig.server.auth.allowed_hosts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,6 @@ async function main() {
       );
     }
 
-    // McpServer construction inputs flow through start(), not the TransportManager constructor
     const transportManager = new TransportManager({
       disableAuth: mcpConfig.server.auth.disabled,
       allowedHosts: mcpConfig.server.auth.allowed_hosts,
@@ -196,21 +195,22 @@ async function main() {
 
     // Start all transports with a single call
     logger.info(`Starting transports: ${transports.join(", ")}`);
-    await transportManager.start(
+    await transportManager.start({
       serverOptions,
-      transports,
-      mcpConfig.server.http.port,
-      mcpConfig.server.http.host,
-      mcpConfig.server.http.mcp_endpoint,
-      mcpConfig.server.http.sse_endpoint,
-      mcpConfig.server.http.sse_message_endpoint,
-    );
+      types: transports,
+      http: {
+        port: mcpConfig.server.http.port,
+        host: mcpConfig.server.http.host,
+        mcpEndpointPath: mcpConfig.server.http.mcp_endpoint,
+        sseEndpointPath: mcpConfig.server.http.sse_endpoint,
+        sseMessageEndpointPath: mcpConfig.server.http.sse_message_endpoint,
+      },
+    });
 
     // Set up cleanup handlers
     const performCleanup = async () => {
       logger.info("Shutting down...");
       await TelemetryService.getInstance().shutdown();
-      // stop() transitively closes every McpServer it owns; no manual close() needed here
       await transportManager.stop();
       // shutdown() is race-safe with an in-flight bootstrap.
       runtime.oauthHolder?.shutdown();

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,24 +156,11 @@ async function main() {
     const runtime = ServerRuntime.fromConfig(mcpConfig);
 
     const serverVersion = getPackageVersion();
-    const server = new McpServer({
-      name: "confluent",
-      version: serverVersion,
-    });
 
     TelemetryService.getInstance().setCommonProperties({
       serverVersion,
       transportType: transports.join(","),
     });
-
-    // Capture MCP client info when the handshake completes.
-    server.server.oninitialized = () => {
-      const clientInfo = server.server.getClientVersion();
-      TelemetryService.getInstance().setCommonProperties({
-        clientName: clientInfo?.name,
-        clientVersion: clientInfo?.version,
-      });
-    };
 
     const toolHandlers = getToolHandlersToRegister(filteredToolNames, runtime);
 
@@ -182,38 +169,62 @@ async function main() {
       `${toolHandlers.size} tool(s) enabled`,
     );
 
-    toolHandlers.forEach((handler, name) => {
-      const config = handler.getToolConfig();
+    // factory that creates a fresh McpServer with all tools registered.
+    // HTTP transport calls this per-session so each client gets its own
+    // McpServer instance (and underlying SDK state).
+    function createMcpServer(): McpServer {
+      const srv = new McpServer({
+        name: "confluent",
+        version: serverVersion,
+      });
 
-      server.registerTool(
-        name as string,
-        {
-          description: config.description,
-          inputSchema: config.inputSchema,
-          annotations: config.annotations,
-        },
-        async (args, context) => {
-          const sessionId = context?.sessionId;
-          const startTime = Date.now();
-          try {
-            const result = await handler.handle(runtime, args, sessionId);
-            TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
-              toolName: name,
-              durationMs: Date.now() - startTime,
-              status: result.isError ? "error" : "success",
-            });
-            return result;
-          } catch (error) {
-            TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
-              toolName: name,
-              durationMs: Date.now() - startTime,
-              status: "error",
-            });
-            throw error;
-          }
-        },
-      );
-    });
+      srv.server.oninitialized = () => {
+        const clientInfo = srv.server.getClientVersion();
+        TelemetryService.getInstance().setCommonProperties({
+          clientName: clientInfo?.name,
+          clientVersion: clientInfo?.version,
+        });
+      };
+
+      toolHandlers.forEach((handler, name) => {
+        const config = handler.getToolConfig();
+
+        srv.registerTool(
+          name as string,
+          {
+            description: config.description,
+            inputSchema: config.inputSchema,
+            annotations: config.annotations,
+          },
+          async (args, context) => {
+            const sessionId = context?.sessionId;
+            const startTime = Date.now();
+            try {
+              const result = await handler.handle(runtime, args, sessionId);
+              TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
+                toolName: name,
+                durationMs: Date.now() - startTime,
+                status: result.isError ? "error" : "success",
+              });
+              return result;
+            } catch (error) {
+              TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
+                toolName: name,
+                durationMs: Date.now() - startTime,
+                status: "error",
+              });
+              throw error;
+            }
+          },
+        );
+      });
+
+      return srv;
+    }
+
+    // primary server instance, used for stdio/sse transports.
+    // HTTP transport receives the factory and builds its own per session.
+    const server = createMcpServer();
 
     // Warn if auth is disabled
     if (mcpConfig.server.auth.disabled) {
@@ -223,11 +234,15 @@ async function main() {
       );
     }
 
-    const transportManager = new TransportManager(server, {
-      disableAuth: mcpConfig.server.auth.disabled,
-      allowedHosts: mcpConfig.server.auth.allowed_hosts,
-      apiKey: mcpConfig.server.auth.api_key,
-    });
+    const transportManager = new TransportManager(
+      server,
+      {
+        disableAuth: mcpConfig.server.auth.disabled,
+        allowedHosts: mcpConfig.server.auth.allowed_hosts,
+        apiKey: mcpConfig.server.auth.api_key,
+      },
+      createMcpServer,
+    );
 
     // Start all transports with a single call
     logger.info(`Starting transports: ${transports.join(", ")}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DisplayedCommandLineUsageError,
   getFilteredToolNames,
@@ -19,6 +18,7 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
 import { logger, setLogLevel } from "@src/logger.js";
+import { CreateMcpServerOptions } from "@src/mcp/server.js";
 import { generateApiKey, TransportManager } from "@src/mcp/transports/index.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
@@ -169,63 +169,6 @@ async function main() {
       `${toolHandlers.size} tool(s) enabled`,
     );
 
-    // factory that creates a fresh McpServer with all tools registered.
-    // HTTP transport calls this per-session so each client gets its own
-    // McpServer instance (and underlying SDK state).
-    function createMcpServer(): McpServer {
-      const srv = new McpServer({
-        name: "confluent",
-        version: serverVersion,
-      });
-
-      srv.server.oninitialized = () => {
-        const clientInfo = srv.server.getClientVersion();
-        TelemetryService.getInstance().setCommonProperties({
-          clientName: clientInfo?.name,
-          clientVersion: clientInfo?.version,
-        });
-      };
-
-      toolHandlers.forEach((handler, name) => {
-        const config = handler.getToolConfig();
-
-        srv.registerTool(
-          name as string,
-          {
-            description: config.description,
-            inputSchema: config.inputSchema,
-            annotations: config.annotations,
-          },
-          async (args, context) => {
-            const sessionId = context?.sessionId;
-            const startTime = Date.now();
-            try {
-              const result = await handler.handle(runtime, args, sessionId);
-              TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
-                toolName: name,
-                durationMs: Date.now() - startTime,
-                status: result.isError ? "error" : "success",
-              });
-              return result;
-            } catch (error) {
-              TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
-                toolName: name,
-                durationMs: Date.now() - startTime,
-                status: "error",
-              });
-              throw error;
-            }
-          },
-        );
-      });
-
-      return srv;
-    }
-
-    // primary server instance, used for stdio/sse transports.
-    // HTTP transport receives the factory and builds its own per session.
-    const server = createMcpServer();
-
     // Warn if auth is disabled
     if (mcpConfig.server.auth.disabled) {
       logger.warn(
@@ -234,19 +177,28 @@ async function main() {
       );
     }
 
-    const transportManager = new TransportManager(
-      server,
-      {
-        disableAuth: mcpConfig.server.auth.disabled,
-        allowedHosts: mcpConfig.server.auth.allowed_hosts,
-        apiKey: mcpConfig.server.auth.api_key,
-      },
-      createMcpServer,
-    );
+    // server construction inputs flow in via start(), keeping transport config and McpServer
+    // config separated on the TransportManager constructor
+    const transportManager = new TransportManager({
+      disableAuth: mcpConfig.server.auth.disabled,
+      allowedHosts: mcpConfig.server.auth.allowed_hosts,
+      apiKey: mcpConfig.server.auth.api_key,
+    });
+
+    const serverOptions: CreateMcpServerOptions = {
+      serverVersion,
+      toolHandlers,
+      runtime,
+      track: (props) =>
+        TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
+          ...props,
+        }),
+    };
 
     // Start all transports with a single call
     logger.info(`Starting transports: ${transports.join(", ")}`);
     await transportManager.start(
+      serverOptions,
       transports,
       mcpConfig.server.http.port,
       mcpConfig.server.http.host,
@@ -259,11 +211,11 @@ async function main() {
     const performCleanup = async () => {
       logger.info("Shutting down...");
       await TelemetryService.getInstance().shutdown();
+      // stop() transitively closes every McpServer it owns; no manual close() needed here
       await transportManager.stop();
       // shutdown() is race-safe with an in-flight bootstrap.
       runtime.oauthHolder?.shutdown();
       await runtime.clientManager.disconnect();
-      await server.close();
       process.exit(0);
     };
 

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -5,9 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
 
-// server wiring (McpServer + tool registration) lives inline in src/index.ts
-// main() and isn't importable directly, so we use createTestServer() with an
-// in-memory transport to test the server lifecycle and protocol handling
+// covers protocol-level behavior that needs a connected client; pure registration shape lives
+// in the unit suite next to src/mcp/server.ts
 describe("MCP server", () => {
   let ctx: TestServerContext;
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,89 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
+
+/** Properties recorded for each tool invocation. */
+export interface ToolCallProps {
+  toolName: ToolName;
+  /** From {@linkcode McpServer.server.getClientVersion}, undefined pre-handshake. */
+  clientName: string | undefined;
+  /** From {@linkcode McpServer.server.getClientVersion}, undefined pre-handshake. */
+  clientVersion: string | undefined;
+  durationMs: number;
+  status: "success" | "error";
+}
+
+/** Optional callback invoked once per tool call with timing + status. */
+export type TrackToolCall = (props: ToolCallProps) => void;
+
+const noopTrack: TrackToolCall = () => {};
+
+export interface CreateMcpServerOptions {
+  /** Surfaced via {@linkcode McpServer.server.getServerVersion}. */
+  serverVersion: string;
+  /** Each entry is registered as a tool on the new server instance. */
+  toolHandlers: Map<ToolName, ToolHandler>;
+  /** Injected into every {@linkcode ToolHandler.handle} invocation. */
+  runtime: ServerRuntime;
+  /** Per-tool-call telemetry hook. Defaults to a no-op. */
+  track?: TrackToolCall;
+}
+
+/** Builds a fresh {@link McpServer} with every supplied {@linkcode ToolHandler} registered. */
+export function createMcpServer({
+  serverVersion,
+  toolHandlers,
+  runtime,
+  track = noopTrack,
+}: CreateMcpServerOptions): McpServer {
+  const srv = new McpServer({
+    name: "confluent",
+    version: serverVersion,
+  });
+
+  toolHandlers.forEach((handler, name) => {
+    const config = handler.getToolConfig();
+
+    srv.registerTool(
+      name,
+      {
+        description: config.description,
+        inputSchema: config.inputSchema,
+        annotations: config.annotations,
+      },
+      async (args, context) => {
+        const startTime = Date.now();
+        // per-instance lookup so concurrent HTTP sessions don't clobber each other's telemetry
+        const clientInfo = srv.server.getClientVersion();
+        const baseProps = {
+          toolName: name,
+          clientName: clientInfo?.name,
+          clientVersion: clientInfo?.version,
+        };
+        try {
+          const result = await handler.handle(
+            runtime,
+            args,
+            context?.sessionId,
+          );
+          track({
+            ...baseProps,
+            durationMs: Date.now() - startTime,
+            status: result.isError ? "error" : "success",
+          });
+          return result;
+        } catch (error) {
+          track({
+            ...baseProps,
+            durationMs: Date.now() - startTime,
+            status: "error",
+          });
+          throw error;
+        }
+      },
+    );
+  });
+
+  return srv;
+}

--- a/src/mcp/transports/http.test.ts
+++ b/src/mcp/transports/http.test.ts
@@ -1,10 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import { HttpTransport } from "@src/mcp/transports/http.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
+import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
 import {
   createMockHttpServerTransport,
   createMockInstance,
+  createMockSessionRegistry,
   MOCK_SESSION_ID,
 } from "@tests/stubs/index.js";
 import Fastify, { FastifyInstance } from "fastify";
@@ -26,15 +29,19 @@ describe("HttpTransport", () => {
   let httpTransport: HttpTransport;
   let httpServer: Mocked<HttpServer>;
   let serverFactory: Mock<() => McpServer>;
+  let mockSessions: Mocked<SessionRegistry<StreamableHTTPServerTransport>>;
 
   beforeEach(async () => {
     // real: fastify (for inject()), httpTransport (unit under test).
-    // stubbed: httpServer (only getInstance has a return value), serverFactory (returns a mocked McpServer).
+    // stubbed: httpServer, serverFactory, sessions registry — every collaborator the route
+    // handlers reach for is a Mocked instance so behavior is isolated to HttpTransport.
     fastify = Fastify();
     httpServer = createMockInstance(HttpServer);
     httpServer.getInstance.mockReturnValue(fastify);
     serverFactory = vi.fn<() => McpServer>(() => createMockInstance(McpServer));
     httpTransport = new HttpTransport(serverFactory, httpServer);
+    mockSessions = createMockSessionRegistry<StreamableHTTPServerTransport>();
+    httpTransport["sessions"] = mockSessions;
     await httpTransport.connect();
   });
 
@@ -68,7 +75,7 @@ describe("HttpTransport", () => {
 
     it("should forward to the existing transport when the session id is known", async () => {
       const knownTransport = createMockHttpServerTransport();
-      httpTransport["sessions"].set(MOCK_SESSION_ID, {
+      mockSessions.get.mockReturnValue({
         transport: knownTransport,
         server: createMockInstance(McpServer),
       });
@@ -94,7 +101,6 @@ describe("HttpTransport", () => {
         ) {
           return newTransport;
         });
-      const bindServerSpy = vi.spyOn(httpTransport["sessions"], "bindServer");
 
       const response = await fastify.inject({
         method: "POST",
@@ -114,7 +120,7 @@ describe("HttpTransport", () => {
       expect(response.statusCode).toBe(200);
       expect(serverFactory).toHaveBeenCalledOnce();
       expect(transportConstructorStub).toHaveBeenCalledOnce();
-      expect(bindServerSpy).toHaveBeenCalledOnce();
+      expect(mockSessions.bindServer).toHaveBeenCalledOnce();
       expect(newTransport.handleRequest).toHaveBeenCalledOnce();
       // production code wires onclose so abandoned sessions can't leak
       expect(newTransport.onclose).toBeTypeOf("function");
@@ -134,7 +140,7 @@ describe("HttpTransport", () => {
 
     it("should forward to the existing transport when the session id is known", async () => {
       const knownTransport = createMockHttpServerTransport();
-      httpTransport["sessions"].set(MOCK_SESSION_ID, {
+      mockSessions.get.mockReturnValue({
         transport: knownTransport,
         server: createMockInstance(McpServer),
       });
@@ -163,7 +169,7 @@ describe("HttpTransport", () => {
 
     it("should delegate cleanup to the SDK transport when the session id is known", async () => {
       const knownTransport = createMockHttpServerTransport();
-      httpTransport["sessions"].set(MOCK_SESSION_ID, {
+      mockSessions.get.mockReturnValue({
         transport: knownTransport,
         server: createMockInstance(McpServer),
       });
@@ -179,13 +185,75 @@ describe("HttpTransport", () => {
     });
   });
 
+  describe("createSession()", () => {
+    let newTransport: ReturnType<typeof createMockHttpServerTransport>;
+
+    beforeEach(() => {
+      // production code does `new sdkTransports.StreamableHTTPServerTransport(...)` inside
+      // createSession(), so we need to spy on the constructor so it returns a test-controlled mock
+      // instead of standing up the real SDK class; tests assign `newTransport` before invoking
+      // createSession and the closure reads it lazily at construction time
+      vi.spyOn(
+        nodeDeps.sdkTransports,
+        "StreamableHTTPServerTransport",
+      ).mockImplementation(function MockStreamableHTTPServerTransport(
+        this: unknown,
+      ) {
+        return newTransport;
+      });
+    });
+
+    it("should register the session when onsessioninitialized fires", async () => {
+      newTransport = createMockHttpServerTransport();
+
+      await httpTransport["createSession"]();
+      vi.mocked(
+        nodeDeps.sdkTransports.StreamableHTTPServerTransport,
+      ).mock.calls[0]?.[0]?.onsessioninitialized?.(MOCK_SESSION_ID);
+
+      expect(mockSessions.set).toHaveBeenCalledWith(
+        MOCK_SESSION_ID,
+        expect.objectContaining({ transport: newTransport }),
+      );
+    });
+
+    it("should call closeAndRemove with the session id when onclose fires", async () => {
+      newTransport = createMockHttpServerTransport(MOCK_SESSION_ID);
+
+      await httpTransport["createSession"]();
+      newTransport.onclose?.();
+
+      expect(mockSessions.closeAndRemove).toHaveBeenCalledWith(MOCK_SESSION_ID);
+    });
+
+    it("should no-op the onclose handler when the transport has no session id", async () => {
+      newTransport = createMockHttpServerTransport();
+      // factory's default fills in MOCK_SESSION_ID; override to exercise the early-return branch.
+      // sessionId is a getter on the SDK class (so typed read-only), but the factory installs
+      // it as a writable data prop, so the runtime assignment is fine.
+      (newTransport as { sessionId: string | undefined }).sessionId = undefined;
+
+      await httpTransport["createSession"]();
+      newTransport.onclose?.();
+
+      expect(mockSessions.closeAndRemove).not.toHaveBeenCalled();
+    });
+
+    it("should propagate errors from bindServer", async () => {
+      newTransport = createMockHttpServerTransport();
+      mockSessions.bindServer.mockRejectedValue(new Error("connect boom"));
+
+      await expect(httpTransport["createSession"]()).rejects.toThrow(
+        "connect boom",
+      );
+    });
+  });
+
   describe("disconnect()", () => {
     it("should delegate to SessionRegistry.closeAll", async () => {
-      const closeAllSpy = vi.spyOn(httpTransport["sessions"], "closeAll");
-
       await httpTransport.disconnect();
 
-      expect(closeAllSpy).toHaveBeenCalledOnce();
+      expect(mockSessions.closeAll).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/mcp/transports/http.test.ts
+++ b/src/mcp/transports/http.test.ts
@@ -1,0 +1,194 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import * as nodeDeps from "@src/confluent/node-deps.js";
+import { HttpTransport } from "@src/mcp/transports/http.js";
+import { HttpServer } from "@src/mcp/transports/server.js";
+import {
+  createMockHttpServerTransport,
+  createMockInstance,
+  MOCK_SESSION_ID,
+} from "@tests/stubs/index.js";
+import Fastify, { FastifyInstance } from "fastify";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  type Mocked,
+  vi,
+} from "vitest";
+
+const UNKNOWN_SESSION = "22222222-2222-2222-2222-222222222222";
+
+describe("HttpTransport", () => {
+  let fastify: FastifyInstance;
+  let httpTransport: HttpTransport;
+  let httpServer: Mocked<HttpServer>;
+  let serverFactory: Mock<() => McpServer>;
+
+  beforeEach(async () => {
+    // real: fastify (for inject()), httpTransport (unit under test).
+    // stubbed: httpServer (only getInstance has a return value), serverFactory (returns a mocked McpServer).
+    fastify = Fastify();
+    httpServer = createMockInstance(HttpServer);
+    httpServer.getInstance.mockReturnValue(fastify);
+    serverFactory = vi.fn<() => McpServer>(
+      () => createMockInstance(McpServer) as unknown as McpServer,
+    );
+    httpTransport = new HttpTransport(serverFactory, httpServer);
+    await httpTransport.connect();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  describe("POST /mcp", () => {
+    it("should respond 400 to a sessionless POST whose body isn't an initialize request and never invoke the server factory", async () => {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/mcp",
+        payload: { jsonrpc: "2.0", id: 1, method: "ping" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(serverFactory).not.toHaveBeenCalled();
+    });
+
+    it("should respond 404 when the mcp-session-id header references an unknown session", async () => {
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/mcp",
+        headers: { "mcp-session-id": UNKNOWN_SESSION },
+        payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(serverFactory).not.toHaveBeenCalled();
+    });
+
+    it("should forward to the existing transport when the session id is known", async () => {
+      const knownTransport = createMockHttpServerTransport();
+      httpTransport["sessions"].set(MOCK_SESSION_ID, {
+        transport: knownTransport as unknown as StreamableHTTPServerTransport,
+        server: createMockInstance(McpServer),
+      });
+
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/mcp",
+        headers: { "mcp-session-id": MOCK_SESSION_ID },
+        payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(knownTransport.handleRequest).toHaveBeenCalledOnce();
+      expect(serverFactory).not.toHaveBeenCalled();
+    });
+
+    it("should construct a per-session server, bind it, and forward the body when an initialize POST arrives", async () => {
+      const newTransport = createMockHttpServerTransport();
+      const transportConstructorStub = vi
+        .spyOn(nodeDeps.sdkTransports, "StreamableHTTPServerTransport")
+        .mockImplementation(function MockStreamableHTTPServerTransport(
+          this: unknown,
+        ) {
+          return newTransport as unknown as StreamableHTTPServerTransport;
+        });
+      const bindServerSpy = vi.spyOn(httpTransport["sessions"], "bindServer");
+
+      const response = await fastify.inject({
+        method: "POST",
+        url: "/mcp",
+        payload: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-11-25",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "0.0.0" },
+          },
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(serverFactory).toHaveBeenCalledOnce();
+      expect(transportConstructorStub).toHaveBeenCalledOnce();
+      expect(bindServerSpy).toHaveBeenCalledOnce();
+      expect(newTransport.handleRequest).toHaveBeenCalledOnce();
+      // production code wires onclose so abandoned sessions can't leak
+      expect(newTransport.onclose).toBeTypeOf("function");
+    });
+  });
+
+  describe("GET /mcp", () => {
+    it("should respond 404 when the mcp-session-id header references an unknown session", async () => {
+      const response = await fastify.inject({
+        method: "GET",
+        url: "/mcp",
+        headers: { "mcp-session-id": UNKNOWN_SESSION },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("should forward to the existing transport when the session id is known", async () => {
+      const knownTransport = createMockHttpServerTransport();
+      httpTransport["sessions"].set(MOCK_SESSION_ID, {
+        transport: knownTransport as unknown as StreamableHTTPServerTransport,
+        server: createMockInstance(McpServer),
+      });
+
+      const response = await fastify.inject({
+        method: "GET",
+        url: "/mcp",
+        headers: { "mcp-session-id": MOCK_SESSION_ID },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(knownTransport.handleRequest).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("DELETE /mcp", () => {
+    it("should respond 404 when the mcp-session-id header references an unknown session", async () => {
+      const response = await fastify.inject({
+        method: "DELETE",
+        url: "/mcp",
+        headers: { "mcp-session-id": UNKNOWN_SESSION },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("should delegate cleanup to the SDK transport when the session id is known", async () => {
+      const knownTransport = createMockHttpServerTransport();
+      httpTransport["sessions"].set(MOCK_SESSION_ID, {
+        transport: knownTransport as unknown as StreamableHTTPServerTransport,
+        server: createMockInstance(McpServer),
+      });
+
+      const response = await fastify.inject({
+        method: "DELETE",
+        url: "/mcp",
+        headers: { "mcp-session-id": MOCK_SESSION_ID },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(knownTransport.handleRequest).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("disconnect()", () => {
+    it("should delegate to SessionRegistry.closeAll", async () => {
+      const closeAllSpy = vi.spyOn(httpTransport["sessions"], "closeAll");
+
+      await httpTransport.disconnect();
+
+      expect(closeAllSpy).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/mcp/transports/http.test.ts
+++ b/src/mcp/transports/http.test.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import { HttpTransport } from "@src/mcp/transports/http.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
@@ -34,9 +33,7 @@ describe("HttpTransport", () => {
     fastify = Fastify();
     httpServer = createMockInstance(HttpServer);
     httpServer.getInstance.mockReturnValue(fastify);
-    serverFactory = vi.fn<() => McpServer>(
-      () => createMockInstance(McpServer) as unknown as McpServer,
-    );
+    serverFactory = vi.fn<() => McpServer>(() => createMockInstance(McpServer));
     httpTransport = new HttpTransport(serverFactory, httpServer);
     await httpTransport.connect();
   });
@@ -72,7 +69,7 @@ describe("HttpTransport", () => {
     it("should forward to the existing transport when the session id is known", async () => {
       const knownTransport = createMockHttpServerTransport();
       httpTransport["sessions"].set(MOCK_SESSION_ID, {
-        transport: knownTransport as unknown as StreamableHTTPServerTransport,
+        transport: knownTransport,
         server: createMockInstance(McpServer),
       });
 
@@ -95,7 +92,7 @@ describe("HttpTransport", () => {
         .mockImplementation(function MockStreamableHTTPServerTransport(
           this: unknown,
         ) {
-          return newTransport as unknown as StreamableHTTPServerTransport;
+          return newTransport;
         });
       const bindServerSpy = vi.spyOn(httpTransport["sessions"], "bindServer");
 
@@ -138,7 +135,7 @@ describe("HttpTransport", () => {
     it("should forward to the existing transport when the session id is known", async () => {
       const knownTransport = createMockHttpServerTransport();
       httpTransport["sessions"].set(MOCK_SESSION_ID, {
-        transport: knownTransport as unknown as StreamableHTTPServerTransport,
+        transport: knownTransport,
         server: createMockInstance(McpServer),
       });
 
@@ -167,7 +164,7 @@ describe("HttpTransport", () => {
     it("should delegate cleanup to the SDK transport when the session id is known", async () => {
       const knownTransport = createMockHttpServerTransport();
       httpTransport["sessions"].set(MOCK_SESSION_ID, {
-        transport: knownTransport as unknown as StreamableHTTPServerTransport,
+        transport: knownTransport,
         server: createMockInstance(McpServer),
       });
 

--- a/src/mcp/transports/http.ts
+++ b/src/mcp/transports/http.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { sdkTransports } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
 import {
   pingHandler,
@@ -95,7 +96,7 @@ export class HttpTransport implements Transport {
         }
 
         const perSessionServer = this.serverFactory();
-        const transport = new StreamableHTTPServerTransport({
+        const transport = new sdkTransports.StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid: string) => {
             this.sessions.set(sid, {

--- a/src/mcp/transports/http.ts
+++ b/src/mcp/transports/http.ts
@@ -95,30 +95,7 @@ export class HttpTransport implements Transport {
           return;
         }
 
-        const perSessionServer = this.serverFactory();
-        const transport = new sdkTransports.StreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          onsessioninitialized: (sid: string) => {
-            this.sessions.set(sid, {
-              transport,
-              server: perSessionServer,
-            });
-          },
-        });
-        // fires on every close path (DELETE, network drop, server-initiated) so abandoned
-        // sessions can't leak; mirrors the SDK's simpleStreamableHttp.ts example
-        transport.onclose = () => {
-          const sid = transport.sessionId;
-          if (!sid) return;
-          this.sessions.closeAndRemove(sid).catch((err) => {
-            logger.error(
-              { err, sessionId: sid },
-              "Failed to close session on transport.onclose",
-            );
-          });
-        };
-
-        await this.sessions.bindServer(perSessionServer, transport);
+        const transport = await this.createSession();
         await transport.handleRequest(request.raw, reply.raw, request.body);
       },
     );
@@ -217,5 +194,35 @@ export class HttpTransport implements Transport {
   async disconnect(): Promise<void> {
     logger.info("Cleaning up HTTP transport sessions...");
     await this.sessions.closeAll();
+  }
+
+  /**
+   * Creates a fresh {@link McpServer} + {@link StreamableHTTPServerTransport} pair for an incoming
+   * initialize POST, sets up session lifecycle callbacks, and binds the server.
+   * NOTE: callers are responsible for forwarding the request to the returned transport
+   */
+  private async createSession(): Promise<StreamableHTTPServerTransport> {
+    const perSessionServer = this.serverFactory();
+    const transport = new sdkTransports.StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid: string) => {
+        this.sessions.set(sid, { transport, server: perSessionServer });
+      },
+    });
+    // fires on every close path (DELETE, network drop, server-initiated) so abandoned sessions
+    // don't leak
+    transport.onclose = () => {
+      const sid = transport.sessionId;
+      if (!sid) return;
+      this.sessions.closeAndRemove(sid).catch((err) => {
+        logger.error(
+          { err, sessionId: sid },
+          "Failed to close session on transport.onclose",
+        );
+      });
+    };
+
+    await this.sessions.bindServer(perSessionServer, transport);
+    return transport;
   }
 }

--- a/src/mcp/transports/http.ts
+++ b/src/mcp/transports/http.ts
@@ -31,9 +31,10 @@ const mcpErrorSchema = {
 
 export class HttpTransport implements Transport {
   private sessions: Record<string, StreamableHTTPServerTransport> = {};
+  private sessionServers: Record<string, McpServer> = {};
 
   constructor(
-    private server: McpServer,
+    private serverFactory: () => McpServer,
     private httpServer: HttpServer,
     private httpMcpEndpointPath: string = "/mcp",
   ) {}
@@ -70,14 +71,18 @@ export class HttpTransport implements Transport {
         if (sessionId && this.sessions[sessionId]) {
           transport = this.sessions[sessionId];
         } else {
+          // create the per-session server first so the onsessioninitialized
+          // callback below doesn't reference a TDZ binding.
+          const perSessionServer = this.serverFactory();
           transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (sid: string) => {
               this.sessions[sid] = transport;
+              this.sessionServers[sid] = perSessionServer;
             },
           });
 
-          await this.server.connect(transport);
+          await perSessionServer.connect(transport);
         }
 
         await transport.handleRequest(request.raw, reply.raw, request.body);
@@ -151,8 +156,14 @@ export class HttpTransport implements Transport {
 
         const transport = this.sessions[sessionId];
         await transport.handleRequest(request.raw, reply.raw);
-        // Clean up the session
+        // clean up session transport and its server
         delete this.sessions[sessionId];
+        transport.close();
+        const server = this.sessionServers[sessionId];
+        if (server) {
+          await server.close();
+          delete this.sessionServers[sessionId];
+        }
       },
     );
 
@@ -177,13 +188,15 @@ export class HttpTransport implements Transport {
 
   async disconnect(): Promise<void> {
     logger.info("Cleaning up HTTP transport sessions...");
-    // Clean up all active sessions
-    Object.values(this.sessions).forEach((transport) => {
-      const sessionId = transport.sessionId;
-      if (sessionId) {
-        delete this.sessions[sessionId];
-      }
+    // close all per-session servers
+    for (const server of Object.values(this.sessionServers)) {
+      await server.close();
+    }
+    this.sessionServers = {};
+    // close all transports
+    for (const transport of Object.values(this.sessions)) {
       transport.close();
-    });
+    }
+    this.sessions = {};
   }
 }

--- a/src/mcp/transports/http.ts
+++ b/src/mcp/transports/http.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "@src/logger.js";
 import {
   pingHandler,
@@ -7,6 +8,7 @@ import {
   pingResponseSchema,
 } from "@src/mcp/transports/ping.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
+import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
 import { Transport } from "@src/mcp/transports/types.js";
 import { randomUUID } from "crypto";
 import { FastifyReply, FastifyRequest } from "fastify";
@@ -30,8 +32,8 @@ const mcpErrorSchema = {
 };
 
 export class HttpTransport implements Transport {
-  private sessions: Record<string, StreamableHTTPServerTransport> = {};
-  private sessionServers: Record<string, McpServer> = {};
+  private readonly sessions =
+    new SessionRegistry<StreamableHTTPServerTransport>();
 
   constructor(
     private serverFactory: () => McpServer,
@@ -57,6 +59,7 @@ export class HttpTransport implements Transport {
           },
           response: {
             200: mcpSessionSchema,
+            400: mcpErrorSchema,
             404: mcpErrorSchema,
           },
         },
@@ -66,25 +69,55 @@ export class HttpTransport implements Transport {
         reply: FastifyReply,
       ) => {
         const sessionId = request.headers["mcp-session-id"];
-        let transport: StreamableHTTPServerTransport;
 
-        if (sessionId && this.sessions[sessionId]) {
-          transport = this.sessions[sessionId];
-        } else {
-          // create the per-session server first so the onsessioninitialized
-          // callback below doesn't reference a TDZ binding.
-          const perSessionServer = this.serverFactory();
-          transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: () => randomUUID(),
-            onsessioninitialized: (sid: string) => {
-              this.sessions[sid] = transport;
-              this.sessionServers[sid] = perSessionServer;
-            },
-          });
-
-          await perSessionServer.connect(transport);
+        if (sessionId) {
+          const entry = this.sessions.get(sessionId);
+          if (!entry) {
+            reply.status(404).send({ error: "Session not found" });
+            return;
+          }
+          await entry.transport.handleRequest(
+            request.raw,
+            reply.raw,
+            request.body,
+          );
+          return;
         }
 
+        // gate sessionless POSTs on init-body shape; the SDK's 400 path doesn't fire
+        // onsessioninitialized or close the transport, which would leak a per-session McpServer
+        if (!isInitializeRequest(request.body)) {
+          reply.status(400).send({
+            error:
+              "Bad Request: Mcp-Session-Id header is required for non-initialize requests",
+          });
+          return;
+        }
+
+        const perSessionServer = this.serverFactory();
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sid: string) => {
+            this.sessions.set(sid, {
+              transport,
+              server: perSessionServer,
+            });
+          },
+        });
+        // fires on every close path (DELETE, network drop, server-initiated) so abandoned
+        // sessions can't leak; mirrors the SDK's simpleStreamableHttp.ts example
+        transport.onclose = () => {
+          const sid = transport.sessionId;
+          if (!sid) return;
+          this.sessions.closeAndRemove(sid).catch((err) => {
+            logger.error(
+              { err, sessionId: sid },
+              "Failed to close session on transport.onclose",
+            );
+          });
+        };
+
+        await this.sessions.bindServer(perSessionServer, transport);
         await transport.handleRequest(request.raw, reply.raw, request.body);
       },
     );
@@ -114,13 +147,13 @@ export class HttpTransport implements Transport {
         reply: FastifyReply,
       ) => {
         const sessionId = request.headers["mcp-session-id"];
-        if (!sessionId || !this.sessions[sessionId]) {
+        const entry = sessionId ? this.sessions.get(sessionId) : undefined;
+        if (!entry) {
           reply.status(404).send({ error: "Session not found" });
           return;
         }
 
-        const transport = this.sessions[sessionId];
-        await transport.handleRequest(request.raw, reply.raw);
+        await entry.transport.handleRequest(request.raw, reply.raw);
       },
     );
 
@@ -149,21 +182,15 @@ export class HttpTransport implements Transport {
         reply: FastifyReply,
       ) => {
         const sessionId = request.headers["mcp-session-id"];
-        if (!sessionId || !this.sessions[sessionId]) {
+        const entry = sessionId ? this.sessions.get(sessionId) : undefined;
+        if (!entry) {
           reply.status(404).send({ error: "Session not found" });
           return;
         }
 
-        const transport = this.sessions[sessionId];
-        await transport.handleRequest(request.raw, reply.raw);
-        // clean up session transport and its server
-        delete this.sessions[sessionId];
-        transport.close();
-        const server = this.sessionServers[sessionId];
-        if (server) {
-          await server.close();
-          delete this.sessionServers[sessionId];
-        }
+        // the SDK's DELETE path closes the transport, which fires onclose (registered in POST)
+        // where session + per-session-server cleanup actually happen
+        await entry.transport.handleRequest(request.raw, reply.raw);
       },
     );
 
@@ -188,15 +215,6 @@ export class HttpTransport implements Transport {
 
   async disconnect(): Promise<void> {
     logger.info("Cleaning up HTTP transport sessions...");
-    // close all per-session servers
-    for (const server of Object.values(this.sessionServers)) {
-      await server.close();
-    }
-    this.sessionServers = {};
-    // close all transports
-    for (const transport of Object.values(this.sessions)) {
-      transport.close();
-    }
-    this.sessions = {};
+    await this.sessions.closeAll();
   }
 }

--- a/src/mcp/transports/http.ts
+++ b/src/mcp/transports/http.ts
@@ -33,8 +33,7 @@ const mcpErrorSchema = {
 };
 
 export class HttpTransport implements Transport {
-  private readonly sessions =
-    new SessionRegistry<StreamableHTTPServerTransport>();
+  private sessions = new SessionRegistry<StreamableHTTPServerTransport>();
 
   constructor(
     private serverFactory: () => McpServer,

--- a/src/mcp/transports/manager.test.ts
+++ b/src/mcp/transports/manager.test.ts
@@ -33,12 +33,5 @@ describe("TransportManager", () => {
 
       expect(second).toBe(first);
     });
-
-    it("should return distinct instances on repeated calls for http", () => {
-      const first = manager.getServer(TransportType.HTTP, serverOptions);
-      const second = manager.getServer(TransportType.HTTP, serverOptions);
-
-      expect(second).not.toBe(first);
-    });
   });
 });

--- a/src/mcp/transports/manager.test.ts
+++ b/src/mcp/transports/manager.test.ts
@@ -1,0 +1,44 @@
+import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { CreateMcpServerOptions } from "@src/mcp/server.js";
+import { TransportManager } from "@src/mcp/transports/manager.js";
+import { TransportType } from "@src/mcp/transports/types.js";
+import { runtimeWith } from "@tests/factories/runtime.js";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("TransportManager", () => {
+  let manager: TransportManager;
+  let serverOptions: CreateMcpServerOptions;
+
+  beforeEach(() => {
+    manager = new TransportManager();
+    serverOptions = {
+      serverVersion: "0.0.0-test",
+      toolHandlers: new Map<ToolName, ToolHandler>(),
+      runtime: runtimeWith(),
+    };
+  });
+
+  describe("getServer()", () => {
+    it("should return the same instance on repeated calls for stdio", () => {
+      const first = manager.getServer(TransportType.STDIO, serverOptions);
+      const second = manager.getServer(TransportType.STDIO, serverOptions);
+
+      expect(second).toBe(first);
+    });
+
+    it("should return the same instance on repeated calls for sse", () => {
+      const first = manager.getServer(TransportType.SSE, serverOptions);
+      const second = manager.getServer(TransportType.SSE, serverOptions);
+
+      expect(second).toBe(first);
+    });
+
+    it("should return distinct instances on repeated calls for http", () => {
+      const first = manager.getServer(TransportType.HTTP, serverOptions);
+      const second = manager.getServer(TransportType.HTTP, serverOptions);
+
+      expect(second).not.toBe(first);
+    });
+  });
+});

--- a/src/mcp/transports/manager.ts
+++ b/src/mcp/transports/manager.ts
@@ -20,25 +20,39 @@ export interface TransportManagerConfig {
   readonly apiKey?: string;
 }
 
+/** HTTP/SSE bind config; ignored for stdio-only setups. */
+export interface HttpStartOptions {
+  readonly port: number;
+  readonly host: string;
+  readonly mcpEndpointPath?: string;
+  readonly sseEndpointPath?: string;
+  readonly sseMessageEndpointPath?: string;
+}
+
+export interface TransportStartOptions {
+  readonly serverOptions: CreateMcpServerOptions;
+  readonly types: readonly TransportType[];
+  /** Required when {@linkcode types} includes HTTP or SSE. */
+  readonly http?: HttpStartOptions;
+}
+
 export class TransportManager {
   private readonly transports: Map<TransportType, Transport> = new Map();
   private httpServer: HttpServer | null = null;
-  // single-instance transports each cache their own McpServer; HTTP mints fresh per session
-  // inside HttpTransport (see SessionRegistry for the multi-instance rationale)
   private stdioServer: McpServer | null = null;
   private sseServer: McpServer | null = null;
 
   constructor(private readonly config?: TransportManagerConfig) {}
 
   /**
-   * Returns the {@link McpServer} for {@linkcode transport}. stdio/SSE share a single lazy
-   * instance; HTTP returns a fresh instance per call.
+   * Returns the cached {@link McpServer} for {@linkcode transport}, creating it lazily on first
+   * call. Only stdio/SSE are cached; HTTP creates a fresh server per session inside the transport.
    *
    * @internal Production callers go through {@linkcode TransportManager.start}; exposed so unit
    *   tests can assert the per-transport invariant directly.
    */
   getServer(
-    transport: TransportType,
+    transport: TransportType.STDIO | TransportType.SSE,
     serverOptions: CreateMcpServerOptions,
   ): McpServer {
     switch (transport) {
@@ -46,22 +60,11 @@ export class TransportManager {
         return (this.stdioServer ??= createMcpServer(serverOptions));
       case TransportType.SSE:
         return (this.sseServer ??= createMcpServer(serverOptions));
-      case TransportType.HTTP:
-        return createMcpServer(serverOptions);
-      default:
-        throw new Error(`Unsupported transport type: ${transport}`);
     }
   }
 
-  async start(
-    serverOptions: CreateMcpServerOptions,
-    types: readonly TransportType[],
-    port?: number,
-    host?: string,
-    httpMcpEndpointPath?: string,
-    sseMcpEndpointPath?: string,
-    sseMcpMessageEndpointPath?: string,
-  ): Promise<void> {
+  async start(options: TransportStartOptions): Promise<void> {
+    const { serverOptions, types, http } = options;
     try {
       const needsHttpServer = types.some(
         (type) => type === TransportType.HTTP || type === TransportType.SSE,
@@ -69,6 +72,11 @@ export class TransportManager {
 
       // Initialize and prepare HTTP server if needed
       if (needsHttpServer) {
+        if (!http) {
+          throw new Error(
+            "HTTP/SSE transports require `http` start options (port, host)",
+          );
+        }
         // Prepare auth configuration
         const authEnabled = !this.config?.disableAuth;
         const apiKey = this.config?.apiKey;
@@ -98,29 +106,15 @@ export class TransportManager {
       // Create and connect all transports
       await Promise.all(
         types.map(async (type) => {
-          const transport = await this.createTransport(
-            type,
-            serverOptions,
-            httpMcpEndpointPath,
-            sseMcpEndpointPath,
-            sseMcpMessageEndpointPath,
-          );
+          const transport = this.createTransport(type, serverOptions, http);
           this.transports.set(type, transport);
           await transport.connect();
         }),
       );
 
       // Start HTTP server if needed (after routes are registered)
-      if (needsHttpServer && this.httpServer) {
-        if (port && host) {
-          await this.httpServer.start({
-            port,
-            host,
-          });
-        } else {
-          logger.error("Port and host are required");
-          throw new Error("Port and host are required");
-        }
+      if (needsHttpServer && this.httpServer && http) {
+        await this.httpServer.start({ port: http.port, host: http.host });
       }
 
       logger.info("All transports started successfully");
@@ -166,22 +160,20 @@ export class TransportManager {
     }
   }
 
-  private async createTransport(
+  private createTransport(
     type: TransportType,
     serverOptions: CreateMcpServerOptions,
-    httpMcpEndpointPath?: string,
-    sseMcpEndpointPath?: string,
-    sseMcpMessageEndpointPath?: string,
-  ): Promise<Transport> {
+    http: HttpStartOptions | undefined,
+  ): Transport {
     switch (type) {
       case TransportType.HTTP:
         if (!this.httpServer) {
           throw new Error("HTTP server not initialized");
         }
         return new HttpTransport(
-          () => this.getServer(TransportType.HTTP, serverOptions),
+          () => createMcpServer(serverOptions),
           this.httpServer,
-          httpMcpEndpointPath,
+          http?.mcpEndpointPath,
         );
       case TransportType.SSE:
         if (!this.httpServer) {
@@ -190,8 +182,8 @@ export class TransportManager {
         return new SseTransport(
           this.getServer(TransportType.SSE, serverOptions),
           this.httpServer,
-          sseMcpEndpointPath,
-          sseMcpMessageEndpointPath,
+          http?.sseEndpointPath,
+          http?.sseMessageEndpointPath,
         );
       case TransportType.STDIO:
         return new StdioTransport(

--- a/src/mcp/transports/manager.ts
+++ b/src/mcp/transports/manager.ts
@@ -26,6 +26,7 @@ export class TransportManager {
   constructor(
     private readonly server: McpServer,
     private readonly config?: TransportManagerConfig,
+    private readonly serverFactory?: () => McpServer,
   ) {}
 
   async start(
@@ -141,7 +142,7 @@ export class TransportManager {
           throw new Error("HTTP server not initialized");
         }
         return new HttpTransport(
-          this.server,
+          this.serverFactory ?? (() => this.server),
           this.httpServer,
           httpMcpEndpointPath,
         );

--- a/src/mcp/transports/manager.ts
+++ b/src/mcp/transports/manager.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logger } from "@src/logger.js";
+import { createMcpServer, CreateMcpServerOptions } from "@src/mcp/server.js";
 import { AuthConfig } from "@src/mcp/transports/auth.js";
 import { HttpTransport } from "@src/mcp/transports/http.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
@@ -22,14 +23,38 @@ export interface TransportManagerConfig {
 export class TransportManager {
   private readonly transports: Map<TransportType, Transport> = new Map();
   private httpServer: HttpServer | null = null;
+  // single-instance transports each cache their own McpServer; HTTP mints fresh per session
+  // inside HttpTransport (see SessionRegistry for the multi-instance rationale)
+  private stdioServer: McpServer | null = null;
+  private sseServer: McpServer | null = null;
 
-  constructor(
-    private readonly server: McpServer,
-    private readonly config?: TransportManagerConfig,
-    private readonly serverFactory?: () => McpServer,
-  ) {}
+  constructor(private readonly config?: TransportManagerConfig) {}
+
+  /**
+   * Returns the {@link McpServer} for {@linkcode transport}. stdio/SSE share a single lazy
+   * instance; HTTP returns a fresh instance per call.
+   *
+   * @internal Production callers go through {@linkcode TransportManager.start}; exposed so unit
+   *   tests can assert the per-transport invariant directly.
+   */
+  getServer(
+    transport: TransportType,
+    serverOptions: CreateMcpServerOptions,
+  ): McpServer {
+    switch (transport) {
+      case TransportType.STDIO:
+        return (this.stdioServer ??= createMcpServer(serverOptions));
+      case TransportType.SSE:
+        return (this.sseServer ??= createMcpServer(serverOptions));
+      case TransportType.HTTP:
+        return createMcpServer(serverOptions);
+      default:
+        throw new Error(`Unsupported transport type: ${transport}`);
+    }
+  }
 
   async start(
+    serverOptions: CreateMcpServerOptions,
     types: readonly TransportType[],
     port?: number,
     host?: string,
@@ -75,6 +100,7 @@ export class TransportManager {
         types.map(async (type) => {
           const transport = await this.createTransport(
             type,
+            serverOptions,
             httpMcpEndpointPath,
             sseMcpEndpointPath,
             sseMcpMessageEndpointPath,
@@ -128,36 +154,49 @@ export class TransportManager {
 
     this.transports.clear();
     this.httpServer = null;
+
+    // close cached stdio/SSE McpServers; HTTP per-session ones were closed by HttpTransport above
+    if (this.stdioServer) {
+      await this.stdioServer.close();
+      this.stdioServer = null;
+    }
+    if (this.sseServer) {
+      await this.sseServer.close();
+      this.sseServer = null;
+    }
   }
 
   private async createTransport(
     type: TransportType,
+    serverOptions: CreateMcpServerOptions,
     httpMcpEndpointPath?: string,
     sseMcpEndpointPath?: string,
     sseMcpMessageEndpointPath?: string,
   ): Promise<Transport> {
     switch (type) {
-      case "http":
+      case TransportType.HTTP:
         if (!this.httpServer) {
           throw new Error("HTTP server not initialized");
         }
         return new HttpTransport(
-          this.serverFactory ?? (() => this.server),
+          () => this.getServer(TransportType.HTTP, serverOptions),
           this.httpServer,
           httpMcpEndpointPath,
         );
-      case "sse":
+      case TransportType.SSE:
         if (!this.httpServer) {
           throw new Error("HTTP server not initialized");
         }
         return new SseTransport(
-          this.server,
+          this.getServer(TransportType.SSE, serverOptions),
           this.httpServer,
           sseMcpEndpointPath,
           sseMcpMessageEndpointPath,
         );
-      case "stdio":
-        return new StdioTransport(this.server);
+      case TransportType.STDIO:
+        return new StdioTransport(
+          this.getServer(TransportType.STDIO, serverOptions),
+        );
       default:
         throw new Error(`Unsupported transport type: ${type}`);
     }

--- a/src/mcp/transports/multi-client.integration.test.ts
+++ b/src/mcp/transports/multi-client.integration.test.ts
@@ -1,0 +1,64 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { TransportType } from "@src/mcp/transports/types.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// transport-layer test (not tool-group), same fixture as the spawned server
+const runtime = integrationRuntime();
+
+describe("HTTP multi-client", { tags: [Tag.SMOKE] }, () => {
+  if (Object.keys(runtime.config.connections).length === 0) {
+    it.skip("requires at least one configured connection in integration.yaml", () => {});
+    return;
+  }
+
+  let server: StartedServer;
+  let secondClient: Client | undefined;
+
+  beforeAll(async () => {
+    server = await startServer({ transport: TransportType.HTTP });
+  });
+
+  afterAll(async () => {
+    await secondClient?.close();
+    await server?.stop();
+  });
+
+  it("should let a second client connect to an active server", async () => {
+    // per-session McpServer wiring in HttpTransport is what makes the second handshake succeed
+    // (pre-#116 this connect() throws "Already connected to a transport")
+    secondClient = new Client({
+      name: "mcp-confluent-multi-client-2",
+      version: "0.0.0-test",
+    });
+    const secondTransport = new StreamableHTTPClientTransport(
+      new URL(`${server.baseUrl}/mcp`),
+    );
+
+    await expect(
+      secondClient.connect(secondTransport),
+    ).resolves.toBeUndefined();
+
+    // a fresh session id server-side = a distinct McpServer in SessionRegistry
+    expect(secondTransport.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(secondTransport.sessionId).not.toEqual(
+      server.client.transport!.sessionId,
+    );
+
+    // both sessions see the same tool set; equality matters, count doesn't
+    const [firstTools, secondTools] = await Promise.all([
+      server.client.listTools(),
+      secondClient.listTools(),
+    ]);
+
+    const firstNames = firstTools.tools.map((t) => t.name).sort();
+    const secondNames = secondTools.tools.map((t) => t.name).sort();
+    expect(secondNames).toEqual(firstNames);
+  });
+});

--- a/src/mcp/transports/multi-client.integration.test.ts
+++ b/src/mcp/transports/multi-client.integration.test.ts
@@ -32,7 +32,7 @@ describe("HTTP multi-client", { tags: [Tag.SMOKE] }, () => {
 
   it("should let a second client connect to an active server", async () => {
     // per-session McpServer wiring in HttpTransport is what makes the second handshake succeed
-    // (pre-#116 this connect() throws "Already connected to a transport")
+    // (a single shared server would throw "Already connected to a transport" here)
     secondClient = new Client({
       name: "mcp-confluent-multi-client-2",
       version: "0.0.0-test",

--- a/src/mcp/transports/session-registry.test.ts
+++ b/src/mcp/transports/session-registry.test.ts
@@ -1,0 +1,153 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
+import {
+  createMockInstance,
+  createMockSdkTransport,
+} from "@tests/stubs/index.js";
+import { describe, expect, it } from "vitest";
+
+describe("session-registry.ts", () => {
+  describe("SessionRegistry", () => {
+    describe("closeAndRemove()", () => {
+      it("should close transport and server then remove the entry for a known session id", async () => {
+        const registry = new SessionRegistry();
+        const transport = createMockSdkTransport();
+        const server = createMockInstance(McpServer);
+        registry.set("session-1", { transport, server });
+
+        await registry.closeAndRemove("session-1");
+
+        expect(transport.close).toHaveBeenCalledOnce();
+        expect(server.close).toHaveBeenCalledOnce();
+        // a follow-up call is a no-op once the entry is gone
+        await registry.closeAndRemove("session-1");
+        expect(transport.close).toHaveBeenCalledOnce();
+        expect(server.close).toHaveBeenCalledOnce();
+      });
+
+      it("should be a no-op for an unknown session id", async () => {
+        const registry = new SessionRegistry();
+        const transport = createMockSdkTransport();
+        const server = createMockInstance(McpServer);
+        registry.set("session-1", { transport, server });
+
+        await registry.closeAndRemove("session-unknown");
+
+        expect(transport.close).not.toHaveBeenCalled();
+        expect(server.close).not.toHaveBeenCalled();
+      });
+
+      it("should still close the server even when transport.close() rejects", async () => {
+        const registry = new SessionRegistry();
+        const transport = createMockSdkTransport();
+        transport.close.mockRejectedValueOnce(new Error("transport boom"));
+        const server = createMockInstance(McpServer);
+        registry.set("session-1", { transport, server });
+
+        await expect(
+          registry.closeAndRemove("session-1"),
+        ).resolves.toBeUndefined();
+
+        expect(transport.close).toHaveBeenCalledOnce();
+        expect(server.close).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("closeAll()", () => {
+      it("should close every registered transport + server pair and clear the registry", async () => {
+        const registry = new SessionRegistry();
+        const a = {
+          transport: createMockSdkTransport(),
+          server: createMockInstance(McpServer),
+        };
+        const b = {
+          transport: createMockSdkTransport(),
+          server: createMockInstance(McpServer),
+        };
+        registry.set("a", a);
+        registry.set("b", b);
+
+        await registry.closeAll();
+
+        expect(a.transport.close).toHaveBeenCalledOnce();
+        expect(a.server.close).toHaveBeenCalledOnce();
+        expect(b.transport.close).toHaveBeenCalledOnce();
+        expect(b.server.close).toHaveBeenCalledOnce();
+        // a subsequent closeAll is a no-op (proves the registry was cleared)
+        await registry.closeAll();
+        expect(a.server.close).toHaveBeenCalledOnce();
+        expect(b.server.close).toHaveBeenCalledOnce();
+      });
+
+      it("should keep closing remaining entries when one entry's close rejects", async () => {
+        const registry = new SessionRegistry();
+        const a = {
+          transport: createMockSdkTransport(),
+          server: createMockInstance(McpServer),
+        };
+        a.transport.close.mockRejectedValueOnce(new Error("transport boom"));
+        const b = {
+          transport: createMockSdkTransport(),
+          server: createMockInstance(McpServer),
+        };
+        registry.set("a", a);
+        registry.set("b", b);
+
+        await expect(registry.closeAll()).resolves.toBeUndefined();
+
+        expect(a.server.close).toHaveBeenCalledOnce();
+        expect(b.transport.close).toHaveBeenCalledOnce();
+        expect(b.server.close).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("get()", () => {
+      it("should return the registered entry for a known session id", () => {
+        const registry = new SessionRegistry();
+        const entry = {
+          transport: createMockSdkTransport(),
+          server: createMockInstance(McpServer),
+        };
+        registry.set("session-1", entry);
+
+        expect(registry.get("session-1")).toBe(entry);
+      });
+
+      it("should return undefined for an unknown session id", () => {
+        const registry = new SessionRegistry();
+
+        expect(registry.get("session-unknown")).toBeUndefined();
+      });
+    });
+
+    describe("bindServer()", () => {
+      it("should resolve when connect() succeeds without closing the server", async () => {
+        const registry = new SessionRegistry();
+        const server = createMockInstance(McpServer);
+        const transport = createMockSdkTransport();
+        server.connect.mockResolvedValueOnce(undefined);
+
+        await registry.bindServer(server, transport);
+
+        expect(server.connect).toHaveBeenCalledOnce();
+        expect(server.close).not.toHaveBeenCalled();
+        expect(transport.close).not.toHaveBeenCalled();
+      });
+
+      it("should close both server and transport and rethrow when connect() rejects", async () => {
+        const registry = new SessionRegistry();
+        const server = createMockInstance(McpServer);
+        const transport = createMockSdkTransport();
+        const failure = new Error("handshake failed");
+        server.connect.mockRejectedValueOnce(failure);
+
+        await expect(registry.bindServer(server, transport)).rejects.toBe(
+          failure,
+        );
+
+        expect(server.close).toHaveBeenCalledOnce();
+        expect(transport.close).toHaveBeenCalledOnce();
+      });
+    });
+  });
+});

--- a/src/mcp/transports/session-registry.ts
+++ b/src/mcp/transports/session-registry.ts
@@ -1,0 +1,75 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Transport as SdkTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { logger } from "@src/logger.js";
+
+/** Paired SDK transport + {@link McpServer} representing one MCP session. */
+export interface SessionEntry<T extends SdkTransport = SdkTransport> {
+  readonly transport: T;
+  readonly server: McpServer;
+}
+
+/**
+ * Registry of {@link SessionEntry} pairs keyed by MCP session id. Multi-client transports need
+ * one {@link McpServer} per session because the SDK binds each server to a single transport.
+ *
+ * {@see https://github.com/modelcontextprotocol/typescript-sdk/blob/main/examples/server/src/simpleStreamableHttp.ts}
+ * {@see https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management}
+ */
+export class SessionRegistry<T extends SdkTransport = SdkTransport> {
+  private readonly sessions = new Map<string, SessionEntry<T>>();
+
+  set(sessionId: string, entry: SessionEntry<T>): void {
+    this.sessions.set(sessionId, entry);
+  }
+
+  get(sessionId: string): SessionEntry<T> | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  /**
+   * Connects {@linkcode server} to {@linkcode transport}; closes both on rejection. The pair
+   * is not in the registry yet at this point (the SDK's {@linkcode T.onsessioninitialized}
+   * callback fires later, during {@linkcode T.handleRequest}), so failure here is an orphan
+   * cleanup, not a registry mutation.
+   */
+  async bindServer(server: McpServer, transport: T): Promise<void> {
+    try {
+      await server.connect(transport);
+    } catch (err) {
+      await this.closeEntry({ transport, server });
+      throw err;
+    }
+  }
+
+  /** Closes the {@link SessionEntry} for {@linkcode sessionId} (if any) and removes it. */
+  async closeAndRemove(sessionId: string): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    // delete first so a re-entrant call from `transport.onclose` is a no-op
+    this.sessions.delete(sessionId);
+    await this.closeEntry(entry);
+  }
+
+  /** Closes every registered transport + server pair and clears the registry. */
+  async closeAll(): Promise<void> {
+    const entries = [...this.sessions.values()];
+    this.sessions.clear();
+    for (const entry of entries) {
+      await this.closeEntry(entry);
+    }
+  }
+
+  /** Closes both halves of {@linkcode entry}, logging (not propagating) any failures. */
+  private async closeEntry(entry: SessionEntry<T>): Promise<void> {
+    try {
+      await entry.transport.close();
+    } catch (err) {
+      logger.error({ err }, "transport.close() failed during session cleanup");
+    }
+    try {
+      await entry.server.close();
+    } catch (err) {
+      logger.error({ err }, "server.close() failed during session cleanup");
+    }
+  }
+}

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -1,9 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
+import { createMcpServer } from "@src/mcp/server.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
 export interface TestServerContext {
@@ -19,6 +21,9 @@ export interface TestServerContext {
  * Spins up an {@link McpServer} and {@link Client} connected via
  * {@link InMemoryTransport} for protocol-level integration tests.
  *
+ * Tool registration delegates to the production {@linkcode createMcpServer} so this helper can't
+ * drift from the real server's wiring.
+ *
  * @param runtime - {@link ServerRuntime} injected into every tool handler
  * @param toolNames - (Optional) Subset of tools to register (defaults to all
  *   {@link ToolName} values)
@@ -31,23 +36,16 @@ export async function createTestServer(
   // in tool schemas (e.g., env.FLINK_REST_ENDPOINT) don't throw
   await initEnv();
 
-  const server = new McpServer({
-    name: "confluent-test",
-    version: "0.0.0-test",
-  });
-
   const names = toolNames ?? Object.values(ToolName);
-  for (const toolName of names) {
-    const handler = ToolHandlerRegistry.getToolHandler(toolName);
-    const config = handler.getToolConfig();
-    server.registerTool(
-      toolName as string,
-      { description: config.description, inputSchema: config.inputSchema },
-      async (args, context) => {
-        return await handler.handle(runtime, args, context?.sessionId);
-      },
-    );
-  }
+  const toolHandlers = new Map<ToolName, ToolHandler>(
+    names.map((name) => [name, ToolHandlerRegistry.getToolHandler(name)]),
+  );
+
+  const server = createMcpServer({
+    serverVersion: "0.0.0-test",
+    toolHandlers,
+    runtime,
+  });
 
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -28,4 +28,9 @@ export {
   createMockSdkTransport,
   type MockedSdkTransport,
 } from "./sdk-transport.js";
+export {
+  MOCK_SESSION_ID,
+  createMockHttpServerTransport,
+  type MockedHttpServerTransport,
+} from "./streamable-http-transport.js";
 export { StubHandler } from "./stub-handler.js";

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -24,4 +24,8 @@ export {
   type MockedHttpServer,
   type MockedOpen,
 } from "./node-deps.js";
+export {
+  createMockSdkTransport,
+  type MockedSdkTransport,
+} from "./sdk-transport.js";
 export { StubHandler } from "./stub-handler.js";

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -31,6 +31,5 @@ export {
 export {
   MOCK_SESSION_ID,
   createMockHttpServerTransport,
-  type MockedHttpServerTransport,
 } from "./streamable-http-transport.js";
 export { StubHandler } from "./stub-handler.js";

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -28,6 +28,7 @@ export {
   createMockSdkTransport,
   type MockedSdkTransport,
 } from "./sdk-transport.js";
+export { createMockSessionRegistry } from "./session-registry.js";
 export {
   MOCK_SESSION_ID,
   createMockHttpServerTransport,

--- a/tests/stubs/sdk-transport.ts
+++ b/tests/stubs/sdk-transport.ts
@@ -4,10 +4,7 @@ import { type Mocked, vi } from "vitest";
 /** {@link SdkTransport} where each method is replaced with a {@linkcode vi.fn}. */
 export type MockedSdkTransport = Mocked<SdkTransport>;
 
-/**
- * Creates a {@link MockedSdkTransport}: a {@link SdkTransport} instance
- * where each method is a {@linkcode vi.fn} stub.
- */
+/** Creates a {@link MockedSdkTransport}. */
 export function createMockSdkTransport(): MockedSdkTransport {
   return {
     start: vi.fn().mockResolvedValue(undefined),

--- a/tests/stubs/sdk-transport.ts
+++ b/tests/stubs/sdk-transport.ts
@@ -1,0 +1,17 @@
+import type { Transport as SdkTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { type Mocked, vi } from "vitest";
+
+/** {@link SdkTransport} where each method is replaced with a {@linkcode vi.fn}. */
+export type MockedSdkTransport = Mocked<SdkTransport>;
+
+/**
+ * Creates a {@link MockedSdkTransport}: a {@link SdkTransport} instance
+ * where each method is a {@linkcode vi.fn} stub.
+ */
+export function createMockSdkTransport(): MockedSdkTransport {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as Mocked<SdkTransport>;
+}

--- a/tests/stubs/session-registry.ts
+++ b/tests/stubs/session-registry.ts
@@ -1,0 +1,21 @@
+import type { Transport as SdkTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
+import { createMockInstance } from "@tests/stubs/mock-instance.js";
+import type { Mocked } from "vitest";
+
+/**
+ * Creates a {@linkcode Mocked} {@link SessionRegistry} with every method pre-stubbed.
+ * Async methods default to {@linkcode mockResolvedValue} so production code that awaits
+ * (or chains `.catch`) on them works without per-test setup.
+ */
+export function createMockSessionRegistry<
+  T extends SdkTransport = SdkTransport,
+>(): Mocked<SessionRegistry<T>> {
+  const mock = createMockInstance(SessionRegistry) as Mocked<
+    SessionRegistry<T>
+  >;
+  mock.bindServer.mockResolvedValue();
+  mock.closeAndRemove.mockResolvedValue();
+  mock.closeAll.mockResolvedValue();
+  return mock;
+}

--- a/tests/stubs/streamable-http-transport.ts
+++ b/tests/stubs/streamable-http-transport.ts
@@ -1,0 +1,38 @@
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  createMockSdkTransport,
+  type MockedSdkTransport,
+} from "@tests/stubs/sdk-transport.js";
+import { type Mock, vi } from "vitest";
+
+/**
+ * Stub-shape for a {@link StreamableHTTPServerTransport}: extends {@link MockedSdkTransport}
+ * with the HTTP-only surface ({@linkcode handleRequest}, {@linkcode sessionId}, {@linkcode onclose}).
+ */
+export interface MockedHttpServerTransport extends MockedSdkTransport {
+  handleRequest: Mock;
+  sessionId: string | undefined;
+  onclose: (() => void) | undefined;
+}
+
+/** Sentinel UUID for stubbed HTTP sessions; pair with any other UUID for "unknown" cases. */
+export const MOCK_SESSION_ID = "11111111-1111-1111-1111-111111111111";
+
+/**
+ * Creates a {@link MockedHttpServerTransport}. {@linkcode handleRequest} writes a 200 to the
+ * raw response so {@linkcode fastify.inject} resolves; {@linkcode close} is a resolved no-op.
+ */
+export function createMockHttpServerTransport(
+  sessionId: string | undefined = MOCK_SESSION_ID,
+): MockedHttpServerTransport {
+  return {
+    ...createMockSdkTransport(),
+    handleRequest: vi.fn().mockImplementation((_req, res) => {
+      res.statusCode = 200;
+      res.end();
+      return Promise.resolve();
+    }),
+    sessionId,
+    onclose: undefined,
+  };
+}

--- a/tests/stubs/streamable-http-transport.ts
+++ b/tests/stubs/streamable-http-transport.ts
@@ -1,30 +1,19 @@
-import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import {
-  createMockSdkTransport,
-  type MockedSdkTransport,
-} from "@tests/stubs/sdk-transport.js";
-import { type Mock, vi } from "vitest";
-
-/**
- * Stub-shape for a {@link StreamableHTTPServerTransport}: extends {@link MockedSdkTransport}
- * with the HTTP-only surface ({@linkcode handleRequest}, {@linkcode sessionId}, {@linkcode onclose}).
- */
-export interface MockedHttpServerTransport extends MockedSdkTransport {
-  handleRequest: Mock;
-  sessionId: string | undefined;
-  onclose: (() => void) | undefined;
-}
+import { type StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createMockSdkTransport } from "@tests/stubs/sdk-transport.js";
+import { type Mocked, vi } from "vitest";
 
 /** Sentinel UUID for stubbed HTTP sessions; pair with any other UUID for "unknown" cases. */
 export const MOCK_SESSION_ID = "11111111-1111-1111-1111-111111111111";
 
 /**
- * Creates a {@link MockedHttpServerTransport}. {@linkcode handleRequest} writes a 200 to the
- * raw response so {@linkcode fastify.inject} resolves; {@linkcode close} is a resolved no-op.
+ * Creates a {@linkcode Mocked} {@link StreamableHTTPServerTransport} stub. {@linkcode handleRequest}
+ * writes a 200 to the raw response so {@linkcode fastify.inject} resolves; {@linkcode sessionId}
+ * and {@linkcode onclose} land as plain data props (the SDK class declares them as accessors,
+ * which {@linkcode createMockInstance} can't auto-stub).
  */
 export function createMockHttpServerTransport(
   sessionId: string | undefined = MOCK_SESSION_ID,
-): MockedHttpServerTransport {
+): Mocked<StreamableHTTPServerTransport> {
   return {
     ...createMockSdkTransport(),
     handleRequest: vi.fn().mockImplementation((_req, res) => {
@@ -32,7 +21,9 @@ export function createMockHttpServerTransport(
       res.end();
       return Promise.resolve();
     }),
+    closeSSEStream: vi.fn(),
+    closeStandaloneSSEStream: vi.fn(),
     sessionId,
     onclose: undefined,
-  };
+  } as unknown as Mocked<StreamableHTTPServerTransport>;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The HTTP transport was holding a single `McpServer` and calling `server.connect(transport)` for every new session, but the SDK only allows one active transport binding per `McpServer`, so a 2nd client (or a fresh session from the same client) crashed with `Already connected to a transport`.

This PR moves to a per-session `McpServer` model, matching the [SDK's `simpleStreamableHttp` example](https://github.com/modelcontextprotocol/typescript-sdk/blob/2c0c481cb9dbfd15c8613f765c940a5f5bace94d/examples/server/src/simpleStreamableHttp.ts#L635-L636):
- new `SessionRegistry` ([`src/mcp/transports/session-registry.ts`](src/mcp/transports/session-registry.ts)) owns the `{transport, server}` pair per session id
- new `createMcpServer` factory ([`src/mcp/server.ts`](src/mcp/server.ts)) builds a fresh `McpServer` with all tool handlers registered, so each session gets its own instance
- `HttpTransport` now uses `SessionRegistry` for routing, with a per-session `McpServer` created on first `POST` and torn down on `DELETE` / `transport.onclose`
- `TransportManager` and `src/index.ts` updated to use the factory instead of the old "build one shared server" path currently in `main`
- `node-deps.ts` re-exports `StreamableHTTPServerTransport` so tests can spy on construction (per the project's stubbing convention)

`SessionRegistry` is generic over the SDK transport type, which will help in a follow-up branch to address #337.

Closes #122.

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1. `npm run build && npm run start:http`
2. Connect two MCP clients (e.g., two `npm run inspector` instances or two Claude Code workspaces) to the same HTTP endpoint
3. Confirm both initialize successfully and can call tools concurrently -- previously the 2nd client got a 500 with `Already connected to a transport`:
<img width="1766" height="299" alt="image" src="https://github.com/user-attachments/assets/938e0097-a260-42d9-bb5c-00eed3408e8f" />


### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- a follow-up branch for #337 will apply the same general pattern (but for the SSE transport)
- new `multi-client.integration.test.ts` spins up two real HTTP clients against the spawned server and verifies independent sessions
- tool-call telemetry now uses `srv.server.getClientVersion()` per server instance so multiple server instances' telemetry events don't mix up client name/version info

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?