### PR TITLE
Have each tool register its read-only, create-update, or destructive delete intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this MCP server will be documented in this file.
 ### Changed
 
 - Removed `baseUrl` invocation parameter from all tool definitions. Now any API non-defaulting endpoint URLs must be provided through environment variable configuration prior to MCP server startup.
+- MCP tool annotations (`readOnlyHint`, `destructiveHint`) for all tools to enable AI clients to distinguish between read-only operations (e.g., `list-topics`) and destructive operations (e.g., `delete-topics`, `delete-schema`).
 
 ## 1.2.1
 

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -2,7 +2,24 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { EnvVar } from "@src/env-schema.js";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { ZodRawShape } from "zod";
+
+/**
+ * Standard MCP tool annotations.
+ * Tools should reference these constants rather than creating ad-hoc instances.
+ */
+export const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+} as const;
+
+export const CREATE_UPDATE: ToolAnnotations = {
+  destructiveHint: false,
+} as const;
+
+export const DESTRUCTIVE: ToolAnnotations = {
+  destructiveHint: true,
+} as const;
 
 export interface ToolHandler {
   handle(
@@ -35,6 +52,7 @@ export interface ToolConfig {
   name: ToolName;
   description: string;
   inputSchema: ZodRawShape;
+  annotations: ToolAnnotations;
 }
 
 export abstract class BaseToolHandler implements ToolHandler {

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -2,7 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { EnvVar } from "@src/env-schema.js";
-import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { ZodRawShape } from "zod";
 
 /**

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -1,8 +1,8 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { EnvVar } from "@src/env-schema.js";
-import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { ZodRawShape } from "zod";
 
 /**
@@ -15,10 +15,12 @@ export const READ_ONLY: ToolAnnotations = {
 
 export const CREATE_UPDATE: ToolAnnotations = {
   destructiveHint: false,
+  readOnlyHint: false,
 } as const;
 
 export const DESTRUCTIVE: ToolAnnotations = {
   destructiveHint: true,
+  readOnlyHint: false,
 } as const;
 
 export interface ToolHandler {

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -208,6 +209,7 @@ Pagination:${metadata.total_size ? `\n  Total Items: ${metadata.total_size}` : "
       description:
         "Retrieve billing cost data for a Confluent Cloud organization within a specified date range with pagination support",
       inputSchema: listBillingCostsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -62,6 +63,7 @@ export class AddTagToTopicHandler extends BaseToolHandler {
       name: ToolName.ADD_TAGS_TO_TOPIC,
       description: "Assign existing tags to Kafka topics in Confluent Cloud.",
       inputSchema: addTagToTopicArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -66,6 +67,7 @@ export class CreateTopicTagsHandler extends BaseToolHandler {
       name: ToolName.CREATE_TOPIC_TAGS,
       description: "Create new tag definitions in Confluent Cloud.",
       inputSchema: createTagsArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/catalog/delete-tag.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -53,6 +54,7 @@ export class DeleteTagHandler extends BaseToolHandler {
       name: ToolName.DELETE_TAG,
       description: "Delete a tag definition from Confluent Cloud.",
       inputSchema: deleteTagArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/catalog/list-tags.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -36,6 +37,7 @@ export class ListTagsHandler extends BaseToolHandler {
       description:
         "Retrieve all tags with definitions from Confluent Cloud Schema Registry.",
       inputSchema: {},
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -70,6 +71,7 @@ export class RemoveTagFromEntityHandler extends BaseToolHandler {
       name: ToolName.REMOVE_TAG_FROM_ENTITY,
       description: "Remove tag from an entity in Confluent Cloud.",
       inputSchema: removeTagFromEntityArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -185,6 +186,7 @@ Cluster: ${cluster.name}
       name: ToolName.LIST_CLUSTERS,
       description: "Get all clusters in the Confluent Cloud environment",
       inputSchema: listClustersArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -128,6 +129,7 @@ export class CreateConnectorHandler extends BaseToolHandler {
       description:
         "Create a new connector. Returns the new connector information if successful.",
       inputSchema: createConnectorArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -80,6 +81,7 @@ export class DeleteConnectorHandler extends BaseToolHandler {
       description:
         "Delete an existing connector. Returns success message if deletion was successful.",
       inputSchema: deleteConnectorArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -76,6 +77,7 @@ export class ListConnectorsHandler extends BaseToolHandler {
       description:
         'Retrieve a list of "names" of the active connectors. You can then make a read request for a specific connector by name.',
       inputSchema: listConnectorArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/connect/read-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/read-connectors-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -80,6 +81,7 @@ export class ReadConnectorHandler extends BaseToolHandler {
       name: ToolName.READ_CONNECTOR,
       description: "Get information about the connector.",
       inputSchema: readConnectorArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -168,6 +169,7 @@ Pagination:${metadata.total_size ? `\n  Total Environments: ${metadata.total_siz
       description:
         "Get all environments in Confluent Cloud with pagination support",
       inputSchema: listEnvironmentsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/environments/read-environment-handler.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
@@ -117,6 +118,7 @@ Environment: ${environmentDetails.name}
       name: ToolName.READ_ENVIRONMENT,
       description: "Get details of a specific environment by ID",
       inputSchema: readEnvironmentArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
@@ -148,6 +149,7 @@ export class DescribeTableHandler extends BaseToolHandler {
       description:
         "Get full schema details for a Flink table via INFORMATION_SCHEMA.COLUMNS. Returns column names, data types (including $rowtime), nullability, and metadata column info.",
       inputSchema: describeTableArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
@@ -144,6 +145,7 @@ export class GetTableInfoHandler extends BaseToolHandler {
       description:
         "Get table metadata via INFORMATION_SCHEMA.TABLES. Returns watermark configuration, distribution info, and table type.",
       inputSchema: getTableInfoArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
@@ -94,6 +95,7 @@ export class ListCatalogsHandler extends BaseToolHandler {
       description:
         "List all catalogs available in the Flink environment via INFORMATION_SCHEMA.CATALOGS.",
       inputSchema: listCatalogsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
@@ -101,6 +102,7 @@ export class ListDatabasesHandler extends BaseToolHandler {
       description:
         "List all databases (schemas) in a Flink catalog via INFORMATION_SCHEMA.SCHEMATA. Returns catalog and database names.",
       inputSchema: listDatabasesArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
@@ -119,6 +120,7 @@ export class ListTablesHandler extends BaseToolHandler {
       description:
         "List all tables in a Flink database via INFORMATION_SCHEMA.TABLES. Returns table names and types.",
       inputSchema: listTablesArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -136,6 +137,7 @@ export class CreateFlinkStatementHandler extends BaseToolHandler {
       name: ToolName.CREATE_FLINK_STATEMENT,
       description: "Make a request to create a statement.",
       inputSchema: createFlinkStatementArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -82,6 +83,7 @@ export class DeleteFlinkStatementHandler extends BaseToolHandler {
       name: ToolName.DELETE_FLINK_STATEMENTS,
       description: "Make a request to delete a statement.",
       inputSchema: deleteFlinkStatementArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -173,6 +174,7 @@ export class CheckHealthHandler extends BaseToolHandler {
       description:
         "Perform an aggregate health check for a Flink SQL statement. Returns status (healthy/warning/critical), current phase, recent exceptions, and diagnostic details.",
       inputSchema: checkHealthArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
@@ -326,6 +327,7 @@ export class DetectIssuesHandler extends BaseToolHandler {
       description:
         "Detect issues for a Flink SQL statement by analyzing status, exceptions, and performance metrics. Identifies problems like failures, backpressure, consumer lag, late data, memory issues, and provides suggested fixes.",
       inputSchema: detectIssuesArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -539,6 +540,7 @@ export class QueryProfilerHandler extends BaseToolHandler {
       description:
         "Get Query Profiler data for a Flink SQL statement. Returns the task graph with human-readable task/operator names, per-task metrics (records in/out, state size, busyness, idleness, backpressure, watermarks), and automated issue detection (backpressure bottlenecks, consumer lag, late data, large state).",
       inputSchema: queryProfilerArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -93,6 +94,7 @@ export class GetFlinkExceptionsHandler extends BaseToolHandler {
       description:
         "Retrieve the 10 most recent exceptions for a Flink SQL statement. Useful for diagnosing failed or failing statements.",
       inputSchema: getFlinkExceptionsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -129,6 +130,7 @@ export class ListFlinkStatementsHandler extends BaseToolHandler {
       description:
         "Retrieve a sorted, filtered, paginated list of all statements.",
       inputSchema: listFlinkStatementsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -115,6 +116,7 @@ export class ReadFlinkStatementHandler extends BaseToolHandler {
       name: ToolName.READ_FLINK_STATEMENT,
       description: "Make a request to read a statement and its results",
       inputSchema: readFlinkStatementArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -77,6 +78,7 @@ export class AlterTopicConfigHandler extends BaseToolHandler {
       name: ToolName.ALTER_TOPIC_CONFIG,
       description: "Alter topic configuration in Confluent Cloud.",
       inputSchema: alterTopicConfigArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -9,6 +9,7 @@ import {
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -258,6 +259,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       description:
         "Consumes messages from one or more Kafka topics. Supports automatic deserialization of Schema Registry encoded messages (AVRO, JSON, PROTOBUF).",
       inputSchema: consumeKafkaMessagesArgs.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -38,6 +39,7 @@ export class CreateTopicsHandler extends BaseToolHandler {
       name: ToolName.CREATE_TOPICS,
       description: "Create one or more Kafka topics.",
       inputSchema: createTopicArgs.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -30,6 +31,7 @@ export class DeleteTopicsHandler extends BaseToolHandler {
       name: ToolName.DELETE_TOPICS,
       description: "Delete the topic with the given names.",
       inputSchema: deleteKafkaTopicsArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -85,6 +86,7 @@ export class GetTopicConfigHandler extends BaseToolHandler {
       name: ToolName.GET_TOPIC_CONFIG,
       description: "Retrieve configuration details for a specific Kafka topic.",
       inputSchema: getTopicConfigArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -27,6 +28,7 @@ export class ListTopicsHandler extends BaseToolHandler {
       name: ToolName.LIST_TOPICS,
       description: "List all topics in the Kafka cluster.",
       inputSchema: listTopicArgs.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -10,6 +10,7 @@ import {
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -207,6 +208,7 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
       name: ToolName.PRODUCE_MESSAGE,
       description: `Produce records to a Kafka topic. Supports Confluent Schema Registry serialization (AVRO, JSON, PROTOBUF) for both key and value.\n\nBefore producing, check if the topic has a registered schema for <topicName>-value and <topicName>-key. If a schema exists, set useSchemaRegistry to true and specify the appropriate schemaType. If the topic does not exist, it can be created via the ${ToolName.CREATE_TOPICS} tool.`,
       inputSchema: produceKafkaMessageArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -256,6 +257,7 @@ export class ListMetricsHandler extends BaseToolHandler {
       description:
         "List available Confluent Cloud metrics and their filter fields from the Telemetry API. Use this tool BEFORE query-metrics to discover valid metric names, resource filter fields, and grouping labels. This avoids guessing metric names.",
       inputSchema: listMetricsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -205,6 +206,7 @@ export class QueryMetricsHandler extends BaseToolHandler {
       description:
         "Query Confluent Cloud metrics from the Telemetry API. IMPORTANT: Use the list-available-metrics tool first to discover valid metric names and filter fields — do not guess them. Supports Kafka, Flink, Connectors, and Schema Registry metrics with flexible filtering, aggregation, and grouping.",
       inputSchema: queryMetricsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -106,6 +107,7 @@ export class DeleteSchemaHandler extends BaseToolHandler {
       description:
         "Delete a schema subject or a specific version from the Schema Registry. If version is omitted, all versions of the subject are deleted.",
       inputSchema: deleteSchemaArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -3,6 +3,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -161,6 +162,7 @@ export class ListSchemasHandler extends BaseToolHandler {
       name: ToolName.LIST_SCHEMAS,
       description: "List all schemas in the Schema Registry.",
       inputSchema: listSchemasArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -61,6 +62,7 @@ export class SearchTopicsByTagHandler extends BaseToolHandler {
       description:
         "List all topics in the Kafka cluster with the specified tag.",
       inputSchema: searchTopicsByTagArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -53,6 +54,7 @@ export class SearchTopicsByNameHandler extends BaseToolHandler {
       description:
         "List all topics in the Kafka cluster matching the specified name.",
       inputSchema: searchTopicsByNameArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -91,6 +92,7 @@ export class CreateTableFlowCatalogIntegrationHandler extends BaseToolHandler {
       name: ToolName.CREATE_TABLEFLOW_CATALOG_INTEGRATION,
       description: `Make a request to create a catalog integration.`,
       inputSchema: createTableflowCatalogIntegrationArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -75,6 +76,7 @@ export class DeleteTableFlowCatalogIntegrationHandler extends BaseToolHandler {
       name: ToolName.DELETE_TABLEFLOW_CATALOG_INTEGRATION,
       description: `Make a request to delete a tableflow catalog integration.`,
       inputSchema: deleteTableflowCatalogIntegrationArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -85,6 +86,7 @@ export class ListTableFlowCatalogIntegrationsHandler extends BaseToolHandler {
       name: ToolName.LIST_TABLEFLOW_CATALOG_INTEGRATIONS,
       description: `Retrieve a sorted, filtered, paginated list of all catalog integrations.`,
       inputSchema: listTableFlowCatalogIntegrationsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -75,6 +76,7 @@ export class ReadTableFlowCatalogIntegrationHandler extends BaseToolHandler {
       name: ToolName.READ_TABLEFLOW_CATALOG_INTEGRATION,
       description: `Make a request to read a catalog integration.`,
       inputSchema: readTableflowCatalogIntegrationArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -87,6 +88,7 @@ export class UpdateTableFlowCatalogIntegrationHandler extends BaseToolHandler {
       name: ToolName.UPDATE_TABLEFLOW_CATALOG_INTEGRATION,
       description: `Make a request to update a catalog integration.`,
       inputSchema: updateTableflowCatalogIntegrationArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -64,6 +65,7 @@ export class ListTableFlowRegionsHandler extends BaseToolHandler {
       name: ToolName.LIST_TABLEFLOW_REGIONS,
       description: `Retrieve a sorted, filtered, paginated list of all tableflow regions.`,
       inputSchema: listTableFlowRegionsArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
@@ -112,6 +113,7 @@ export class CreateTableFlowTopicHandler extends BaseToolHandler {
       name: ToolName.CREATE_TABLEFLOW_TOPIC,
       description: `Make a request to create a tableflow topic.`,
       inputSchema: createTableflowTopicArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -77,6 +78,7 @@ export class DeleteTableFlowTopicHandler extends BaseToolHandler {
       name: ToolName.DELETE_TABLEFLOW_TOPIC,
       description: `Make a request to delete a tableflow topic.`,
       inputSchema: deleteTableflowTopicArguments.shape,
+      annotations: DESTRUCTIVE,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -83,6 +84,7 @@ export class ListTableFlowTopicsHandler extends BaseToolHandler {
       name: ToolName.LIST_TABLEFLOW_TOPICS,
       description: `Retrieve a sorted, filtered, paginated list of all tableflow topics.`,
       inputSchema: listTableFlowTopicArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
@@ -3,6 +3,7 @@ import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -75,6 +76,7 @@ export class ReadTableFlowTopicHandler extends BaseToolHandler {
       name: ToolName.READ_TABLEFLOW_TOPIC,
       description: `Make a request to read a tableflow topic.`,
       inputSchema: readTableflowTopicArguments.shape,
+      annotations: READ_ONLY,
     };
   }
 

--- a/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
@@ -2,6 +2,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
+  CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -115,6 +116,7 @@ export class UpdateTableFlowTopicHandler extends BaseToolHandler {
       name: ToolName.UPDATE_TABLEFLOW_TOPIC,
       description: `Make a request to update a tableflow topic.`,
       inputSchema: updateTableflowTopicArguments.shape,
+      annotations: CREATE_UPDATE,
     };
   }
 

--- a/src/confluent/tools/tool-factory.test.ts
+++ b/src/confluent/tools/tool-factory.test.ts
@@ -1,3 +1,8 @@
+import {
+  CREATE_UPDATE,
+  DESTRUCTIVE,
+  READ_ONLY,
+} from "@src/confluent/tools/base-tools.js";
 import { ToolFactory } from "@src/confluent/tools/tool-factory.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { describe, expect, it } from "vitest";
@@ -21,6 +26,87 @@ describe("tool-factory.ts", () => {
           expect(config.name).toBe(name);
           expect(config.description.length).toBeGreaterThan(10);
           expect(config.inputSchema).toBeDefined();
+        }
+      });
+
+      it("should have a valid annotation (READ_ONLY, CREATE_UPDATE, or DESTRUCTIVE) for every tool", () => {
+        for (const name of ALL_TOOL_NAMES) {
+          const handler = ToolFactory.createToolHandler(name);
+          const config = handler.getToolConfig();
+
+          expect(config.annotations).toBeDefined();
+
+          const isValidAnnotation =
+            config.annotations === READ_ONLY ||
+            config.annotations === CREATE_UPDATE ||
+            config.annotations === DESTRUCTIVE;
+
+          expect(
+            isValidAnnotation,
+            `Tool ${name} must use one of: READ_ONLY, CREATE_UPDATE, or DESTRUCTIVE`,
+          ).toBe(true);
+        }
+      });
+
+      it("should use annotations that match the tool name prefix convention", () => {
+        const readOnlyPrefixes = new Set([
+          "list",
+          "read",
+          "get",
+          "search",
+          "describe",
+          "check",
+          "detect",
+          "query",
+          "consume",
+        ]);
+        const createUpdatePrefixes = new Set([
+          "create",
+          "produce",
+          "add",
+          "update",
+          "alter",
+        ]);
+        const destructivePrefixes = new Set(["delete", "remove"]);
+
+        // Prove the three sets are disjoint (no overlapping elements)
+        const allPrefixes = [
+          ...readOnlyPrefixes,
+          ...createUpdatePrefixes,
+          ...destructivePrefixes,
+        ];
+        const uniquePrefixCount = new Set(allPrefixes).size;
+        expect(
+          uniquePrefixCount,
+          "Prefix sets must be disjoint (no overlapping elements)",
+        ).toBe(allPrefixes.length);
+
+        for (const name of ALL_TOOL_NAMES) {
+          const handler = ToolFactory.createToolHandler(name);
+          const config = handler.getToolConfig();
+
+          const prefix = name.split("-")[0]!;
+
+          if (readOnlyPrefixes.has(prefix)) {
+            expect(
+              config.annotations,
+              `Tool ${name} with prefix "${prefix}" should use READ_ONLY`,
+            ).toBe(READ_ONLY);
+          } else if (createUpdatePrefixes.has(prefix)) {
+            expect(
+              config.annotations,
+              `Tool ${name} with prefix "${prefix}" should use CREATE_UPDATE`,
+            ).toBe(CREATE_UPDATE);
+          } else if (destructivePrefixes.has(prefix)) {
+            expect(
+              config.annotations,
+              `Tool ${name} with prefix "${prefix}" should use DESTRUCTIVE`,
+            ).toBe(DESTRUCTIVE);
+          } else {
+            throw new Error(
+              `Tool ${name} has unrecognized prefix "${prefix}" - add it to one of the prefix sets`,
+            );
+          }
         }
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,11 @@ async function main() {
 
       server.registerTool(
         name as string,
-        { description: config.description, inputSchema: config.inputSchema },
+        {
+          description: config.description,
+          inputSchema: config.inputSchema,
+          annotations: config.annotations,
+        },
         async (args, context) => {
           const sessionId = context?.sessionId;
           const startTime = Date.now();


### PR DESCRIPTION
Adds [MCP tool annotations](https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations) (`readOnlyHint`, `destructiveHint`) to all 52 tools, enabling AI clients (Claude Desktop, Cursor) to distinguish between safe read operations (`list-topics`, `consume-messages`) and destructive operations (`delete-topics`, `delete-schema --permanent`, `delete-connector`).

Without these annotations, prompt injection could trigger destructive actions with the same friction as read-only queries.

Implements three annotation constants (`READ_ONLY`, `CREATE_UPDATE`, `DESTRUCTIVE`) referenced by all tool handlers, with unit tests validating both correct constant usage and adherence to naming conventions (tools prefixed with `delete-`/`remove-` use `DESTRUCTIVE`, `create-`/`update-`/`add-` use `CREATE_UPDATE`, etc.).

Closes #145.
