### PR TITLE
fix: set actual default HTTP port in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       # Required variables (with defaults if not in .env)
       # Also hardcode env variables in the docker compose environment section below
       HTTP_HOST: "${HTTP_HOST:-0.0.0.0}" # Default to 0.0.0.0 for container accessibility
-      # HTTP_PORT: "${HTTP_PORT:-3000}"    # Default to 3000
+      # HTTP_PORT: "${HTTP_PORT:-8080}"    # Default to 8080
       # BOOTSTRAP_SERVERS: "${BOOTSTRAP_SERVERS}"
       # CONFLUENT_CLOUD_API_KEY: "${CONFLUENT_CLOUD_API_KEY}"
       # CONFLUENT_CLOUD_API_SECRET: "${CONFLUENT_CLOUD_API_SECRET}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,21 @@ services:
   mcp-server:
     build: . ## build Dockerfile
     ports:
-      - "${HTTP_PORT:-3000}:${HTTP_PORT:-3000}" # Use default 3000 if HTTP_PORT not set in .env
+      - "${HTTP_PORT:-8080}:${HTTP_PORT:-8080}" # Use default (8080) if HTTP_PORT not set in .env
 
     # keeping the container running
-    stdin_open: true 
-    tty: true 
+    stdin_open: true
+    tty: true
 
     # Docker Compose will automatically look for a .env file in the same directory
     # You can also explicitly specify it with `env_file: ./.env`
     env_file:
       - .env
-    
+
     environment:
       # Required variables (with defaults if not in .env)
       # Also hardcode env variables in the docker compose environment section below
-      # HTTP_HOST: "${HTTP_HOST:-0.0.0.0}" # Default to 0.0.0.0 for container accessibility
+      HTTP_HOST: "${HTTP_HOST:-0.0.0.0}" # Default to 0.0.0.0 for container accessibility
       # HTTP_PORT: "${HTTP_PORT:-3000}"    # Default to 3000
       # BOOTSTRAP_SERVERS: "${BOOTSTRAP_SERVERS}"
       # CONFLUENT_CLOUD_API_KEY: "${CONFLUENT_CLOUD_API_KEY}"


### PR DESCRIPTION
The current `3000:3000` doesn't match the default `HTTP_PORT`, so if the container runs with the `:8080` defaults, clients will fail to connect properly.

This PR sets the default port to match the `HTTP_PORT` default (`8080`), and also adds a (redundant) `environment.HTTP_HOST` since the current empty `environment` results in an error if nothing is changed (e.g. if the user has everything configured in their `.env`):
```
❯ docker compose up --build          
validating .../mcp-confluent/docker-compose.yml: services.mcp-server.environment must be a mapping
```

Tested locally with the following `.mcp.json` (with `MCP_AUTH_DISABLED=true` in `.env`):
```json
{
  "mcpServers": {
    "confluent-docker": {
      "type": "http",
      "url": "http://localhost:3000/mcp"
    }
  }
}
```
<img width="1608" height="1614" alt="image" src="https://github.com/user-attachments/assets/eea50bf2-618b-4299-9894-b357e3f04eb1" />

(Ran with this `docker-compose.yml` against the `v1.2.x` release branch, but there are currently no meaningful changes affecting how docker compose runs between the two branches.)


Closes #157