### PR TITLE
feat(oauth): add OAuth type definitions and Auth0 environment config

### DIFF
--- a/src/confluent/oauth/auth0-config.test.ts
+++ b/src/confluent/oauth/auth0-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAuth0Config,
+  OAUTH_CALLBACK_PORT,
+  OAUTH_CALLBACK_PATH,
+} from "@src/confluent/oauth/auth0-config.js";
+import type { Auth0Environment } from "@src/confluent/oauth/types.js";
+
+describe("oauth/auth0-config.ts", () => {
+  describe("getAuth0Config", () => {
+    it("should return devel config with correct client ID", () => {
+      const config = getAuth0Config("devel");
+
+      expect(config.clientId).toBe("D8DV9ee7XrKX4ncAc6vJtBFgIzTMNgoY");
+      expect(config.domain).toBe("login.confluent.io");
+      expect(config.apiUrl).toBe("https://devel.cpdev.cloud");
+      expect(config.callbackUrl).toBe(
+        "http://127.0.0.1:26640/gateway/v1/callback-local-mcp-docs",
+      );
+      expect(config.scopes).toBe("email openid offline_access");
+    });
+
+    it("should return stag config with correct client ID", () => {
+      const config = getAuth0Config("stag");
+
+      expect(config.clientId).toBe("adtjckxmHbjddhNK36PvcXIDDbrJUMDH");
+      expect(config.apiUrl).toBe("https://stag.cpdev.cloud");
+    });
+
+    it("should return prod config with correct API URL", () => {
+      const config = getAuth0Config("prod");
+
+      expect(config.apiUrl).toBe("https://confluent.cloud");
+      expect(config.domain).toBe("login.confluent.io");
+    });
+
+    it("should use consistent callback URL across all environments", () => {
+      const environments: Auth0Environment[] = ["devel", "stag", "prod"];
+      const callbacks = environments.map(
+        (env) => getAuth0Config(env).callbackUrl,
+      );
+
+      expect(new Set(callbacks).size).toBe(1);
+      expect(callbacks[0]).toContain("127.0.0.1:26640");
+    });
+  });
+
+  describe("constants", () => {
+    it("should export the callback port", () => {
+      expect(OAUTH_CALLBACK_PORT).toBe(26640);
+    });
+
+    it("should export the callback path", () => {
+      expect(OAUTH_CALLBACK_PATH).toBe("/gateway/v1/callback-local-mcp-docs");
+    });
+  });
+});

--- a/src/confluent/oauth/auth0-config.test.ts
+++ b/src/confluent/oauth/auth0-config.test.ts
@@ -12,7 +12,7 @@ describe("oauth/auth0-config.ts", () => {
       const config = getAuth0Config("devel");
 
       expect(config.clientId).toBe("D8DV9ee7XrKX4ncAc6vJtBFgIzTMNgoY");
-      expect(config.domain).toBe("login.confluent.io");
+      expect(config.domain).toBe("login.confluent-dev.io");
       expect(config.apiUrl).toBe("https://devel.cpdev.cloud");
       expect(config.callbackUrl).toBe(
         "http://127.0.0.1:26640/gateway/v1/callback-local-mcp-docs",
@@ -24,6 +24,7 @@ describe("oauth/auth0-config.ts", () => {
       const config = getAuth0Config("stag");
 
       expect(config.clientId).toBe("adtjckxmHbjddhNK36PvcXIDDbrJUMDH");
+      expect(config.domain).toBe("login-stag.confluent-dev.io");
       expect(config.apiUrl).toBe("https://stag.cpdev.cloud");
     });
 

--- a/src/confluent/oauth/auth0-config.ts
+++ b/src/confluent/oauth/auth0-config.ts
@@ -7,26 +7,24 @@ export const OAUTH_CALLBACK_PORT = 26640;
 export const OAUTH_CALLBACK_PATH = "/gateway/v1/callback-local-mcp-docs";
 const OAUTH_CALLBACK_URL = `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
 const OAUTH_SCOPES = "email openid offline_access";
-const AUTH0_DOMAIN = "login.confluent.io";
-
 const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
   devel: {
     clientId: "D8DV9ee7XrKX4ncAc6vJtBFgIzTMNgoY",
-    domain: AUTH0_DOMAIN,
+    domain: "login.confluent-dev.io",
     apiUrl: "https://devel.cpdev.cloud",
     callbackUrl: OAUTH_CALLBACK_URL,
     scopes: OAUTH_SCOPES,
   },
   stag: {
     clientId: "adtjckxmHbjddhNK36PvcXIDDbrJUMDH",
-    domain: AUTH0_DOMAIN,
+    domain: "login-stag.confluent-dev.io",
     apiUrl: "https://stag.cpdev.cloud",
     callbackUrl: OAUTH_CALLBACK_URL,
     scopes: OAUTH_SCOPES,
   },
   prod: {
     clientId: "", // TBD: not yet registered in identity-login-static
-    domain: AUTH0_DOMAIN,
+    domain: "login.confluent.io",
     apiUrl: "https://confluent.cloud",
     callbackUrl: OAUTH_CALLBACK_URL,
     scopes: OAUTH_SCOPES,

--- a/src/confluent/oauth/auth0-config.ts
+++ b/src/confluent/oauth/auth0-config.ts
@@ -1,0 +1,38 @@
+import type {
+  Auth0Config,
+  Auth0Environment,
+} from "@src/confluent/oauth/types.js";
+
+export const OAUTH_CALLBACK_PORT = 26640;
+export const OAUTH_CALLBACK_PATH = "/gateway/v1/callback-local-mcp-docs";
+const OAUTH_CALLBACK_URL = `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
+const OAUTH_SCOPES = "email openid offline_access";
+const AUTH0_DOMAIN = "login.confluent.io";
+
+const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
+  devel: {
+    clientId: "D8DV9ee7XrKX4ncAc6vJtBFgIzTMNgoY",
+    domain: AUTH0_DOMAIN,
+    apiUrl: "https://devel.cpdev.cloud",
+    callbackUrl: OAUTH_CALLBACK_URL,
+    scopes: OAUTH_SCOPES,
+  },
+  stag: {
+    clientId: "adtjckxmHbjddhNK36PvcXIDDbrJUMDH",
+    domain: AUTH0_DOMAIN,
+    apiUrl: "https://stag.cpdev.cloud",
+    callbackUrl: OAUTH_CALLBACK_URL,
+    scopes: OAUTH_SCOPES,
+  },
+  prod: {
+    clientId: "", // TBD: not yet registered in identity-login-static
+    domain: AUTH0_DOMAIN,
+    apiUrl: "https://confluent.cloud",
+    callbackUrl: OAUTH_CALLBACK_URL,
+    scopes: OAUTH_SCOPES,
+  },
+};
+
+export function getAuth0Config(environment: Auth0Environment): Auth0Config {
+  return AUTH0_CONFIGS[environment];
+}

--- a/src/confluent/oauth/types.test.ts
+++ b/src/confluent/oauth/types.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Auth0Environment,
+  Auth0TokenResponse,
+  ConfluentTokenSet,
+  ControlPlaneTokenResponse,
+  DataPlaneTokenResponse,
+  OAuthConfig,
+} from "@src/confluent/oauth/types.js";
+
+describe("oauth/types.ts", () => {
+  describe("ConfluentTokenSet", () => {
+    it("should be constructable with all required fields", () => {
+      const tokenSet: ConfluentTokenSet = {
+        refreshToken: "refresh-abc",
+        refreshTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+        controlPlaneToken: "cp-token",
+        controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+        dataPlaneToken: "dp-token",
+        dataPlaneExpiresAt: Date.now() + 10 * 60 * 1000,
+        accessToken: "opaque-token",
+      };
+
+      expect(tokenSet.refreshToken).toBe("refresh-abc");
+      expect(tokenSet.accessToken).toBe("opaque-token");
+    });
+  });
+
+  describe("OAuthConfig", () => {
+    it("should accept valid environment values", () => {
+      const environments: Auth0Environment[] = ["devel", "stag", "prod"];
+      for (const env of environments) {
+        const config: OAuthConfig = { auth: "oauth", environment: env };
+        expect(config.environment).toBe(env);
+      }
+    });
+  });
+
+  describe("Auth0TokenResponse", () => {
+    it("should match expected Auth0 response shape", () => {
+      const response: Auth0TokenResponse = {
+        id_token: "eyJ...",
+        refresh_token: "v1.MZpf...",
+        access_token: "access...",
+        token_type: "Bearer",
+        expires_in: 60,
+      };
+
+      expect(response.id_token).toBe("eyJ...");
+      expect(response.expires_in).toBe(60);
+    });
+  });
+
+  describe("ControlPlaneTokenResponse", () => {
+    it("should match expected control plane response shape", () => {
+      const response: ControlPlaneTokenResponse = {
+        token: "cp-bearer-token",
+        expires_at: "2026-04-15T12:05:00Z",
+      };
+
+      expect(response.token).toBe("cp-bearer-token");
+    });
+  });
+
+  describe("DataPlaneTokenResponse", () => {
+    it("should match expected data plane response shape", () => {
+      const response: DataPlaneTokenResponse = {
+        token: "dp-bearer-token",
+        expires_at: "2026-04-15T12:10:00Z",
+      };
+
+      expect(response.token).toBe("dp-bearer-token");
+    });
+  });
+});

--- a/src/confluent/oauth/types.ts
+++ b/src/confluent/oauth/types.ts
@@ -1,0 +1,61 @@
+export type Auth0Environment = "devel" | "stag" | "prod";
+
+export interface Auth0Config {
+  clientId: string;
+  domain: string;
+  apiUrl: string;
+  callbackUrl: string;
+  scopes: string;
+}
+
+export interface ConfluentTokenSet {
+  /** Auth0 refresh token — single-use, rotated each refresh cycle */
+  refreshToken: string;
+  /** Absolute expiration of the refresh token (epoch ms). 8hr from original login. */
+  refreshTokenExpiresAt: number;
+
+  /** Confluent Cloud control plane token (Bearer token for api.confluent.cloud) */
+  controlPlaneToken: string;
+  /** Control plane token expiration (epoch ms). ~5 min TTL. */
+  controlPlaneExpiresAt: number;
+
+  /** Confluent Cloud data plane token (Bearer token for cluster-specific endpoints) */
+  dataPlaneToken: string;
+  /** Data plane token expiration (epoch ms). ~10 min TTL. */
+  dataPlaneExpiresAt: number;
+
+  /** Opaque access token returned to MCP clients. Stable across refreshes. */
+  accessToken: string;
+}
+
+export interface OAuthConfig {
+  auth: "oauth";
+  environment: Auth0Environment;
+}
+
+/**
+ * Response from POST login.confluent.io/oauth/token
+ */
+export interface Auth0TokenResponse {
+  id_token: string;
+  refresh_token: string;
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+/**
+ * Response from POST confluent.cloud/api/sessions
+ */
+export interface ControlPlaneTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+/**
+ * Response from POST confluent.cloud/api/access_tokens
+ */
+export interface DataPlaneTokenResponse {
+  token: string;
+  expires_at: string;
+}


### PR DESCRIPTION
### Summary
- Add `ConfluentTokenSet`, `Auth0Config`, `OAuthConfig`, and API response type definitions (`src/confluent/oauth/types.ts`)
- Add per-environment Auth0 configuration with correct login domains, client IDs, and API URLs (`src/confluent/oauth/auth0-config.ts`)
- 11 unit tests covering all types and config lookups

Closes #178

### PR Stack
- (this) #183
  - #185 
    - #187 
      - #193