### PR TITLE
chore: update PR template and add script for regenerating CCloud openapi client code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,11 +26,6 @@ Please check if your PR fulfills the following (if applicable):
 - [ ] Updated existing
 - [ ] Deleted existing
 
-#### OpenAPI types
-
-<!-- prettier-ignore -->
-- [ ] If this PR introduces calls to a new Confluent Cloud REST endpoint, have you updated `openapi.json` and regenerated `src/confluent/openapi-schema.d.ts`?
-
 #### Release notes
 
 <!-- prettier-ignore -->

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 src/generated
+# Confluent Cloud API spec; keep upstream formatting so spec bumps
+# don't mix with prettier whitespace churn.
+openapi.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Tools are **auto-enabled/disabled** based on which environment variables are pre
 2. Create handler class extending `BaseToolHandler` in `src/confluent/tools/handlers/<domain>/`.
 3. Implement `getToolConfig()` (name, description, Zod input schema), `handle()`, and `getRequiredEnvVars()`.
 4. Register the handler in `ToolFactory.handlers` map in `src/confluent/tools/tool-factory.ts`.
-5. If the tool calls a new Confluent Cloud REST endpoint, add it to `openapi.json` and regenerate types with `openapi-typescript` (`npx openapi-typescript openapi.json -o src/confluent/openapi-schema.d.ts`).
+5. If the tool calls a new Confluent Cloud REST endpoint, add it to `openapi.json` and regenerate types with `npm run generate:openapi-types`. Commit the updated `src/confluent/openapi-schema.d.ts` alongside the `openapi.json` change.
 
 ## Code Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,7 +287,14 @@ After pressing F5, your MCP client should automatically discover the `confluent-
 
 ### Generating Types
 
+`openapi.json` is a vendored snapshot of the public Confluent Cloud API spec. It drives the typed `openapi-fetch` clients in `src/confluent/client-manager.ts`, and only needs changes when a new handler calls a Confluent Cloud REST endpoint whose path or response shape isn't already described there (for example, a preview API the snapshot predates). Handlers that wrap existing typed endpoints, or that go through the Kafka / Schema Registry SDKs, don't require a spec edit.
+
+If you edit `openapi.json`, regenerate `src/confluent/openapi-schema.d.ts`:
+
 ```bash
-# as of v7.5.2 there is a bug when using allOf w/ required https://github.com/openapi-ts/openapi-typescript/issues/1474. need --empty-objects-unknown flag to avoid it
-npx openapi-typescript ./openapi.json -o ./src/confluent/openapi-schema.d.ts --empty-objects-unknown
+npm run generate:openapi-types
 ```
+
+Commit both files together so downstream contributors see the same types the vendored spec describes.
+
+> The script passes `--empty-objects-unknown` to work around [openapi-typescript#1474](https://github.com/openapi-ts/openapi-typescript/issues/1474) (a bug since v7.5.2 with `allOf` + `required`).

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.+(js|ts|json)\"",
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "generate:openapi-types": "openapi-typescript ./openapi.json -o ./src/confluent/openapi-schema.d.ts --empty-objects-unknown",
     "print:schema": "node dist/print-md-schema.js",
     "inspector": "npx @modelcontextprotocol/inspector node dist/index.js --env-file .env",
     "prepare": "husky",


### PR DESCRIPTION
I mistakenly thought `openapi.json` was something we had to provide for non-AI MCP server clients in https://github.com/confluentinc/mcp-confluent/pull/196, but that's not the case.
Removed the reference from the PR template in https://github.com/confluentinc/mcp-confluent/pull/196, made the "generate TS client code" step into a single `generate:openapi-types` script, and added some additional documentation.
