### PR TITLE
Begin refactoring main() into subordinate functions with test coverage.

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,88 @@
+import { getFilteredToolNames } from "@src/cli.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { describe, expect, it } from "vitest";
+
+describe("cli.ts", () => {
+  const ALL_TOOL_NAMES = Object.values(ToolName).sort();
+  describe("getFilteredToolNames()", () => {
+    it("should return all tools sorted when both lists are empty", () => {
+      const result = getFilteredToolNames([], []);
+      expect(result).toEqual(ALL_TOOL_NAMES);
+    });
+
+    it("should return only the specified tools when allow list contains valid names", () => {
+      const result = getFilteredToolNames(
+        [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+        [],
+      );
+      expect(result).toEqual(
+        [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS].sort(),
+      );
+    });
+
+    it("should return empty array when allow list contains only invalid names", () => {
+      const result = getFilteredToolNames(["not-a-real-tool", "also-fake"], []);
+      expect(result).toEqual([]);
+    });
+
+    it("should include only valid names when allow list mixes valid and invalid", () => {
+      const result = getFilteredToolNames(
+        [ToolName.LIST_TOPICS, "not-a-real-tool"],
+        [],
+      );
+      expect(result).toEqual([ToolName.LIST_TOPICS]);
+    });
+
+    it("should return all tools except the blocked one when block list contains a valid name", () => {
+      const result = getFilteredToolNames([], [ToolName.LIST_TOPICS]);
+      expect(result).not.toContain(ToolName.LIST_TOPICS);
+      expect(result.length).toBe(ALL_TOOL_NAMES.length - 1);
+      expect(result).toEqual(
+        ALL_TOOL_NAMES.filter((t) => t !== ToolName.LIST_TOPICS),
+      );
+    });
+
+    it("should block only valid names when block list mixes valid and invalid", () => {
+      const result = getFilteredToolNames(
+        [],
+        [ToolName.LIST_TOPICS, "not-a-real-tool"],
+      );
+      expect(result).not.toContain(ToolName.LIST_TOPICS);
+      expect(result.length).toBe(ALL_TOOL_NAMES.length - 1);
+    });
+
+    it("should return all tools unchanged when block list contains only invalid names", () => {
+      const result = getFilteredToolNames([], ["not-a-real-tool"]);
+      expect(result).toEqual(ALL_TOOL_NAMES);
+    });
+
+    it("should apply allow list first then subtract block list", () => {
+      const result = getFilteredToolNames(
+        [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+        [ToolName.CREATE_TOPICS],
+      );
+      expect(result).toEqual([ToolName.LIST_TOPICS]);
+    });
+
+    it("should return empty array when all allowed tools are also blocked", () => {
+      const result = getFilteredToolNames(
+        [ToolName.LIST_TOPICS],
+        [ToolName.LIST_TOPICS],
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("should always return results in alphabetical order", () => {
+      const result = getFilteredToolNames(
+        [
+          ToolName.PRODUCE_MESSAGE,
+          ToolName.LIST_TOPICS,
+          ToolName.CREATE_TOPICS,
+        ],
+        [],
+      );
+      const sorted = [...result].sort();
+      expect(result).toEqual(sorted);
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,20 +254,20 @@ export function loadEnvironmentVariables(envFile: string): void {
  *
  * This function determines which tools should be enabled for the server by applying
  * the following logic:
- *   1. If an allow list (`allowTools`) is provided and non-empty, only those
+ *   1. If allow list (`allowTools`) is non-empty, only those
  *      tool names present in the allow list (and valid) will be enabled. Any invalid
  *      tool names in the allow list are ignored and a warning is logged.
- *   2. If a block list (`blockTools`) is provided and non-empty, any tool
+ *   2. If block list (`blockTools`) is non-empty, any tool
  *      names present in the block list (and valid) will be removed from the enabled
  *      set. Any invalid tool names in the block list are ignored and a warning is logged.
- *   3. If neither allow nor block lists are provided, all available tools are enabled.
+ *   3. If both lists are empty, all available tools are enabled.
  *
  * The returned list is always sorted alphabetically.
  *
- * @param allowTools - Optional array of tool names to allow/enable. If provided, only these tools will possibly
+ * @param allowTools - Array of tool names to explicitly allow/enable. If nonempty, only these tools will possibly
  *                    be enabled (subject to block list). If not provided or empty, all tools are initially
  *                    considered for enabling.
- * @param blockTools - Optional array of tool names to block. If provided, these tools will be disabled (even if
+ * @param blockTools - Array of tool names to block. If nonempty, these tools will be disabled (even if
  *                      they are in the allow list).
  *
  * @returns An alphabetically sorted array of enabled ToolNames.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,64 +254,71 @@ export function loadEnvironmentVariables(envFile: string): void {
  *
  * This function determines which tools should be enabled for the server by applying
  * the following logic:
- *   1. If an allow list (`cliOptions.allowTools`) is provided and non-empty, only those
+ *   1. If an allow list (`allowTools`) is provided and non-empty, only those
  *      tool names present in the allow list (and valid) will be enabled. Any invalid
  *      tool names in the allow list are ignored and a warning is logged.
- *   2. If a block list (`cliOptions.blockTools`) is provided and non-empty, any tool
+ *   2. If a block list (`blockTools`) is provided and non-empty, any tool
  *      names present in the block list (and valid) will be removed from the enabled
  *      set. Any invalid tool names in the block list are ignored and a warning is logged.
  *   3. If neither allow nor block lists are provided, all available tools are enabled.
  *
  * The returned list is always sorted alphabetically.
  *
- * @param cliOptions - The parsed CLI options containing allow/block tool lists.
+ * @param allowTools - Optional array of tool names to allow/enable. If provided, only these tools will possibly
+ *                    be enabled (subject to block list). If not provided or empty, all tools are initially
+ *                    considered for enabling.
+ * @param blockTools - Optional array of tool names to block. If provided, these tools will be disabled (even if
+ *                      they are in the allow list).
+ *
  * @returns An alphabetically sorted array of enabled ToolNames.
  */
-export function getFilteredToolNames(cliOptions: CLIOptions): ToolName[] {
-  let filteredToolNames: ToolName[] = Object.values(ToolName);
+export function getFilteredToolNames(
+  allowTools: string[],
+  blockTools: string[],
+): ToolName[] {
+  let filteredToolNames: Set<ToolName> = new Set(Object.values(ToolName));
   const validToolNames = new Set(Object.values(ToolName));
 
-  if (cliOptions.allowTools && cliOptions.allowTools.length > 0) {
-    const valid = cliOptions.allowTools.filter((t) =>
-      validToolNames.has(t as ToolName),
-    );
-    const invalid = cliOptions.allowTools.filter(
-      (t) => !validToolNames.has(t as ToolName),
-    );
-    if (invalid.length > 0) {
-      logger.warn(
-        `Ignoring invalid tool names in allow list: ${invalid.join(", ")}`,
-      );
-    }
-    filteredToolNames = valid.map((t) => t as ToolName);
-  }
-  if (cliOptions.blockTools && cliOptions.blockTools.length > 0) {
-    const validBlock = cliOptions.blockTools.filter((t) =>
-      validToolNames.has(t as ToolName),
-    );
-    const invalidBlock = cliOptions.blockTools.filter(
-      (t) => !validToolNames.has(t as ToolName),
-    );
-    if (invalidBlock.length > 0) {
-      logger.warn(
-        `Ignoring invalid tool names in block list: ${invalidBlock.join(", ")}`,
-      );
-    }
-    filteredToolNames = filteredToolNames.filter(
-      (t) => !validBlock.includes(t),
-    );
-  }
-  // Deduplicate and sort
-  const deduped = Array.from(new Set(filteredToolNames)).sort();
   if (
-    (!cliOptions.allowTools || cliOptions.allowTools.length === 0) &&
-    (!cliOptions.blockTools || cliOptions.blockTools.length === 0)
+    (!allowTools || allowTools.length === 0) &&
+    (!blockTools || blockTools.length === 0)
   ) {
     logger.info(
       "No allow/block tool lists provided; all tools are enabled by default.",
     );
+  } else {
+    if (allowTools.length > 0) {
+      const valid = allowTools.filter((t) => validToolNames.has(t as ToolName));
+      const invalid = allowTools.filter(
+        (t) => !validToolNames.has(t as ToolName),
+      );
+      if (invalid.length > 0) {
+        logger.warn(
+          `Ignoring invalid tool names in allow list: ${invalid.join(", ")}`,
+        );
+      }
+      filteredToolNames = new Set(valid.map((t) => t as ToolName));
+    }
+    if (blockTools.length > 0) {
+      const validBlock = new Set(
+        blockTools.filter((t) => validToolNames.has(t as ToolName)),
+      );
+      const invalidBlock = blockTools.filter(
+        (t) => !validToolNames.has(t as ToolName),
+      );
+      if (invalidBlock.length > 0) {
+        logger.warn(
+          `Ignoring invalid tool names in block list: ${invalidBlock.join(", ")}`,
+        );
+      }
+      for (const tool of validBlock) {
+        filteredToolNames.delete(tool as ToolName);
+      }
+    }
   }
-  return deduped;
+
+  // Convert to array, sort, return.
+  return Array.from(filteredToolNames).sort();
 }
 
 /**

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -3,8 +3,8 @@ import {
   DESTRUCTIVE,
   READ_ONLY,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolFactory } from "@src/confluent/tools/tool-factory.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { describe, expect, it } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
@@ -14,13 +14,13 @@ describe("tool-factory.ts", () => {
     describe("createToolHandler()", () => {
       it("should have a handler for every tool", () => {
         for (const name of ALL_TOOL_NAMES) {
-          expect(() => ToolFactory.createToolHandler(name)).not.toThrow();
+          expect(() => ToolHandlerRegistry.getToolHandler(name)).not.toThrow();
         }
       });
 
       it("should return valid ToolConfig for every registered tool", () => {
         for (const name of ALL_TOOL_NAMES) {
-          const handler = ToolFactory.createToolHandler(name);
+          const handler = ToolHandlerRegistry.getToolHandler(name);
           const config = handler.getToolConfig();
 
           expect(config.name).toBe(name);
@@ -31,7 +31,7 @@ describe("tool-factory.ts", () => {
 
       it("should have a valid annotation (READ_ONLY, CREATE_UPDATE, or DESTRUCTIVE) for every tool", () => {
         for (const name of ALL_TOOL_NAMES) {
-          const handler = ToolFactory.createToolHandler(name);
+          const handler = ToolHandlerRegistry.getToolHandler(name);
           const config = handler.getToolConfig();
 
           expect(config.annotations).toBeDefined();
@@ -82,7 +82,7 @@ describe("tool-factory.ts", () => {
         ).toBe(allPrefixes.length);
 
         for (const name of ALL_TOOL_NAMES) {
-          const handler = ToolFactory.createToolHandler(name);
+          const handler = ToolHandlerRegistry.getToolHandler(name);
           const config = handler.getToolConfig();
 
           const prefix = name.split("-")[0]!;

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -9,9 +9,9 @@ import { describe, expect, it } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
 
-describe("tool-factory.ts", () => {
-  describe("ToolFactory", () => {
-    describe("createToolHandler()", () => {
+describe("tool-registry.ts", () => {
+  describe("ToolHandlerRegistry", () => {
+    describe("getToolHandler()", () => {
       it("should have a handler for every tool", () => {
         for (const name of ALL_TOOL_NAMES) {
           expect(() => ToolHandlerRegistry.getToolHandler(name)).not.toThrow();

--- a/src/confluent/tools/tool-registry.ts
+++ b/src/confluent/tools/tool-registry.ts
@@ -1,4 +1,5 @@
 import { ToolConfig, ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { ListBillingCostsHandler } from "@src/confluent/tools/handlers/billing/list-billing-costs-handler.js";
 import { AddTagToTopicHandler } from "@src/confluent/tools/handlers/catalog/add-tags-to-topic.js";
 import { CreateTopicTagsHandler } from "@src/confluent/tools/handlers/catalog/create-topic-tags.js";
 import { DeleteTagHandler } from "@src/confluent/tools/handlers/catalog/delete-tag.js";
@@ -11,13 +12,13 @@ import { ListConnectorsHandler } from "@src/confluent/tools/handlers/connect/lis
 import { ReadConnectorHandler } from "@src/confluent/tools/handlers/connect/read-connectors-handler.js";
 import { ListEnvironmentsHandler } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
 import { ReadEnvironmentHandler } from "@src/confluent/tools/handlers/environments/read-environment-handler.js";
-import { CreateFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/create-flink-statement-handler.js";
-import { DeleteFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/delete-flink-statement-handler.js";
 import { DescribeTableHandler } from "@src/confluent/tools/handlers/flink/catalog/describe-table-handler.js";
 import { GetTableInfoHandler } from "@src/confluent/tools/handlers/flink/catalog/get-table-info-handler.js";
 import { ListCatalogsHandler } from "@src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.js";
 import { ListDatabasesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-databases-handler.js";
 import { ListTablesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-tables-handler.js";
+import { CreateFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/create-flink-statement-handler.js";
+import { DeleteFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/delete-flink-statement-handler.js";
 import { CheckHealthHandler } from "@src/confluent/tools/handlers/flink/diagnostics/check-health-handler.js";
 import { DetectIssuesHandler } from "@src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.js";
 import { QueryProfilerHandler } from "@src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.js";
@@ -31,6 +32,8 @@ import { DeleteTopicsHandler } from "@src/confluent/tools/handlers/kafka/delete-
 import { GetTopicConfigHandler } from "@src/confluent/tools/handlers/kafka/get-topic-config.js";
 import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topics-handler.js";
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
+import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
+import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
 import { DeleteSchemaHandler } from "@src/confluent/tools/handlers/schema/delete-schema-handler.js";
 import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
 import { SearchTopicsByTagHandler } from "@src/confluent/tools/handlers/search/search-topic-by-tag-handler.js";
@@ -46,12 +49,12 @@ import { DeleteTableFlowTopicHandler } from "@src/confluent/tools/handlers/table
 import { ListTableFlowTopicsHandler } from "@src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.js";
 import { ReadTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.js";
 import { UpdateTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.js";
-import { ListBillingCostsHandler } from "@src/confluent/tools/handlers/billing/list-billing-costs-handler.js";
-import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
-import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 
-export class ToolFactory {
+/**
+ * Central registry for all tool call handlers.
+ */
+export class ToolHandlerRegistry {
   private static handlers: Map<ToolName, ToolHandler> = new Map([
     [ToolName.LIST_TOPICS, new ListTopicsHandler()],
     [ToolName.CREATE_TOPICS, new CreateTopicsHandler()],
@@ -120,24 +123,11 @@ export class ToolFactory {
     [ToolName.LIST_METRICS, new ListMetricsHandler()],
   ]);
 
-  static createToolHandler(toolName: ToolName): ToolHandler {
-    if (!this.handlers.has(toolName)) {
-      throw new Error(`Unknown tool name: ${toolName}`);
-    }
+  static getToolHandler(toolName: ToolName): ToolHandler {
     return this.handlers.get(toolName)!;
   }
 
-  static getToolConfigs(): ToolConfig[] {
-    // iterate through all the handlers and collect their configurations
-    return Array.from(this.handlers.values()).map((handler) =>
-      handler.getToolConfig(),
-    );
-  }
-
   static getToolConfig(toolName: ToolName): ToolConfig {
-    if (!this.handlers.has(toolName)) {
-      throw new Error(`Unknown tool name: ${toolName}`);
-    }
-    return this.handlers.get(toolName)!.getToolConfig();
+    return this.getToolHandler(toolName).getToolConfig();
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,343 @@
+import { DefaultClientManager } from "@src/confluent/client-manager.js";
+import type {
+  ToolConfig,
+  ToolHandler,
+} from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
+import type { EnvVar } from "@src/env-schema.js";
+import {
+  constructDefaultClientManager,
+  getToolHandlersToRegister,
+  outputApiKey,
+  outputToolList,
+} from "@src/index.js";
+import { generateApiKey } from "@src/mcp/transports/index.js";
+import { cliOptionsFactory } from "@tests/factories/cli-options.js";
+import { envFactory } from "@tests/factories/env.js";
+import sinon from "sinon";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// generateApiKey is an ESM live binding — must be mocked at the module level
+// via vi.mock (hoisted by Vitest) so index.ts receives the mock on import.
+vi.mock("@src/mcp/transports/index.js", () => ({
+  generateApiKey: vi.fn(),
+}));
+
+function fakeHandler(requiredVars: EnvVar[], isCloudOnly = false): ToolHandler {
+  return {
+    getRequiredEnvVars: () => requiredVars,
+    isConfluentCloudOnly: () => isCloudOnly,
+    getToolConfig: () => ({
+      name: ToolName.LIST_TOPICS,
+      description: "test handler",
+      inputSchema: {},
+      annotations: READ_ONLY,
+    }),
+    handle: sinon.stub() as ToolHandler["handle"],
+  };
+}
+
+describe("index.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let consoleLog: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    consoleLog = sandbox.stub(console, "log");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("outputToolList()", () => {
+    it("should not call console.log when the tool list is empty", () => {
+      outputToolList([]);
+      sinon.assert.notCalled(consoleLog);
+    });
+
+    it("should call console.log once for a single tool", () => {
+      outputToolList([ToolName.LIST_TOPICS]);
+      sinon.assert.calledOnce(consoleLog);
+    });
+
+    it("should call console.log once per tool for multiple tools", () => {
+      outputToolList([
+        ToolName.LIST_TOPICS,
+        ToolName.CREATE_TOPICS,
+        ToolName.DELETE_TOPICS,
+      ]);
+      sinon.assert.callCount(consoleLog, 3);
+    });
+
+    it("should include the tool name in the output line", () => {
+      outputToolList([ToolName.LIST_TOPICS]);
+      const output: string = consoleLog.firstCall.args[0];
+      expect(output).toContain(ToolName.LIST_TOPICS);
+    });
+
+    it("should include the full description when it is within 120 characters", () => {
+      const shortDesc = "A short description.";
+      sandbox.stub(ToolHandlerRegistry, "getToolConfig").returns({
+        name: ToolName.LIST_TOPICS,
+        description: shortDesc,
+        inputSchema: {},
+        annotations: {},
+      } as ToolConfig);
+
+      outputToolList([ToolName.LIST_TOPICS]);
+
+      const output: string = consoleLog.firstCall.args[0];
+      expect(output).toContain(shortDesc);
+      expect(output).not.toContain("...");
+    });
+
+    it("should truncate descriptions longer than 120 characters with ellipsis", () => {
+      const longDesc = "x".repeat(150);
+      sandbox.stub(ToolHandlerRegistry, "getToolConfig").returns({
+        name: ToolName.LIST_TOPICS,
+        description: longDesc,
+        inputSchema: {},
+        annotations: {},
+      } as ToolConfig);
+
+      outputToolList([ToolName.LIST_TOPICS]);
+
+      const output: string = consoleLog.firstCall.args[0];
+      expect(output).toContain("...");
+      // ANSI codes only wrap the tool name before the ": " separator, so
+      // splitting there isolates the description without needing regex stripping.
+      const descPart = output.split(": ").slice(1).join(": ");
+      expect(descPart.length).toBe(120);
+    });
+  });
+
+  describe("getToolHandlersToRegister()", () => {
+    it("should include a tool when all its required env vars are present", () => {
+      sandbox
+        .stub(ToolHandlerRegistry, "getToolHandler")
+        .returns(fakeHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]));
+
+      const result = getToolHandlersToRegister(
+        [ToolName.LIST_TOPICS],
+        false,
+        envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+      );
+
+      expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
+    });
+
+    it("should exclude a tool when a required env var is missing", () => {
+      sandbox
+        .stub(ToolHandlerRegistry, "getToolHandler")
+        .returns(fakeHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]));
+
+      expect(() =>
+        getToolHandlersToRegister(
+          [ToolName.LIST_TOPICS],
+          false,
+          envFactory(), // no credentials
+        ),
+      ).toThrow("No tools enabled");
+    });
+
+    it("should exclude a tool absent from filteredToolNames even when env vars are present", () => {
+      const getToolHandler = sandbox.stub(
+        ToolHandlerRegistry,
+        "getToolHandler",
+      );
+
+      expect(() =>
+        getToolHandlersToRegister(
+          [], // LIST_TOPICS not in the allowed set
+          false,
+          envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+        ),
+      ).toThrow("No tools enabled");
+
+      sinon.assert.notCalled(getToolHandler);
+    });
+
+    it("should exclude a cloud-only tool when disableConfluentCloudTools is true", () => {
+      sandbox
+        .stub(ToolHandlerRegistry, "getToolHandler")
+        .returns(
+          fakeHandler(
+            ["CONFLUENT_CLOUD_API_KEY", "CONFLUENT_CLOUD_API_SECRET"],
+            true,
+          ),
+        );
+
+      expect(() =>
+        getToolHandlersToRegister(
+          [ToolName.LIST_TOPICS],
+          true, // cloud tools disabled
+          envFactory({
+            CONFLUENT_CLOUD_API_KEY: "key",
+            CONFLUENT_CLOUD_API_SECRET: "secret",
+          }),
+        ),
+      ).toThrow("No tools enabled");
+    });
+
+    it("should include a cloud-only tool when disableConfluentCloudTools is false", () => {
+      sandbox
+        .stub(ToolHandlerRegistry, "getToolHandler")
+        .returns(
+          fakeHandler(
+            ["CONFLUENT_CLOUD_API_KEY", "CONFLUENT_CLOUD_API_SECRET"],
+            true,
+          ),
+        );
+
+      const result = getToolHandlersToRegister(
+        [ToolName.LIST_TOPICS],
+        false,
+        envFactory({
+          CONFLUENT_CLOUD_API_KEY: "key",
+          CONFLUENT_CLOUD_API_SECRET: "secret",
+        }),
+      );
+
+      expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
+    });
+
+    it("should include only the tool whose env vars are satisfied when tools have mixed satisfaction", () => {
+      const getToolHandler = sandbox.stub(
+        ToolHandlerRegistry,
+        "getToolHandler",
+      );
+      getToolHandler
+        .withArgs(ToolName.LIST_TOPICS)
+        .returns(fakeHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]));
+      getToolHandler
+        .withArgs(ToolName.CREATE_TOPICS)
+        .returns(fakeHandler(["FLINK_API_KEY", "FLINK_API_SECRET"]));
+
+      const result = getToolHandlersToRegister(
+        [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+        false,
+        envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+      );
+
+      expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
+      expect(result.has(ToolName.CREATE_TOPICS)).toBe(false);
+    });
+  });
+
+  describe("constructDefaultClientManager()", () => {
+    it("should always set client.id to mcp-confluent", () => {
+      const manager = constructDefaultClientManager(
+        envFactory(),
+        cliOptionsFactory(),
+      );
+      expect(manager["kafkaConfig"]["client.id"]).toBe("mcp-confluent");
+    });
+
+    it("should set bootstrap.servers from env", () => {
+      const manager = constructDefaultClientManager(
+        envFactory({ BOOTSTRAP_SERVERS: "broker:9092" }),
+        cliOptionsFactory(),
+      );
+      expect(manager["kafkaConfig"]["bootstrap.servers"]).toBe("broker:9092");
+    });
+
+    it("should include SASL config when both KAFKA_API_KEY and KAFKA_API_SECRET are present", () => {
+      const manager = constructDefaultClientManager(
+        envFactory({
+          KAFKA_API_KEY: "the-key",
+          KAFKA_API_SECRET: "the-secret",
+        }),
+        cliOptionsFactory(),
+      );
+      expect(manager["kafkaConfig"]["security.protocol"]).toBe("sasl_ssl");
+      expect(manager["kafkaConfig"]["sasl.username"]).toBe("the-key");
+      expect(manager["kafkaConfig"]["sasl.password"]).toBe("the-secret");
+    });
+
+    it("should omit SASL config when KAFKA_API_KEY is absent", () => {
+      const manager = constructDefaultClientManager(
+        envFactory({ KAFKA_API_SECRET: "the-secret" }),
+        cliOptionsFactory(),
+      );
+      expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
+    });
+
+    it("should omit SASL config when KAFKA_API_SECRET is absent", () => {
+      const manager = constructDefaultClientManager(
+        envFactory({ KAFKA_API_KEY: "the-key" }),
+        cliOptionsFactory(),
+      );
+      expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
+    });
+
+    it("should omit SASL config when neither key nor secret is present", () => {
+      const manager = constructDefaultClientManager(
+        envFactory(),
+        cliOptionsFactory(),
+      );
+      expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
+    });
+
+    it("should merge cliOptions.kafkaConfig last, overriding env-derived values", () => {
+      const manager = constructDefaultClientManager(
+        envFactory({ BOOTSTRAP_SERVERS: "from-env:9092" }),
+        cliOptionsFactory({
+          kafkaConfig: { "bootstrap.servers": "override:9092" },
+        }),
+      );
+      expect(manager["kafkaConfig"]["bootstrap.servers"]).toBe("override:9092");
+    });
+
+    it("should map the cloud endpoint to confluentCloudBaseUrl", () => {
+      const manager = constructDefaultClientManager(
+        envFactory({ CONFLUENT_CLOUD_REST_ENDPOINT: "https://my.cloud.api" }),
+        cliOptionsFactory(),
+      );
+      expect(manager["confluentCloudBaseUrl"]).toBe("https://my.cloud.api");
+    });
+
+    it("should use the telemetry endpoint default from env", () => {
+      const manager = constructDefaultClientManager(
+        envFactory(),
+        cliOptionsFactory(),
+      );
+      expect(manager["confluentCloudTelemetryBaseUrl"]).toBe(
+        "https://api.telemetry.confluent.cloud",
+      );
+    });
+
+    it("should return a DefaultClientManager instance", () => {
+      const manager = constructDefaultClientManager(
+        envFactory(),
+        cliOptionsFactory(),
+      );
+      expect(manager).toBeInstanceOf(DefaultClientManager);
+    });
+  });
+
+  describe("outputApiKey()", () => {
+    const FAKE_API_KEY = "fake-api-key-for-testing";
+
+    beforeEach(() => {
+      vi.mocked(generateApiKey).mockReturnValue(FAKE_API_KEY);
+    });
+
+    afterEach(() => {
+      vi.mocked(generateApiKey).mockReset();
+    });
+
+    it("should call generateApiKey once", () => {
+      outputApiKey();
+      expect(vi.mocked(generateApiKey)).toHaveBeenCalledOnce();
+    });
+
+    it("should print the generated key to console.log", () => {
+      outputApiKey();
+      const allArgs: unknown[] = (console.log as sinon.SinonStub).args.flat();
+      expect(allArgs).toContain(FAKE_API_KEY);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { GlobalConfig } from "@confluentinc/kafka-javascript";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
+  CLIOptions,
   getFilteredToolNames,
   getPackageVersion,
   parseCliArgs,
@@ -11,18 +12,67 @@ import { loadConfigFromYaml } from "@src/config/index.js";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { ToolFactory } from "@src/confluent/tools/tool-factory.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { EnvVar } from "@src/env-schema.js";
+import type { Environment } from "@src/env.js";
 import { initEnv } from "@src/env.js";
 import { logger, setLogLevel } from "@src/logger.js";
 import { generateApiKey, TransportManager } from "@src/mcp/transports/index.js";
 
-// Parse command line arguments and load environment variables if --env-file is specified
-const cliOptions = parseCliArgs();
+/**
+ * Determine the subset of ToolHandlers to register based on the filtered tool names,
+ * cloud tool settings, and environment variables
+ **/
+export function getToolHandlersToRegister(
+  filteredToolNames: ToolName[],
+  disableConfluentCloudTools: boolean,
+  env: Environment,
+): Map<ToolName, ToolHandler> {
+  const toolHandlers = new Map<ToolName, ToolHandler>();
 
-// Handle --generate-key early (before any other initialization)
-if (cliOptions.generateKey) {
+  Object.values(ToolName).forEach((toolName) => {
+    // Skip names that are not in the filtered list of tool names provided.
+    if (!filteredToolNames.includes(toolName)) {
+      logger.warn(`Tool ${toolName} disabled due to allow/block list rules`);
+      return;
+    }
+
+    const handler = ToolHandlerRegistry.getToolHandler(toolName);
+
+    // Skip cloud-only tools if disabled by CLI/env
+    if (disableConfluentCloudTools && handler.isConfluentCloudOnly()) {
+      logger.warn(
+        `Tool ${toolName} disabled due to --disable-confluent-cloud-tools flag or DISABLE_CONFLUENT_CLOUD_TOOLS env var`,
+      );
+      return;
+    }
+
+    const missingVars = handler
+      .getRequiredEnvVars()
+      .filter((varName: EnvVar) => !env[varName]);
+
+    if (missingVars.length === 0) {
+      toolHandlers.set(toolName, handler);
+      logger.info(`Tool ${toolName} enabled`);
+    } else {
+      logger.warn(
+        `Tool ${toolName} disabled due to missing environment variables: ${missingVars.join(", ")}`,
+      );
+    }
+  });
+
+  // Raise an error if no tools are enabled, as the server would be non-functional without any tools.
+  if (toolHandlers.size === 0) {
+    throw new Error(
+      "No tools enabled. Please check your configuration and environment variables.",
+    );
+  }
+
+  return toolHandlers;
+}
+
+export function outputApiKey(): void {
   const apiKey = generateApiKey();
   console.log("\nGenerated MCP API Key:");
   console.log("=".repeat(64));
@@ -30,12 +80,106 @@ if (cliOptions.generateKey) {
   console.log("=".repeat(64));
   console.log("\nAdd this to your .env file:");
   console.log(`MCP_API_KEY=${apiKey}\n`);
-  process.exit(0);
+}
+
+export function outputToolList(filteredToolNames: ToolName[]): void {
+  const MAX_DESC_LENGTH = 120;
+  filteredToolNames.forEach((toolName) => {
+    const config = ToolHandlerRegistry.getToolConfig(toolName);
+    let desc = config.description.replaceAll(/\s+/g, " ").trim();
+    if (desc.length > MAX_DESC_LENGTH) {
+      desc = desc.slice(0, MAX_DESC_LENGTH - 3) + "...";
+    }
+    console.log(`\x1b[32m${config.name}\x1b[0m: ${desc}`);
+  });
+}
+
+export function constructDefaultClientManager(
+  env: Environment,
+  cliOptions: CLIOptions,
+): DefaultClientManager {
+  // Merge environment variables with kafka config from CLI
+  // some additional configurations could be set in the client manager
+  // like separating groupIds by sessionId
+  const kafkaClientConfig: GlobalConfig = {
+    // Base configuration from environment variables
+    "bootstrap.servers": env.BOOTSTRAP_SERVERS,
+    "client.id": "mcp-confluent",
+    ...(env.KAFKA_API_KEY && env.KAFKA_API_SECRET
+      ? {
+          "security.protocol": "sasl_ssl",
+          "sasl.mechanisms": "PLAIN",
+          "sasl.username": env.KAFKA_API_KEY,
+          "sasl.password": env.KAFKA_API_SECRET,
+        }
+      : {}),
+    // Merge any additional properties from the kafka config file
+    ...cliOptions.kafkaConfig,
+  };
+
+  return new DefaultClientManager({
+    kafka: kafkaClientConfig,
+    endpoints: {
+      cloud: env.CONFLUENT_CLOUD_REST_ENDPOINT,
+      flink: env.FLINK_REST_ENDPOINT,
+      schemaRegistry: env.SCHEMA_REGISTRY_ENDPOINT,
+      kafka: env.KAFKA_REST_ENDPOINT,
+      telemetry:
+        env.TELEMETRY_ENDPOINT ?? "https://api.telemetry.confluent.cloud",
+    },
+    auth: {
+      cloud: {
+        apiKey: env.CONFLUENT_CLOUD_API_KEY!,
+        apiSecret: env.CONFLUENT_CLOUD_API_SECRET!,
+      },
+      tableflow: {
+        apiKey: env.TABLEFLOW_API_KEY!,
+        apiSecret: env.TABLEFLOW_API_SECRET!,
+      },
+      flink: {
+        apiKey: env.FLINK_API_KEY!,
+        apiSecret: env.FLINK_API_SECRET!,
+      },
+      schemaRegistry: {
+        apiKey: env.SCHEMA_REGISTRY_API_KEY!,
+        apiSecret: env.SCHEMA_REGISTRY_API_SECRET!,
+      },
+      kafka: {
+        apiKey: env.KAFKA_API_KEY!,
+        apiSecret: env.KAFKA_API_SECRET!,
+      },
+      telemetry: {
+        apiKey: (env.TELEMETRY_API_KEY ?? env.CONFLUENT_CLOUD_API_KEY)!,
+        apiSecret: (env.TELEMETRY_API_SECRET ??
+          env.CONFLUENT_CLOUD_API_SECRET)!,
+      },
+    },
+  });
 }
 
 async function main() {
   try {
-    // Initialize environment after CLI args are processed
+    // Parse command line arguments and load environment variables if --env-file is specified
+    const cliOptions = parseCliArgs();
+
+    // Handle early-exit modes as requested by CLI args before initializing the server.
+    if (cliOptions.generateKey) {
+      outputApiKey();
+      process.exit(0);
+    }
+
+    const filteredToolNames = getFilteredToolNames(
+      cliOptions.allowTools ?? [],
+      cliOptions.blockTools ?? [],
+    );
+
+    // If --list-tools is set, print the filtered tool names with descriptions and exit.
+    if (cliOptions.listTools) {
+      outputToolList(filteredToolNames);
+      process.exit(0);
+    }
+
+    // Load environment variables and set log level before doing anything else.
     const env = await initEnv();
     setLogLevel(env.LOG_LEVEL);
 
@@ -49,112 +193,7 @@ async function main() {
       );
     }
 
-    // Merge environment variables with kafka config from CLI
-    // some additional configurations could be set in the client manager
-    // like separating groupIds by sessionId
-    const kafkaClientConfig: GlobalConfig = {
-      // Base configuration from environment variables
-      "bootstrap.servers": env.BOOTSTRAP_SERVERS!,
-      "client.id": "mcp-confluent",
-      ...(env.KAFKA_API_KEY && env.KAFKA_API_SECRET
-        ? {
-            "security.protocol": "sasl_ssl",
-            "sasl.mechanisms": "PLAIN",
-            "sasl.username": env.KAFKA_API_KEY!,
-            "sasl.password": env.KAFKA_API_SECRET!,
-          }
-        : {}),
-      // Merge any additional properties from the kafka config file
-      ...cliOptions.kafkaConfig,
-    };
-
-    const clientManager = new DefaultClientManager({
-      kafka: kafkaClientConfig,
-      endpoints: {
-        cloud: env.CONFLUENT_CLOUD_REST_ENDPOINT,
-        flink: env.FLINK_REST_ENDPOINT,
-        schemaRegistry: env.SCHEMA_REGISTRY_ENDPOINT,
-        kafka: env.KAFKA_REST_ENDPOINT,
-        telemetry:
-          env.TELEMETRY_ENDPOINT ?? "https://api.telemetry.confluent.cloud",
-      },
-      auth: {
-        cloud: {
-          apiKey: env.CONFLUENT_CLOUD_API_KEY!,
-          apiSecret: env.CONFLUENT_CLOUD_API_SECRET!,
-        },
-        tableflow: {
-          apiKey: env.TABLEFLOW_API_KEY!,
-          apiSecret: env.TABLEFLOW_API_SECRET!,
-        },
-        flink: {
-          apiKey: env.FLINK_API_KEY!,
-          apiSecret: env.FLINK_API_SECRET!,
-        },
-        schemaRegistry: {
-          apiKey: env.SCHEMA_REGISTRY_API_KEY!,
-          apiSecret: env.SCHEMA_REGISTRY_API_SECRET!,
-        },
-        kafka: {
-          apiKey: env.KAFKA_API_KEY!,
-          apiSecret: env.KAFKA_API_SECRET!,
-        },
-        telemetry: {
-          apiKey: (env.TELEMETRY_API_KEY ?? env.CONFLUENT_CLOUD_API_KEY)!,
-          apiSecret: (env.TELEMETRY_API_SECRET ??
-            env.CONFLUENT_CLOUD_API_SECRET)!,
-        },
-      },
-    });
-
-    const filteredToolNames = getFilteredToolNames(cliOptions);
-
-    // If --list-tools is set, print tool names with descriptions and exit
-    if (cliOptions.listTools) {
-      const MAX_DESC_LENGTH = 120;
-      filteredToolNames.forEach((toolName) => {
-        const config = ToolFactory.getToolConfig(toolName);
-        let desc = config.description.replace(/\s+/g, " ").trim();
-        if (desc.length > MAX_DESC_LENGTH) {
-          desc = desc.slice(0, MAX_DESC_LENGTH - 3) + "...";
-        }
-        console.log(`\x1b[32m${config.name}\x1b[0m: ${desc}`);
-      });
-      process.exit(0);
-    }
-
-    const toolHandlers = new Map<ToolName, ToolHandler>();
-
-    // Initialize tools and check their requirements
-    Object.values(ToolName).forEach((toolName) => {
-      if (!filteredToolNames.includes(toolName)) {
-        logger.warn(`Tool ${toolName} disabled due to allow/block list rules`);
-        return;
-      }
-      const handler = ToolFactory.createToolHandler(toolName);
-      // Skip cloud-only tools if disabled by CLI/env
-      if (
-        cliOptions.disableConfluentCloudTools &&
-        handler.isConfluentCloudOnly()
-      ) {
-        logger.warn(
-          `Tool ${toolName} disabled due to --disable-confluent-cloud-tools flag or DISABLE_CONFLUENT_CLOUD_TOOLS env var`,
-        );
-        return;
-      }
-      const missingVars = handler
-        .getRequiredEnvVars()
-        .filter((varName: EnvVar) => !env[varName]);
-
-      if (missingVars.length === 0) {
-        toolHandlers.set(toolName, handler);
-        logger.info(`Tool ${toolName} enabled`);
-      } else {
-        logger.warn(
-          `Tool ${toolName} disabled due to missing environment variables: ${missingVars.join(", ")}`,
-        );
-      }
-    });
+    const clientManager = constructDefaultClientManager(env, cliOptions);
 
     const serverVersion = getPackageVersion();
     const server = new McpServer({
@@ -175,6 +214,12 @@ async function main() {
         clientVersion: clientInfo?.version,
       });
     };
+
+    const toolHandlers = getToolHandlersToRegister(
+      filteredToolNames,
+      cliOptions.disableConfluentCloudTools ?? false,
+      env,
+    );
 
     toolHandlers.forEach((handler, name) => {
       const config = handler.getToolConfig();
@@ -259,7 +304,6 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  logger.error({ error }, "Error starting server");
-  process.exit(1);
-});
+if (process.env.NODE_ENV !== "test") {
+  await main();
+}

--- a/tests/factories/cli-options.ts
+++ b/tests/factories/cli-options.ts
@@ -1,0 +1,26 @@
+import type { CLIOptions } from "@src/cli.js";
+import { TransportType } from "@src/mcp/transports/types.js";
+
+const BASE_CLI_OPTIONS: CLIOptions = {
+  transports: [TransportType.STDIO],
+  kafkaConfig: {},
+  envFile: undefined,
+  config: undefined,
+  allowTools: undefined,
+  blockTools: undefined,
+  listTools: false,
+  disableConfluentCloudTools: false,
+  disableAuth: false,
+  allowedHosts: undefined,
+  generateKey: false,
+};
+
+/**
+ * Constructs a minimal valid {@link CLIOptions} for use in tests.
+ * Pass overrides to exercise specific CLI option combinations.
+ */
+export function cliOptionsFactory(
+  overrides: Partial<CLIOptions> = {},
+): CLIOptions {
+  return { ...BASE_CLI_OPTIONS, ...overrides };
+}

--- a/tests/factories/env.ts
+++ b/tests/factories/env.ts
@@ -1,0 +1,51 @@
+import type { Environment } from "@src/env.js";
+
+const BASE_ENV: Environment = {
+  // envSchema fields — use Zod defaults
+  HTTP_PORT: 8080,
+  HTTP_HOST: "127.0.0.1",
+  HTTP_MCP_ENDPOINT_PATH: "/mcp",
+  SSE_MCP_ENDPOINT_PATH: "/sse",
+  SSE_MCP_MESSAGE_ENDPOINT_PATH: "/messages",
+  LOG_LEVEL: "info",
+  MCP_AUTH_DISABLED: false,
+  DO_NOT_TRACK: false,
+  MCP_ALLOWED_HOSTS: ["localhost", "127.0.0.1"],
+  // configSchema fields with defaults
+  CONFLUENT_CLOUD_REST_ENDPOINT: "https://api.confluent.cloud",
+  TELEMETRY_ENDPOINT: "https://api.telemetry.confluent.cloud",
+  // All credential / endpoint / runtime-config fields: absent
+  MCP_API_KEY: undefined,
+  BOOTSTRAP_SERVERS: undefined,
+  KAFKA_API_KEY: undefined,
+  KAFKA_API_SECRET: undefined,
+  FLINK_API_KEY: undefined,
+  FLINK_API_SECRET: undefined,
+  CONFLUENT_CLOUD_API_KEY: undefined,
+  CONFLUENT_CLOUD_API_SECRET: undefined,
+  SCHEMA_REGISTRY_API_KEY: undefined,
+  SCHEMA_REGISTRY_API_SECRET: undefined,
+  TABLEFLOW_API_KEY: undefined,
+  TABLEFLOW_API_SECRET: undefined,
+  FLINK_REST_ENDPOINT: undefined,
+  SCHEMA_REGISTRY_ENDPOINT: undefined,
+  KAFKA_REST_ENDPOINT: undefined,
+  TELEMETRY_API_KEY: undefined,
+  TELEMETRY_API_SECRET: undefined,
+  FLINK_ENV_ID: undefined,
+  FLINK_ORG_ID: undefined,
+  FLINK_COMPUTE_POOL_ID: undefined,
+  FLINK_ENV_NAME: undefined,
+  FLINK_DATABASE_NAME: undefined,
+  KAFKA_CLUSTER_ID: undefined,
+  KAFKA_ENV_ID: undefined,
+};
+
+/**
+ * Constructs a minimal valid {@link Environment} for use in tests.
+ * All credential and endpoint fields default to `undefined` (tool disabled).
+ * Pass overrides to selectively satisfy the env vars required by specific tools.
+ */
+export function envFactory(overrides: Partial<Environment> = {}): Environment {
+  return { ...BASE_ENV, ...overrides };
+}

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -2,8 +2,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ClientManager } from "@src/confluent/client-manager.js";
-import { ToolFactory } from "@src/confluent/tools/tool-factory.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
 
 export interface TestServerContext {
@@ -39,7 +39,7 @@ export async function createTestServer(
 
   const names = toolNames ?? Object.values(ToolName);
   for (const toolName of names) {
-    const handler = ToolFactory.createToolHandler(toolName);
+    const handler = ToolHandlerRegistry.getToolHandler(toolName);
     const config = handler.getToolConfig();
     server.registerTool(
       toolName as string,


### PR DESCRIPTION
1. Begin to split `main()` up into testable functions:
    * `getToolHandlersToRegister()`: Does the env and ccloud-based filtering, returning the final ToolHandlers to register. Throws if ends up with no tools to be registered, causing the process to exit. This was the original ask of the ticket, but there was so much more low hanging fruit to clean up.
    * `outputApiKey()`: prints out a generated MCP server API key to use.
    * `outputToolList()`: prints out the list of possible tools.
    * `constructDefaultClientManager()`: Construct the ClientManager given the env and cli options.
2.  Simplify and optimize `getFilteredToolNames()`:
    * take in the explicit name list strings to assist in yaml migration away from cmdline.
    * use set logic throughout.
    * ... and write tests.
3. Simplify and rename `ToolFactory` to `ToolHandlerRegistry` --- 
    * It was statically constructing all handlers all along up front, so is a registry, not a factory.
    * Remove the guards over testing instance of ToolName --- the single callpath (from main()) is guaranteed to be calling with valid names.
    * Simplify `getToolConfig()` by reëxpressing in terms of `getToolHandler()`.
    * Remove never called `getToolConfigs()`.
    
    
 `main()` got respelled quite a bit but remains uncovered, hence the SC complaint about coverage. As the configuration epic progresses, more and more of `main()` will get factored out and covered.


Closes #161 .