### PR TITLE
feat(oauth): auto-refresh token lifecycle

### DIFF
--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -14,6 +14,13 @@ import {
 import sinon from "sinon";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+function jsonResponse(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("oauth/token-chain.ts", () => {
   const sandbox = sinon.createSandbox();
   let fetchStub: sinon.SinonStub;
@@ -30,18 +37,13 @@ describe("oauth/token-chain.ts", () => {
     const auth0Config = getAuth0Config("devel");
 
     it("should exchange auth code for ID token and refresh token", async () => {
-      const mockResponse = {
-        id_token: "mock-id-token",
-        refresh_token: "mock-refresh-token",
-        access_token: "mock-access-token",
-        token_type: "Bearer",
-        expires_in: 60,
-      };
-
       fetchStub.resolves(
-        new Response(JSON.stringify(mockResponse), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
+        jsonResponse({
+          id_token: "mock-id-token",
+          refresh_token: "mock-refresh-token",
+          access_token: "mock-access-token",
+          token_type: "Bearer",
+          expires_in: 60,
         }),
       );
 
@@ -68,11 +70,7 @@ describe("oauth/token-chain.ts", () => {
     });
 
     it("should throw on non-200 response", async () => {
-      fetchStub.resolves(
-        new Response(JSON.stringify({ error: "invalid_grant" }), {
-          status: 400,
-        }),
-      );
+      fetchStub.resolves(jsonResponse({ error: "invalid_grant" }, 400));
 
       await expect(
         exchangeAuthCodeForTokens(auth0Config, "bad-code", "verifier"),
@@ -91,15 +89,12 @@ describe("oauth/token-chain.ts", () => {
 
     it("should throw when the response is missing refresh_token", async () => {
       fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            id_token: "id",
-            access_token: "a",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        jsonResponse({
+          id_token: "id",
+          access_token: "a",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
       );
 
       await expect(
@@ -109,15 +104,12 @@ describe("oauth/token-chain.ts", () => {
 
     it("should throw when the response is missing id_token", async () => {
       fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            refresh_token: "r",
-            access_token: "a",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        jsonResponse({
+          refresh_token: "r",
+          access_token: "a",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
       );
 
       await expect(
@@ -128,16 +120,7 @@ describe("oauth/token-chain.ts", () => {
 
   describe("exchangeIdTokenForControlPlaneToken", () => {
     it("should exchange ID token for control plane token", async () => {
-      const mockResponse = {
-        token: "cp-bearer-token-123",
-      };
-
-      fetchStub.resolves(
-        new Response(JSON.stringify(mockResponse), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+      fetchStub.resolves(jsonResponse({ token: "cp-bearer-token-123" }));
 
       const result = await exchangeIdTokenForControlPlaneToken(
         "https://devel.cpdev.cloud",
@@ -168,12 +151,7 @@ describe("oauth/token-chain.ts", () => {
     });
 
     it("should throw when the response is missing token", async () => {
-      fetchStub.resolves(
-        new Response(JSON.stringify({}), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+      fetchStub.resolves(jsonResponse({}));
 
       await expect(
         exchangeIdTokenForControlPlaneToken(
@@ -186,16 +164,7 @@ describe("oauth/token-chain.ts", () => {
 
   describe("exchangeControlPlaneForDataPlaneToken", () => {
     it("should exchange control plane token for data plane token", async () => {
-      const mockResponse = {
-        token: "dp-bearer-token-456",
-      };
-
-      fetchStub.resolves(
-        new Response(JSON.stringify(mockResponse), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+      fetchStub.resolves(jsonResponse({ token: "dp-bearer-token-456" }));
 
       const result = await exchangeControlPlaneForDataPlaneToken(
         "https://devel.cpdev.cloud",
@@ -228,12 +197,7 @@ describe("oauth/token-chain.ts", () => {
     });
 
     it("should throw when the response is missing token", async () => {
-      fetchStub.resolves(
-        new Response(JSON.stringify({}), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+      fetchStub.resolves(jsonResponse({}));
 
       await expect(
         exchangeControlPlaneForDataPlaneToken(
@@ -248,21 +212,16 @@ describe("oauth/token-chain.ts", () => {
     const auth0Config = getAuth0Config("devel");
 
     it("should POST grant_type=refresh_token and return the Auth0 response", async () => {
-      // First call: refresh token → Auth0 token endpoint
       fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            id_token: "new-id-token",
-            refresh_token: "rotated-refresh-token",
-            access_token: "new-access",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        jsonResponse({
+          id_token: "new-id-token",
+          refresh_token: "rotated-refresh-token",
+          access_token: "new-access",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
       );
 
-      // Second call: ID token → control plane
       const result = await exchangeRefreshTokenForAuth0Tokens(
         auth0Config,
         "old-refresh-token",
@@ -283,11 +242,7 @@ describe("oauth/token-chain.ts", () => {
     });
 
     it("should throw on non-200 response", async () => {
-      fetchStub.resolves(
-        new Response(JSON.stringify({ error: "invalid_grant" }), {
-          status: 400,
-        }),
-      );
+      fetchStub.resolves(jsonResponse({ error: "invalid_grant" }, 400));
 
       await expect(
         exchangeRefreshTokenForAuth0Tokens(auth0Config, "bad-refresh"),
@@ -296,15 +251,12 @@ describe("oauth/token-chain.ts", () => {
 
     it("should throw when the response is missing refresh_token", async () => {
       fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            id_token: "id",
-            access_token: "a",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        jsonResponse({
+          id_token: "id",
+          access_token: "a",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
       );
 
       await expect(
@@ -314,15 +266,12 @@ describe("oauth/token-chain.ts", () => {
 
     it("should throw when the response is missing id_token", async () => {
       fetchStub.resolves(
-        new Response(
-          JSON.stringify({
-            refresh_token: "rotated",
-            access_token: "a",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        jsonResponse({
+          refresh_token: "rotated",
+          access_token: "a",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
       );
 
       await expect(
@@ -335,39 +284,17 @@ describe("oauth/token-chain.ts", () => {
     const auth0Config = getAuth0Config("devel");
 
     it("should run auth code → ID → CP → DP chain", async () => {
-      // First call: auth code → Auth0 tokens
       fetchStub.onCall(0).resolves(
-        new Response(
-          JSON.stringify({
-            id_token: "id-token",
-            refresh_token: "refresh-token",
-            access_token: "access",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        jsonResponse({
+          id_token: "id-token",
+          refresh_token: "refresh-token",
+          access_token: "access",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
       );
-
-      // Second call: ID → CP
-      fetchStub.onCall(1).resolves(
-        new Response(
-          JSON.stringify({
-            token: "cp-token",
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      );
-
-      // Third call: CP → DP
-      fetchStub.onCall(2).resolves(
-        new Response(
-          JSON.stringify({
-            token: "dp-token",
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      );
+      fetchStub.onCall(1).resolves(jsonResponse({ token: "cp-token" }));
+      fetchStub.onCall(2).resolves(jsonResponse({ token: "dp-token" }));
 
       const result = await executeFullTokenChain(
         auth0Config,

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -88,6 +88,42 @@ describe("oauth/token-chain.ts", () => {
         exchangeAuthCodeForTokens(auth0Config, "code", "verifier"),
       ).rejects.toThrow(/Auth0 token exchange timed out/);
     });
+
+    it("should throw when the response is missing refresh_token", async () => {
+      fetchStub.resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "id",
+            access_token: "a",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      await expect(
+        exchangeAuthCodeForTokens(auth0Config, "code", "verifier"),
+      ).rejects.toThrow(/refresh_token/);
+    });
+
+    it("should throw when the response is missing id_token", async () => {
+      fetchStub.resolves(
+        new Response(
+          JSON.stringify({
+            refresh_token: "r",
+            access_token: "a",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      await expect(
+        exchangeAuthCodeForTokens(auth0Config, "code", "verifier"),
+      ).rejects.toThrow(/id_token/);
+    });
   });
 
   describe("exchangeIdTokenForControlPlaneToken", () => {
@@ -129,6 +165,22 @@ describe("oauth/token-chain.ts", () => {
           "bad-token",
         ),
       ).rejects.toThrow(/Control plane token exchange failed/);
+    });
+
+    it("should throw when the response is missing token", async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(
+        exchangeIdTokenForControlPlaneToken(
+          "https://devel.cpdev.cloud",
+          "id-token",
+        ),
+      ).rejects.toThrow(/Control plane token exchange.*token/);
     });
   });
 
@@ -173,6 +225,22 @@ describe("oauth/token-chain.ts", () => {
           "bad-cp-token",
         ),
       ).rejects.toThrow(/Data plane token exchange failed/);
+    });
+
+    it("should throw when the response is missing token", async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(
+        exchangeControlPlaneForDataPlaneToken(
+          "https://devel.cpdev.cloud",
+          "cp-token",
+        ),
+      ).rejects.toThrow(/Data plane token exchange.*token/);
     });
   });
 
@@ -224,6 +292,42 @@ describe("oauth/token-chain.ts", () => {
       await expect(
         exchangeRefreshTokenForAuth0Tokens(auth0Config, "bad-refresh"),
       ).rejects.toThrow(/Auth0 token refresh failed/);
+    });
+
+    it("should throw when the response is missing refresh_token", async () => {
+      fetchStub.resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "id",
+            access_token: "a",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      await expect(
+        exchangeRefreshTokenForAuth0Tokens(auth0Config, "old-refresh"),
+      ).rejects.toThrow(/refresh_token/);
+    });
+
+    it("should throw when the response is missing id_token", async () => {
+      fetchStub.resolves(
+        new Response(
+          JSON.stringify({
+            refresh_token: "rotated",
+            access_token: "a",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      await expect(
+        exchangeRefreshTokenForAuth0Tokens(auth0Config, "old-refresh"),
+      ).rejects.toThrow(/id_token/);
     });
   });
 

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -5,7 +5,7 @@ import {
   exchangeAuthCodeForTokens,
   exchangeIdTokenForControlPlaneToken,
   exchangeControlPlaneForDataPlaneToken,
-  refreshTokenChain,
+  exchangeRefreshTokenForAuth0Tokens,
   executeFullTokenChain,
 } from "@src/confluent/oauth/token-chain.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
@@ -176,16 +176,16 @@ describe("oauth/token-chain.ts", () => {
     });
   });
 
-  describe("refreshTokenChain", () => {
+  describe("exchangeRefreshTokenForAuth0Tokens", () => {
     const auth0Config = getAuth0Config("devel");
 
-    it("should use refresh token to get new ID token and derive CP + DP tokens", async () => {
+    it("should POST grant_type=refresh_token and return the Auth0 response", async () => {
       // First call: refresh token → Auth0 token endpoint
-      fetchStub.onCall(0).resolves(
+      fetchStub.resolves(
         new Response(
           JSON.stringify({
             id_token: "new-id-token",
-            refresh_token: "new-refresh-token",
+            refresh_token: "rotated-refresh-token",
             access_token: "new-access",
             token_type: "Bearer",
             expires_in: 60,
@@ -195,46 +195,35 @@ describe("oauth/token-chain.ts", () => {
       );
 
       // Second call: ID token → control plane
-      fetchStub.onCall(1).resolves(
-        new Response(
-          JSON.stringify({
-            token: "new-cp-token",
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+      const result = await exchangeRefreshTokenForAuth0Tokens(
+        auth0Config,
+        "old-refresh-token",
       );
 
-      // Third call: CP token → data plane
-      fetchStub.onCall(2).resolves(
-        new Response(
-          JSON.stringify({
-            token: "new-dp-token",
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+      expect(result.id_token).toBe("new-id-token");
+      expect(result.refresh_token).toBe("rotated-refresh-token");
+
+      sinon.assert.calledOnce(fetchStub);
+      const [url, options] = fetchStub.firstCall.args;
+      expect(url).toBe("https://login.confluent-dev.io/oauth/token");
+      expect(options.method).toBe("POST");
+
+      const body = new URLSearchParams(options.body);
+      expect(body.get("grant_type")).toBe("refresh_token");
+      expect(body.get("refresh_token")).toBe("old-refresh-token");
+      expect(body.get("client_id")).toBe(auth0Config.clientId);
+    });
+
+    it("should throw on non-200 response", async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+        }),
       );
 
-      const result = await refreshTokenChain(auth0Config, "old-refresh-token");
-
-      expect(result.refreshToken).toBe("new-refresh-token");
-      expect(result.controlPlaneToken).toBe("new-cp-token");
-      expect(result.dataPlaneToken).toBe("new-dp-token");
-      // Refresh should reset idle (4hr) but NOT set absolute (8hr)
-      expect(result.refreshTokenIdleExpiresAt).toBeGreaterThan(
-        Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS - 5000,
-      );
-      expect(result.refreshTokenIdleExpiresAt).toBeLessThanOrEqual(
-        Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS,
-      );
-      expect(result.refreshTokenAbsoluteExpiresAt).toBeUndefined();
-
-      sinon.assert.calledThrice(fetchStub);
-
-      // Verify the refresh token call uses grant_type=refresh_token
-      const [, refreshOpts] = fetchStub.firstCall.args;
-      const refreshBody = new URLSearchParams(refreshOpts.body);
-      expect(refreshBody.get("grant_type")).toBe("refresh_token");
-      expect(refreshBody.get("refresh_token")).toBe("old-refresh-token");
+      await expect(
+        exchangeRefreshTokenForAuth0Tokens(auth0Config, "bad-refresh"),
+      ).rejects.toThrow(/Auth0 token refresh failed/);
     });
   });
 

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -9,9 +9,10 @@ import {
   executeFullTokenChain,
 } from "@src/confluent/oauth/token-chain.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
-
-const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
-const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;
+import {
+  REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+  REFRESH_TOKEN_IDLE_LIFETIME_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 
 describe("oauth/token-chain.ts", () => {
   const sandbox = sinon.createSandbox();
@@ -220,10 +221,10 @@ describe("oauth/token-chain.ts", () => {
       expect(result.dataPlaneToken).toBe("new-dp-token");
       // Refresh should reset idle (4hr) but NOT set absolute (8hr)
       expect(result.refreshTokenIdleExpiresAt).toBeGreaterThan(
-        Date.now() + FOUR_HOURS_MS - 5000,
+        Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS - 5000,
       );
       expect(result.refreshTokenIdleExpiresAt).toBeLessThanOrEqual(
-        Date.now() + FOUR_HOURS_MS,
+        Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS,
       );
       expect(result.refreshTokenAbsoluteExpiresAt).toBeUndefined();
 
@@ -288,10 +289,10 @@ describe("oauth/token-chain.ts", () => {
       expect(result.dataPlaneExpiresAt).toBeGreaterThan(0);
       // Initial login sets both absolute (8hr) and idle (4hr)
       expect(result.refreshTokenAbsoluteExpiresAt).toBeGreaterThan(
-        Date.now() + EIGHT_HOURS_MS - 5000,
+        Date.now() + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS - 5000,
       );
       expect(result.refreshTokenIdleExpiresAt).toBeGreaterThan(
-        Date.now() + FOUR_HOURS_MS - 5000,
+        Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS - 5000,
       );
     });
   });

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -16,12 +16,7 @@ import {
 /** Per-request timeout bounding each Auth0/Confluent HTTP call. */
 const REQUEST_TIMEOUT_MS = 30_000;
 
-/**
- * Result of a single token-chain execution — either the initial login
- * ({@link executeFullTokenChain}) or a subsequent refresh ({@link refreshTokenChain}).
- * Callers persist this into the token store so downstream CP/DP requests can
- * retrieve still-valid credentials.
- */
+/** Result of a full initial-login token chain from {@link executeFullTokenChain}. */
 export interface TokenChainResult {
   refreshToken: string;
   /** Only set on initial login. Absent on refresh — callers must preserve the original value. */
@@ -138,20 +133,23 @@ export async function exchangeControlPlaneForDataPlaneToken(
 }
 
 /**
- * Uses a refresh token to obtain new Auth0 tokens, then derives CP and DP tokens.
- * This is used by the background refresh loop.
+ * Exchanges a refresh token for a new Auth0 token set (ID token + rotated
+ * refresh token). This is a single-use destructive operation: on success the
+ * old refresh token is invalidated by Auth0. Callers that then derive CP/DP
+ * tokens should persist the new refresh token BEFORE the CP/DP calls so a
+ * failure there doesn't lose the rotated token.
  */
-export async function refreshTokenChain(
+export async function exchangeRefreshTokenForAuth0Tokens(
   auth0Config: Auth0Config,
   refreshToken: string,
-): Promise<TokenChainResult> {
+): Promise<Auth0TokenResponse> {
   const body = new URLSearchParams({
     grant_type: "refresh_token",
     client_id: auth0Config.clientId,
     refresh_token: refreshToken,
   });
 
-  const auth0Response = await postJson<Auth0TokenResponse>(
+  return postJson<Auth0TokenResponse>(
     `https://${auth0Config.domain}/oauth/token`,
     {
       method: "POST",
@@ -160,8 +158,6 @@ export async function refreshTokenChain(
     },
     "Auth0 token refresh",
   );
-
-  return deriveConfluentTokens(auth0Config, auth0Response);
 }
 
 /**

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -21,7 +21,7 @@ export interface TokenChainResult {
   refreshToken: string;
   /** Set once on initial login and preserved across subsequent refreshes. */
   refreshTokenAbsoluteExpiresAt: number;
-  /** Reset on every rotation (initial login and refresh). */
+  /** Set on initial login; subsequent refreshes bump this value in the store directly. */
   refreshTokenIdleExpiresAt: number;
   controlPlaneToken: string;
   controlPlaneExpiresAt: number;
@@ -80,7 +80,7 @@ export async function exchangeAuthCodeForTokens(
     redirect_uri: auth0Config.callbackUrl,
   });
 
-  return postJson<Auth0TokenResponse>(
+  const response = await postJson<Auth0TokenResponse>(
     `https://${auth0Config.domain}/oauth/token`,
     {
       method: "POST",
@@ -89,6 +89,13 @@ export async function exchangeAuthCodeForTokens(
     },
     "Auth0 token exchange",
   );
+  if (!response.id_token) {
+    throw new Error("Auth0 token exchange: missing id_token");
+  }
+  if (!response.refresh_token) {
+    throw new Error("Auth0 token exchange: missing refresh_token");
+  }
+  return response;
 }
 
 /**
@@ -99,7 +106,7 @@ export async function exchangeIdTokenForControlPlaneToken(
   apiUrl: string,
   idToken: string,
 ): Promise<ControlPlaneTokenResponse> {
-  return postJson<ControlPlaneTokenResponse>(
+  const response = await postJson<ControlPlaneTokenResponse>(
     `${apiUrl}/api/sessions`,
     {
       method: "POST",
@@ -108,6 +115,10 @@ export async function exchangeIdTokenForControlPlaneToken(
     },
     "Control plane token exchange",
   );
+  if (!response.token) {
+    throw new Error("Control plane token exchange: missing token");
+  }
+  return response;
 }
 
 /**
@@ -118,7 +129,7 @@ export async function exchangeControlPlaneForDataPlaneToken(
   apiUrl: string,
   controlPlaneToken: string,
 ): Promise<DataPlaneTokenResponse> {
-  return postJson<DataPlaneTokenResponse>(
+  const response = await postJson<DataPlaneTokenResponse>(
     `${apiUrl}/api/access_tokens`,
     {
       method: "POST",
@@ -130,6 +141,10 @@ export async function exchangeControlPlaneForDataPlaneToken(
     },
     "Data plane token exchange",
   );
+  if (!response.token) {
+    throw new Error("Data plane token exchange: missing token");
+  }
+  return response;
 }
 
 /**
@@ -149,7 +164,7 @@ export async function exchangeRefreshTokenForAuth0Tokens(
     refresh_token: refreshToken,
   });
 
-  return postJson<Auth0TokenResponse>(
+  const response = await postJson<Auth0TokenResponse>(
     `https://${auth0Config.domain}/oauth/token`,
     {
       method: "POST",
@@ -158,6 +173,13 @@ export async function exchangeRefreshTokenForAuth0Tokens(
     },
     "Auth0 token refresh",
   );
+  if (!response.id_token) {
+    throw new Error("Auth0 token refresh: missing id_token");
+  }
+  if (!response.refresh_token) {
+    throw new Error("Auth0 token refresh: missing refresh_token");
+  }
+  return response;
 }
 
 /**

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -6,18 +6,12 @@ import type {
 } from "@src/confluent/oauth/types.js";
 import { nodeFetch } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
-
-/** 5 minutes in milliseconds — control plane token lifetime */
-const CONTROL_PLANE_TOKEN_LIFETIME_MS = 5 * 60 * 1000;
-
-/** 10 minutes in milliseconds — data plane token lifetime */
-const DATA_PLANE_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
-
-/** 8 hours in milliseconds — refresh token absolute lifetime from original login */
-const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
-
-/** 4 hours in milliseconds — refresh token idle timeout, resets on each rotation */
-const REFRESH_TOKEN_IDLE_LIFETIME_MS = 4 * 60 * 60 * 1000;
+import {
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
+  DATA_PLANE_TOKEN_LIFETIME_MS,
+  REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+  REFRESH_TOKEN_IDLE_LIFETIME_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 
 /** Per-request timeout bounding each Auth0/Confluent HTTP call. */
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -19,8 +19,8 @@ const REQUEST_TIMEOUT_MS = 30_000;
 /** Result of a full initial-login token chain from {@link executeFullTokenChain}. */
 export interface TokenChainResult {
   refreshToken: string;
-  /** Only set on initial login. Absent on refresh — callers must preserve the original value. */
-  refreshTokenAbsoluteExpiresAt?: number;
+  /** Set once on initial login and preserved across subsequent refreshes. */
+  refreshTokenAbsoluteExpiresAt: number;
   /** Reset on every rotation (initial login and refresh). */
   refreshTokenIdleExpiresAt: number;
   controlPlaneToken: string;
@@ -177,25 +177,6 @@ export async function executeFullTokenChain(
     codeVerifier,
   );
 
-  const result = await deriveConfluentTokens(auth0Config, auth0Response);
-
-  return {
-    ...result,
-    refreshTokenAbsoluteExpiresAt:
-      Date.now() + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
-  };
-}
-
-/**
- * Given Auth0 tokens, derives Confluent control plane and data plane tokens.
- * Expiration times are computed client-side using fixed durations.
- *
- * Does NOT set refreshTokenAbsoluteExpiresAt — that is only set on initial login.
- */
-async function deriveConfluentTokens(
-  auth0Config: Auth0Config,
-  auth0Response: Auth0TokenResponse,
-): Promise<TokenChainResult> {
   const cpResponse = await exchangeIdTokenForControlPlaneToken(
     auth0Config.apiUrl,
     auth0Response.id_token,
@@ -210,6 +191,7 @@ async function deriveConfluentTokens(
 
   return {
     refreshToken: auth0Response.refresh_token,
+    refreshTokenAbsoluteExpiresAt: now + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
     refreshTokenIdleExpiresAt: now + REFRESH_TOKEN_IDLE_LIFETIME_MS,
     controlPlaneToken: cpResponse.token,
     controlPlaneExpiresAt: now + CONTROL_PLANE_TOKEN_LIFETIME_MS,

--- a/src/confluent/oauth/token-lifetimes.ts
+++ b/src/confluent/oauth/token-lifetimes.ts
@@ -1,0 +1,14 @@
+/** 5 minutes in milliseconds — control plane token lifetime */
+export const CONTROL_PLANE_TOKEN_LIFETIME_MS = 5 * 60 * 1000;
+
+/** 10 minutes in milliseconds — data plane token lifetime */
+export const DATA_PLANE_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
+
+/** 8 hours in milliseconds — refresh token absolute lifetime from original login */
+export const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
+
+/** 4 hours in milliseconds — refresh token idle timeout, resets on each rotation */
+export const REFRESH_TOKEN_IDLE_LIFETIME_MS = 4 * 60 * 60 * 1000;
+
+/** 4 minutes in milliseconds — default auto-refresh interval (1 min before CP expiry) */
+export const DEFAULT_REFRESH_INTERVAL_MS = 4 * 60 * 1000;

--- a/src/confluent/oauth/token-lifetimes.ts
+++ b/src/confluent/oauth/token-lifetimes.ts
@@ -10,5 +10,9 @@ export const REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS = 8 * 60 * 60 * 1000;
 /** 4 hours in milliseconds — refresh token idle timeout, resets on each rotation */
 export const REFRESH_TOKEN_IDLE_LIFETIME_MS = 4 * 60 * 60 * 1000;
 
-/** 4 minutes in milliseconds — default auto-refresh interval (1 min before CP expiry) */
-export const DEFAULT_REFRESH_INTERVAL_MS = 4 * 60 * 1000;
+/** 1 minute in milliseconds — refresh control plane token this much before expiry */
+export const CONTROL_PLANE_REFRESH_WINDOW_MS = 60 * 1000;
+
+/** Default auto-refresh interval — CP lifetime minus the refresh window. */
+export const DEFAULT_REFRESH_INTERVAL_MS =
+  CONTROL_PLANE_TOKEN_LIFETIME_MS - CONTROL_PLANE_REFRESH_WINDOW_MS;

--- a/src/confluent/oauth/token-refresh.test.ts
+++ b/src/confluent/oauth/token-refresh.test.ts
@@ -5,6 +5,7 @@ import { TokenStore } from "@src/confluent/oauth/token-store.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 import {
   createRefreshCallback,
+  refreshTokenSet,
   startAutoRefresh,
 } from "@src/confluent/oauth/token-refresh.js";
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
@@ -50,7 +51,6 @@ describe("oauth/token-refresh.ts", () => {
   }
 
   function stubSuccessfulRefreshChain() {
-    // Auth0 refresh → new tokens
     fetchStub.onCall(0).resolves(
       new Response(
         JSON.stringify({
@@ -63,14 +63,12 @@ describe("oauth/token-refresh.ts", () => {
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
     );
-    // ID → CP
     fetchStub.onCall(1).resolves(
       new Response(JSON.stringify({ token: "new-cp-token" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
     );
-    // CP → DP
     fetchStub.onCall(2).resolves(
       new Response(JSON.stringify({ token: "new-dp-token" }), {
         status: 200,
@@ -79,8 +77,219 @@ describe("oauth/token-refresh.ts", () => {
     );
   }
 
+  describe("refreshTokenSet", () => {
+    it("should rotate refresh + CP + DP on full success", async () => {
+      const tokenSet = createTokenSet({ refreshToken: "old-refresh" });
+      store.store(tokenSet);
+      stubSuccessfulRefreshChain();
+
+      const before = Date.now();
+      await refreshTokenSet(
+        auth0Config,
+        store,
+        "opaque-access-token",
+        tokenSet,
+      );
+      const after = Date.now();
+
+      const saved = store.get("opaque-access-token")!;
+      expect(saved.refreshToken).toBe("new-refresh-token");
+      expect(saved.controlPlaneToken).toBe("new-cp-token");
+      expect(saved.dataPlaneToken).toBe("new-dp-token");
+      // accessToken never mutates
+      expect(saved.accessToken).toBe("opaque-access-token");
+
+      // Expiry timestamps set from the post-Auth0 rotation time
+      expect(saved.refreshTokenIdleExpiresAt).toBeGreaterThanOrEqual(
+        before + REFRESH_TOKEN_IDLE_LIFETIME_MS,
+      );
+      expect(saved.refreshTokenIdleExpiresAt).toBeLessThanOrEqual(
+        after + REFRESH_TOKEN_IDLE_LIFETIME_MS,
+      );
+      expect(saved.controlPlaneExpiresAt).toBeGreaterThanOrEqual(
+        before + CONTROL_PLANE_TOKEN_LIFETIME_MS,
+      );
+      expect(saved.controlPlaneExpiresAt).toBeLessThanOrEqual(
+        after + CONTROL_PLANE_TOKEN_LIFETIME_MS,
+      );
+      expect(saved.dataPlaneExpiresAt).toBeGreaterThanOrEqual(
+        before + DATA_PLANE_TOKEN_LIFETIME_MS,
+      );
+      expect(saved.dataPlaneExpiresAt).toBeLessThanOrEqual(
+        after + DATA_PLANE_TOKEN_LIFETIME_MS,
+      );
+
+      sinon.assert.calledThrice(fetchStub);
+    });
+
+    it("should leave state unchanged when Auth0 refresh fails", async () => {
+      const tokenSet = createTokenSet({ refreshToken: "old-refresh" });
+      store.store(tokenSet);
+      fetchStub.resolves(new Response("server error", { status: 500 }));
+
+      await refreshTokenSet(
+        auth0Config,
+        store,
+        "opaque-access-token",
+        tokenSet,
+      );
+
+      const saved = store.get("opaque-access-token")!;
+      expect(saved.refreshToken).toBe("old-refresh");
+      expect(saved.controlPlaneToken).toBe("cp-token");
+      expect(saved.dataPlaneToken).toBe("dp-token");
+    });
+
+    it("should persist the rotated refresh token even if CP exchange fails", async () => {
+      const tokenSet = createTokenSet({
+        refreshToken: "old-refresh",
+        controlPlaneToken: "old-cp",
+        dataPlaneToken: "old-dp",
+      });
+      store.store(tokenSet);
+      fetchStub.onCall(0).resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "new-id-token",
+            refresh_token: "rotated-refresh",
+            access_token: "new-access",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      fetchStub
+        .onCall(1)
+        .resolves(new Response("bad gateway", { status: 502 }));
+
+      await refreshTokenSet(
+        auth0Config,
+        store,
+        "opaque-access-token",
+        tokenSet,
+      );
+
+      const saved = store.get("opaque-access-token")!;
+      // Critical invariant: rotated refresh is safe so next tick can retry
+      expect(saved.refreshToken).toBe("rotated-refresh");
+      expect(saved.controlPlaneToken).toBe("old-cp");
+      expect(saved.dataPlaneToken).toBe("old-dp");
+    });
+
+    it("should persist the rotated refresh token even if DP exchange fails", async () => {
+      const tokenSet = createTokenSet({
+        refreshToken: "old-refresh",
+        controlPlaneToken: "old-cp",
+        dataPlaneToken: "old-dp",
+      });
+      store.store(tokenSet);
+      fetchStub.onCall(0).resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "new-id-token",
+            refresh_token: "rotated-refresh",
+            access_token: "new-access",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      fetchStub.onCall(1).resolves(
+        new Response(JSON.stringify({ token: "new-cp" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      fetchStub.onCall(2).resolves(new Response("forbidden", { status: 403 }));
+
+      await refreshTokenSet(
+        auth0Config,
+        store,
+        "opaque-access-token",
+        tokenSet,
+      );
+
+      const saved = store.get("opaque-access-token")!;
+      expect(saved.refreshToken).toBe("rotated-refresh");
+      // CP/DP only advance together via the final atomic update
+      expect(saved.controlPlaneToken).toBe("old-cp");
+      expect(saved.dataPlaneToken).toBe("old-dp");
+    });
+
+    it("should no-op if the token was removed between scan and refresh", async () => {
+      const tokenSet = createTokenSet();
+      // Don't store into `store` — simulates concurrent removal
+      stubSuccessfulRefreshChain();
+
+      await refreshTokenSet(
+        auth0Config,
+        store,
+        "opaque-access-token",
+        tokenSet,
+      );
+
+      expect(store.get("opaque-access-token")).toBeUndefined();
+      // Auth0 call fires (already in flight) but CP/DP should not
+      sinon.assert.calledOnce(fetchStub);
+    });
+
+    it("should discard phase-2 update when the token is removed after phase-1 persistence", async () => {
+      const tokenSet = createTokenSet({ refreshToken: "old-refresh" });
+      store.store(tokenSet);
+      fetchStub.onCall(0).resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "new-id-token",
+            refresh_token: "rotated-refresh",
+            access_token: "new-access",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      // Remove the token mid-flight, as CP is being fetched. Phase-2 will
+      // still succeed but the final store.update must be a no-op.
+      fetchStub.onCall(1).callsFake(async () => {
+        store.remove("opaque-access-token");
+        return new Response(JSON.stringify({ token: "new-cp-token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      fetchStub.onCall(2).resolves(
+        new Response(JSON.stringify({ token: "new-dp-token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await refreshTokenSet(
+        auth0Config,
+        store,
+        "opaque-access-token",
+        tokenSet,
+      );
+
+      expect(store.get("opaque-access-token")).toBeUndefined();
+      expect(store.size).toBe(0);
+      // All three phases ran even though the final update was a no-op.
+      expect(fetchStub.callCount).toBe(3);
+    });
+  });
+
   describe("createRefreshCallback", () => {
-    it("should skip tokens with CP expiry more than 1 minute away", async () => {
+    it("should do nothing when store is empty", async () => {
+      const callback = createRefreshCallback(auth0Config);
+
+      await callback(store);
+
+      sinon.assert.notCalled(fetchStub);
+    });
+
+    it("should skip tokens with CP fresher than the refresh window", async () => {
       const callback = createRefreshCallback(auth0Config);
       store.store(
         createTokenSet({
@@ -93,192 +302,73 @@ describe("oauth/token-refresh.ts", () => {
       sinon.assert.notCalled(fetchStub);
     });
 
-    it("should refresh tokens when CP expiry is within 1 minute", async () => {
-      const callback = createRefreshCallback(auth0Config);
-      store.store(
-        createTokenSet({
-          controlPlaneExpiresAt: Date.now() + 30_000,
-        }),
-      );
-
-      stubSuccessfulRefreshChain();
-
-      await callback(store);
-
-      sinon.assert.calledThrice(fetchStub);
-
-      const updated = store.get("opaque-access-token");
-      expect(updated!.controlPlaneToken).toBe("new-cp-token");
-      expect(updated!.dataPlaneToken).toBe("new-dp-token");
-      expect(updated!.refreshToken).toBe("new-refresh-token");
-      expect(updated!.accessToken).toBe("opaque-access-token");
-    });
-
-    it("should refresh tokens when CP is already expired", async () => {
-      const callback = createRefreshCallback(auth0Config);
-      store.store(
-        createTokenSet({
-          controlPlaneExpiresAt: Date.now() - 1000,
-        }),
-      );
-
-      stubSuccessfulRefreshChain();
-
-      await callback(store);
-
-      sinon.assert.calledThrice(fetchStub);
-      expect(store.get("opaque-access-token")!.controlPlaneToken).toBe(
-        "new-cp-token",
-      );
-    });
-
-    it("should remove token set when absolute expiry has passed", async () => {
+    it("should remove token sets with expired absolute refresh expiry", async () => {
       const callback = createRefreshCallback(auth0Config);
       store.store(
         createTokenSet({
           refreshTokenAbsoluteExpiresAt: Date.now() - 1000,
-          controlPlaneExpiresAt: Date.now() - 1000,
         }),
       );
 
       await callback(store);
 
       sinon.assert.notCalled(fetchStub);
-      expect(store.get("opaque-access-token")).toBeUndefined();
       expect(store.size).toBe(0);
     });
 
-    it("should remove token set when idle expiry has passed", async () => {
+    it("should remove token sets with expired idle refresh expiry", async () => {
       const callback = createRefreshCallback(auth0Config);
       store.store(
         createTokenSet({
           refreshTokenIdleExpiresAt: Date.now() - 1000,
-          controlPlaneExpiresAt: Date.now() - 1000,
         }),
       );
 
       await callback(store);
 
       sinon.assert.notCalled(fetchStub);
-      expect(store.get("opaque-access-token")).toBeUndefined();
       expect(store.size).toBe(0);
     });
 
-    it("should do nothing when store is empty", async () => {
+    it("should iterate every due token (no early exit after one refresh)", async () => {
       const callback = createRefreshCallback(auth0Config);
-
-      await callback(store);
-
-      sinon.assert.notCalled(fetchStub);
-    });
-
-    it("should continue to next token if one fails to refresh", async () => {
-      const callback = createRefreshCallback(auth0Config);
-
-      store.store(
-        createTokenSet({
-          accessToken: "token-a",
-          refreshToken: "refresh-a",
-          controlPlaneExpiresAt: Date.now() + 10_000,
-        }),
-      );
-      store.store(
-        createTokenSet({
-          accessToken: "token-b",
-          refreshToken: "refresh-b",
-          controlPlaneExpiresAt: Date.now() + 10_000,
-        }),
-      );
-
-      // First refresh (token-a): fails at Auth0
-      fetchStub
-        .onCall(0)
-        .resolves(new Response("bad request", { status: 400 }));
-      // Second refresh (token-b): succeeds
-      fetchStub.onCall(1).resolves(
-        new Response(
-          JSON.stringify({
-            id_token: "b-id",
-            refresh_token: "b-new-refresh",
-            access_token: "b-access",
-            token_type: "Bearer",
-            expires_in: 60,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      );
-      fetchStub.onCall(2).resolves(
-        new Response(JSON.stringify({ token: "b-new-cp" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-      fetchStub.onCall(3).resolves(
-        new Response(JSON.stringify({ token: "b-new-dp" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-
-      await callback(store);
-
-      // Token A should still have old values (refresh failed)
-      expect(store.get("token-a")!.controlPlaneToken).toBe("cp-token");
-      // Token B should be updated
-      expect(store.get("token-b")!.controlPlaneToken).toBe("b-new-cp");
-    });
-
-    it("should refresh multiple tokens that are all near expiry", async () => {
-      const callback = createRefreshCallback(auth0Config);
-
       store.store(
         createTokenSet({
           accessToken: "token-1",
-          refreshToken: "refresh-1",
           controlPlaneExpiresAt: Date.now() + 20_000,
         }),
       );
       store.store(
         createTokenSet({
           accessToken: "token-2",
-          refreshToken: "refresh-2",
           controlPlaneExpiresAt: Date.now() + 20_000,
         }),
       );
 
-      for (let i = 0; i < 2; i++) {
-        const base = i * 3;
-        fetchStub.onCall(base).resolves(
-          new Response(
-            JSON.stringify({
-              id_token: `id-${i}`,
-              refresh_token: `refresh-new-${i}`,
-              access_token: `access-${i}`,
-              token_type: "Bearer",
-              expires_in: 60,
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-        );
-        fetchStub.onCall(base + 1).resolves(
-          new Response(JSON.stringify({ token: `cp-new-${i}` }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-        );
-        fetchStub.onCall(base + 2).resolves(
-          new Response(JSON.stringify({ token: `dp-new-${i}` }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-        );
-      }
+      // 2 tokens × 3 fetches each. callsFake builds a fresh Response per call
+      // (Response bodies are single-use, so .resolves(shared) would fail on reuse).
+      const auth0Body = JSON.stringify({
+        id_token: "id",
+        refresh_token: "rt",
+        access_token: "a",
+        token_type: "Bearer",
+        expires_in: 60,
+      });
+      const cpBody = JSON.stringify({ token: "cp" });
+      const dpBody = JSON.stringify({ token: "dp" });
+      const jsonHeaders = { "Content-Type": "application/json" };
+      fetchStub.callsFake(async () => {
+        const calls = fetchStub.callCount;
+        const phase = (calls - 1) % 3;
+        const body = phase === 0 ? auth0Body : phase === 1 ? cpBody : dpBody;
+        return new Response(body, { status: 200, headers: jsonHeaders });
+      });
 
       await callback(store);
 
       expect(fetchStub.callCount).toBe(6);
-      expect(store.get("token-1")!.controlPlaneToken).toBe("cp-new-0");
-      expect(store.get("token-2")!.controlPlaneToken).toBe("cp-new-1");
+      expect(store.get("token-1")!.controlPlaneToken).toBe("cp");
+      expect(store.get("token-2")!.controlPlaneToken).toBe("cp");
     });
   });
 

--- a/src/confluent/oauth/token-refresh.test.ts
+++ b/src/confluent/oauth/token-refresh.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import sinon from "sinon";
+import { nodeFetch } from "@src/confluent/node-deps.js";
+import { TokenStore } from "@src/confluent/oauth/token-store.js";
+import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
+import {
+  createRefreshCallback,
+  startAutoRefresh,
+} from "@src/confluent/oauth/token-refresh.js";
+import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
+
+describe("oauth/token-refresh.ts", () => {
+  const sandbox = sinon.createSandbox();
+  const auth0Config = getAuth0Config("devel");
+  let fetchStub: sinon.SinonStub;
+  let store: TokenStore;
+
+  beforeEach(() => {
+    fetchStub = sandbox.stub(nodeFetch, "fetch");
+    store = new TokenStore();
+  });
+
+  afterEach(() => {
+    store.shutdown();
+    sandbox.restore();
+  });
+
+  function createTokenSet(
+    overrides?: Partial<ConfluentTokenSet>,
+  ): ConfluentTokenSet {
+    return {
+      refreshToken: "refresh-token",
+      refreshTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+      controlPlaneToken: "cp-token",
+      controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+      dataPlaneToken: "dp-token",
+      dataPlaneExpiresAt: Date.now() + 15 * 60 * 1000,
+      accessToken: "opaque-access-token",
+      ...overrides,
+    };
+  }
+
+  function stubSuccessfulRefreshChain() {
+    // Auth0 refresh → new tokens
+    fetchStub.onCall(0).resolves(
+      new Response(
+        JSON.stringify({
+          id_token: "new-id-token",
+          refresh_token: "new-refresh-token",
+          access_token: "new-access",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    // ID → CP
+    fetchStub.onCall(1).resolves(
+      new Response(JSON.stringify({ token: "new-cp-token" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    // CP → DP
+    fetchStub.onCall(2).resolves(
+      new Response(JSON.stringify({ token: "new-dp-token" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+
+  describe("createRefreshCallback", () => {
+    it("should skip tokens with CP expiry more than 1 minute away", async () => {
+      const callback = createRefreshCallback(auth0Config);
+      store.store(
+        createTokenSet({
+          controlPlaneExpiresAt: Date.now() + 3 * 60 * 1000,
+        }),
+      );
+
+      await callback(store);
+
+      sinon.assert.notCalled(fetchStub);
+    });
+
+    it("should refresh tokens when CP expiry is within 1 minute", async () => {
+      const callback = createRefreshCallback(auth0Config);
+      store.store(
+        createTokenSet({
+          controlPlaneExpiresAt: Date.now() + 30_000,
+        }),
+      );
+
+      stubSuccessfulRefreshChain();
+
+      await callback(store);
+
+      sinon.assert.calledThrice(fetchStub);
+
+      const updated = store.get("opaque-access-token");
+      expect(updated!.controlPlaneToken).toBe("new-cp-token");
+      expect(updated!.dataPlaneToken).toBe("new-dp-token");
+      expect(updated!.refreshToken).toBe("new-refresh-token");
+      expect(updated!.accessToken).toBe("opaque-access-token");
+    });
+
+    it("should refresh tokens when CP is already expired", async () => {
+      const callback = createRefreshCallback(auth0Config);
+      store.store(
+        createTokenSet({
+          controlPlaneExpiresAt: Date.now() - 1000,
+        }),
+      );
+
+      stubSuccessfulRefreshChain();
+
+      await callback(store);
+
+      sinon.assert.calledThrice(fetchStub);
+      expect(store.get("opaque-access-token")!.controlPlaneToken).toBe(
+        "new-cp-token",
+      );
+    });
+
+    it("should remove token set when refresh token has expired", async () => {
+      const callback = createRefreshCallback(auth0Config);
+      store.store(
+        createTokenSet({
+          refreshTokenExpiresAt: Date.now() - 1000,
+          controlPlaneExpiresAt: Date.now() - 1000,
+        }),
+      );
+
+      await callback(store);
+
+      sinon.assert.notCalled(fetchStub);
+      expect(store.get("opaque-access-token")).toBeUndefined();
+      expect(store.size).toBe(0);
+    });
+
+    it("should do nothing when store is empty", async () => {
+      const callback = createRefreshCallback(auth0Config);
+
+      await callback(store);
+
+      sinon.assert.notCalled(fetchStub);
+    });
+
+    it("should continue to next token if one fails to refresh", async () => {
+      const callback = createRefreshCallback(auth0Config);
+
+      store.store(
+        createTokenSet({
+          accessToken: "token-a",
+          refreshToken: "refresh-a",
+          controlPlaneExpiresAt: Date.now() + 10_000,
+        }),
+      );
+      store.store(
+        createTokenSet({
+          accessToken: "token-b",
+          refreshToken: "refresh-b",
+          controlPlaneExpiresAt: Date.now() + 10_000,
+        }),
+      );
+
+      // First refresh (token-a): fails at Auth0
+      fetchStub
+        .onCall(0)
+        .resolves(new Response("bad request", { status: 400 }));
+      // Second refresh (token-b): succeeds
+      fetchStub.onCall(1).resolves(
+        new Response(
+          JSON.stringify({
+            id_token: "b-id",
+            refresh_token: "b-new-refresh",
+            access_token: "b-access",
+            token_type: "Bearer",
+            expires_in: 60,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      fetchStub.onCall(2).resolves(
+        new Response(JSON.stringify({ token: "b-new-cp" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      fetchStub.onCall(3).resolves(
+        new Response(JSON.stringify({ token: "b-new-dp" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await callback(store);
+
+      // Token A should still have old values (refresh failed)
+      expect(store.get("token-a")!.controlPlaneToken).toBe("cp-token");
+      // Token B should be updated
+      expect(store.get("token-b")!.controlPlaneToken).toBe("b-new-cp");
+    });
+
+    it("should refresh multiple tokens that are all near expiry", async () => {
+      const callback = createRefreshCallback(auth0Config);
+
+      store.store(
+        createTokenSet({
+          accessToken: "token-1",
+          refreshToken: "refresh-1",
+          controlPlaneExpiresAt: Date.now() + 20_000,
+        }),
+      );
+      store.store(
+        createTokenSet({
+          accessToken: "token-2",
+          refreshToken: "refresh-2",
+          controlPlaneExpiresAt: Date.now() + 20_000,
+        }),
+      );
+
+      for (let i = 0; i < 2; i++) {
+        const base = i * 3;
+        fetchStub.onCall(base).resolves(
+          new Response(
+            JSON.stringify({
+              id_token: `id-${i}`,
+              refresh_token: `refresh-new-${i}`,
+              access_token: `access-${i}`,
+              token_type: "Bearer",
+              expires_in: 60,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+        fetchStub.onCall(base + 1).resolves(
+          new Response(JSON.stringify({ token: `cp-new-${i}` }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+        fetchStub.onCall(base + 2).resolves(
+          new Response(JSON.stringify({ token: `dp-new-${i}` }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      await callback(store);
+
+      expect(fetchStub.callCount).toBe(6);
+      expect(store.get("token-1")!.controlPlaneToken).toBe("cp-new-0");
+      expect(store.get("token-2")!.controlPlaneToken).toBe("cp-new-1");
+    });
+  });
+
+  describe("startAutoRefresh", () => {
+    it("should wire the refresh callback into the store loop", () => {
+      const startSpy = sandbox.spy(store, "startRefreshLoop");
+
+      startAutoRefresh(store, auth0Config);
+
+      sinon.assert.calledOnce(startSpy);
+      const [intervalMs, callback] = startSpy.firstCall.args;
+      expect(intervalMs).toBe(4 * 60 * 1000);
+      expect(typeof callback).toBe("function");
+    });
+
+    it("should accept a custom interval", () => {
+      const startSpy = sandbox.spy(store, "startRefreshLoop");
+
+      startAutoRefresh(store, auth0Config, 60_000);
+
+      sinon.assert.calledOnce(startSpy);
+      expect(startSpy.firstCall.args[0]).toBe(60_000);
+    });
+  });
+});

--- a/src/confluent/oauth/token-refresh.test.ts
+++ b/src/confluent/oauth/token-refresh.test.ts
@@ -8,6 +8,13 @@ import {
   startAutoRefresh,
 } from "@src/confluent/oauth/token-refresh.js";
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
+import {
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
+  DATA_PLANE_TOKEN_LIFETIME_MS,
+  DEFAULT_REFRESH_INTERVAL_MS,
+  REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+  REFRESH_TOKEN_IDLE_LIFETIME_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 
 describe("oauth/token-refresh.ts", () => {
   const sandbox = sinon.createSandbox();
@@ -30,11 +37,13 @@ describe("oauth/token-refresh.ts", () => {
   ): ConfluentTokenSet {
     return {
       refreshToken: "refresh-token",
-      refreshTokenExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
+      refreshTokenAbsoluteExpiresAt:
+        Date.now() + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+      refreshTokenIdleExpiresAt: Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS,
       controlPlaneToken: "cp-token",
-      controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+      controlPlaneExpiresAt: Date.now() + CONTROL_PLANE_TOKEN_LIFETIME_MS,
       dataPlaneToken: "dp-token",
-      dataPlaneExpiresAt: Date.now() + 15 * 60 * 1000,
+      dataPlaneExpiresAt: Date.now() + DATA_PLANE_TOKEN_LIFETIME_MS,
       accessToken: "opaque-access-token",
       ...overrides,
     };
@@ -123,11 +132,27 @@ describe("oauth/token-refresh.ts", () => {
       );
     });
 
-    it("should remove token set when refresh token has expired", async () => {
+    it("should remove token set when absolute expiry has passed", async () => {
       const callback = createRefreshCallback(auth0Config);
       store.store(
         createTokenSet({
-          refreshTokenExpiresAt: Date.now() - 1000,
+          refreshTokenAbsoluteExpiresAt: Date.now() - 1000,
+          controlPlaneExpiresAt: Date.now() - 1000,
+        }),
+      );
+
+      await callback(store);
+
+      sinon.assert.notCalled(fetchStub);
+      expect(store.get("opaque-access-token")).toBeUndefined();
+      expect(store.size).toBe(0);
+    });
+
+    it("should remove token set when idle expiry has passed", async () => {
+      const callback = createRefreshCallback(auth0Config);
+      store.store(
+        createTokenSet({
+          refreshTokenIdleExpiresAt: Date.now() - 1000,
           controlPlaneExpiresAt: Date.now() - 1000,
         }),
       );
@@ -265,7 +290,7 @@ describe("oauth/token-refresh.ts", () => {
 
       sinon.assert.calledOnce(startSpy);
       const [intervalMs, callback] = startSpy.firstCall.args;
-      expect(intervalMs).toBe(4 * 60 * 1000);
+      expect(intervalMs).toBe(DEFAULT_REFRESH_INTERVAL_MS);
       expect(typeof callback).toBe("function");
     });
 

--- a/src/confluent/oauth/token-refresh.ts
+++ b/src/confluent/oauth/token-refresh.ts
@@ -1,21 +1,106 @@
-import type { Auth0Config } from "@src/confluent/oauth/types.js";
+import type {
+  Auth0Config,
+  ConfluentTokenSet,
+} from "@src/confluent/oauth/types.js";
 import type { TokenStore } from "@src/confluent/oauth/token-store.js";
-import { refreshTokenChain } from "@src/confluent/oauth/token-chain.js";
+import {
+  exchangeControlPlaneForDataPlaneToken,
+  exchangeIdTokenForControlPlaneToken,
+  exchangeRefreshTokenForAuth0Tokens,
+} from "@src/confluent/oauth/token-chain.js";
 import {
   CONTROL_PLANE_REFRESH_WINDOW_MS,
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
+  DATA_PLANE_TOKEN_LIFETIME_MS,
   DEFAULT_REFRESH_INTERVAL_MS,
+  REFRESH_TOKEN_IDLE_LIFETIME_MS,
 } from "@src/confluent/oauth/token-lifetimes.js";
 import { logger } from "@src/logger.js";
 
+/** Refreshes one token set, persisting to `store` at each phase boundary. */
+export async function refreshTokenSet(
+  auth0Config: Auth0Config,
+  store: TokenStore,
+  accessToken: string,
+  tokenSet: ConfluentTokenSet,
+): Promise<void> {
+  // Phase 1: rotate the refresh token with Auth0. Auth0 invalidates the old
+  // token on success, so we persist the rotated token IMMEDIATELY before
+  // attempting CP/DP exchange — otherwise a CP/DP failure would leave the
+  // store with an already-burned refresh token and brick the session.
+  let auth0Response;
+  try {
+    auth0Response = await exchangeRefreshTokenForAuth0Tokens(
+      auth0Config,
+      tokenSet.refreshToken,
+    );
+  } catch (error) {
+    logger.error(
+      { error },
+      "Auth0 refresh failed; keeping existing stored token set for next tick",
+    );
+    return;
+  }
+
+  const rotationTime = Date.now();
+  const rotatedIdleExpiresAt = rotationTime + REFRESH_TOKEN_IDLE_LIFETIME_MS;
+
+  const rotationPersisted = store.update(accessToken, {
+    refreshToken: auth0Response.refresh_token,
+    refreshTokenIdleExpiresAt: rotatedIdleExpiresAt,
+    controlPlaneToken: tokenSet.controlPlaneToken,
+    controlPlaneExpiresAt: tokenSet.controlPlaneExpiresAt,
+    dataPlaneToken: tokenSet.dataPlaneToken,
+    dataPlaneExpiresAt: tokenSet.dataPlaneExpiresAt,
+  });
+
+  if (!rotationPersisted) {
+    logger.debug(
+      "Token removed during refresh; discarding rotated credentials",
+    );
+    return;
+  }
+
+  // Phase 2: derive new CP and DP tokens. A single-attempt failure here
+  // leaves the rotated refresh token safely in the store; the next scheduler
+  // tick will re-rotate and retry. Smarter retry (transient-only, bounded
+  // attempts) lands in the transient/non-transient classification work.
+  try {
+    const cpResponse = await exchangeIdTokenForControlPlaneToken(
+      auth0Config.apiUrl,
+      auth0Response.id_token,
+    );
+    const dpResponse = await exchangeControlPlaneForDataPlaneToken(
+      auth0Config.apiUrl,
+      cpResponse.token,
+    );
+
+    const updated = store.update(accessToken, {
+      controlPlaneToken: cpResponse.token,
+      controlPlaneExpiresAt: rotationTime + CONTROL_PLANE_TOKEN_LIFETIME_MS,
+      dataPlaneToken: dpResponse.token,
+      dataPlaneExpiresAt: rotationTime + DATA_PLANE_TOKEN_LIFETIME_MS,
+    });
+
+    if (!updated) {
+      logger.debug(
+        "Token removed during refresh; discarding rotated credentials",
+      );
+    } else {
+      logger.debug("Token set refreshed successfully");
+    }
+  } catch (error) {
+    logger.error(
+      { error },
+      "CP/DP exchange failed; rotated refresh token preserved for next tick",
+    );
+  }
+}
+
 /**
- * Creates the refresh callback that iterates all stored token sets
- * and refreshes any whose control plane token is approaching expiry.
- *
- * For each token set:
- * - Skips if the refresh token itself has expired (removes the token set)
- * - Skips if the control plane token is still fresh (more than 1 min remaining)
- * - Calls refreshTokenChain to get new tokens and updates the store
- * - On failure, logs the error but continues to the next token set
+ * Creates the refresh callback: scans the store and for each token set either
+ * removes it (refresh token expired), skips it (CP still fresh), or delegates
+ * to {@link refreshTokenSet}.
  */
 export function createRefreshCallback(
   auth0Config: Auth0Config,
@@ -38,7 +123,6 @@ export function createRefreshCallback(
 
       const now = Date.now();
 
-      // Remove if the refresh token has expired (8hr absolute or 4hr idle)
       if (
         now >= tokenSet.refreshTokenAbsoluteExpiresAt ||
         now >= tokenSet.refreshTokenIdleExpiresAt
@@ -48,31 +132,14 @@ export function createRefreshCallback(
         continue;
       }
 
-      // Skip if CP token still has more than the refresh window remaining
-      const cpTimeRemaining = tokenSet.controlPlaneExpiresAt - now;
-      if (cpTimeRemaining > CONTROL_PLANE_REFRESH_WINDOW_MS) {
+      if (
+        tokenSet.controlPlaneExpiresAt - now >
+        CONTROL_PLANE_REFRESH_WINDOW_MS
+      ) {
         continue;
       }
 
-      try {
-        const result = await refreshTokenChain(
-          auth0Config,
-          tokenSet.refreshToken,
-        );
-
-        store.update(accessToken, {
-          refreshToken: result.refreshToken,
-          refreshTokenIdleExpiresAt: result.refreshTokenIdleExpiresAt,
-          controlPlaneToken: result.controlPlaneToken,
-          controlPlaneExpiresAt: result.controlPlaneExpiresAt,
-          dataPlaneToken: result.dataPlaneToken,
-          dataPlaneExpiresAt: result.dataPlaneExpiresAt,
-        });
-
-        logger.debug("Token set refreshed successfully");
-      } catch (error) {
-        logger.error({ error }, "Failed to refresh token set");
-      }
+      await refreshTokenSet(auth0Config, store, accessToken, tokenSet);
     }
   };
 }

--- a/src/confluent/oauth/token-refresh.ts
+++ b/src/confluent/oauth/token-refresh.ts
@@ -13,6 +13,7 @@ import {
 import type { TokenStore } from "@src/confluent/oauth/token-store.js";
 import type {
   Auth0Config,
+  Auth0TokenResponse,
   ConfluentTokenSet,
 } from "@src/confluent/oauth/types.js";
 import { logger } from "@src/logger.js";
@@ -28,7 +29,7 @@ export async function refreshTokenSet(
   // token on success, so we persist the rotated token IMMEDIATELY before
   // attempting CP/DP exchange — otherwise a CP/DP failure would leave the
   // store with an already-burned refresh token and brick the session.
-  let auth0Response;
+  let auth0Response: Auth0TokenResponse;
   try {
     auth0Response = await exchangeRefreshTokenForAuth0Tokens(
       auth0Config,
@@ -48,10 +49,6 @@ export async function refreshTokenSet(
   const rotationPersisted = store.update(accessToken, {
     refreshToken: auth0Response.refresh_token,
     refreshTokenIdleExpiresAt: rotatedIdleExpiresAt,
-    controlPlaneToken: tokenSet.controlPlaneToken,
-    controlPlaneExpiresAt: tokenSet.controlPlaneExpiresAt,
-    dataPlaneToken: tokenSet.dataPlaneToken,
-    dataPlaneExpiresAt: tokenSet.dataPlaneExpiresAt,
   });
 
   if (!rotationPersisted) {

--- a/src/confluent/oauth/token-refresh.ts
+++ b/src/confluent/oauth/token-refresh.ts
@@ -1,10 +1,8 @@
 import type { Auth0Config } from "@src/confluent/oauth/types.js";
 import type { TokenStore } from "@src/confluent/oauth/token-store.js";
 import { refreshTokenChain } from "@src/confluent/oauth/token-chain.js";
+import { DEFAULT_REFRESH_INTERVAL_MS } from "@src/confluent/oauth/token-lifetimes.js";
 import { logger } from "@src/logger.js";
-
-/** Refresh tokens 1 minute before CP expiry (4 min interval for 5 min CP TTL) */
-const DEFAULT_REFRESH_INTERVAL_MS = 4 * 60 * 1000;
 
 /**
  * Creates the refresh callback that iterates all stored token sets
@@ -37,8 +35,11 @@ export function createRefreshCallback(
 
       const now = Date.now();
 
-      // Remove if the refresh token has expired (8hr absolute lifetime)
-      if (now >= tokenSet.refreshTokenExpiresAt) {
+      // Remove if the refresh token has expired (8hr absolute or 4hr idle)
+      if (
+        now >= tokenSet.refreshTokenAbsoluteExpiresAt ||
+        now >= tokenSet.refreshTokenIdleExpiresAt
+      ) {
         logger.info("Refresh token expired, removing token set");
         store.remove(accessToken);
         continue;
@@ -58,6 +59,7 @@ export function createRefreshCallback(
 
         store.update(accessToken, {
           refreshToken: result.refreshToken,
+          refreshTokenIdleExpiresAt: result.refreshTokenIdleExpiresAt,
           controlPlaneToken: result.controlPlaneToken,
           controlPlaneExpiresAt: result.controlPlaneExpiresAt,
           dataPlaneToken: result.dataPlaneToken,

--- a/src/confluent/oauth/token-refresh.ts
+++ b/src/confluent/oauth/token-refresh.ts
@@ -1,0 +1,86 @@
+import type { Auth0Config } from "@src/confluent/oauth/types.js";
+import type { TokenStore } from "@src/confluent/oauth/token-store.js";
+import { refreshTokenChain } from "@src/confluent/oauth/token-chain.js";
+import { logger } from "@src/logger.js";
+
+/** Refresh tokens 1 minute before CP expiry (4 min interval for 5 min CP TTL) */
+const DEFAULT_REFRESH_INTERVAL_MS = 4 * 60 * 1000;
+
+/**
+ * Creates the refresh callback that iterates all stored token sets
+ * and refreshes any whose control plane token is approaching expiry.
+ *
+ * For each token set:
+ * - Skips if the refresh token itself has expired (removes the token set)
+ * - Skips if the control plane token is still fresh (more than 1 min remaining)
+ * - Calls refreshTokenChain to get new tokens and updates the store
+ * - On failure, logs the error but continues to the next token set
+ */
+export function createRefreshCallback(
+  auth0Config: Auth0Config,
+): (store: TokenStore) => Promise<void> {
+  return async (store: TokenStore): Promise<void> => {
+    const accessTokens = store.getAllAccessTokens();
+
+    if (accessTokens.length === 0) {
+      return;
+    }
+
+    logger.debug(
+      { count: accessTokens.length },
+      "Refresh loop: checking tokens",
+    );
+
+    for (const accessToken of accessTokens) {
+      const tokenSet = store.get(accessToken);
+      if (!tokenSet) continue;
+
+      const now = Date.now();
+
+      // Remove if the refresh token has expired (8hr absolute lifetime)
+      if (now >= tokenSet.refreshTokenExpiresAt) {
+        logger.info("Refresh token expired, removing token set");
+        store.remove(accessToken);
+        continue;
+      }
+
+      // Skip if CP token still has more than 1 minute remaining
+      const cpTimeRemaining = tokenSet.controlPlaneExpiresAt - now;
+      if (cpTimeRemaining > 60_000) {
+        continue;
+      }
+
+      try {
+        const result = await refreshTokenChain(
+          auth0Config,
+          tokenSet.refreshToken,
+        );
+
+        store.update(accessToken, {
+          refreshToken: result.refreshToken,
+          controlPlaneToken: result.controlPlaneToken,
+          controlPlaneExpiresAt: result.controlPlaneExpiresAt,
+          dataPlaneToken: result.dataPlaneToken,
+          dataPlaneExpiresAt: result.dataPlaneExpiresAt,
+        });
+
+        logger.debug("Token set refreshed successfully");
+      } catch (error) {
+        logger.error({ error }, "Failed to refresh token set");
+      }
+    }
+  };
+}
+
+/**
+ * Starts the auto-refresh loop on the given token store.
+ * Convenience function that wires createRefreshCallback into store.startRefreshLoop.
+ */
+export function startAutoRefresh(
+  store: TokenStore,
+  auth0Config: Auth0Config,
+  intervalMs: number = DEFAULT_REFRESH_INTERVAL_MS,
+): void {
+  const callback = createRefreshCallback(auth0Config);
+  store.startRefreshLoop(intervalMs, callback);
+}

--- a/src/confluent/oauth/token-refresh.ts
+++ b/src/confluent/oauth/token-refresh.ts
@@ -1,7 +1,10 @@
 import type { Auth0Config } from "@src/confluent/oauth/types.js";
 import type { TokenStore } from "@src/confluent/oauth/token-store.js";
 import { refreshTokenChain } from "@src/confluent/oauth/token-chain.js";
-import { DEFAULT_REFRESH_INTERVAL_MS } from "@src/confluent/oauth/token-lifetimes.js";
+import {
+  CONTROL_PLANE_REFRESH_WINDOW_MS,
+  DEFAULT_REFRESH_INTERVAL_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 import { logger } from "@src/logger.js";
 
 /**
@@ -45,9 +48,9 @@ export function createRefreshCallback(
         continue;
       }
 
-      // Skip if CP token still has more than 1 minute remaining
+      // Skip if CP token still has more than the refresh window remaining
       const cpTimeRemaining = tokenSet.controlPlaneExpiresAt - now;
-      if (cpTimeRemaining > 60_000) {
+      if (cpTimeRemaining > CONTROL_PLANE_REFRESH_WINDOW_MS) {
         continue;
       }
 

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -103,6 +103,32 @@ describe("oauth/token-store.ts", () => {
 
         expect(result).toBe(false);
       });
+
+      it("should leave omitted fields unchanged when given a partial update", () => {
+        const tokenSet = createTokenSet();
+        store.store(tokenSet);
+
+        store.update("opaque-access-token", {
+          refreshToken: "new-refresh",
+        });
+
+        const updated = store.get("opaque-access-token")!;
+        expect(updated.refreshToken).toBe("new-refresh");
+        // Every other field preserved from the original
+        expect(updated.refreshTokenAbsoluteExpiresAt).toBe(
+          tokenSet.refreshTokenAbsoluteExpiresAt,
+        );
+        expect(updated.refreshTokenIdleExpiresAt).toBe(
+          tokenSet.refreshTokenIdleExpiresAt,
+        );
+        expect(updated.controlPlaneToken).toBe("cp-token");
+        expect(updated.controlPlaneExpiresAt).toBe(
+          tokenSet.controlPlaneExpiresAt,
+        );
+        expect(updated.dataPlaneToken).toBe("dp-token");
+        expect(updated.dataPlaneExpiresAt).toBe(tokenSet.dataPlaneExpiresAt);
+        expect(updated.accessToken).toBe("opaque-access-token");
+      });
     });
 
     describe("getAllAccessTokens", () => {

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -2,11 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import sinon from "sinon";
 import { TokenStore } from "@src/confluent/oauth/token-store.js";
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
-
-const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
-const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;
-const FIVE_MINUTES_MS = 5 * 60 * 1000;
-const TEN_MINUTES_MS = 10 * 60 * 1000;
+import {
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
+  DATA_PLANE_TOKEN_LIFETIME_MS,
+  REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+  REFRESH_TOKEN_IDLE_LIFETIME_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 
 describe("oauth/token-store.ts", () => {
   describe("TokenStore", () => {
@@ -25,12 +26,13 @@ describe("oauth/token-store.ts", () => {
     ): ConfluentTokenSet {
       return {
         refreshToken: "refresh-token",
-        refreshTokenAbsoluteExpiresAt: Date.now() + EIGHT_HOURS_MS,
-        refreshTokenIdleExpiresAt: Date.now() + FOUR_HOURS_MS,
+        refreshTokenAbsoluteExpiresAt:
+          Date.now() + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+        refreshTokenIdleExpiresAt: Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS,
         controlPlaneToken: "cp-token",
-        controlPlaneExpiresAt: Date.now() + FIVE_MINUTES_MS,
+        controlPlaneExpiresAt: Date.now() + CONTROL_PLANE_TOKEN_LIFETIME_MS,
         dataPlaneToken: "dp-token",
-        dataPlaneExpiresAt: Date.now() + TEN_MINUTES_MS,
+        dataPlaneExpiresAt: Date.now() + DATA_PLANE_TOKEN_LIFETIME_MS,
         accessToken: "opaque-access-token",
         ...overrides,
       };
@@ -73,11 +75,12 @@ describe("oauth/token-store.ts", () => {
 
         store.update("opaque-access-token", {
           refreshToken: "new-refresh",
-          refreshTokenIdleExpiresAt: Date.now() + FOUR_HOURS_MS,
+          refreshTokenIdleExpiresAt:
+            Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS,
           controlPlaneToken: "new-cp",
           dataPlaneToken: "new-dp",
-          controlPlaneExpiresAt: Date.now() + FIVE_MINUTES_MS,
-          dataPlaneExpiresAt: Date.now() + TEN_MINUTES_MS,
+          controlPlaneExpiresAt: Date.now() + CONTROL_PLANE_TOKEN_LIFETIME_MS,
+          dataPlaneExpiresAt: Date.now() + DATA_PLANE_TOKEN_LIFETIME_MS,
         });
 
         const updated = store.get("opaque-access-token");

--- a/src/confluent/oauth/token-store.ts
+++ b/src/confluent/oauth/token-store.ts
@@ -39,22 +39,16 @@ export class TokenStore {
   }
 
   /**
-   * Update the refreshable fields of an existing token set.
+   * Update a subset of the refreshable fields of an existing token set.
    * Returns false if the access token is not found.
    */
-  update(accessToken: string, fields: TokenUpdateFields): boolean {
+  update(accessToken: string, fields: Partial<TokenUpdateFields>): boolean {
     const existing = this.tokens.get(accessToken);
     if (!existing) {
       return false;
     }
 
-    existing.refreshToken = fields.refreshToken;
-    existing.refreshTokenIdleExpiresAt = fields.refreshTokenIdleExpiresAt;
-    existing.controlPlaneToken = fields.controlPlaneToken;
-    existing.controlPlaneExpiresAt = fields.controlPlaneExpiresAt;
-    existing.dataPlaneToken = fields.dataPlaneToken;
-    existing.dataPlaneExpiresAt = fields.dataPlaneExpiresAt;
-
+    Object.assign(existing, fields);
     return true;
   }
 

--- a/src/confluent/oauth/types.test.ts
+++ b/src/confluent/oauth/types.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from "vitest";
+import {
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
+  DATA_PLANE_TOKEN_LIFETIME_MS,
+  REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+  REFRESH_TOKEN_IDLE_LIFETIME_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 import type {
   Auth0Environment,
   Auth0TokenResponse,
@@ -13,12 +19,13 @@ describe("oauth/types.ts", () => {
     it("should be constructable with all required fields", () => {
       const tokenSet: ConfluentTokenSet = {
         refreshToken: "refresh-abc",
-        refreshTokenAbsoluteExpiresAt: Date.now() + 8 * 60 * 60 * 1000,
-        refreshTokenIdleExpiresAt: Date.now() + 4 * 60 * 60 * 1000,
+        refreshTokenAbsoluteExpiresAt:
+          Date.now() + REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+        refreshTokenIdleExpiresAt: Date.now() + REFRESH_TOKEN_IDLE_LIFETIME_MS,
         controlPlaneToken: "cp-token",
-        controlPlaneExpiresAt: Date.now() + 5 * 60 * 1000,
+        controlPlaneExpiresAt: Date.now() + CONTROL_PLANE_TOKEN_LIFETIME_MS,
         dataPlaneToken: "dp-token",
-        dataPlaneExpiresAt: Date.now() + 10 * 60 * 1000,
+        dataPlaneExpiresAt: Date.now() + DATA_PLANE_TOKEN_LIFETIME_MS,
         accessToken: "opaque-token",
       };
 


### PR DESCRIPTION
### Summary

Background refresh for the OAuth token store:

- Scans stored token sets; removes any whose refresh token has expired (8hr absolute or 4hr idle); skips any whose control-plane token is still fresh; otherwise refreshes.
- Each refresh runs in two atomic phases. Phase 1 rotates the Auth0 refresh token and persists it immediately (partial update). Phase 2 derives new control-plane and data plane tokens and persists them together. A phase-2 failure leaves the rotated refresh safely stored so the next tick can retry without bricking the session.
- Retry on phase-2 failure is deferred to #195, where it ships with transient vs non-transient error classification.
- Shared lifetime constants (CP/DP/refresh/window) with `DEFAULT_REFRESH_INTERVAL_MS` derived as `CP_LIFETIME - REFRESH_WINDOW`.
- `startAutoRefresh` convenience wires the callback into the store's refresh loop.
- Tightens `TokenChainResult` (absolute refresh expiry now required) and relaxes `TokenStore.update` to accept a partial field set.

Closes #182

### PR Stack
- #183
  - #185
    - #187
      - (this) #193