### PR TITLE
MINOR: update `npm-audit` pipeline to catch nonzero exits

### DIFF
--- a/.semaphore/npm-audit.yml
+++ b/.semaphore/npm-audit.yml
@@ -35,7 +35,9 @@ blocks:
             - npm ci --prefer-offline
             # `npm audit fix` applies non-breaking security fixes; including `--force` should only
             # be done manually on local branches and include evaluating any breaking changes
-            - npm audit fix
+            # ( || true to avoid exiting with non-zero if there are unfixable vulnerabilities that
+            # require manual possibly-breaking changes to package.json)
+            - npm audit fix || true
             - |
               if git diff --quiet -- package.json package-lock.json; then
                 echo "No changes after npm audit fix; nothing to do."


### PR DESCRIPTION
This wasn't an issue in #189 since all dependency updates were cleanly applied, but over in another repo the behavior wasn't as straightforward -- when some dependencies couldn't be fixed via `npm audit fix`, it failed the pipeline:
<img width="799" height="260" alt="image" src="https://github.com/user-attachments/assets/ecfb8d95-d405-4645-82c6-8dd7b5dabaf7" />

So now we attempt to catch those errors, hope there were still some changes applied to `package-lock.json`, and create/update the PR.