### PR TITLE
Add partition count option to create topics tool

### DIFF
--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -54,7 +54,7 @@ export class CreateTopicsHandler extends BaseToolHandler {
     return {
       name: ToolName.CREATE_TOPICS,
       description:
-        "Create one or more Kafka topics with optional partition count and replication factor.",
+        "Create one or more Kafka topics with an optional partition count.",
       inputSchema: createTopicArgs.shape,
       annotations: CREATE_UPDATE,
     };

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -10,8 +10,20 @@ import { EnvVar } from "@src/env-schema.js";
 import { z } from "zod";
 
 const createTopicArgs = z.object({
-  topicNames: z
-    .array(z.string().describe("Names of kafka topics to create"))
+  topics: z
+    .array(
+      z.object({
+        topic: z.string().describe("Name of the Kafka topic to create"),
+        numPartitions: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            "Number of partitions for the topic. If not specified, the broker default is used.",
+          ),
+      }),
+    )
     .nonempty(),
 });
 export class CreateTopicsHandler extends BaseToolHandler {
@@ -19,25 +31,30 @@ export class CreateTopicsHandler extends BaseToolHandler {
     clientManager: ClientManager,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const { topicNames } = createTopicArgs.parse(toolArguments);
+    const { topics } = createTopicArgs.parse(toolArguments);
     const success = await (
       await clientManager.getAdminClient()
     ).createTopics({
-      topics: topicNames.map((name) => ({ topic: name })),
+      topics: topics.map(({ topic, numPartitions }) => ({
+        topic,
+        numPartitions,
+      })),
     });
+    const topicNames = topics.map((t) => t.topic).join(",");
     if (!success) {
       return this.createResponse(
-        `Failed to create Kafka topics: ${topicNames.join(",")}`,
+        `Failed to create Kafka topics: ${topicNames}`,
         true,
       );
     }
-    return this.createResponse(`Created Kafka topics: ${topicNames.join(",")}`);
+    return this.createResponse(`Created Kafka topics: ${topicNames}`);
   }
 
   getToolConfig(): ToolConfig {
     return {
       name: ToolName.CREATE_TOPICS,
-      description: "Create one or more Kafka topics.",
+      description:
+        "Create one or more Kafka topics with optional partition count and replication factor.",
       inputSchema: createTopicArgs.shape,
       annotations: CREATE_UPDATE,
     };


### PR DESCRIPTION
## Summary

- Enhances the `create_topics` tool to accept an optional `numPartitions` parameter per topic, allowing users to specify the number of partitions when creating Kafka topics instead of always relying on broker defaults.
- Restructures the tool's input schema from a flat `topicNames` string array to a richer `topics` array of objects, where each entry includes a `topic` name and an optional `numPartitions`.

## Changes

The `CreateTopicsHandler` input schema was changed from:

```typescript
topicNames: z.array(z.string())
```

to:

```typescript
topics: z.array(z.object({
  topic: z.string(),
  numPartitions: z.number().int().positive().optional(),
}))
```

This is passed through to the Kafka admin client's `createTopics` call, which already supports the `numPartitions` field — it was simply not exposed to the MCP tool before.

## Motivation

Partition count is a fundamental topic configuration that impacts parallelism and throughput. Previously, users had no way to control this through the MCP tool and were always subject to broker defaults, which may not be suitable for all use cases.