### PR TITLE
feat(oauth): implement token exchange chain

### DIFF
--- a/src/confluent/node-deps.ts
+++ b/src/confluent/node-deps.ts
@@ -2,6 +2,7 @@
 import { Analytics } from "@segment/analytics-node";
 import { TELEMETRY_WRITE_KEY } from "@src/build-config.js";
 import envProxy from "@src/env.js";
+import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { arch, homedir, platform, release } from "node:os";
 import { join } from "node:path";
@@ -12,3 +13,5 @@ export const os = { homedir, platform, release, arch };
 export const path = { join };
 export const segment = { Analytics };
 export const config = { env: envProxy };
+export const nodeFetch = { fetch: globalThis.fetch };
+export const nodeCrypto = { randomBytes };

--- a/src/confluent/oauth/crypto-utils.test.ts
+++ b/src/confluent/oauth/crypto-utils.test.ts
@@ -11,7 +11,7 @@ describe("oauth/crypto-utils.ts", () => {
       const token = generateOpaqueToken();
 
       expect(token).toHaveLength(64);
-      expect(token).toMatch(/^[0-9a-f]{64}$/);
+      expect(Buffer.from(token, "hex")).toHaveLength(32);
     });
 
     it("should generate unique tokens on each call", () => {
@@ -26,9 +26,7 @@ describe("oauth/crypto-utils.ts", () => {
     it("should return a base64url-encoded string of appropriate length", () => {
       const verifier = generateCodeVerifier();
 
-      // 32 bytes → 43 base64url characters (no padding)
-      expect(verifier.length).toBeGreaterThanOrEqual(43);
-      expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(Buffer.from(verifier, "base64url")).toHaveLength(32);
     });
   });
 
@@ -37,9 +35,7 @@ describe("oauth/crypto-utils.ts", () => {
       const verifier = generateCodeVerifier();
       const challenge = generateCodeChallenge(verifier);
 
-      // SHA-256 → 32 bytes → 43 base64url characters
-      expect(challenge.length).toBe(43);
-      expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(Buffer.from(challenge, "base64url")).toHaveLength(32);
     });
 
     it("should produce different challenges for different verifiers", () => {

--- a/src/confluent/oauth/crypto-utils.test.ts
+++ b/src/confluent/oauth/crypto-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateOpaqueToken,
+  generateCodeVerifier,
+  generateCodeChallenge,
+} from "@src/confluent/oauth/crypto-utils.js";
+
+describe("oauth/crypto-utils.ts", () => {
+  describe("generateOpaqueToken", () => {
+    it("should return a 64-character hex string", () => {
+      const token = generateOpaqueToken();
+
+      expect(token).toHaveLength(64);
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("should generate unique tokens on each call", () => {
+      const token1 = generateOpaqueToken();
+      const token2 = generateOpaqueToken();
+
+      expect(token1).not.toBe(token2);
+    });
+  });
+
+  describe("generateCodeVerifier", () => {
+    it("should return a base64url-encoded string of appropriate length", () => {
+      const verifier = generateCodeVerifier();
+
+      // 32 bytes → 43 base64url characters (no padding)
+      expect(verifier.length).toBeGreaterThanOrEqual(43);
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  describe("generateCodeChallenge", () => {
+    it("should return a base64url-encoded SHA-256 hash of the verifier", () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+
+      // SHA-256 → 32 bytes → 43 base64url characters
+      expect(challenge.length).toBe(43);
+      expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it("should produce different challenges for different verifiers", () => {
+      const challenge1 = generateCodeChallenge("verifier-1");
+      const challenge2 = generateCodeChallenge("verifier-2");
+
+      expect(challenge1).not.toBe(challenge2);
+    });
+
+    it("should produce the same challenge for the same verifier", () => {
+      const verifier = "deterministic-verifier";
+      const challenge1 = generateCodeChallenge(verifier);
+      const challenge2 = generateCodeChallenge(verifier);
+
+      expect(challenge1).toBe(challenge2);
+    });
+  });
+});

--- a/src/confluent/oauth/crypto-utils.ts
+++ b/src/confluent/oauth/crypto-utils.ts
@@ -1,0 +1,25 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Generates a cryptographically secure opaque access token.
+ * Returns a 64-character hex string (32 random bytes).
+ */
+export function generateOpaqueToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Generates a PKCE code verifier (RFC 7636).
+ * Returns a base64url-encoded string of 32 random bytes.
+ */
+export function generateCodeVerifier(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Generates a PKCE code challenge from a code verifier (RFC 7636, S256 method).
+ * Returns the base64url-encoded SHA-256 hash of the verifier.
+ */
+export function generateCodeChallenge(codeVerifier: string): string {
+  return createHash("sha256").update(codeVerifier).digest("base64url");
+}

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import sinon from "sinon";
+import { nodeFetch } from "@src/confluent/node-deps.js";
+import {
+  exchangeAuthCodeForTokens,
+  exchangeIdTokenForControlPlaneToken,
+  exchangeControlPlaneForDataPlaneToken,
+  refreshTokenChain,
+  executeFullTokenChain,
+} from "@src/confluent/oauth/token-chain.js";
+import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
+
+describe("oauth/token-chain.ts", () => {
+  const sandbox = sinon.createSandbox();
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fetchStub = sandbox.stub(nodeFetch, "fetch");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("exchangeAuthCodeForTokens", () => {
+    const auth0Config = getAuth0Config("devel");
+
+    it("should exchange auth code for ID token and refresh token", async () => {
+      const mockResponse = {
+        id_token: "mock-id-token",
+        refresh_token: "mock-refresh-token",
+        access_token: "mock-access-token",
+        token_type: "Bearer",
+        expires_in: 60,
+      };
+
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await exchangeAuthCodeForTokens(
+        auth0Config,
+        "test-auth-code",
+        "test-code-verifier",
+      );
+
+      expect(result.id_token).toBe("mock-id-token");
+      expect(result.refresh_token).toBe("mock-refresh-token");
+
+      sinon.assert.calledOnce(fetchStub);
+      const [url, options] = fetchStub.firstCall.args;
+      expect(url).toBe("https://login.confluent.io/oauth/token");
+      expect(options.method).toBe("POST");
+
+      const body = new URLSearchParams(options.body);
+      expect(body.get("grant_type")).toBe("authorization_code");
+      expect(body.get("code")).toBe("test-auth-code");
+      expect(body.get("code_verifier")).toBe("test-code-verifier");
+      expect(body.get("client_id")).toBe(auth0Config.clientId);
+      expect(body.get("redirect_uri")).toBe(auth0Config.callbackUrl);
+    });
+
+    it("should throw on non-200 response", async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+        }),
+      );
+
+      await expect(
+        exchangeAuthCodeForTokens(auth0Config, "bad-code", "verifier"),
+      ).rejects.toThrow(/Auth0 token exchange failed/);
+    });
+  });
+
+  describe("exchangeIdTokenForControlPlaneToken", () => {
+    it("should exchange ID token for control plane token", async () => {
+      const mockResponse = {
+        token: "cp-bearer-token-123",
+      };
+
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await exchangeIdTokenForControlPlaneToken(
+        "https://devel.cpdev.cloud",
+        "mock-id-token",
+      );
+
+      expect(result.token).toBe("cp-bearer-token-123");
+
+      sinon.assert.calledOnce(fetchStub);
+      const [url, options] = fetchStub.firstCall.args;
+      expect(url).toBe("https://devel.cpdev.cloud/api/sessions");
+      expect(options.method).toBe("POST");
+      expect(options.headers["Content-Type"]).toBe("application/json");
+
+      const body = JSON.parse(options.body);
+      expect(body.id_token).toBe("mock-id-token");
+    });
+
+    it("should throw on non-200 response", async () => {
+      fetchStub.resolves(new Response("Unauthorized", { status: 401 }));
+
+      await expect(
+        exchangeIdTokenForControlPlaneToken(
+          "https://devel.cpdev.cloud",
+          "bad-token",
+        ),
+      ).rejects.toThrow(/Control plane token exchange failed/);
+    });
+  });
+
+  describe("exchangeControlPlaneForDataPlaneToken", () => {
+    it("should exchange control plane token for data plane token", async () => {
+      const mockResponse = {
+        token: "dp-bearer-token-456",
+      };
+
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await exchangeControlPlaneForDataPlaneToken(
+        "https://devel.cpdev.cloud",
+        "cp-bearer-token-123",
+      );
+
+      expect(result.token).toBe("dp-bearer-token-456");
+
+      sinon.assert.calledOnce(fetchStub);
+      const [url, options] = fetchStub.firstCall.args;
+      expect(url).toBe("https://devel.cpdev.cloud/api/access_tokens");
+      expect(options.method).toBe("POST");
+      expect(options.headers["Authorization"]).toBe(
+        "Bearer cp-bearer-token-123",
+      );
+
+      const body = JSON.parse(options.body);
+      expect(body).toEqual({});
+    });
+
+    it("should throw on non-200 response", async () => {
+      fetchStub.resolves(new Response("Forbidden", { status: 403 }));
+
+      await expect(
+        exchangeControlPlaneForDataPlaneToken(
+          "https://devel.cpdev.cloud",
+          "bad-cp-token",
+        ),
+      ).rejects.toThrow(/Data plane token exchange failed/);
+    });
+  });
+
+  describe("refreshTokenChain", () => {
+    const auth0Config = getAuth0Config("devel");
+
+    it("should use refresh token to get new ID token and derive CP + DP tokens", async () => {
+      // First call: refresh token → Auth0 token endpoint
+      fetchStub.onCall(0).resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "new-id-token",
+            refresh_token: "new-refresh-token",
+            access_token: "new-access",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      // Second call: ID token → control plane
+      fetchStub.onCall(1).resolves(
+        new Response(
+          JSON.stringify({
+            token: "new-cp-token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      // Third call: CP token → data plane
+      fetchStub.onCall(2).resolves(
+        new Response(
+          JSON.stringify({
+            token: "new-dp-token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      const result = await refreshTokenChain(auth0Config, "old-refresh-token");
+
+      expect(result.refreshToken).toBe("new-refresh-token");
+      expect(result.controlPlaneToken).toBe("new-cp-token");
+      expect(result.dataPlaneToken).toBe("new-dp-token");
+
+      sinon.assert.calledThrice(fetchStub);
+
+      // Verify the refresh token call uses grant_type=refresh_token
+      const [, refreshOpts] = fetchStub.firstCall.args;
+      const refreshBody = new URLSearchParams(refreshOpts.body);
+      expect(refreshBody.get("grant_type")).toBe("refresh_token");
+      expect(refreshBody.get("refresh_token")).toBe("old-refresh-token");
+    });
+  });
+
+  describe("executeFullTokenChain", () => {
+    const auth0Config = getAuth0Config("devel");
+
+    it("should run auth code → ID → CP → DP chain", async () => {
+      // First call: auth code → Auth0 tokens
+      fetchStub.onCall(0).resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "id-token",
+            refresh_token: "refresh-token",
+            access_token: "access",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      // Second call: ID → CP
+      fetchStub.onCall(1).resolves(
+        new Response(
+          JSON.stringify({
+            token: "cp-token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      // Third call: CP → DP
+      fetchStub.onCall(2).resolves(
+        new Response(
+          JSON.stringify({
+            token: "dp-token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      const result = await executeFullTokenChain(
+        auth0Config,
+        "auth-code",
+        "code-verifier",
+      );
+
+      expect(result.refreshToken).toBe("refresh-token");
+      expect(result.controlPlaneToken).toBe("cp-token");
+      expect(result.dataPlaneToken).toBe("dp-token");
+      expect(result.controlPlaneExpiresAt).toBeGreaterThan(0);
+      expect(result.dataPlaneExpiresAt).toBeGreaterThan(0);
+      expect(result.refreshTokenExpiresAt).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -52,7 +52,7 @@ describe("oauth/token-chain.ts", () => {
 
       sinon.assert.calledOnce(fetchStub);
       const [url, options] = fetchStub.firstCall.args;
-      expect(url).toBe("https://login.confluent.io/oauth/token");
+      expect(url).toBe("https://login.confluent-dev.io/oauth/token");
       expect(options.method).toBe("POST");
 
       const body = new URLSearchParams(options.body);

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -10,6 +10,9 @@ import {
 } from "@src/confluent/oauth/token-chain.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;
+
 describe("oauth/token-chain.ts", () => {
   const sandbox = sinon.createSandbox();
   let fetchStub: sinon.SinonStub;
@@ -205,6 +208,14 @@ describe("oauth/token-chain.ts", () => {
       expect(result.refreshToken).toBe("new-refresh-token");
       expect(result.controlPlaneToken).toBe("new-cp-token");
       expect(result.dataPlaneToken).toBe("new-dp-token");
+      // Refresh should reset idle (4hr) but NOT set absolute (8hr)
+      expect(result.refreshTokenIdleExpiresAt).toBeGreaterThan(
+        Date.now() + FOUR_HOURS_MS - 5000,
+      );
+      expect(result.refreshTokenIdleExpiresAt).toBeLessThanOrEqual(
+        Date.now() + FOUR_HOURS_MS,
+      );
+      expect(result.refreshTokenAbsoluteExpiresAt).toBeUndefined();
 
       sinon.assert.calledThrice(fetchStub);
 
@@ -265,7 +276,13 @@ describe("oauth/token-chain.ts", () => {
       expect(result.dataPlaneToken).toBe("dp-token");
       expect(result.controlPlaneExpiresAt).toBeGreaterThan(0);
       expect(result.dataPlaneExpiresAt).toBeGreaterThan(0);
-      expect(result.refreshTokenExpiresAt).toBeGreaterThan(0);
+      // Initial login sets both absolute (8hr) and idle (4hr)
+      expect(result.refreshTokenAbsoluteExpiresAt).toBeGreaterThan(
+        Date.now() + EIGHT_HOURS_MS - 5000,
+      );
+      expect(result.refreshTokenIdleExpiresAt).toBeGreaterThan(
+        Date.now() + FOUR_HOURS_MS - 5000,
+      );
     });
   });
 });

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -77,6 +77,16 @@ describe("oauth/token-chain.ts", () => {
         exchangeAuthCodeForTokens(auth0Config, "bad-code", "verifier"),
       ).rejects.toThrow(/Auth0 token exchange failed/);
     });
+
+    it("should throw a timeout error when the fetch aborts", async () => {
+      const timeoutError = new Error("The operation was aborted");
+      timeoutError.name = "TimeoutError";
+      fetchStub.rejects(timeoutError);
+
+      await expect(
+        exchangeAuthCodeForTokens(auth0Config, "code", "verifier"),
+      ).rejects.toThrow(/Auth0 token exchange timed out/);
+    });
   });
 
   describe("exchangeIdTokenForControlPlaneToken", () => {

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -13,12 +13,18 @@ const CONTROL_PLANE_TOKEN_LIFETIME_MS = 5 * 60 * 1000;
 /** 10 minutes in milliseconds — data plane token lifetime */
 const DATA_PLANE_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
 
-/** 8 hours in milliseconds — refresh token absolute lifetime */
+/** 8 hours in milliseconds — refresh token absolute lifetime from original login */
 const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
+
+/** 4 hours in milliseconds — refresh token idle timeout, resets on each rotation */
+const REFRESH_TOKEN_IDLE_LIFETIME_MS = 4 * 60 * 60 * 1000;
 
 export interface TokenChainResult {
   refreshToken: string;
-  refreshTokenExpiresAt: number;
+  /** Only set on initial login. Absent on refresh — callers must preserve the original value. */
+  refreshTokenAbsoluteExpiresAt?: number;
+  /** Reset on every rotation (initial login and refresh). */
+  refreshTokenIdleExpiresAt: number;
   controlPlaneToken: string;
   controlPlaneExpiresAt: number;
   dataPlaneToken: string;
@@ -162,6 +168,8 @@ export async function refreshTokenChain(
 /**
  * Runs the full token chain from an authorization code.
  * auth code → ID token + refresh token → control plane → data plane
+ *
+ * Sets both absolute (8hr) and idle (4hr) refresh token expiry.
  */
 export async function executeFullTokenChain(
   auth0Config: Auth0Config,
@@ -174,12 +182,20 @@ export async function executeFullTokenChain(
     codeVerifier,
   );
 
-  return deriveConfluentTokens(auth0Config, auth0Response);
+  const result = await deriveConfluentTokens(auth0Config, auth0Response);
+
+  return {
+    ...result,
+    refreshTokenAbsoluteExpiresAt:
+      Date.now() + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+  };
 }
 
 /**
  * Given Auth0 tokens, derives Confluent control plane and data plane tokens.
  * Expiration times are computed client-side using fixed durations.
+ *
+ * Does NOT set refreshTokenAbsoluteExpiresAt — that is only set on initial login.
  */
 async function deriveConfluentTokens(
   auth0Config: Auth0Config,
@@ -199,7 +215,7 @@ async function deriveConfluentTokens(
 
   return {
     refreshToken: auth0Response.refresh_token,
-    refreshTokenExpiresAt: now + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+    refreshTokenIdleExpiresAt: now + REFRESH_TOKEN_IDLE_LIFETIME_MS,
     controlPlaneToken: cpResponse.token,
     controlPlaneExpiresAt: now + CONTROL_PLANE_TOKEN_LIFETIME_MS,
     dataPlaneToken: dpResponse.token,

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -19,6 +19,12 @@ const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
 /** 4 hours in milliseconds — refresh token idle timeout, resets on each rotation */
 const REFRESH_TOKEN_IDLE_LIFETIME_MS = 4 * 60 * 60 * 1000;
 
+/**
+ * Result of a single token-chain execution — either the initial login
+ * ({@link executeFullTokenChain}) or a subsequent refresh ({@link refreshTokenChain}).
+ * Callers persist this into the token store so downstream CP/DP requests can
+ * retrieve still-valid credentials.
+ */
 export interface TokenChainResult {
   refreshToken: string;
   /** Only set on initial login. Absent on refresh — callers must preserve the original value. */
@@ -32,6 +38,26 @@ export interface TokenChainResult {
 }
 
 /**
+ * POSTs to the OAuth/Confluent endpoint and returns the decoded JSON body,
+ * throwing a labeled error when the response is not OK.
+ */
+async function postJson<T>(
+  url: string,
+  init: RequestInit,
+  operation: string,
+): Promise<T> {
+  const response = await nodeFetch.fetch(url, init);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error({ status: response.status }, `${operation} failed`);
+    throw new Error(`${operation} failed (${response.status}): ${errorText}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+/**
  * Exchanges an authorization code for Auth0 tokens (ID token + refresh token).
  * This is the first step in the Confluent token chain.
  */
@@ -40,8 +66,6 @@ export async function exchangeAuthCodeForTokens(
   authCode: string,
   codeVerifier: string,
 ): Promise<Auth0TokenResponse> {
-  const tokenUrl = `https://${auth0Config.domain}/oauth/token`;
-
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     client_id: auth0Config.clientId,
@@ -50,21 +74,15 @@ export async function exchangeAuthCodeForTokens(
     redirect_uri: auth0Config.callbackUrl,
   });
 
-  const response = await nodeFetch.fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    logger.error({ status: response.status }, "Auth0 token exchange failed");
-    throw new Error(
-      `Auth0 token exchange failed (${response.status}): ${errorText}`,
-    );
-  }
-
-  return (await response.json()) as Auth0TokenResponse;
+  return postJson<Auth0TokenResponse>(
+    `https://${auth0Config.domain}/oauth/token`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    },
+    "Auth0 token exchange",
+  );
 }
 
 /**
@@ -75,26 +93,15 @@ export async function exchangeIdTokenForControlPlaneToken(
   apiUrl: string,
   idToken: string,
 ): Promise<ControlPlaneTokenResponse> {
-  const url = `${apiUrl}/api/sessions`;
-
-  const response = await nodeFetch.fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id_token: idToken }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    logger.error(
-      { status: response.status },
-      "Control plane token exchange failed",
-    );
-    throw new Error(
-      `Control plane token exchange failed (${response.status}): ${errorText}`,
-    );
-  }
-
-  return (await response.json()) as ControlPlaneTokenResponse;
+  return postJson<ControlPlaneTokenResponse>(
+    `${apiUrl}/api/sessions`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id_token: idToken }),
+    },
+    "Control plane token exchange",
+  );
 }
 
 /**
@@ -105,29 +112,18 @@ export async function exchangeControlPlaneForDataPlaneToken(
   apiUrl: string,
   controlPlaneToken: string,
 ): Promise<DataPlaneTokenResponse> {
-  const url = `${apiUrl}/api/access_tokens`;
-
-  const response = await nodeFetch.fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${controlPlaneToken}`,
+  return postJson<DataPlaneTokenResponse>(
+    `${apiUrl}/api/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${controlPlaneToken}`,
+      },
+      body: JSON.stringify({}),
     },
-    body: JSON.stringify({}),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    logger.error(
-      { status: response.status },
-      "Data plane token exchange failed",
-    );
-    throw new Error(
-      `Data plane token exchange failed (${response.status}): ${errorText}`,
-    );
-  }
-
-  return (await response.json()) as DataPlaneTokenResponse;
+    "Data plane token exchange",
+  );
 }
 
 /**
@@ -138,29 +134,21 @@ export async function refreshTokenChain(
   auth0Config: Auth0Config,
   refreshToken: string,
 ): Promise<TokenChainResult> {
-  const tokenUrl = `https://${auth0Config.domain}/oauth/token`;
-
   const body = new URLSearchParams({
     grant_type: "refresh_token",
     client_id: auth0Config.clientId,
     refresh_token: refreshToken,
   });
 
-  const response = await nodeFetch.fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    logger.error({ status: response.status }, "Auth0 token refresh failed");
-    throw new Error(
-      `Auth0 token refresh failed (${response.status}): ${errorText}`,
-    );
-  }
-
-  const auth0Response = (await response.json()) as Auth0TokenResponse;
+  const auth0Response = await postJson<Auth0TokenResponse>(
+    `https://${auth0Config.domain}/oauth/token`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    },
+    "Auth0 token refresh",
+  );
 
   return deriveConfluentTokens(auth0Config, auth0Response);
 }

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -19,6 +19,9 @@ const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
 /** 4 hours in milliseconds — refresh token idle timeout, resets on each rotation */
 const REFRESH_TOKEN_IDLE_LIFETIME_MS = 4 * 60 * 60 * 1000;
 
+/** Per-request timeout bounding each Auth0/Confluent HTTP call. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 /**
  * Result of a single token-chain execution — either the initial login
  * ({@link executeFullTokenChain}) or a subsequent refresh ({@link refreshTokenChain}).
@@ -39,14 +42,28 @@ export interface TokenChainResult {
 
 /**
  * POSTs to the OAuth/Confluent endpoint and returns the decoded JSON body,
- * throwing a labeled error when the response is not OK.
+ * throwing a labeled error when the response is not OK. Each request is bounded
+ * by {@link REQUEST_TIMEOUT_MS} so a hung Auth0/Confluent call can't stall the
+ * refresh loop.
  */
 async function postJson<T>(
   url: string,
   init: RequestInit,
   operation: string,
 ): Promise<T> {
-  const response = await nodeFetch.fetch(url, init);
+  let response: Response;
+  try {
+    response = await nodeFetch.fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      logger.error(`${operation} timed out`);
+      throw new Error(`${operation} timed out after ${REQUEST_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  }
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -1,0 +1,208 @@
+import type {
+  Auth0Config,
+  Auth0TokenResponse,
+  ControlPlaneTokenResponse,
+  DataPlaneTokenResponse,
+} from "@src/confluent/oauth/types.js";
+import { nodeFetch } from "@src/confluent/node-deps.js";
+import { logger } from "@src/logger.js";
+
+/** 5 minutes in milliseconds — control plane token lifetime */
+const CONTROL_PLANE_TOKEN_LIFETIME_MS = 5 * 60 * 1000;
+
+/** 10 minutes in milliseconds — data plane token lifetime */
+const DATA_PLANE_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
+
+/** 8 hours in milliseconds — refresh token absolute lifetime */
+const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
+
+export interface TokenChainResult {
+  refreshToken: string;
+  refreshTokenExpiresAt: number;
+  controlPlaneToken: string;
+  controlPlaneExpiresAt: number;
+  dataPlaneToken: string;
+  dataPlaneExpiresAt: number;
+}
+
+/**
+ * Exchanges an authorization code for Auth0 tokens (ID token + refresh token).
+ * This is the first step in the Confluent token chain.
+ */
+export async function exchangeAuthCodeForTokens(
+  auth0Config: Auth0Config,
+  authCode: string,
+  codeVerifier: string,
+): Promise<Auth0TokenResponse> {
+  const tokenUrl = `https://${auth0Config.domain}/oauth/token`;
+
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: auth0Config.clientId,
+    code: authCode,
+    code_verifier: codeVerifier,
+    redirect_uri: auth0Config.callbackUrl,
+  });
+
+  const response = await nodeFetch.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error({ status: response.status }, "Auth0 token exchange failed");
+    throw new Error(
+      `Auth0 token exchange failed (${response.status}): ${errorText}`,
+    );
+  }
+
+  return (await response.json()) as Auth0TokenResponse;
+}
+
+/**
+ * Exchanges an Auth0 ID token for a Confluent Cloud control plane token.
+ * POST {apiUrl}/api/sessions with the ID token in the body.
+ */
+export async function exchangeIdTokenForControlPlaneToken(
+  apiUrl: string,
+  idToken: string,
+): Promise<ControlPlaneTokenResponse> {
+  const url = `${apiUrl}/api/sessions`;
+
+  const response = await nodeFetch.fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id_token: idToken }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error(
+      { status: response.status },
+      "Control plane token exchange failed",
+    );
+    throw new Error(
+      `Control plane token exchange failed (${response.status}): ${errorText}`,
+    );
+  }
+
+  return (await response.json()) as ControlPlaneTokenResponse;
+}
+
+/**
+ * Exchanges a control plane token for a Confluent Cloud data plane token.
+ * POST {apiUrl}/api/access_tokens with the CP token as Bearer auth.
+ */
+export async function exchangeControlPlaneForDataPlaneToken(
+  apiUrl: string,
+  controlPlaneToken: string,
+): Promise<DataPlaneTokenResponse> {
+  const url = `${apiUrl}/api/access_tokens`;
+
+  const response = await nodeFetch.fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${controlPlaneToken}`,
+    },
+    body: JSON.stringify({}),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error(
+      { status: response.status },
+      "Data plane token exchange failed",
+    );
+    throw new Error(
+      `Data plane token exchange failed (${response.status}): ${errorText}`,
+    );
+  }
+
+  return (await response.json()) as DataPlaneTokenResponse;
+}
+
+/**
+ * Uses a refresh token to obtain new Auth0 tokens, then derives CP and DP tokens.
+ * This is used by the background refresh loop.
+ */
+export async function refreshTokenChain(
+  auth0Config: Auth0Config,
+  refreshToken: string,
+): Promise<TokenChainResult> {
+  const tokenUrl = `https://${auth0Config.domain}/oauth/token`;
+
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: auth0Config.clientId,
+    refresh_token: refreshToken,
+  });
+
+  const response = await nodeFetch.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error({ status: response.status }, "Auth0 token refresh failed");
+    throw new Error(
+      `Auth0 token refresh failed (${response.status}): ${errorText}`,
+    );
+  }
+
+  const auth0Response = (await response.json()) as Auth0TokenResponse;
+
+  return deriveConfluentTokens(auth0Config, auth0Response);
+}
+
+/**
+ * Runs the full token chain from an authorization code.
+ * auth code → ID token + refresh token → control plane → data plane
+ */
+export async function executeFullTokenChain(
+  auth0Config: Auth0Config,
+  authCode: string,
+  codeVerifier: string,
+): Promise<TokenChainResult> {
+  const auth0Response = await exchangeAuthCodeForTokens(
+    auth0Config,
+    authCode,
+    codeVerifier,
+  );
+
+  return deriveConfluentTokens(auth0Config, auth0Response);
+}
+
+/**
+ * Given Auth0 tokens, derives Confluent control plane and data plane tokens.
+ * Expiration times are computed client-side using fixed durations.
+ */
+async function deriveConfluentTokens(
+  auth0Config: Auth0Config,
+  auth0Response: Auth0TokenResponse,
+): Promise<TokenChainResult> {
+  const cpResponse = await exchangeIdTokenForControlPlaneToken(
+    auth0Config.apiUrl,
+    auth0Response.id_token,
+  );
+
+  const dpResponse = await exchangeControlPlaneForDataPlaneToken(
+    auth0Config.apiUrl,
+    cpResponse.token,
+  );
+
+  const now = Date.now();
+
+  return {
+    refreshToken: auth0Response.refresh_token,
+    refreshTokenExpiresAt: now + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+    controlPlaneToken: cpResponse.token,
+    controlPlaneExpiresAt: now + CONTROL_PLANE_TOKEN_LIFETIME_MS,
+    dataPlaneToken: dpResponse.token,
+    dataPlaneExpiresAt: now + DATA_PLANE_TOKEN_LIFETIME_MS,
+  };
+}

--- a/src/confluent/oauth/types.test.ts
+++ b/src/confluent/oauth/types.test.ts
@@ -13,7 +13,8 @@ describe("oauth/types.ts", () => {
     it("should be constructable with all required fields", () => {
       const tokenSet: ConfluentTokenSet = {
         refreshToken: "refresh-abc",
-        refreshTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+        refreshTokenAbsoluteExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+        refreshTokenIdleExpiresAt: Date.now() + 4 * 60 * 60 * 1000,
         controlPlaneToken: "cp-token",
         controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
         dataPlaneToken: "dp-token",

--- a/src/confluent/oauth/types.ts
+++ b/src/confluent/oauth/types.ts
@@ -11,8 +11,10 @@ export interface Auth0Config {
 export interface ConfluentTokenSet {
   /** Auth0 refresh token — single-use, rotated each refresh cycle */
   refreshToken: string;
-  /** Absolute expiration of the refresh token (epoch ms). 8hr from original login. */
-  refreshTokenExpiresAt: number;
+  /** Absolute expiration of the refresh token family (epoch ms). 8hr from original login. */
+  refreshTokenAbsoluteExpiresAt: number;
+  /** Idle expiration of the current refresh token (epoch ms). 4hr from last rotation. */
+  refreshTokenIdleExpiresAt: number;
 
   /** Confluent Cloud control plane token (Bearer token for api.confluent.cloud) */
   controlPlaneToken: string;

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -1,1 +1,9 @@
 export { createStubAdmin, type StubbedAdmin } from "./admin.js";
+export {
+  createFsWrappers,
+  type StubbedFsWrappers,
+  createFetchWrapper,
+  type StubbedFetchWrapper,
+  createCryptoWrapper,
+  type StubbedCryptoWrapper,
+} from "./node-deps.js";

--- a/tests/stubs/node-deps.ts
+++ b/tests/stubs/node-deps.ts
@@ -36,3 +36,35 @@ export function createFsWrappers(
     mkdirSync: sandbox.stub(nodeDeps.fs, "mkdirSync"),
   };
 }
+
+/** Stubbed fetch wrapper from {@link nodeDeps.nodeFetch}. */
+export type StubbedFetchWrapper = {
+  fetch: sinon.SinonStub;
+};
+
+/**
+ * Stubs the fetch wrapper in {@link nodeDeps.nodeFetch} using the provided sandbox.
+ */
+export function createFetchWrapper(
+  sandbox: sinon.SinonSandbox,
+): StubbedFetchWrapper {
+  return {
+    fetch: sandbox.stub(nodeDeps.nodeFetch, "fetch"),
+  };
+}
+
+/** Stubbed crypto wrapper from {@link nodeDeps.nodeCrypto}. */
+export type StubbedCryptoWrapper = {
+  randomBytes: sinon.SinonStub;
+};
+
+/**
+ * Stubs the crypto wrapper in {@link nodeDeps.nodeCrypto} using the provided sandbox.
+ */
+export function createCryptoWrapper(
+  sandbox: sinon.SinonSandbox,
+): StubbedCryptoWrapper {
+  return {
+    randomBytes: sandbox.stub(nodeDeps.nodeCrypto, "randomBytes"),
+  };
+}


### PR DESCRIPTION
### Summary
- Add stubbable `nodeFetch` and `nodeCrypto` wrappers in `node-deps.ts` for test isolation
- Add PKCE code verifier/challenge generation and opaque token utilities (`crypto-utils.ts`)
- Implement full Confluent token chain: auth code → ID token → control plane → data plane (`token-chain.ts`)
- Implement refresh token grant for background token renewal
- bound each token-chain fetch with a 30s timeout 
- 14 unit tests covering all exchange functions, error handling, and chain orchestration

Closes #180

### PR Stack
- #183
  - (this) #185
    - #187 
      - #193