### PR TITLE
Interpolate env vars into YAML-loaded configuration prior to Zod validation.

### DIFF
--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -3,12 +3,12 @@ import {
   loadConfigFromYaml,
   parseYamlConfiguration,
 } from "@src/config/index.js";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import sinon from "sinon";
 import {
   createFsWrappers,
   type StubbedFsWrappers,
 } from "@tests/stubs/node-deps.js";
+import sinon from "sinon";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("config/index.ts", () => {
   describe("parseYamlConfiguration", () => {
@@ -20,7 +20,7 @@ describe("config/index.ts", () => {
       bootstrap_servers: "localhost:9092"
 `;
 
-      const config = parseYamlConfiguration(yamlContent);
+      const config = parseYamlConfiguration(yamlContent, {});
 
       expect(config.connections).toBeDefined();
       expect(Object.keys(config.connections)).toHaveLength(1);
@@ -42,7 +42,7 @@ describe("config/index.ts", () => {
       endpoint: "http://localhost:8081"
 `;
 
-      const config = parseYamlConfiguration(yamlContent);
+      const config = parseYamlConfiguration(yamlContent, {});
 
       expect(config.connections.local!.schema_registry).toBeDefined();
       expect(config.connections.local!.schema_registry?.endpoint).toBe(
@@ -58,7 +58,7 @@ describe("config/index.ts", () => {
       bootstrap_servers: "broker1:9092,broker2:9092,broker3:9092"
 `;
 
-      const config = parseYamlConfiguration(yamlContent);
+      const config = parseYamlConfiguration(yamlContent, {});
 
       expect(config.connections.cluster!.kafka!.bootstrap_servers).toBe(
         "broker1:9092,broker2:9092,broker3:9092",
@@ -72,7 +72,7 @@ describe("config/index.ts", () => {
     kafka: [unmatched bracket
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Failed to parse YAML/,
       );
     });
@@ -80,11 +80,11 @@ describe("config/index.ts", () => {
     it("should throw error when root is not an object", () => {
       const yamlContent = `"just a string"`;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
       // Should not have empty path prefix like "- :"
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /- Invalid input: expected object, received string/,
       );
     });
@@ -93,7 +93,7 @@ describe("config/index.ts", () => {
       const yamlContent = `some_other_field: "value"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
     });
@@ -105,7 +105,7 @@ describe("config/index.ts", () => {
       bootstrap_servers: "localhost:9092"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
     });
@@ -118,7 +118,7 @@ describe("config/index.ts", () => {
       bootstrap_servers: "localhost:9092"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
     });
@@ -129,10 +129,10 @@ describe("config/index.ts", () => {
     type: "direct"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /At least one of 'kafka' or 'schema_registry' must be defined/,
       );
     });
@@ -145,7 +145,7 @@ describe("config/index.ts", () => {
       some_other_field: "value"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
     });
@@ -158,7 +158,7 @@ describe("config/index.ts", () => {
       bootstrap_servers: ""
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
     });
@@ -171,10 +171,10 @@ describe("config/index.ts", () => {
       bootstrap_servers: "invalid-no-port"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Invalid format 'invalid-no-port': must be host:port/,
       );
     });
@@ -189,10 +189,10 @@ describe("config/index.ts", () => {
       endpoint: "not-a-url"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /must be a valid URL/,
       );
     });
@@ -207,7 +207,7 @@ describe("config/index.ts", () => {
       some_other_field: "value"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
     });
@@ -216,10 +216,10 @@ describe("config/index.ts", () => {
       const yamlContent = `connections: {}
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Exactly one connection must be defined/,
       );
     });
@@ -236,10 +236,10 @@ describe("config/index.ts", () => {
       bootstrap_servers: "staging:9092"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Exactly one connection must be defined/,
       );
     });
@@ -252,10 +252,10 @@ describe("config/index.ts", () => {
       bootstrap_servers: "localhost:9092"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Configuration validation failed/,
       );
-      expect(() => parseYamlConfiguration(yamlContent)).toThrow(
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
         /Invalid key in record/,
       );
     });
@@ -270,7 +270,7 @@ describe("config/index.ts", () => {
       endpoint: "https://schema-registry.example.com:8081"
 `;
 
-      const config = parseYamlConfiguration(yamlContent);
+      const config = parseYamlConfiguration(yamlContent, {});
 
       expect(config.connections.local!.schema_registry?.endpoint).toBe(
         "https://schema-registry.example.com:8081",
@@ -285,12 +285,71 @@ describe("config/index.ts", () => {
       endpoint: "http://localhost:8081"
 `;
 
-      const config = parseYamlConfiguration(yamlContent);
+      const config = parseYamlConfiguration(yamlContent, {});
 
       expect(config.connections.local!.schema_registry?.endpoint).toBe(
         "http://localhost:8081",
       );
       expect(config.connections.local!.kafka).toBeUndefined();
+    });
+
+    it("should interpolate ${VAR} references using provided env before Zod validation", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "\${BOOTSTRAP}"
+    schema_registry:
+      endpoint: "\${SR_URL}"
+`;
+
+      const config = parseYamlConfiguration(yamlContent, {
+        BOOTSTRAP: "broker1:9092",
+        SR_URL: "http://localhost:8081",
+      });
+
+      expect(config.connections.local!.kafka!.bootstrap_servers).toBe(
+        "broker1:9092",
+      );
+      expect(config.connections.local!.schema_registry!.endpoint).toBe(
+        "http://localhost:8081",
+      );
+    });
+
+    it("should raise a Zod validation error when an interpolated env var fails schema validation", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "\${BOOTSTRAP}"
+`;
+
+      expect(() =>
+        parseYamlConfiguration(yamlContent, {
+          BOOTSTRAP: "not-a-valid-host-port",
+        }),
+      ).toThrow(/Configuration validation failed/);
+      expect(() =>
+        parseYamlConfiguration(yamlContent, {
+          BOOTSTRAP: "not-a-valid-host-port",
+        }),
+      ).toThrow(/Invalid format 'not-a-valid-host-port': must be host:port/);
+    });
+
+    it("should throw when a referenced variable is missing from env", () => {
+      const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "\${MISSING_VAR}"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+        /Failed to interpolate configuration values/,
+      );
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+        /MISSING_VAR/,
+      );
     });
   });
 
@@ -316,7 +375,7 @@ describe("config/index.ts", () => {
       fsStubs.existsSync.returns(true);
       fsStubs.readFileSync.returns(yamlContent);
 
-      const config = loadConfigFromYaml("/path/to/config.yaml");
+      const config = loadConfigFromYaml("/path/to/config.yaml", {});
 
       expect(config.connections.local).toBeDefined();
       expect(config.connections.local!.kafka!.bootstrap_servers).toBe(
@@ -327,7 +386,7 @@ describe("config/index.ts", () => {
     it("should throw error when file does not exist", () => {
       fsStubs.existsSync.returns(false);
 
-      expect(() => loadConfigFromYaml("/nonexistent.yaml")).toThrow(
+      expect(() => loadConfigFromYaml("/nonexistent.yaml", {})).toThrow(
         /Configuration file not found/,
       );
     });
@@ -336,7 +395,7 @@ describe("config/index.ts", () => {
       fsStubs.existsSync.returns(true);
       fsStubs.readFileSync.returns("invalid: [yaml");
 
-      expect(() => loadConfigFromYaml("/path/to/config.yaml")).toThrow(
+      expect(() => loadConfigFromYaml("/path/to/config.yaml", {})).toThrow(
         /Failed to parse YAML/,
       );
     });
@@ -350,7 +409,7 @@ describe("config/index.ts", () => {
       fsStubs.existsSync.returns(true);
       fsStubs.readFileSync.returns(invalidYaml);
 
-      expect(() => loadConfigFromYaml("/path/to/config.yaml")).toThrow(
+      expect(() => loadConfigFromYaml("/path/to/config.yaml", {})).toThrow(
         /Configuration validation failed/,
       );
     });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,4 @@
+import { interpolateValues } from "@src/config/interpolation.js";
 import { MCPServerConfiguration, mcpConfigSchema } from "@src/config/models.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import path from "node:path";
@@ -9,12 +10,16 @@ export type { MCPServerConfiguration } from "@src/config/models.js";
  * Loads and validates an MCP server configuration from a YAML file.
  *
  * @param filePath - Path to the YAML configuration file
+ * @param env      - Environment variables used for ${VAR} interpolation
  * @returns Validated MCPServerConfiguration object
- * @throws Error if file doesn't exist, YAML is invalid, or validation fails
+ * @throws Error if file doesn't exist, YAML is invalid, interpolation fails, or validation fails
  */
-export function loadConfigFromYaml(filePath: string): MCPServerConfiguration {
+export function loadConfigFromYaml(
+  filePath: string,
+  env: Record<string, string | undefined>,
+): MCPServerConfiguration {
   const yamlContent = loadConfigFileContents(filePath);
-  return parseYamlConfiguration(yamlContent);
+  return parseYamlConfiguration(yamlContent, env);
 }
 
 /* All the rest of the functions in this file are internal helpers for loading and validating the configuration, only exported for
@@ -47,13 +52,16 @@ export function loadConfigFileContents(filePath: string): string {
 
 /**
  * Parses and validates YAML configuration content.
+ * Always performs ${VAR} and ${VAR:-default} interpolation before Zod validation.
  *
  * @param yamlContent - YAML string content
+ * @param env         - Environment variables used for ${VAR} interpolation
  * @returns Validated MCPServerConfiguration object
- * @throws Error if YAML is invalid or validation fails
+ * @throws Error if YAML is invalid, interpolation fails, or validation fails
  */
 export function parseYamlConfiguration(
   yamlContent: string,
+  env: Record<string, string | undefined>,
 ): MCPServerConfiguration {
   // Parse YAML
   let parsedYaml: unknown;
@@ -62,6 +70,15 @@ export function parseYamlConfiguration(
   } catch (error) {
     throw new Error(
       `Failed to parse YAML: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  // Interpolate environment variables (before Zod sees the values)
+  try {
+    parsedYaml = interpolateValues(parsedYaml, env);
+  } catch (error) {
+    throw new Error(
+      `Failed to interpolate configuration values: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 

--- a/src/config/interpolation.test.ts
+++ b/src/config/interpolation.test.ts
@@ -5,6 +5,7 @@ describe("config/interpolation.ts", () => {
   describe("interpolateValues", () => {
     const env = {
       MY_VAR: "hello",
+      MY_VAR_99: "99",
       EMPTY_VAR: "",
       MULTI: "a,b,c",
     };
@@ -12,6 +13,10 @@ describe("config/interpolation.ts", () => {
     describe("basic ${VAR} substitution", () => {
       it("should replace a known variable", () => {
         expect(interpolateValues("${MY_VAR}", env)).toBe("hello");
+      });
+
+      it("should replace a variable with a numeric suffix", () => {
+        expect(interpolateValues("${MY_VAR_99}", env)).toBe("99");
       });
 
       it("should replace a variable embedded in a larger string", () => {

--- a/src/config/interpolation.test.ts
+++ b/src/config/interpolation.test.ts
@@ -1,0 +1,144 @@
+import { interpolateValues } from "@src/config/interpolation.js";
+import { describe, expect, it } from "vitest";
+
+describe("config/interpolation.ts", () => {
+  describe("interpolateValues", () => {
+    const env = {
+      MY_VAR: "hello",
+      EMPTY_VAR: "",
+      MULTI: "a,b,c",
+    };
+
+    describe("basic ${VAR} substitution", () => {
+      it("should replace a known variable", () => {
+        expect(interpolateValues("${MY_VAR}", env)).toBe("hello");
+      });
+
+      it("should replace a variable embedded in a larger string", () => {
+        expect(interpolateValues("prefix-${MY_VAR}-suffix", env)).toBe(
+          "prefix-hello-suffix",
+        );
+      });
+
+      it("should replace multiple variables in one string", () => {
+        expect(interpolateValues("${MY_VAR}:${MULTI}", env)).toBe(
+          "hello:a,b,c",
+        );
+      });
+
+      it("should substitute an empty-string variable as empty string", () => {
+        expect(interpolateValues("${EMPTY_VAR}", env)).toBe("");
+      });
+    });
+
+    describe("${VAR:-default} default values", () => {
+      it("should use the default when the variable is absent", () => {
+        expect(interpolateValues("${MISSING:-fallback}", env)).toBe("fallback");
+      });
+
+      it("should use the actual value when the variable is present", () => {
+        expect(interpolateValues("${MY_VAR:-fallback}", env)).toBe("hello");
+      });
+
+      it("should use the actual value (empty string) when the variable is present but empty", () => {
+        // Variable exists in env with value ""; default should NOT kick in
+        expect(interpolateValues("${EMPTY_VAR:-fallback}", env)).toBe("");
+      });
+
+      it("should use an empty default when specified as ${VAR:-}", () => {
+        expect(interpolateValues("${MISSING:-}", env)).toBe("");
+      });
+    });
+
+    describe("$${...} escape sequences", () => {
+      it("should render $${LITERAL} as literal ${LITERAL}", () => {
+        expect(interpolateValues("$${LITERAL}", env)).toBe("${LITERAL}");
+      });
+
+      it("should not interpolate the escaped variable name", () => {
+        // MY_VAR is in env, but $${MY_VAR} should not be substituted
+        expect(interpolateValues("$${MY_VAR}", env)).toBe("${MY_VAR}");
+      });
+
+      it("should handle escape alongside a real substitution", () => {
+        expect(
+          interpolateValues("real=${MY_VAR} escaped=$${MY_VAR}", env),
+        ).toBe("real=hello escaped=${MY_VAR}");
+      });
+    });
+
+    describe("missing variable error handling", () => {
+      it("should throw a descriptive error for an undefined variable", () => {
+        expect(() => interpolateValues("${MISSING}", env)).toThrow(
+          "Environment variable not found: MISSING (referenced in ${MISSING})",
+        );
+      });
+    });
+
+    describe("recursive interpolation", () => {
+      it("should interpolate values in a nested object", () => {
+        const input = {
+          outer: "${MY_VAR}",
+          nested: {
+            inner: "${MULTI}",
+            deep: {
+              value: "${MY_VAR}-${MULTI}",
+            },
+          },
+        };
+        expect(interpolateValues(input, env)).toStrictEqual({
+          outer: "hello",
+          nested: {
+            inner: "a,b,c",
+            deep: {
+              value: "hello-a,b,c",
+            },
+          },
+        });
+      });
+
+      it("should interpolate values inside arrays", () => {
+        const input = ["${MY_VAR}", "${MULTI}", "literal"];
+        expect(interpolateValues(input, env)).toStrictEqual([
+          "hello",
+          "a,b,c",
+          "literal",
+        ]);
+      });
+
+      it("should interpolate strings inside arrays nested in objects", () => {
+        const input = { items: ["${MY_VAR}", "${MULTI}"] };
+        expect(interpolateValues(input, env)).toStrictEqual({
+          items: ["hello", "a,b,c"],
+        });
+      });
+    });
+
+    describe("non-string values are unchanged", () => {
+      it("should leave numbers unchanged", () => {
+        expect(interpolateValues(42, env)).toBe(42);
+      });
+
+      it("should leave booleans unchanged", () => {
+        expect(interpolateValues(true, env)).toBe(true);
+        expect(interpolateValues(false, env)).toBe(false);
+      });
+
+      it("should leave null unchanged", () => {
+        expect(interpolateValues(null, env)).toBeNull();
+      });
+
+      it("should leave undefined unchanged", () => {
+        expect(interpolateValues(undefined, env)).toBeUndefined();
+      });
+
+      it("should leave number fields in objects unchanged", () => {
+        const input = { port: 9092, host: "${MY_VAR}" };
+        expect(interpolateValues(input, env)).toStrictEqual({
+          port: 9092,
+          host: "hello",
+        });
+      });
+    });
+  });
+});

--- a/src/config/interpolation.ts
+++ b/src/config/interpolation.ts
@@ -3,7 +3,7 @@
 //   ${VAR}          — basic substitution (group 2 = var name, group 3 = undefined)
 //   ${VAR:-default} — substitution with default (group 2 = var name, group 3 = default)
 const INTERPOLATION_RE =
-  /\$\$\{([^}]*)\}|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([\s\S]*?))?\}/g;
+  /\$\$\{([^}]*)\}|\$\{([A-Za-z_]\w*)(?::-([\s\S]*?))?\}/g;
 
 function interpolateString(
   value: string,

--- a/src/config/interpolation.ts
+++ b/src/config/interpolation.ts
@@ -12,7 +12,7 @@ function interpolateString(
   return value.replaceAll(
     INTERPOLATION_RE,
     (
-      match,
+      _match,
       escaped: string | undefined,
       varName: string | undefined,
       defaultValue: string | undefined,

--- a/src/config/interpolation.ts
+++ b/src/config/interpolation.ts
@@ -1,0 +1,73 @@
+// Matches either:
+//   $${...}         — escape sequence (group 1 = inner text)
+//   ${VAR}          — basic substitution (group 2 = var name, group 3 = undefined)
+//   ${VAR:-default} — substitution with default (group 2 = var name, group 3 = default)
+const INTERPOLATION_RE =
+  /\$\$\{([^}]*)\}|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([\s\S]*?))?\}/g;
+
+function interpolateString(
+  value: string,
+  env: Record<string, string | undefined>,
+): string {
+  return value.replaceAll(
+    INTERPOLATION_RE,
+    (
+      match,
+      escaped: string | undefined,
+      varName: string | undefined,
+      defaultValue: string | undefined,
+    ) => {
+      // $${...} → literal ${...}
+      if (escaped !== undefined) {
+        return `\${${escaped}}`;
+      }
+
+      // ${VAR} or ${VAR:-default}
+      const resolved = varName ? env[varName] : undefined;
+      if (resolved !== undefined) {
+        return resolved;
+      }
+
+      // Variable is absent from env — use default if provided
+      if (defaultValue !== undefined) {
+        return defaultValue;
+      }
+
+      throw new Error(
+        `Environment variable not found: ${varName} (referenced in \${${varName}})`,
+      );
+    },
+  );
+}
+
+/**
+ * Recursively interpolates `${VAR}` and `${VAR:-default}` patterns in all
+ * string values of the given object/array/primitive. Non-string leaves
+ * (numbers, booleans, null, undefined) are returned unchanged.
+ *
+ * Escaping: `$${LITERAL}` is replaced with the literal text `${LITERAL}`.
+ */
+export function interpolateValues(
+  obj: unknown,
+  env: Record<string, string | undefined>,
+): unknown {
+  function walk(value: unknown): unknown {
+    if (typeof value === "string") {
+      return interpolateString(value, env);
+    }
+    if (Array.isArray(value)) {
+      return value.map(walk);
+    }
+    if (value !== null && typeof value === "object") {
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        result[k] = walk(v);
+      }
+      return result;
+    }
+    // number, boolean, null, undefined — unchanged
+    return value;
+  }
+
+  return walk(obj);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,11 +195,6 @@ async function main() {
 
     const clientManager = constructDefaultClientManager(env, cliOptions);
 
-    logger.info(
-      { enabledTools: [...toolHandlers.keys()] },
-      `${toolHandlers.size} tool(s) enabled`,
-    );
-
     const serverVersion = getPackageVersion();
     const server = new McpServer({
       name: "confluent",
@@ -224,6 +219,11 @@ async function main() {
       filteredToolNames,
       cliOptions.disableConfluentCloudTools ?? false,
       env,
+    );
+
+    logger.info(
+      { enabledTools: [...toolHandlers.keys()] },
+      `${toolHandlers.size} tool(s) enabled`,
     );
 
     toolHandlers.forEach((handler, name) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ async function main() {
 
     // Load and validate YAML configuration if --config is provided
     if (cliOptions.config) {
-      loadConfigFromYaml(cliOptions.config);
+      loadConfigFromYaml(cliOptions.config, process.env);
       // TODO(issue #151): Use config to construct connection manager instead of env vars
       logger.warn(
         "Configuration file parsed and validated successfully, but it is not applied yet; startup still uses" +


### PR DESCRIPTION
Interpolate env vars into post-YAML-loaded object so that YAML configurations can be built with structure but still not directly embed secrets.

Currently operates directly off of Process.env. Will revise in near future to prefer from explicit named env file contents through integration with the existing cmdline argument naming an env file, #175.

Closes #152.