### PR TITLE
MINOR: remove `createTestServer` mention from sinon skill

### DIFF
--- a/.claude/skills/sinon/SKILL.md
+++ b/.claude/skills/sinon/SKILL.md
@@ -221,5 +221,3 @@ Use Vitest `expect` for non-Sinon assertions (return values, thrown errors, data
   non-Sinon values. Adapt any Chai-based examples from docs accordingly
 - `stub.resolves()` / `stub.rejects()` are the async-friendly counterparts to `stub.returns()` /
   `stub.throws()` - use these for Promise-based code
-- For integration-style tests, use `createTestServer()` from `tests/server.ts` which provides an
-  MCP server + client connected via `InMemoryTransport`


### PR DESCRIPTION
Isn't needed since it doesn't have anything to do with `sinon` usage and is already in https://github.com/confluentinc/mcp-confluent/blob/main/.claude/rules/unit-tests.md#key-patterns