### PR TITLE
chore: set default behavior for import sorting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; [ -n \"$f\" ] && npx prettier --write --ignore-unknown \"$f\"; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | { read -r f; [ -n \"$f\" ] && npx prettier --write --ignore-unknown \"$f\"; } 2>/dev/null || true"
+            "command": "command -v jq >/dev/null 2>&1 && jq -r '.tool_input.file_path' | xargs npx prettier --write --ignore-unknown 2>/dev/null || true"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ TEST-result*.xml
 .vscode/*
 !.vscode/launch.json
 !.vscode/mcp.json
+!.vscode/settings.json
 !.vscode/tasks.json
 .idea
 .continue

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,6 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "arrowParens": "always",
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.formatOnType": false,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.formatOnType": false
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "husky": "^9.1.7",
         "openapi-typescript": "^7.8.0",
         "prettier": "3.6.1",
+        "prettier-plugin-organize-imports": "^4.3.0",
         "sinon": "^21.0.2",
         "tsc-alias": "^1.8.16",
         "typescript": "^5.8.3",
@@ -8638,6 +8639,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz",
+      "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/process-warning": {

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "fastify": "^5.7.3",
     "openapi-fetch": "^0.14.0",
     "pino": "^10.1.0",
+    "pino-pretty": "^13.1.3",
     "properties-file": "^3.5.12",
-    "yaml": "^2.8.3",
-    "pino-pretty": "^13.1.3"
+    "yaml": "^2.8.3"
   },
   "overrides": {
     "zod": "^4.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "husky": "^9.1.7",
     "openapi-typescript": "^7.8.0",
     "prettier": "3.6.1",
+    "prettier-plugin-organize-imports": "^4.3.0",
     "sinon": "^21.0.2",
     "tsc-alias": "^1.8.16",
     "typescript": "^5.8.3",

--- a/src/confluent/oauth/auth0-config.test.ts
+++ b/src/confluent/oauth/auth0-config.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
 import {
   getAuth0Config,
-  OAUTH_CALLBACK_PORT,
   OAUTH_CALLBACK_PATH,
+  OAUTH_CALLBACK_PORT,
 } from "@src/confluent/oauth/auth0-config.js";
 import type { Auth0Environment } from "@src/confluent/oauth/types.js";
+import { describe, expect, it } from "vitest";
 
 describe("oauth/auth0-config.ts", () => {
   describe("getAuth0Config", () => {

--- a/src/confluent/oauth/crypto-utils.test.ts
+++ b/src/confluent/oauth/crypto-utils.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
 import {
-  generateOpaqueToken,
-  generateCodeVerifier,
   generateCodeChallenge,
+  generateCodeVerifier,
+  generateOpaqueToken,
 } from "@src/confluent/oauth/crypto-utils.js";
+import { describe, expect, it } from "vitest";
 
 describe("oauth/crypto-utils.ts", () => {
   describe("generateOpaqueToken", () => {

--- a/src/confluent/oauth/token-chain.test.ts
+++ b/src/confluent/oauth/token-chain.test.ts
@@ -1,14 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import sinon from "sinon";
 import { nodeFetch } from "@src/confluent/node-deps.js";
+import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 import {
   exchangeAuthCodeForTokens,
-  exchangeIdTokenForControlPlaneToken,
   exchangeControlPlaneForDataPlaneToken,
-  refreshTokenChain,
+  exchangeIdTokenForControlPlaneToken,
   executeFullTokenChain,
+  refreshTokenChain,
 } from "@src/confluent/oauth/token-chain.js";
-import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
+import sinon from "sinon";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
 const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;

--- a/src/confluent/oauth/token-chain.ts
+++ b/src/confluent/oauth/token-chain.ts
@@ -1,10 +1,10 @@
+import { nodeFetch } from "@src/confluent/node-deps.js";
 import type {
   Auth0Config,
   Auth0TokenResponse,
   ControlPlaneTokenResponse,
   DataPlaneTokenResponse,
 } from "@src/confluent/oauth/types.js";
-import { nodeFetch } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
 
 /** 5 minutes in milliseconds — control plane token lifetime */

--- a/src/confluent/oauth/token-store.test.ts
+++ b/src/confluent/oauth/token-store.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import sinon from "sinon";
 import { TokenStore } from "@src/confluent/oauth/token-store.js";
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
+import sinon from "sinon";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
 const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;

--- a/src/confluent/oauth/types.test.ts
+++ b/src/confluent/oauth/types.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import type {
   Auth0Environment,
   Auth0TokenResponse,
@@ -7,6 +6,7 @@ import type {
   DataPlaneTokenResponse,
   OAuthConfig,
 } from "@src/confluent/oauth/types.js";
+import { describe, expect, it } from "vitest";
 
 describe("oauth/types.ts", () => {
   describe("ConfluentTokenSet", () => {

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
@@ -1,11 +1,11 @@
 import { ClientManager } from "@src/confluent/client-manager.js";
+import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { EnvVar } from "@src/env-schema.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";

--- a/src/mcp/transports/auth.ts
+++ b/src/mcp/transports/auth.ts
@@ -1,6 +1,6 @@
+import { logger } from "@src/logger.js";
 import { randomBytes, timingSafeEqual } from "crypto";
 import { FastifyReply, FastifyRequest } from "fastify";
-import { logger } from "@src/logger.js";
 
 /**
  * Configuration for MCP server authentication

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -1,9 +1,9 @@
 export { createStubAdmin, type StubbedAdmin } from "./admin.js";
 export {
-  createFsWrappers,
-  type StubbedFsWrappers,
-  createFetchWrapper,
-  type StubbedFetchWrapper,
   createCryptoWrapper,
+  createFetchWrapper,
+  createFsWrappers,
   type StubbedCryptoWrapper,
+  type StubbedFetchWrapper,
+  type StubbedFsWrappers,
 } from "./node-deps.js";


### PR DESCRIPTION
Includes:
- new [`prettier-plugin-organize-imports`](https://www.npmjs.com/package/prettier-plugin-organize-imports) dev dependency
- `.prettierrc` config to use the above plugin
- VS Code project settings to incorporate the prettier formatting into document save actions (only applicable for users with https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode installed)
- new project-level Claude setting including an Edit+Write [hook](https://code.claude.com/docs/en/hooks) 