### PR TITLE
feat(oauth): add in-memory token store with CRUD

### DIFF
--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import sinon from "sinon";
+import { TokenStore } from "@src/confluent/oauth/token-store.js";
+import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
+
+describe("oauth/token-store.ts", () => {
+  describe("TokenStore", () => {
+    let store: TokenStore;
+
+    beforeEach(() => {
+      store = new TokenStore();
+    });
+
+    afterEach(() => {
+      store.shutdown();
+    });
+
+    function createTokenSet(
+      overrides?: Partial<ConfluentTokenSet>,
+    ): ConfluentTokenSet {
+      return {
+        refreshToken: "refresh-token",
+        refreshTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+        controlPlaneToken: "cp-token",
+        controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+        dataPlaneToken: "dp-token",
+        dataPlaneExpiresAt: Date.now() + 10 * 60 * 1000,
+        accessToken: "opaque-access-token",
+        ...overrides,
+      };
+    }
+
+    describe("store and get", () => {
+      it("should store a token set and retrieve it by access token", () => {
+        const tokenSet = createTokenSet();
+        store.store(tokenSet);
+
+        const retrieved = store.get("opaque-access-token");
+        expect(retrieved).toBeDefined();
+        expect(retrieved!.controlPlaneToken).toBe("cp-token");
+      });
+
+      it("should return undefined for unknown access token", () => {
+        expect(store.get("nonexistent")).toBeUndefined();
+      });
+    });
+
+    describe("remove", () => {
+      it("should remove a token set by access token", () => {
+        const tokenSet = createTokenSet();
+        store.store(tokenSet);
+
+        store.remove("opaque-access-token");
+
+        expect(store.get("opaque-access-token")).toBeUndefined();
+      });
+
+      it("should be a no-op for unknown access token", () => {
+        store.remove("nonexistent"); // should not throw
+      });
+    });
+
+    describe("update", () => {
+      it("should update an existing token set in place", () => {
+        const tokenSet = createTokenSet();
+        store.store(tokenSet);
+
+        store.update("opaque-access-token", {
+          refreshToken: "new-refresh",
+          controlPlaneToken: "new-cp",
+          dataPlaneToken: "new-dp",
+          controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+          dataPlaneExpiresAt: Date.now() + 10 * 60 * 1000,
+        });
+
+        const updated = store.get("opaque-access-token");
+        expect(updated!.refreshToken).toBe("new-refresh");
+        expect(updated!.controlPlaneToken).toBe("new-cp");
+        expect(updated!.dataPlaneToken).toBe("new-dp");
+        // accessToken should remain unchanged
+        expect(updated!.accessToken).toBe("opaque-access-token");
+      });
+
+      it("should return false when updating nonexistent token", () => {
+        const result = store.update("nonexistent", {
+          refreshToken: "r",
+          controlPlaneToken: "c",
+          dataPlaneToken: "d",
+          controlPlaneExpiresAt: 0,
+          dataPlaneExpiresAt: 0,
+        });
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("getAllAccessTokens", () => {
+      it("should return all stored access tokens", () => {
+        store.store(createTokenSet({ accessToken: "token-1" }));
+        store.store(createTokenSet({ accessToken: "token-2" }));
+
+        const tokens = store.getAllAccessTokens();
+        expect(tokens).toContain("token-1");
+        expect(tokens).toContain("token-2");
+        expect(tokens).toHaveLength(2);
+      });
+
+      it("should return empty array when store is empty", () => {
+        expect(store.getAllAccessTokens()).toHaveLength(0);
+      });
+    });
+
+    describe("size", () => {
+      it("should return 0 for empty store", () => {
+        expect(store.size).toBe(0);
+      });
+
+      it("should return correct count after stores and removes", () => {
+        store.store(createTokenSet({ accessToken: "a" }));
+        store.store(createTokenSet({ accessToken: "b" }));
+        expect(store.size).toBe(2);
+
+        store.remove("a");
+        expect(store.size).toBe(1);
+      });
+    });
+
+    describe("startRefreshLoop", () => {
+      let clock: sinon.SinonFakeTimers;
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers({ shouldAdvanceTime: false });
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it("should call the refresh callback at the specified interval", async () => {
+        const callback = sinon.stub().resolves();
+        store.startRefreshLoop(240_000, callback);
+
+        // Advance 4 minutes
+        await clock.tickAsync(240_000);
+        sinon.assert.calledOnce(callback);
+        sinon.assert.calledWith(callback, store);
+
+        // Advance another 4 minutes
+        await clock.tickAsync(240_000);
+        sinon.assert.calledTwice(callback);
+      });
+
+      it("should not start a second loop if already running", () => {
+        const callback = sinon.stub().resolves();
+        store.startRefreshLoop(240_000, callback);
+        store.startRefreshLoop(240_000, callback); // second call should be no-op
+
+        // Only one interval should be active — verified by shutdown not throwing
+        store.shutdown();
+      });
+
+      it("should stop the loop on shutdown", async () => {
+        const callback = sinon.stub().resolves();
+        store.startRefreshLoop(240_000, callback);
+
+        store.shutdown();
+
+        await clock.tickAsync(240_000);
+        sinon.assert.notCalled(callback);
+      });
+
+      it("should not throw if refresh callback throws", async () => {
+        const callback = sinon.stub().rejects(new Error("refresh failed"));
+        store.startRefreshLoop(240_000, callback);
+
+        // Should not throw
+        await clock.tickAsync(240_000);
+        sinon.assert.calledOnce(callback);
+
+        // Loop should still be alive
+        await clock.tickAsync(240_000);
+        sinon.assert.calledTwice(callback);
+      });
+    });
+  });
+});

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -3,6 +3,11 @@ import sinon from "sinon";
 import { TokenStore } from "@src/confluent/oauth/token-store.js";
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
 
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
 describe("oauth/token-store.ts", () => {
   describe("TokenStore", () => {
     let store: TokenStore;
@@ -20,11 +25,12 @@ describe("oauth/token-store.ts", () => {
     ): ConfluentTokenSet {
       return {
         refreshToken: "refresh-token",
-        refreshTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+        refreshTokenAbsoluteExpiresAt: Date.now() + EIGHT_HOURS_MS,
+        refreshTokenIdleExpiresAt: Date.now() + FOUR_HOURS_MS,
         controlPlaneToken: "cp-token",
-        controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+        controlPlaneExpiresAt: Date.now() + FIVE_MINUTES_MS,
         dataPlaneToken: "dp-token",
-        dataPlaneExpiresAt: Date.now() + 10 * 60 * 1000,
+        dataPlaneExpiresAt: Date.now() + TEN_MINUTES_MS,
         accessToken: "opaque-access-token",
         ...overrides,
       };
@@ -67,10 +73,11 @@ describe("oauth/token-store.ts", () => {
 
         store.update("opaque-access-token", {
           refreshToken: "new-refresh",
+          refreshTokenIdleExpiresAt: Date.now() + FOUR_HOURS_MS,
           controlPlaneToken: "new-cp",
           dataPlaneToken: "new-dp",
-          controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
-          dataPlaneExpiresAt: Date.now() + 10 * 60 * 1000,
+          controlPlaneExpiresAt: Date.now() + FIVE_MINUTES_MS,
+          dataPlaneExpiresAt: Date.now() + TEN_MINUTES_MS,
         });
 
         const updated = store.get("opaque-access-token");
@@ -84,6 +91,7 @@ describe("oauth/token-store.ts", () => {
       it("should return false when updating nonexistent token", () => {
         const result = store.update("nonexistent", {
           refreshToken: "r",
+          refreshTokenIdleExpiresAt: 0,
           controlPlaneToken: "c",
           dataPlaneToken: "d",
           controlPlaneExpiresAt: 0,

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -133,6 +133,19 @@ describe("oauth/token-store.ts", () => {
       });
     });
 
+    describe("shutdown", () => {
+      it("should clear all stored token sets", () => {
+        store.store(createTokenSet({ accessToken: "a" }));
+        store.store(createTokenSet({ accessToken: "b" }));
+        expect(store.size).toBe(2);
+
+        store.shutdown();
+
+        expect(store.size).toBe(0);
+        expect(store.get("a")).toBeUndefined();
+      });
+    });
+
     describe("startRefreshLoop", () => {
       let clock: sinon.SinonFakeTimers;
 
@@ -175,6 +188,16 @@ describe("oauth/token-store.ts", () => {
 
         await clock.tickAsync(240_000);
         sinon.assert.notCalled(callback);
+      });
+
+      it("should throw if intervalMs is not a finite positive number", () => {
+        const callback = sinon.stub().resolves();
+        expect(() => store.startRefreshLoop(0, callback)).toThrow(RangeError);
+        expect(() => store.startRefreshLoop(-1, callback)).toThrow(RangeError);
+        expect(() => store.startRefreshLoop(NaN, callback)).toThrow(RangeError);
+        expect(() => store.startRefreshLoop(Infinity, callback)).toThrow(
+          RangeError,
+        );
       });
 
       it("should not throw if refresh callback throws", async () => {

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -189,6 +189,33 @@ describe("oauth/token-store.ts", () => {
         await clock.tickAsync(240_000);
         sinon.assert.calledTwice(callback);
       });
+
+      it("should skip a tick when the previous tick is still running", async () => {
+        // Callback that never resolves on the first call, resolves on later calls
+        let resolveFirst: () => void = () => {};
+        const firstCall = new Promise<void>((r) => {
+          resolveFirst = r;
+        });
+        const callback = sinon.stub();
+        callback.onCall(0).returns(firstCall);
+        callback.onCall(1).resolves();
+        callback.onCall(2).resolves();
+
+        store.startRefreshLoop(240_000, callback);
+
+        // First tick starts and hangs
+        await clock.tickAsync(240_000);
+        sinon.assert.calledOnce(callback);
+
+        // Second tick fires while first is still in flight — should be skipped
+        await clock.tickAsync(240_000);
+        sinon.assert.calledOnce(callback);
+
+        // Let the first tick finish, then the next tick should run
+        resolveFirst();
+        await clock.tickAsync(240_000);
+        sinon.assert.calledTwice(callback);
+      });
     });
   });
 });

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -171,13 +171,17 @@ describe("oauth/token-store.ts", () => {
         sinon.assert.calledTwice(callback);
       });
 
-      it("should not start a second loop if already running", () => {
+      it("should not start a second loop if already running", async () => {
         const callback = sinon.stub().resolves();
         store.startRefreshLoop(240_000, callback);
         store.startRefreshLoop(240_000, callback); // second call should be no-op
 
-        // Only one interval should be active — verified by shutdown not throwing
-        store.shutdown();
+        // Only one interval should be active — a single tick fires the callback once, not twice.
+        await clock.tickAsync(240_000);
+        sinon.assert.calledOnce(callback);
+
+        await clock.tickAsync(240_000);
+        sinon.assert.calledTwice(callback);
       });
 
       it("should stop the loop on shutdown", async () => {

--- a/src/confluent/oauth/token-store.ts
+++ b/src/confluent/oauth/token-store.ts
@@ -1,14 +1,16 @@
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
 import { logger } from "@src/logger.js";
 
-interface TokenUpdateFields {
-  refreshToken: string;
-  refreshTokenIdleExpiresAt: number;
-  controlPlaneToken: string;
-  controlPlaneExpiresAt: number;
-  dataPlaneToken: string;
-  dataPlaneExpiresAt: number;
-}
+/** Refreshable subset of {@link ConfluentTokenSet}; all fields required. */
+type TokenUpdateFields = Pick<
+  ConfluentTokenSet,
+  | "refreshToken"
+  | "refreshTokenIdleExpiresAt"
+  | "controlPlaneToken"
+  | "controlPlaneExpiresAt"
+  | "dataPlaneToken"
+  | "dataPlaneExpiresAt"
+>;
 
 export class TokenStore {
   private tokens = new Map<string, ConfluentTokenSet>();
@@ -82,6 +84,10 @@ export class TokenStore {
     intervalMs: number,
     refreshCallback: (store: TokenStore) => Promise<void>,
   ): void {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+      throw new RangeError("intervalMs must be a finite number greater than 0");
+    }
+
     if (this.refreshInterval) {
       logger.warn("Refresh loop already running, skipping");
       return;

--- a/src/confluent/oauth/token-store.ts
+++ b/src/confluent/oauth/token-store.ts
@@ -3,7 +3,7 @@ import { logger } from "@src/logger.js";
 
 interface TokenUpdateFields {
   refreshToken: string;
-  refreshTokenExpiresAt?: number;
+  refreshTokenIdleExpiresAt: number;
   controlPlaneToken: string;
   controlPlaneExpiresAt: number;
   dataPlaneToken: string;
@@ -47,9 +47,7 @@ export class TokenStore {
     }
 
     existing.refreshToken = fields.refreshToken;
-    if (fields.refreshTokenExpiresAt !== undefined) {
-      existing.refreshTokenExpiresAt = fields.refreshTokenExpiresAt;
-    }
+    existing.refreshTokenIdleExpiresAt = fields.refreshTokenIdleExpiresAt;
     existing.controlPlaneToken = fields.controlPlaneToken;
     existing.controlPlaneExpiresAt = fields.controlPlaneExpiresAt;
     existing.dataPlaneToken = fields.dataPlaneToken;

--- a/src/confluent/oauth/token-store.ts
+++ b/src/confluent/oauth/token-store.ts
@@ -1,0 +1,110 @@
+import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
+import { logger } from "@src/logger.js";
+
+interface TokenUpdateFields {
+  refreshToken: string;
+  refreshTokenExpiresAt?: number;
+  controlPlaneToken: string;
+  controlPlaneExpiresAt: number;
+  dataPlaneToken: string;
+  dataPlaneExpiresAt: number;
+}
+
+export class TokenStore {
+  private tokens = new Map<string, ConfluentTokenSet>();
+  private refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Store a new token set. Keyed by the opaque accessToken.
+   */
+  store(tokenSet: ConfluentTokenSet): void {
+    this.tokens.set(tokenSet.accessToken, tokenSet);
+    logger.debug("Token set stored");
+  }
+
+  /**
+   * Retrieve a token set by its opaque access token.
+   */
+  get(accessToken: string): ConfluentTokenSet | undefined {
+    return this.tokens.get(accessToken);
+  }
+
+  /**
+   * Remove a token set by its opaque access token.
+   */
+  remove(accessToken: string): void {
+    this.tokens.delete(accessToken);
+  }
+
+  /**
+   * Update the refreshable fields of an existing token set.
+   * Returns false if the access token is not found.
+   */
+  update(accessToken: string, fields: TokenUpdateFields): boolean {
+    const existing = this.tokens.get(accessToken);
+    if (!existing) {
+      return false;
+    }
+
+    existing.refreshToken = fields.refreshToken;
+    if (fields.refreshTokenExpiresAt !== undefined) {
+      existing.refreshTokenExpiresAt = fields.refreshTokenExpiresAt;
+    }
+    existing.controlPlaneToken = fields.controlPlaneToken;
+    existing.controlPlaneExpiresAt = fields.controlPlaneExpiresAt;
+    existing.dataPlaneToken = fields.dataPlaneToken;
+    existing.dataPlaneExpiresAt = fields.dataPlaneExpiresAt;
+
+    return true;
+  }
+
+  /**
+   * Returns all stored access tokens.
+   */
+  getAllAccessTokens(): string[] {
+    return Array.from(this.tokens.keys());
+  }
+
+  /**
+   * Number of token sets in the store.
+   */
+  get size(): number {
+    return this.tokens.size;
+  }
+
+  /**
+   * Start a background refresh loop that calls the provided callback every intervalMs.
+   * The callback receives this store instance.
+   */
+  startRefreshLoop(
+    intervalMs: number,
+    refreshCallback: (store: TokenStore) => Promise<void>,
+  ): void {
+    if (this.refreshInterval) {
+      logger.warn("Refresh loop already running, skipping");
+      return;
+    }
+
+    this.refreshInterval = setInterval(async () => {
+      try {
+        await refreshCallback(this);
+      } catch (error) {
+        logger.error({ error }, "Token refresh loop error");
+      }
+    }, intervalMs);
+
+    logger.info({ intervalMs }, "Token refresh loop started");
+  }
+
+  /**
+   * Stop the background refresh loop and clear all tokens.
+   */
+  shutdown(): void {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = null;
+      logger.info("Token refresh loop stopped");
+    }
+    this.tokens.clear();
+  }
+}

--- a/src/confluent/oauth/token-store.ts
+++ b/src/confluent/oauth/token-store.ts
@@ -73,6 +73,10 @@ export class TokenStore {
   /**
    * Start a background refresh loop that calls the provided callback every intervalMs.
    * The callback receives this store instance.
+   *
+   * Ticks are single-flighted: if a previous tick is still running when the
+   * interval fires, the new tick is skipped. This prevents two callbacks from
+   * concurrently refreshing the same single-use refresh token and burning it.
    */
   startRefreshLoop(
     intervalMs: number,
@@ -83,11 +87,19 @@ export class TokenStore {
       return;
     }
 
+    let tickInProgress = false;
     this.refreshInterval = setInterval(async () => {
+      if (tickInProgress) {
+        logger.debug("Previous refresh tick still running, skipping");
+        return;
+      }
+      tickInProgress = true;
       try {
         await refreshCallback(this);
       } catch (error) {
         logger.error({ error }, "Token refresh loop error");
+      } finally {
+        tickInProgress = false;
       }
     }, intervalMs);
 

--- a/src/confluent/oauth/token-store.ts
+++ b/src/confluent/oauth/token-store.ts
@@ -76,7 +76,7 @@ export class TokenStore {
    * Start a background refresh loop that calls the provided callback every intervalMs.
    * The callback receives this store instance.
    *
-   * Ticks are single-flighted: if a previous tick is still running when the
+   * Ticks are single-flight enforced: if a previous tick is still running when the
    * interval fires, the new tick is skipped. This prevents two callbacks from
    * concurrently refreshing the same single-use refresh token and burning it.
    */


### PR DESCRIPTION
### Summary
- In-memory store keyed by access token for managing OAuth sessions
- CRUD operations: store, get, remove, and update of token sets
- Initial simple background refresh loop via `setInterval` that invokes a callback to refresh tokens ever 4 mins
- Clean shutdown clears both the interval and all stored tokens
- Added unit tests

Closes #181

### PR Stack
- #183
  - #185
    - (this) (#187)
      - #193