### PR TITLE
Feat/147 local connection yaml parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm run lint:fix       # eslint --fix
 npm run format         # prettier --write
 npm run test           # vitest run
 npm run test:coverage  # vitest run --coverage
-npm run typecheck      # "tsc --noEmit", also includes type checking the test suite.
+npm run test:ts        # "tsc --noEmit", also includes type checking the test suite.
 npm run start          # node dist/index.js --env-file .env (stdio transport)
 npm run start:http     # HTTP transport
 npm run start:all      # all transports (http, sse, stdio)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ npm run lint:fix       # eslint --fix
 npm run format         # prettier --write
 npm run test           # vitest run
 npm run test:coverage  # vitest run --coverage
+npm run typecheck      # "tsc --noEmit", also includes type checking the test suite.
 npm run start          # node dist/index.js --env-file .env (stdio transport)
 npm run start:http     # HTTP transport
 npm run start:all      # all transports (http, sse, stdio)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ npm run dev            # watch mode: tsc + tsc-alias in parallel
 npm run lint           # eslint
 npm run lint:fix       # eslint --fix
 npm run format         # prettier --write
-npm run test:ts        # tsc --noEmit (type-check only, no tests exist yet)
+npm run test           # vitest run
+npm run test:coverage  # vitest run --coverage
 npm run start          # node dist/index.js --env-file .env (stdio transport)
 npm run start:http     # HTTP transport
 npm run start:all      # all transports (http, sse, stdio)
@@ -68,3 +69,14 @@ Tools are **auto-enabled/disabled** based on which environment variables are pre
 - Prettier + ESLint enforced; pre-commit hook runs both automatically via Husky.
 - `noImplicitAny` is disabled in tsconfig due to OpenAPI type resolution issues.
 - REST API calls use `openapi-fetch` with typed paths from the generated schema — prefer this over raw fetch.
+
+## Unit Test Conventions
+
+- Write unit tests using vitest package and its `describe()`, `it()`, and `expect()`.
+- Test modules are stored beside the files they test, using `.test.ts` file extensions.
+- Use an outermost `describe()` block for the file, then inner `describe()` blocks for each item being tested.
+- Testing classes are done with a `describe()` block for the entire class, then individual `describe()` blocks for each method, with it() blocks for each aspect of the method.
+- External system interactions (including filesystem and environment variables) should be stubbed, primarily using `sinon` sandboxes.
+- Install and remove sinon sandboxes within `beforeEach()` and `afterEach()` at the widest appropriate scope in a test suite module.
+- Writing test suite utilities to install common blocks of stubs is a good technique to reduce test suite bloat. Those utilities should reside within the `tests/stubs` subtree.
+- Some node modules cannot be stubbed due to being implemented in C. The codebase should only use those indirectly, going through a stubbable js layer in `src/confluent/node-deps.js`. Look there and possibly add to it before making new parts of the codebase interact directly with the filesystem, etc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "fastify": "^5.7.3",
         "openapi-fetch": "^0.14.0",
         "pino": "^10.1.0",
-        "properties-file": "^3.5.12"
+        "properties-file": "^3.5.12",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "mcp-confluent": "dist/index.js"
@@ -10413,9 +10414,8 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10282,7 +10282,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/yaml/-/yaml-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "fastify": "^5.7.3",
     "openapi-fetch": "^0.14.0",
     "pino": "^10.1.0",
-    "properties-file": "^3.5.12"
+    "properties-file": "^3.5.12",
+    "yaml": "^2.8.3"
   },
   "overrides": {
     "zod": "^4.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "test:ts": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js --env-file .env",
     "start:http": "node dist/index.js --env-file .env --transport http",
     "start:sse": "node dist/index.js --env-file .env --transport sse",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
+    "test:ts": "tsc --noEmit",
     "start": "node dist/index.js --env-file .env",
     "start:http": "node dist/index.js --env-file .env --transport http",
     "start:sse": "node dist/index.js --env-file .env --transport sse",

--- a/sample_configs/local-docker-and-sr.yaml
+++ b/sample_configs/local-docker-and-sr.yaml
@@ -1,5 +1,5 @@
 # Example MCP Confluent Server Configuration
-# This demonstrates a single direct (local/Docker) connection
+# This demonstrates a single direct (local/Docker) connection with a local Schema Registry.
 
 connections:
   local:

--- a/sample_configs/local-docker-sr-only.yaml
+++ b/sample_configs/local-docker-sr-only.yaml
@@ -1,0 +1,8 @@
+# Example MCP Confluent Server Configuration
+# This demonstrates a single direct (local/Docker) connection with only a local Schema Registry.
+
+connections:
+  local:
+    type: "direct"
+    schema_registry:
+      endpoint: "http://localhost:8081"

--- a/sample_configs/local-docker.yaml
+++ b/sample_configs/local-docker.yaml
@@ -1,0 +1,8 @@
+# Example MCP Confluent Server Configuration
+# This demonstrates a single direct (local/Docker) connection w/o local SR.
+
+connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"

--- a/sample_configs/local-docker.yaml
+++ b/sample_configs/local-docker.yaml
@@ -1,0 +1,10 @@
+# Example MCP Confluent Server Configuration
+# This demonstrates a single direct (local/Docker) connection
+
+connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "http://localhost:8081"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import pkg from "../package.json" with { type: "json" };
 // Define the interface for our CLI options
 export interface CLIOptions {
   envFile?: string;
+  config?: string;
   transports: TransportType[];
   allowTools?: string[];
   blockTools?: string[];
@@ -106,6 +107,10 @@ export function parseCliArgs(): CLIOptions {
     .version(getPackageVersion())
     .option("-e, --env-file <path>", "Load environment variables from file")
     .option(
+      "-c, --config <path>",
+      "Path to YAML configuration file describing connection settings",
+    )
+    .option(
       "-k, --kafka-config-file <file>",
       "Path to a properties file for configuring kafka clients",
     )
@@ -181,6 +186,7 @@ export function parseCliArgs(): CLIOptions {
     }
     return {
       envFile: opts.envFile,
+      config: opts.config,
       transports: Array.isArray(opts.transport)
         ? opts.transport
         : [opts.transport],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,7 @@ export function parseCliArgs(): CLIOptions {
     .option("-e, --env-file <path>", "Load environment variables from file")
     .option(
       "-c, --config <path>",
-      "Path to YAML configuration file describing connection settings",
+      "EXPERIMENTAL: Path to YAML configuration file describing connection settings (work in progress, not fully functional yet)",
     )
     .option(
       "-k, --kafka-config-file <file>",

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -26,7 +26,7 @@ describe("config/index.ts", () => {
       expect(Object.keys(config.connections)).toHaveLength(1);
       expect(config.connections.local).toBeDefined();
       expect(config.connections.local!.type).toBe("direct");
-      expect(config.connections.local!.kafka.bootstrap_servers).toBe(
+      expect(config.connections.local!.kafka!.bootstrap_servers).toBe(
         "localhost:9092",
       );
       expect(config.connections.local!.schema_registry).toBeUndefined();
@@ -60,7 +60,7 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent);
 
-      expect(config.connections.cluster!.kafka.bootstrap_servers).toBe(
+      expect(config.connections.cluster!.kafka!.bootstrap_servers).toBe(
         "broker1:9092,broker2:9092,broker3:9092",
       );
     });
@@ -319,7 +319,7 @@ describe("config/index.ts", () => {
       const config = loadConfigFromYaml("/path/to/config.yaml");
 
       expect(config.connections.local).toBeDefined();
-      expect(config.connections.local!.kafka.bootstrap_servers).toBe(
+      expect(config.connections.local!.kafka!.bootstrap_servers).toBe(
         "localhost:9092",
       );
     });

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -26,7 +26,6 @@ describe("config/index.ts", () => {
       expect(Object.keys(config.connections)).toHaveLength(1);
       expect(config.connections.local).toBeDefined();
       expect(config.connections.local!.type).toBe("direct");
-      expect(config.connections.local!.connectionId).toBe("local");
       expect(config.connections.local!.kafka.bootstrap_servers).toBe(
         "localhost:9092",
       );
@@ -64,21 +63,6 @@ describe("config/index.ts", () => {
       expect(config.connections.cluster!.kafka.bootstrap_servers).toBe(
         "broker1:9092,broker2:9092,broker3:9092",
       );
-    });
-
-    it("should inject connectionId from YAML key", () => {
-      const yamlContent = `connections:
-  my-custom-connection-name:
-    type: "direct"
-    kafka:
-      bootstrap_servers: "localhost:9092"
-`;
-
-      const config = parseYamlConfiguration(yamlContent);
-
-      expect(
-        config.connections["my-custom-connection-name"]!.connectionId,
-      ).toBe("my-custom-connection-name");
     });
 
     it("should throw error on invalid YAML syntax", () => {
@@ -242,6 +226,22 @@ describe("config/index.ts", () => {
       );
       expect(() => parseYamlConfiguration(yamlContent)).toThrow(
         /Exactly one connection must be defined/,
+      );
+    });
+
+    it("should throw error when connection name is whitespace-only", () => {
+      const yamlContent = `connections:
+  " ":
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Invalid key in record/,
       );
     });
 

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,0 +1,375 @@
+import {
+  loadConfigFileContents,
+  loadConfigFromYaml,
+  parseYamlConfiguration,
+} from "@src/config/index.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import sinon from "sinon";
+import {
+  createFsWrappers,
+  type StubbedFsWrappers,
+} from "@tests/stubs/node-deps.js";
+
+describe("config/index.ts", () => {
+  describe("parseYamlConfiguration", () => {
+    it("should successfully parse minimal valid config (kafka only)", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+
+      const config = parseYamlConfiguration(yamlContent);
+
+      expect(config.connections).toBeDefined();
+      expect(Object.keys(config.connections)).toHaveLength(1);
+      expect(config.connections.local).toBeDefined();
+      expect(config.connections.local!.type).toBe("direct");
+      expect(config.connections.local!.connectionId).toBe("local");
+      expect(config.connections.local!.kafka.bootstrap_servers).toBe(
+        "localhost:9092",
+      );
+      expect(config.connections.local!.schema_registry).toBeUndefined();
+    });
+
+    it("should successfully parse full valid config (kafka + schema_registry)", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "http://localhost:8081"
+`;
+
+      const config = parseYamlConfiguration(yamlContent);
+
+      expect(config.connections.local!.schema_registry).toBeDefined();
+      expect(config.connections.local!.schema_registry?.endpoint).toBe(
+        "http://localhost:8081",
+      );
+    });
+
+    it("should accept multiple bootstrap servers", () => {
+      const yamlContent = `connections:
+  cluster:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "broker1:9092,broker2:9092,broker3:9092"
+`;
+
+      const config = parseYamlConfiguration(yamlContent);
+
+      expect(config.connections.cluster!.kafka.bootstrap_servers).toBe(
+        "broker1:9092,broker2:9092,broker3:9092",
+      );
+    });
+
+    it("should inject connectionId from YAML key", () => {
+      const yamlContent = `connections:
+  my-custom-connection-name:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+
+      const config = parseYamlConfiguration(yamlContent);
+
+      expect(
+        config.connections["my-custom-connection-name"]!.connectionId,
+      ).toBe("my-custom-connection-name");
+    });
+
+    it("should throw error on invalid YAML syntax", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct
+    kafka: [unmatched bracket
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Failed to parse YAML/,
+      );
+    });
+
+    it("should throw error when connections field is missing", () => {
+      const yamlContent = `some_other_field: "value"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when type field is missing", () => {
+      const yamlContent = `connections:
+  local:
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when type is not 'direct'", () => {
+      const yamlContent = `connections:
+  local:
+    type: "unknown"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when kafka field is missing", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when bootstrap_servers is missing", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      some_other_field: "value"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when bootstrap_servers is empty", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: ""
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when bootstrap_servers has invalid format", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "invalid-no-port"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Invalid format 'invalid-no-port': must be host:port/,
+      );
+    });
+
+    it("should throw error when schema_registry endpoint is not a valid URL", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "not-a-url"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /must be a valid URL/,
+      );
+    });
+
+    it("should throw error when schema_registry is present but endpoint is missing", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      some_other_field: "value"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+
+    it("should throw error when connections map is empty", () => {
+      const yamlContent = `connections: {}
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Exactly one connection must be defined/,
+      );
+    });
+
+    it("should throw error when connections map has more than one entry", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+  staging:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "staging:9092"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Exactly one connection must be defined/,
+      );
+    });
+
+    it("should accept https schema_registry endpoint", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "https://schema-registry.example.com:8081"
+`;
+
+      const config = parseYamlConfiguration(yamlContent);
+
+      expect(config.connections.local!.schema_registry?.endpoint).toBe(
+        "https://schema-registry.example.com:8081",
+      );
+    });
+  });
+
+  describe("loadConfigFromYaml", () => {
+    const sandbox = sinon.createSandbox();
+    let fsStubs: StubbedFsWrappers;
+
+    beforeEach(() => {
+      fsStubs = createFsWrappers(sandbox);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should successfully load and parse a valid config file", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+      fsStubs.existsSync.returns(true);
+      fsStubs.readFileSync.returns(yamlContent);
+
+      const config = loadConfigFromYaml("/path/to/config.yaml");
+
+      expect(config.connections.local).toBeDefined();
+      expect(config.connections.local!.kafka.bootstrap_servers).toBe(
+        "localhost:9092",
+      );
+    });
+
+    it("should throw error when file does not exist", () => {
+      fsStubs.existsSync.returns(false);
+
+      expect(() => loadConfigFromYaml("/nonexistent.yaml")).toThrow(
+        /Configuration file not found/,
+      );
+    });
+
+    it("should throw error on invalid YAML syntax", () => {
+      fsStubs.existsSync.returns(true);
+      fsStubs.readFileSync.returns("invalid: [yaml");
+
+      expect(() => loadConfigFromYaml("/path/to/config.yaml")).toThrow(
+        /Failed to parse YAML/,
+      );
+    });
+
+    it("should throw error on validation failure", () => {
+      const invalidYaml = `connections:
+  local:
+    type: "direct"
+    # missing required kafka field
+`;
+      fsStubs.existsSync.returns(true);
+      fsStubs.readFileSync.returns(invalidYaml);
+
+      expect(() => loadConfigFromYaml("/path/to/config.yaml")).toThrow(
+        /Configuration validation failed/,
+      );
+    });
+  });
+
+  describe("loadConfigFileContents", () => {
+    const sandbox = sinon.createSandbox();
+    let fsStubs: StubbedFsWrappers;
+
+    beforeEach(() => {
+      fsStubs = createFsWrappers(sandbox);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should read file contents successfully", () => {
+      const testContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+`;
+      fsStubs.existsSync.returns(true);
+      fsStubs.readFileSync.returns(testContent);
+
+      const content = loadConfigFileContents("/some/path/config.yaml");
+
+      expect(content).toBe(testContent);
+      sinon.assert.calledOnce(fsStubs.existsSync);
+      sinon.assert.calledOnce(fsStubs.readFileSync);
+    });
+
+    it("should throw error when file does not exist", () => {
+      fsStubs.existsSync.returns(false);
+
+      expect(() =>
+        loadConfigFileContents("/nonexistent/path/to/config.yaml"),
+      ).toThrow(/Configuration file not found/);
+      sinon.assert.calledOnce(fsStubs.existsSync);
+    });
+
+    it("should throw error when file cannot be read", () => {
+      fsStubs.existsSync.returns(true);
+      fsStubs.readFileSync.throws(new Error("Permission denied"));
+
+      expect(() => loadConfigFileContents("/some/path/config.yaml")).toThrow(
+        /Failed to read configuration file: Permission denied/,
+      );
+    });
+  });
+});

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -123,7 +123,7 @@ describe("config/index.ts", () => {
       );
     });
 
-    it("should throw error when kafka field is missing", () => {
+    it("should throw error when neither kafka nor schema_registry is defined", () => {
       const yamlContent = `connections:
   local:
     type: "direct"
@@ -131,6 +131,9 @@ describe("config/index.ts", () => {
 
       expect(() => parseYamlConfiguration(yamlContent)).toThrow(
         /Configuration validation failed/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /At least one of 'kafka' or 'schema_registry' must be defined/,
       );
     });
 
@@ -273,6 +276,22 @@ describe("config/index.ts", () => {
         "https://schema-registry.example.com:8081",
       );
     });
+
+    it("should successfully parse config with schema_registry only (no kafka)", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    schema_registry:
+      endpoint: "http://localhost:8081"
+`;
+
+      const config = parseYamlConfiguration(yamlContent);
+
+      expect(config.connections.local!.schema_registry?.endpoint).toBe(
+        "http://localhost:8081",
+      );
+      expect(config.connections.local!.kafka).toBeUndefined();
+    });
   });
 
   describe("loadConfigFromYaml", () => {
@@ -326,7 +345,7 @@ describe("config/index.ts", () => {
       const invalidYaml = `connections:
   local:
     type: "direct"
-    # missing required kafka field
+    # missing both kafka and schema_registry
 `;
       fsStubs.existsSync.returns(true);
       fsStubs.readFileSync.returns(invalidYaml);

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -77,6 +77,18 @@ describe("config/index.ts", () => {
       );
     });
 
+    it("should throw error when root is not an object", () => {
+      const yamlContent = `"just a string"`;
+
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /Configuration validation failed/,
+      );
+      // Should not have empty path prefix like "- :"
+      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+        /- Invalid input: expected object, received string/,
+      );
+    });
+
     it("should throw error when connections field is missing", () => {
       const yamlContent = `some_other_field: "value"
 `;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -70,7 +70,10 @@ export function parseYamlConfiguration(
 
   if (!validationResult.success) {
     const errors = validationResult.error.issues
-      .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+      .map((issue) => {
+        const path = issue.path.join(".");
+        return path ? `  - ${path}: ${issue.message}` : `  - ${issue.message}`;
+      })
       .join("\n");
     throw new Error(`Configuration validation failed:\n${errors}`);
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,8 +1,4 @@
-import {
-  ConnectionConfig,
-  MCPServerConfiguration,
-  mcpConfigSchema,
-} from "@src/config/models.js";
+import { MCPServerConfiguration, mcpConfigSchema } from "@src/config/models.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
@@ -79,19 +75,5 @@ export function parseYamlConfiguration(
     throw new Error(`Configuration validation failed:\n${errors}`);
   }
 
-  const validated = validationResult.data;
-
-  // Inject connectionId from YAML map key into each connection object
-  const connections: Record<string, ConnectionConfig> = {};
-  for (const [connectionId, connection] of Object.entries(
-    validated.connections,
-  )) {
-    connections[connectionId] = {
-      ...connection,
-      connectionId,
-    };
-  }
-
-  // Return as MCPServerConfiguration.
-  return { connections };
+  return validationResult.data;
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,97 @@
+import {
+  ConnectionConfig,
+  MCPServerConfiguration,
+  mcpConfigSchema,
+} from "@src/config/models.js";
+import * as nodeDeps from "@src/confluent/node-deps.js";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export type { MCPServerConfiguration } from "@src/config/models.js";
+
+/**
+ * Loads and validates an MCP server configuration from a YAML file.
+ *
+ * @param filePath - Path to the YAML configuration file
+ * @returns Validated MCPServerConfiguration object
+ * @throws Error if file doesn't exist, YAML is invalid, or validation fails
+ */
+export function loadConfigFromYaml(filePath: string): MCPServerConfiguration {
+  const yamlContent = loadConfigFileContents(filePath);
+  return parseYamlConfiguration(yamlContent);
+}
+
+/* All the rest of the functions in this file are internal helpers for loading and validating the configuration, only exported for
+  test suite purposes. */
+
+/**
+ * Reads configuration file contents from disk.
+ *
+ * @param filePath - Path to the YAML configuration file
+ * @returns File contents as string
+ * @throws Error if file doesn't exist or cannot be read
+ */
+export function loadConfigFileContents(filePath: string): string {
+  const absolutePath = path.resolve(filePath);
+
+  // Check if file exists
+  if (!nodeDeps.fs.existsSync(absolutePath)) {
+    throw new Error(`Configuration file not found: ${absolutePath}`);
+  }
+
+  // Read file contents
+  try {
+    return nodeDeps.fs.readFileSync(absolutePath, "utf-8");
+  } catch (error) {
+    throw new Error(
+      `Failed to read configuration file: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Parses and validates YAML configuration content.
+ *
+ * @param yamlContent - YAML string content
+ * @returns Validated MCPServerConfiguration object
+ * @throws Error if YAML is invalid or validation fails
+ */
+export function parseYamlConfiguration(
+  yamlContent: string,
+): MCPServerConfiguration {
+  // Parse YAML
+  let parsedYaml: unknown;
+  try {
+    parsedYaml = parseYaml(yamlContent);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse YAML: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  // Validate with Zod
+  const validationResult = mcpConfigSchema.safeParse(parsedYaml);
+
+  if (!validationResult.success) {
+    const errors = validationResult.error.issues
+      .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+      .join("\n");
+    throw new Error(`Configuration validation failed:\n${errors}`);
+  }
+
+  const validated = validationResult.data;
+
+  // Inject connectionId from YAML map key into each connection object
+  const connections: Record<string, ConnectionConfig> = {};
+  for (const [connectionId, connection] of Object.entries(
+    validated.connections,
+  )) {
+    connections[connectionId] = {
+      ...connection,
+      connectionId,
+    };
+  }
+
+  // Return as MCPServerConfiguration.
+  return { connections };
+}

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -3,11 +3,11 @@ import { validateBootstrapServers } from "@src/config/validation.js";
 
 /**
  * Connection configuration for a direct (local/Docker) Kafka cluster.
- * No authentication required.
+ * No authentication required. At least one of kafka or schema_registry must be present.
  */
 export interface DirectConnectionConfig {
   type: "direct";
-  kafka: {
+  kafka?: {
     bootstrap_servers: string;
   };
   schema_registry?: {
@@ -31,22 +31,24 @@ export interface MCPServerConfiguration {
 // Zod schema for direct connection type
 const directConnectionSchema = z.object({
   type: z.literal("direct"),
-  kafka: z.object({
-    bootstrap_servers: z
-      .string()
-      .trim()
-      .min(1, "bootstrap_servers cannot be empty")
-      .superRefine((value, ctx) => {
-        try {
-          validateBootstrapServers(value);
-        } catch (error) {
-          ctx.addIssue({
-            code: "custom",
-            message: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }),
-  }),
+  kafka: z
+    .object({
+      bootstrap_servers: z
+        .string()
+        .trim()
+        .min(1, "bootstrap_servers cannot be empty")
+        .superRefine((value, ctx) => {
+          try {
+            validateBootstrapServers(value);
+          } catch (error) {
+            ctx.addIssue({
+              code: "custom",
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }),
+    })
+    .optional(),
   schema_registry: z
     .object({
       endpoint: z
@@ -57,10 +59,19 @@ const directConnectionSchema = z.object({
     .optional(),
 });
 
-// Discriminated union of all connection types (currently just direct)
-const connectionConfigSchema = z.discriminatedUnion("type", [
-  directConnectionSchema,
-]);
+// Discriminated union of all connection types (currently just direct).
+// superRefine is placed here (after the union) rather than on directConnectionSchema
+// because wrapping a ZodObject in ZodEffects breaks z.discriminatedUnion's discriminant lookup.
+const connectionConfigSchema = z
+  .discriminatedUnion("type", [directConnectionSchema])
+  .superRefine((data, ctx) => {
+    if (data.type === "direct" && !data.kafka && !data.schema_registry) {
+      ctx.addIssue({
+        code: "custom",
+        message: "At least one of 'kafka' or 'schema_registry' must be defined",
+      });
+    }
+  });
 
 // Root configuration schema
 export const mcpConfigSchema = z.object({

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -7,7 +7,6 @@ import { validateBootstrapServers } from "@src/config/validation.js";
  */
 export interface DirectConnectionConfig {
   type: "direct";
-  connectionId: string;
   kafka: {
     bootstrap_servers: string;
   };
@@ -67,7 +66,7 @@ const connectionConfigSchema = z.discriminatedUnion("type", [
 export const mcpConfigSchema = z.object({
   connections: z
     .record(
-      z.string().min(1, "Connection name cannot be empty"),
+      z.string().trim().min(1, "Connection name cannot be empty"),
       connectionConfigSchema,
     )
     .refine(

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { validateBootstrapServers } from "@src/config/validation.js";
+
+/**
+ * Connection configuration for a direct (local/Docker) Kafka cluster.
+ * No authentication required.
+ */
+export interface DirectConnectionConfig {
+  type: "direct";
+  connectionId: string;
+  kafka: {
+    bootstrap_servers: string;
+  };
+  schema_registry?: {
+    endpoint: string;
+  };
+}
+
+/**
+ * Union of all connection types (future-proof discriminated union).
+ * Currently only supports "direct" type.
+ */
+export type ConnectionConfig = DirectConnectionConfig;
+
+/**
+ * Root configuration object representing the entire MCP server configuration.
+ */
+export interface MCPServerConfiguration {
+  connections: Record<string, ConnectionConfig>;
+}
+
+// Zod schema for direct connection type
+const directConnectionSchema = z.object({
+  type: z.literal("direct"),
+  kafka: z.object({
+    bootstrap_servers: z
+      .string()
+      .trim()
+      .min(1, "bootstrap_servers cannot be empty")
+      .superRefine((value, ctx) => {
+        try {
+          validateBootstrapServers(value);
+        } catch (error) {
+          ctx.addIssue({
+            code: "custom",
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }),
+  }),
+  schema_registry: z
+    .object({
+      endpoint: z
+        .string()
+        .trim()
+        .url("schema_registry.endpoint must be a valid URL"),
+    })
+    .optional(),
+});
+
+// Discriminated union of all connection types (currently just direct)
+const connectionConfigSchema = z.discriminatedUnion("type", [
+  directConnectionSchema,
+]);
+
+// Root configuration schema
+export const mcpConfigSchema = z.object({
+  connections: z
+    .record(
+      z.string().min(1, "Connection name cannot be empty"),
+      connectionConfigSchema,
+    )
+    .refine(
+      (connections) => Object.keys(connections).length === 1,
+      "Exactly one connection must be defined (multiple connections not yet supported)",
+    ),
+});

--- a/src/config/validation.test.ts
+++ b/src/config/validation.test.ts
@@ -64,6 +64,15 @@ describe("config/validation.ts", () => {
       );
     });
 
+    it("should reject servers with empty port", () => {
+      expect(() => validateBootstrapServers("localhost:")).toThrow(
+        "Invalid server 'localhost:': port cannot be empty",
+      );
+      expect(() => validateBootstrapServers("host1:9092,host2:")).toThrow(
+        "Invalid server 'host2:': port cannot be empty",
+      );
+    });
+
     it("should reject servers with invalid port (non-numeric)", () => {
       expect(() => validateBootstrapServers("localhost:abc")).toThrow(
         "Invalid server 'localhost:abc': port 'abc' is not numeric",

--- a/src/config/validation.test.ts
+++ b/src/config/validation.test.ts
@@ -88,6 +88,24 @@ describe("config/validation.ts", () => {
       );
     });
 
+    it("should reject servers with trailing comma", () => {
+      expect(() => validateBootstrapServers("localhost:9092,")).toThrow(
+        "Invalid format: empty server entries (check for trailing or consecutive commas)",
+      );
+    });
+
+    it("should reject servers with consecutive commas", () => {
+      expect(() => validateBootstrapServers("host1:9092,,host2:9093")).toThrow(
+        "Invalid format: empty server entries (check for trailing or consecutive commas)",
+      );
+    });
+
+    it("should reject servers with leading comma", () => {
+      expect(() => validateBootstrapServers(",localhost:9092")).toThrow(
+        "Invalid format: empty server entries (check for trailing or consecutive commas)",
+      );
+    });
+
     it("should reject servers with multiple colons", () => {
       expect(() => validateBootstrapServers("host:9092:extra")).toThrow(
         "Invalid format 'host:9092:extra': must be host:port",

--- a/src/config/validation.test.ts
+++ b/src/config/validation.test.ts
@@ -1,0 +1,112 @@
+import { validateBootstrapServers } from "@src/config/validation.js";
+import { describe, expect, it } from "vitest";
+
+describe("config/validation.ts", () => {
+  describe("validateBootstrapServers", () => {
+    it("should accept valid single server", () => {
+      expect(() => validateBootstrapServers("localhost:9092")).not.toThrow();
+    });
+
+    it("should accept valid multiple servers", () => {
+      expect(() =>
+        validateBootstrapServers("host1:9092,host2:9093"),
+      ).not.toThrow();
+      expect(() =>
+        validateBootstrapServers(
+          "kafka1.example.com:9092,kafka2.example.com:9093,kafka3.example.com:9094",
+        ),
+      ).not.toThrow();
+    });
+
+    it("should accept servers with IP addresses", () => {
+      expect(() => validateBootstrapServers("127.0.0.1:9092")).not.toThrow();
+      expect(() =>
+        validateBootstrapServers("192.168.1.100:9092,192.168.1.101:9093"),
+      ).not.toThrow();
+    });
+
+    it("should accept servers with whitespace around commas", () => {
+      expect(() =>
+        validateBootstrapServers("host1:9092, host2:9093"),
+      ).not.toThrow();
+      expect(() =>
+        validateBootstrapServers("host1:9092 , host2:9093 , host3:9094"),
+      ).not.toThrow();
+    });
+
+    it("should accept valid port ranges", () => {
+      expect(() => validateBootstrapServers("localhost:1")).not.toThrow();
+      expect(() => validateBootstrapServers("localhost:65535")).not.toThrow();
+      expect(() => validateBootstrapServers("localhost:8080")).not.toThrow();
+    });
+
+    it("should reject empty string", () => {
+      expect(() => validateBootstrapServers("")).toThrow(
+        "Value must be a non-empty string",
+      );
+    });
+
+    it("should reject servers missing port", () => {
+      expect(() => validateBootstrapServers("localhost")).toThrow(
+        "Invalid format 'localhost': must be host:port",
+      );
+      expect(() => validateBootstrapServers("host1:9092,host2")).toThrow(
+        "Invalid format 'host2': must be host:port",
+      );
+    });
+
+    it("should reject servers missing host", () => {
+      expect(() => validateBootstrapServers(":9092")).toThrow(
+        "Invalid server ':9092': host cannot be empty",
+      );
+      expect(() => validateBootstrapServers("host1:9092,:9093")).toThrow(
+        "Invalid server ':9093': host cannot be empty",
+      );
+    });
+
+    it("should reject servers with invalid port (non-numeric)", () => {
+      expect(() => validateBootstrapServers("localhost:abc")).toThrow(
+        "Invalid server 'localhost:abc': port 'abc' is not numeric",
+      );
+      expect(() => validateBootstrapServers("localhost:90a92")).toThrow(
+        "Invalid server 'localhost:90a92': port '90a92' contains non-numeric characters",
+      );
+    });
+
+    it("should reject servers with port out of range", () => {
+      expect(() => validateBootstrapServers("localhost:0")).toThrow(
+        "Invalid server 'localhost:0': port 0 out of range (1-65535)",
+      );
+      expect(() => validateBootstrapServers("localhost:65536")).toThrow(
+        "Invalid server 'localhost:65536': port 65536 out of range (1-65535)",
+      );
+      expect(() => validateBootstrapServers("localhost:-1")).toThrow(
+        "Invalid server 'localhost:-1': port -1 out of range (1-65535)",
+      );
+      expect(() => validateBootstrapServers("localhost:99999")).toThrow(
+        "Invalid server 'localhost:99999': port 99999 out of range (1-65535)",
+      );
+    });
+
+    it("should reject servers with multiple colons", () => {
+      expect(() => validateBootstrapServers("host:9092:extra")).toThrow(
+        "Invalid format 'host:9092:extra': must be host:port",
+      );
+    });
+
+    it("should reject non-string values", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => validateBootstrapServers(null as any)).toThrow(
+        "Value must be a non-empty string",
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => validateBootstrapServers(undefined as any)).toThrow(
+        "Value must be a non-empty string",
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => validateBootstrapServers(123 as any)).toThrow(
+        "Value must be a non-empty string",
+      );
+    });
+  });
+});

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,0 +1,62 @@
+/**
+ * Validates a Kafka bootstrap servers string.
+ * Expects comma-separated host:port pairs where port is in range 1-65535.
+ *
+ * @param value - Bootstrap servers string (e.g., "localhost:9092" or "host1:9092,host2:9093")
+ * @throws Error with specific message if validation fails
+ */
+export function validateBootstrapServers(value: string): void {
+  if (!value || typeof value !== "string") {
+    throw new Error("Value must be a non-empty string");
+  }
+
+  const servers = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (servers.length === 0) {
+    throw new Error("Must contain at least one server");
+  }
+
+  for (const server of servers) {
+    // Must contain exactly one colon separating host and port
+    const parts = server.split(":");
+    if (parts.length !== 2) {
+      throw new Error(`Invalid format '${server}': must be host:port`);
+    }
+
+    const [host, portStr] = parts;
+
+    // Host must be non-empty
+    if (!host || host.trim().length === 0) {
+      throw new Error(`Invalid server '${server}': host cannot be empty`);
+    }
+
+    // Port must be non-empty and valid
+    if (!portStr) {
+      throw new Error(`Invalid server '${server}': port cannot be empty`);
+    }
+
+    // Port must be a valid integer in range 1-65535
+    const port = Number.parseInt(portStr, 10);
+    if (Number.isNaN(port)) {
+      throw new TypeError(
+        `Invalid server '${server}': port '${portStr}' is not numeric`,
+      );
+    }
+
+    if (port < 1 || port > 65535) {
+      throw new Error(
+        `Invalid server '${server}': port ${port} out of range (1-65535)`,
+      );
+    }
+
+    // Ensure port string is purely numeric (no trailing characters)
+    if (port.toString() !== portStr) {
+      throw new Error(
+        `Invalid server '${server}': port '${portStr}' contains non-numeric characters`,
+      );
+    }
+  }
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -10,13 +10,17 @@ export function validateBootstrapServers(value: string): void {
     throw new Error("Value must be a non-empty string");
   }
 
-  const servers = value
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const servers = value.split(",").map((s) => s.trim());
 
   if (servers.length === 0) {
     throw new Error("Must contain at least one server");
+  }
+
+  // Check for empty entries (trailing/consecutive commas)
+  if (servers.includes("")) {
+    throw new Error(
+      "Invalid format: empty server entries (check for trailing or consecutive commas)",
+    );
   }
 
   for (const server of servers) {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -12,10 +12,6 @@ export function validateBootstrapServers(value: string): void {
 
   const servers = value.split(",").map((s) => s.trim());
 
-  if (servers.length === 0) {
-    throw new Error("Must contain at least one server");
-  }
-
   // Check for empty entries (trailing/consecutive commas)
   if (servers.includes("")) {
     throw new Error(

--- a/src/confluent/node-deps.ts
+++ b/src/confluent/node-deps.ts
@@ -2,12 +2,12 @@
 import { Analytics } from "@segment/analytics-node";
 import { TELEMETRY_WRITE_KEY } from "@src/build-config.js";
 import envProxy from "@src/env.js";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { arch, homedir, platform, release } from "node:os";
 import { join } from "node:path";
 
 export const buildConfig = { TELEMETRY_WRITE_KEY };
-export const fs = { readFileSync, writeFileSync, mkdirSync };
+export const fs = { existsSync, readFileSync, writeFileSync, mkdirSync };
 export const os = { homedir, platform, release, arch };
 export const path = { join };
 export const segment = { Analytics };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,12 @@ import {
   getPackageVersion,
   parseCliArgs,
 } from "@src/cli.js";
+import { loadConfigFromYaml } from "@src/config/index.js";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
+import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolFactory } from "@src/confluent/tools/tool-factory.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { EnvVar } from "@src/env-schema.js";
 import { initEnv } from "@src/env.js";
 import { logger, setLogLevel } from "@src/logger.js";
@@ -37,6 +38,13 @@ async function main() {
     // Initialize environment after CLI args are processed
     const env = await initEnv();
     setLogLevel(env.LOG_LEVEL);
+
+    // Load and validate YAML configuration if --config is provided
+    if (cliOptions.config) {
+      loadConfigFromYaml(cliOptions.config);
+      // TODO(issue #151): Use config to construct connection manager instead of env vars
+      logger.info("Configuration file parsed and validated successfully");
+    }
 
     // Merge environment variables with kafka config from CLI
     // some additional configurations could be set in the client manager

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,10 @@ async function main() {
     if (cliOptions.config) {
       loadConfigFromYaml(cliOptions.config);
       // TODO(issue #151): Use config to construct connection manager instead of env vars
-      logger.info("Configuration file parsed and validated successfully");
+      logger.warn(
+        "Configuration file parsed and validated successfully, but it is not applied yet; startup still uses" +
+          " environment variables and CLI Kafka properties",
+      );
     }
 
     // Merge environment variables with kafka config from CLI

--- a/tests/stubs/node-deps.ts
+++ b/tests/stubs/node-deps.ts
@@ -1,0 +1,38 @@
+import * as nodeDeps from "@src/confluent/node-deps.js";
+import sinon from "sinon";
+
+/** Stubbed fs wrapper methods from {@link nodeDeps.fs}. */
+export type StubbedFsWrappers = {
+  existsSync: sinon.SinonStub;
+  readFileSync: sinon.SinonStub;
+  writeFileSync: sinon.SinonStub;
+  mkdirSync: sinon.SinonStub;
+};
+
+/**
+ * Stubs all fs wrapper methods in {@link nodeDeps.fs} using the provided sandbox.
+ * The stubs are automatically restored when the sandbox is restored.
+ *
+ * @param sandbox - Sinon sandbox to use for stubbing
+ * @returns Object containing all installed stubs
+ *
+ * @example
+ * ```typescript
+ * const sandbox = sinon.createSandbox();
+ * const fsStubs = createFsWrappers(sandbox);
+ * fsStubs.existsSync.returns(true);
+ * fsStubs.readFileSync.returns("file contents");
+ * // ... run tests ...
+ * sandbox.restore(); // automatically restores all stubs
+ * ```
+ */
+export function createFsWrappers(
+  sandbox: sinon.SinonSandbox,
+): StubbedFsWrappers {
+  return {
+    existsSync: sandbox.stub(nodeDeps.fs, "existsSync"),
+    readFileSync: sandbox.stub(nodeDeps.fs, "readFileSync"),
+    writeFileSync: sandbox.stub(nodeDeps.fs, "writeFileSync"),
+    mkdirSync: sandbox.stub(nodeDeps.fs, "mkdirSync"),
+  };
+}


### PR DESCRIPTION
# Begin the migration to yaml configuration

## Step 1. Model and parse local docker only connection, then discard.

Start down the [yaml migration of a single connection epic](https://github.com/confluentinc/mcp-confluent/issues/151) by hooking in a `--config` cmdline argument referencing a yaml file configuration, which gets parsed and validated, but then (currently) discarded.

Making this technology more thorough to describe the entirety of our existing configuration needs, to become an alternative way instead of implicitly through env vars, etc. are TBD.

The modeling and parsing is only smart enough to support a single `direct` auth-free connection to Kafka or a schema registry. Either is optional, but have to have at least one. Point it at the sample local-docker.yaml, ocal-docker-and-sr.yaml, or local-docker-sr-only.yaml:

```
# Example MCP Confluent Server Configuration
# This demonstrates a single direct (local/Docker) connection

connections:
  local:
    type: "direct"
    kafka:
      bootstrap_servers: "localhost:9092"
    schema_registry:
      endpoint: "http://localhost:8081"
```

via cmdline `--config sample_configs/local-docker.yaml ` or `--config sample_configs/local-docker-and-sr.yaml `:

```
jlrobins$ npm build
jlrobins$ node dist/index.js --config sample_configs/local-docker.yaml 
{"level":"warn","time":"2026-04-10T20:28:21.976Z","pid":97547,"hostname":"KCX6P9D7XG","name":"mcp-confluent","msg":"Configuration file parsed and validated successfully, but it is not applied yet; startup still uses environment variables and CLI Kafka properties"}
...
```

While here, also:

  1. augmented our sinon stubbing utilities and install another stubbable reference to more fs operations.
  2. Wrote a CLAUDE.md block describing our unit test philosophy.
  
  
  Closes #147.