### PR TITLE
[v1.2.x] release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this MCP server will be documented in this file.
 
 ## Unreleased
 
+## 1.2.2
+
 ### Changed
 
 - Removed `baseUrl` invocation parameter from all tool definitions. Now any API non-defaulting endpoint URLs must be provided through environment variable configuration prior to MCP server startup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@confluentinc/mcp-confluent",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@confluentinc/mcp-confluent",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@confluentinc/mcp-confluent",
   "description": "Confluent MCP Server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Confluent Inc.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Mainly changes from https://github.com/confluentinc/mcp-confluent/pull/168:

Security-related fixes:
- #140
- #141
- #143
- #146
- #148
- #156

Additional cleanup that will make any other other patches easier to avoid conflicts:
- #130
- #138
- #142
- #153