### PR TITLE
chore: update Dockerfile and add docker image scan block for CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,6 +63,15 @@ blocks:
             - sem-version java 17
             - emit-sonarqube-data --run_only_sonar_scan --enable_sonarqube_enterprise
 
+  - name: "Docker Image Scan"
+    dependencies: ["Static Analysis"]
+    task:
+      jobs:
+        - name: "Trivy Scan"
+          commands:
+            - docker build -t mcp-confluent:${SEMAPHORE_GIT_SHA:0:7} .
+            - trivy image --exit-code 1 --severity HIGH,CRITICAL --no-progress mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
+
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -70,7 +70,10 @@ blocks:
         - name: "Trivy Scan"
           commands:
             - docker build -t mcp-confluent:${SEMAPHORE_GIT_SHA:0:7} .
-            - trivy image --exit-code 1 --severity HIGH,CRITICAL --no-progress mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
+            # fail the job only on CRITICAL vulnerabilities
+            - trivy image --exit-code 1 --severity CRITICAL mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
+            # report HIGH and MEDIUM vulnerabilities but don't fail the job
+            - trivy image --severity HIGH,MEDIUM mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
 
 after_pipeline:
   task:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22-alpine AS builder
+# https://hub.docker.com/layers/library/node/22-alpine
+ARG NODE_IMAGE=node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3
+FROM ${NODE_IMAGE} AS builder
 
 WORKDIR /app
 
@@ -15,7 +17,7 @@ COPY src/ ./src/
 RUN npm run build
 
 # Production stage
-FROM node:22-alpine
+FROM ${NODE_IMAGE}
 WORKDIR /app
 
 # Update npm to the latest version in production stage as well

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ FROM ${NODE_IMAGE} AS builder
 
 WORKDIR /app
 
-# Update npm to the latest version to fix CVE-2024-21626 (brace-expansion vulnerability)
-RUN npm install -g npm@latest
 
 COPY package.json package-lock.json ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ COPY src/ ./src/
 
 RUN npm run build
 
+# remove dev dependencies, keeping compiled native modules intact
+RUN npm prune --omit=dev
+
 # Production stage
 FROM ${NODE_IMAGE}
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,8 @@ RUN npm prune --omit=dev
 FROM ${NODE_IMAGE}
 WORKDIR /app
 
-# Update npm to the latest version in production stage as well
-RUN npm install -g npm@latest
-
-# Explicitly copy package.json and package-lock.json to the root of /app
-COPY package.json package-lock.json ./
-
-# Copy the compiled application files
+COPY --from=builder /app/package.json ./
 COPY --from=builder /app/dist ./dist
-
-# Copy the node_modules from the builder
 COPY --from=builder /app/node_modules ./node_modules/
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json package-lock.json ./
 
 RUN npm ci
 
-COPY tsconfig.json ./
+COPY tsconfig.json tsconfig.build.json ./
 COPY src/ ./src/
 
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ COPY --from=builder /app/package.json ./
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules/
 
+# run as non-root (node user is built into node:alpine images)
+USER node
+
 ENV NODE_ENV=production
 EXPOSE 8080
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
Addresses security review feedback for the Docker image and CI pipeline:
  - pins Docker base image by digest (multi-arch) SHA @ https://hub.docker.com/layers/library/node/22-alpine
  - runs as non-root in the production stage
  - strips dev dependencies
  - removes `npm install -g npm@latest` since it was an unnecessary upgrade that was breaking builds
  - adds Trivy image scanning to CI pipeline and will fail if any critical vulnerabilities are found

Also fixes missing `tsconfig.build.json` in the builder stage.

(Also filed #157 for a docker-compose port mismatch found during testing)
