### PR TITLE
MINOR: rename TypeScript `test:ts` script to `typecheck` for clarity

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
             - npm run lint
         - name: "TypeScript"
           commands:
-            - npm run test:ts
+            - npm run typecheck
 
   - name: "Build"
     dependencies: ["Static Analysis"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm run lint:fix       # eslint --fix
 npm run format         # prettier --write
 npm run test           # vitest run
 npm run test:coverage  # vitest run --coverage
-npm run test:ts        # "tsc --noEmit", also includes type checking the test suite.
+npm run typecheck      # tsc --noEmit (type-check only, includes test suite)
 npm run start          # node dist/index.js --env-file .env (stdio transport)
 npm run start:http     # HTTP transport
 npm run start:all      # all transports (http, sse, stdio)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "test:ts": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js --env-file .env",
     "start:http": "node dist/index.js --env-file .env --transport http",
     "start:sse": "node dist/index.js --env-file .env --transport sse",


### PR DESCRIPTION
Closes #166 