### PR TITLE
docs: update README to split tooling based on API key/secret requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These tools require endpoints and authentication against specific Confluent Clou
 
 ### Available Tools for Local Confluent
 
-These tools only require Kafka or Schema Registry endpoints. No authentication is required, making them ideal for local development with Docker Compose or self-managed clusters.
+These tools only require Kafka or Schema Registry endpoints - no Confluent Cloud API key/secret is needed. Ideal for local development with Docker Compose or self-managed clusters.
 
 ```properties
 # minimal .env for local development


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/mcp-confluent/pull/102 to more clearly document what tools don't require `*_API_KEY`/`*_API_SECRET` values set in `.env`.

Preview: https://github.com/confluentinc/mcp-confluent/blob/djs/readme-local-tool-support/README.md#available-tools

Closes #115 