### PR TITLE
Define api-key based auth clause blocks in YAML config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Or install the [npm package](https://www.npmjs.com/package/@confluentinc/mcp-con
 - [User Guide](#user-guide)
   - [Getting Started](#getting-started)
   - [Configuration](#configuration)
+    - [YAML Configuration](#yaml-configuration)
   - [Authentication for HTTP/SSE Transports](#authentication-for-httpsse-transports)
   - [Usage](#usage)
   - [CLI Usage](#cli-usage)
@@ -136,7 +137,41 @@ You can configure the MCP server using the following environment variables:
 | TELEMETRY_ENDPOINT            | Base URL for Confluent Cloud Telemetry API (metrics)                                                                                                                                                                                                              | "https://api.telemetry.confluent.cloud" | No       |
 | TELEMETRY_API_KEY             | Optional API key for telemetry access. Falls back to CONFLUENT_CLOUD_API_KEY if not set. (See [Metrics API authentication docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#create-an-api-key-to-authenticate-to-the-metrics-api).)       |                                         | No       |
 | TELEMETRY_API_SECRET          | Optional API secret for telemetry access. Falls back to CONFLUENT_CLOUD_API_SECRET if not set. (See [Metrics API authentication docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#create-an-api-key-to-authenticate-to-the-metrics-api).) |                                         | No       |
-| DO_NOT_TRACK                  | Set to `true` to opt out of anonymous telemetry data collection. See [Telemetry](#telemetry) for details.                                                                                                                                                        |                                         | No       |
+| DO_NOT_TRACK                  | Set to `true` to opt out of anonymous telemetry data collection. See [Telemetry](#telemetry) for details.                                                                                                                                                         |                                         | No       |
+
+### YAML Configuration
+
+> **Note:** YAML-based configuration is actively being built out as the replacement for env-var-only startup. The two modes coexist during the transition — the server accepts both.
+
+Pass a YAML config file at startup with the `--config` flag:
+
+```bash
+npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
+```
+
+#### Why YAML over environment variables
+
+Flat environment variables can only express a single implicit connection. A YAML file can define multiple named connections, which is necessary for real-world workflows — for example, a `local-dev` connection pointing at a local Docker Kafka alongside a `staging` connection to a Confluent Cloud cluster, all in one file.
+
+#### Configuration examples
+
+Browse [test-fixtures/yaml_configs/valid/](test-fixtures/yaml_configs/valid/) for working examples covering a range of configurations. These files are executed as part of the test suite on every CI run, so they are always valid and current — use them as your starting point.
+
+#### Env-var interpolation in YAML
+
+`${VAR}` and `${VAR:-default}` syntax is supported anywhere in a config file, so secrets can stay in environment variables while structure lives in the YAML:
+
+```yaml
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        key: "${KAFKA_API_KEY}"
+        secret: "${KAFKA_API_SECRET}"
+```
 
 #### Prerequisites & Setup for Tableflow Commands
 

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -85,5 +85,145 @@ describe("config/env-config.ts", () => {
         ).toThrow(/Invalid format 'invalid-no-port': must be host:port/);
       });
     });
+
+    describe("with auth env vars", () => {
+      it("should populate kafka auth when both KAFKA_API_KEY and KAFKA_API_SECRET are set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: "localhost:9092",
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: "mykey",
+          KAFKA_API_SECRET: "mysecret",
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.kafka?.auth).toEqual({
+          type: "api_key",
+          key: "mykey",
+          secret: "mysecret",
+        });
+      });
+
+      it("should populate schema_registry auth when both SR vars are set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: "https://sr.example.com",
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: "srkey",
+          SCHEMA_REGISTRY_API_SECRET: "srsecret",
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.schema_registry?.auth).toEqual({
+          type: "api_key",
+          key: "srkey",
+          secret: "srsecret",
+        });
+      });
+
+      it("should populate auth on both sides when all four auth vars are set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: "localhost:9092",
+          SCHEMA_REGISTRY_ENDPOINT: "https://sr.example.com",
+          KAFKA_API_KEY: "kafkakey",
+          KAFKA_API_SECRET: "kafkasecret",
+          SCHEMA_REGISTRY_API_KEY: "srkey",
+          SCHEMA_REGISTRY_API_SECRET: "srsecret",
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.kafka?.auth).toEqual({
+          type: "api_key",
+          key: "kafkakey",
+          secret: "kafkasecret",
+        });
+        expect(conn.schema_registry?.auth).toEqual({
+          type: "api_key",
+          key: "srkey",
+          secret: "srsecret",
+        });
+      });
+    });
+
+    describe("partial auth credentials (misconfiguration)", () => {
+      it("should throw when KAFKA_API_KEY is set but KAFKA_API_SECRET is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: "localhost:9092",
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: "mykey",
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+          }),
+        ).toThrow(/KAFKA_API_SECRET/);
+      });
+
+      it("should throw when KAFKA_API_SECRET is set but KAFKA_API_KEY is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: "localhost:9092",
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: "mysecret",
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+          }),
+        ).toThrow(/KAFKA_API_KEY/);
+      });
+
+      it("should throw when SCHEMA_REGISTRY_API_KEY is set but SCHEMA_REGISTRY_API_SECRET is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: "https://sr.example.com",
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: "srkey",
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+          }),
+        ).toThrow(/SCHEMA_REGISTRY_API_SECRET/);
+      });
+
+      it("should throw when SCHEMA_REGISTRY_API_SECRET is set but SCHEMA_REGISTRY_API_KEY is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: "https://sr.example.com",
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: "srsecret",
+          }),
+        ).toThrow(/SCHEMA_REGISTRY_API_KEY/);
+      });
+    });
+
+    describe("auth credentials without corresponding endpoint (misconfiguration)", () => {
+      it("should throw when Kafka auth is set but BOOTSTRAP_SERVERS is absent", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: "mykey",
+            KAFKA_API_SECRET: "mysecret",
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+          }),
+        ).toThrow(/BOOTSTRAP_SERVERS/);
+      });
+
+      it("should throw when SR auth is set but SCHEMA_REGISTRY_ENDPOINT is absent", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: "srkey",
+            SCHEMA_REGISTRY_API_SECRET: "srsecret",
+          }),
+        ).toThrow(/SCHEMA_REGISTRY_ENDPOINT/);
+      });
+    });
   });
 });

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -7,27 +7,70 @@ import type { Environment } from "@src/env.js";
 
 const ENV_CONNECTION_NAME = "env-connection";
 
+/** The manufactured document path prefix for the single connection configured from env vars. */
+const CONN = `connections.${ENV_CONNECTION_NAME}`;
+
+/**
+ * Maps each environment variable name handled by consConfigFromEnv to its
+ * corresponding Zod document path in the manufactured MCPServerConfiguration.
+ * The keys drive the Pick<Environment, ...> type of consConfigFromEnv, so every
+ * env var the function touches must have an entry here.
+ */
+const ENV_VAR_TO_ZPATH = {
+  // Kafka connection parameters
+  BOOTSTRAP_SERVERS: `${CONN}.kafka.bootstrap_servers`,
+  KAFKA_API_KEY: `${CONN}.kafka.auth.key`,
+  KAFKA_API_SECRET: `${CONN}.kafka.auth.secret`,
+  // Schema Registry connection parameters
+  SCHEMA_REGISTRY_ENDPOINT: `${CONN}.schema_registry.endpoint`,
+  SCHEMA_REGISTRY_API_KEY: `${CONN}.schema_registry.auth.key`,
+  SCHEMA_REGISTRY_API_SECRET: `${CONN}.schema_registry.auth.secret`,
+} satisfies Partial<Record<keyof Environment, string>>;
+
 /**
  * Constructs a single-direct-connection MCPServerConfiguration from environment variables.
  *
  * This is peer to the functionality provided by loadConfigFromYaml(), but for users
- * who want to configure the server solely via environment variables. Called when
+ * who want to configure the server solely via (legacy) environment variables. Called when
  * no YAML config file is provided via CLI args.
  *
  * @returns MCPServerConfiguration with a single connection constructed from an Environment object
  * @throws Error if required environment variables are missing or if validation fails
  */
 export function consConfigFromEnv(
-  env: Pick<Environment, "BOOTSTRAP_SERVERS" | "SCHEMA_REGISTRY_ENDPOINT">,
+  env: Pick<Environment, keyof typeof ENV_VAR_TO_ZPATH>,
 ): MCPServerConfiguration {
   const connection: Record<string, unknown> = { type: "direct" };
 
-  if (env.BOOTSTRAP_SERVERS) {
-    connection.kafka = { bootstrap_servers: env.BOOTSTRAP_SERVERS };
+  if (env.BOOTSTRAP_SERVERS || env.KAFKA_API_KEY || env.KAFKA_API_SECRET) {
+    const kafka: Record<string, unknown> = {};
+    if (env.BOOTSTRAP_SERVERS) kafka.bootstrap_servers = env.BOOTSTRAP_SERVERS;
+    if (env.KAFKA_API_KEY || env.KAFKA_API_SECRET) {
+      kafka.auth = {
+        type: "api_key",
+        key: env.KAFKA_API_KEY,
+        secret: env.KAFKA_API_SECRET,
+      };
+    }
+    connection.kafka = kafka;
   }
 
-  if (env.SCHEMA_REGISTRY_ENDPOINT) {
-    connection.schema_registry = { endpoint: env.SCHEMA_REGISTRY_ENDPOINT };
+  if (
+    env.SCHEMA_REGISTRY_ENDPOINT ||
+    env.SCHEMA_REGISTRY_API_KEY ||
+    env.SCHEMA_REGISTRY_API_SECRET
+  ) {
+    const sr: Record<string, unknown> = {};
+    if (env.SCHEMA_REGISTRY_ENDPOINT)
+      sr.endpoint = env.SCHEMA_REGISTRY_ENDPOINT;
+    if (env.SCHEMA_REGISTRY_API_KEY || env.SCHEMA_REGISTRY_API_SECRET) {
+      sr.auth = {
+        type: "api_key",
+        key: env.SCHEMA_REGISTRY_API_KEY,
+        secret: env.SCHEMA_REGISTRY_API_SECRET,
+      };
+    }
+    connection.schema_registry = sr;
   }
 
   const result = mcpConfigSchema.safeParse({
@@ -35,10 +78,25 @@ export function consConfigFromEnv(
   });
 
   if (!result.success) {
+    const formattedIssues = humanizeEnvConfigPaths(
+      formatZodIssues(result.error.issues),
+    );
     throw new Error(
-      `Failed to construct MCPServerConfiguration from environment variables:\n${formatZodIssues(result.error.issues)}`,
+      `Failed to construct MCPServerConfiguration from environment variables:\n${formattedIssues}`,
     );
   }
 
   return new MCPServerConfiguration(result.data);
+}
+
+/**
+ * Replaces Zod document path segments in a formatted error string with their
+ * corresponding environment variable names, translating schema-space errors
+ * back into the env-var space the user configured.
+ */
+function humanizeEnvConfigPaths(message: string): string {
+  return Object.entries(ENV_VAR_TO_ZPATH).reduce(
+    (msg, [envVar, zodPath]) => msg.replaceAll(zodPath, envVar),
+    message,
+  );
 }

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -335,6 +335,64 @@ describe("config/index.ts", () => {
       ).toThrow(/Invalid format 'not-a-valid-host-port': must be host:port/);
     });
 
+    describe("unknown key rejection", () => {
+      it("should reject an unknown key at the connection level", () => {
+        const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    typo_field: "oops"
+`;
+        expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+          /Configuration validation failed/,
+        );
+      });
+
+      it("should reject an unknown key inside the kafka sub-object", () => {
+        const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+      boostrap_servers: "typo"
+`;
+        expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+          /Configuration validation failed/,
+        );
+      });
+
+      it("should reject an unknown key inside the schema_registry sub-object", () => {
+        const yamlContent = `connections:
+  local:
+    type: "direct"
+    schema_registry:
+      endpoint: "http://localhost:8081"
+      endpint: "typo"
+`;
+        expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+          /Configuration validation failed/,
+        );
+      });
+
+      it("should reject an unknown key inside the auth block", () => {
+        const yamlContent = `connections:
+  local:
+    type: "direct"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+      auth:
+        type: api_key
+        key: "mykey"
+        secret: "mysecret"
+        extra_field: "oops"
+`;
+        expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+          /Configuration validation failed/,
+        );
+      });
+    });
+
     it("should throw when a referenced variable is missing from env", () => {
       const yamlContent = `connections:
   local:

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,4 +1,4 @@
-import { MCPServerConfiguration } from "@src/config/models.js";
+import { MCPServerConfiguration, mcpConfigSchema } from "@src/config/models.js";
 import { describe, expect, it } from "vitest";
 
 const directConnection = {
@@ -7,6 +7,16 @@ const directConnection = {
 };
 
 describe("config/models.ts", () => {
+  describe("mcpConfigSchema", () => {
+    it("should reject unknown keys at the document root", () => {
+      const result = mcpConfigSchema.safeParse({
+        conenctions: { local: directConnection },
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe("MCPServerConfiguration", () => {
     describe("getConnectionNames", () => {
       it("should return connection names sorted alphabetically", () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,17 +1,27 @@
 import { validateBootstrapServers } from "@src/config/validation.js";
 import { z } from "zod";
 
+export interface ApiKeyAuthConfig {
+  type: "api_key";
+  key: string;
+  secret: string;
+}
+
+export type AuthConfig = ApiKeyAuthConfig;
+
 /**
  * Connection configuration for a direct (local/Docker) Kafka cluster.
- * No authentication required. At least one of kafka or schema_registry must be present.
+ * At least one of kafka or schema_registry must be present.
  */
 export interface DirectConnectionConfig {
   type: "direct";
   kafka?: {
     bootstrap_servers: string;
+    auth?: AuthConfig;
   };
   schema_registry?: {
     endpoint: string;
+    auth?: AuthConfig;
   };
 }
 
@@ -60,36 +70,54 @@ export class MCPServerConfiguration {
 
 /* And now, Zod schemas for validation of MCPServerConfiguration and contained objects. */
 
+const apiKeyAuthSchema = z
+  .object({
+    type: z.literal("api_key"),
+    key: z.string().trim().min(1, "auth.key cannot be empty"),
+    secret: z.string().trim().min(1, "auth.secret cannot be empty"),
+  })
+  .strict();
+
+const authConfigSchema = z.discriminatedUnion("type", [apiKeyAuthSchema]);
+
 /** Zod schema for direct connection type */
-const directConnectionSchema = z.object({
-  type: z.literal("direct"),
-  kafka: z
-    .object({
-      bootstrap_servers: z
-        .string()
-        .trim()
-        .min(1, "bootstrap_servers cannot be empty")
-        .superRefine((value, ctx) => {
-          try {
-            validateBootstrapServers(value);
-          } catch (error) {
-            ctx.addIssue({
-              code: "custom",
-              message: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }),
-    })
-    .optional(),
-  schema_registry: z
-    .object({
-      endpoint: z
-        .string()
-        .trim()
-        .url("schema_registry.endpoint must be a valid URL"),
-    })
-    .optional(),
-});
+const directConnectionSchema = z
+  .object({
+    type: z.literal("direct"),
+    kafka: z
+      .object({
+        bootstrap_servers: z
+          .string()
+          .trim()
+          .min(1, "bootstrap_servers cannot be empty")
+          .superRefine((value, ctx) => {
+            try {
+              validateBootstrapServers(value);
+            } catch (error) {
+              ctx.addIssue({
+                code: "custom",
+                message: error instanceof Error ? error.message : String(error),
+              });
+            }
+          }),
+        auth: authConfigSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    schema_registry: z
+      .object({
+        endpoint: z
+          .string()
+          .trim()
+          .check(
+            z.url({ error: "schema_registry.endpoint must be a valid URL" }),
+          ),
+        auth: authConfigSchema.optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
 
 /**
  * Discriminated union of all connection types (currently just direct).

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -141,17 +141,19 @@ const connectionConfigSchema = z
  * Parsed output is wrapped in {@link MCPServerConfiguration} by
  * parseYamlConfiguration().
  */
-export const mcpConfigSchema = z.object({
-  connections: z
-    .record(
-      z.string().trim().min(1, "Connection name cannot be empty"),
-      connectionConfigSchema,
-    )
-    .refine(
-      (connections) => Object.keys(connections).length === 1,
-      "Exactly one connection must be defined (multiple connections not yet supported)",
-    ),
-});
+export const mcpConfigSchema = z
+  .object({
+    connections: z
+      .record(
+        z.string().trim().min(1, "Connection name cannot be empty"),
+        connectionConfigSchema,
+      )
+      .refine(
+        (connections) => Object.keys(connections).length === 1,
+        "Exactly one connection must be defined (multiple connections not yet supported)",
+      ),
+  })
+  .strict();
 
 /** Format Zod issues into a human-readable string */
 export function formatZodIssues(issues: z.ZodError["issues"]): string {

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -1,0 +1,163 @@
+import { loadConfigFromYaml } from "@src/config/index.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const FIXTURES_DIR = fileURLToPath(
+  new URL("../../test-fixtures/yaml_configs", import.meta.url),
+);
+
+function fixtureFile(relative: string): string {
+  return path.join(FIXTURES_DIR, relative);
+}
+
+const NO_ENV: Record<string, string | undefined> = {};
+
+describe("config/yaml-fixtures.test.ts", () => {
+  describe("valid fixtures", () => {
+    it("should load kafka-only config", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-only.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.type).toBe("direct");
+      expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
+      expect(conn.kafka?.auth).toBeUndefined();
+      expect(conn.schema_registry).toBeUndefined();
+    });
+
+    it("should load sr-only config", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/sr-only.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.type).toBe("direct");
+      expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
+      expect(conn.schema_registry?.auth).toBeUndefined();
+      expect(conn.kafka).toBeUndefined();
+    });
+
+    it("should load kafka-and-sr config with no auth", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-and-sr.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
+      expect(conn.kafka?.auth).toBeUndefined();
+      expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
+      expect(conn.schema_registry?.auth).toBeUndefined();
+    });
+
+    it("should load kafka-with-auth and parse the auth block", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.kafka?.auth).toEqual({
+        type: "api_key",
+        key: "mykafkakey",
+        secret: "mykafkasecret",
+      });
+      expect(conn.schema_registry).toBeUndefined();
+    });
+
+    it("should load sr-with-auth and parse the auth block", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/sr-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.schema_registry?.auth).toEqual({
+        type: "api_key",
+        key: "mysrkey",
+        secret: "mysrsecret",
+      });
+      expect(conn.kafka).toBeUndefined();
+    });
+
+    it("should load kafka-and-sr-both-with-auth with auth on both sides", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-and-sr-both-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.kafka?.auth).toEqual({
+        type: "api_key",
+        key: "mykafkakey",
+        secret: "mykafkasecret",
+      });
+      expect(conn.schema_registry?.auth).toEqual({
+        type: "api_key",
+        key: "mysrkey",
+        secret: "mysrsecret",
+      });
+    });
+
+    it("should resolve ${VAR} interpolation in auth fields", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-with-interpolated-auth.yaml"),
+        { KAFKA_API_KEY: "envkey", KAFKA_API_SECRET: "envsecret" },
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.kafka?.auth).toEqual({
+        type: "api_key",
+        key: "envkey",
+        secret: "envsecret",
+      });
+    });
+  });
+
+  describe("invalid fixtures", () => {
+    it("should reject auth block missing secret", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/auth-missing-secret.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/Configuration validation failed/);
+    });
+
+    it("should reject auth block missing key", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/auth-missing-key.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/Configuration validation failed/);
+    });
+
+    it("should reject auth block with unknown type", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/auth-unknown-type.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/Configuration validation failed/);
+    });
+
+    it("should reject auth block with empty key string", () => {
+      expect(() =>
+        loadConfigFromYaml(fixtureFile("invalid/auth-empty-key.yaml"), NO_ENV),
+      ).toThrow(/Configuration validation failed/);
+    });
+
+    it("should include a descriptive field path in error messages for missing secret", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/auth-missing-secret.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/auth/);
+    });
+
+    it("should include a descriptive field path in error messages for empty key", () => {
+      expect(() =>
+        loadConfigFromYaml(fixtureFile("invalid/auth-empty-key.yaml"), NO_ENV),
+      ).toThrow(/auth\.key cannot be empty/);
+    });
+  });
+});

--- a/test-fixtures/yaml_configs/invalid/auth-empty-key.yaml
+++ b/test-fixtures/yaml_configs/invalid/auth-empty-key.yaml
@@ -1,0 +1,9 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        key: ""
+        secret: "mykafkasecret"

--- a/test-fixtures/yaml_configs/invalid/auth-missing-key.yaml
+++ b/test-fixtures/yaml_configs/invalid/auth-missing-key.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        secret: "mykafkasecret"

--- a/test-fixtures/yaml_configs/invalid/auth-missing-secret.yaml
+++ b/test-fixtures/yaml_configs/invalid/auth-missing-secret.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        key: "mykafkakey"

--- a/test-fixtures/yaml_configs/invalid/auth-unknown-type.yaml
+++ b/test-fixtures/yaml_configs/invalid/auth-unknown-type.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: oauth2
+        token: "sometoken"

--- a/test-fixtures/yaml_configs/valid/kafka-and-sr-both-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-and-sr-both-with-auth.yaml
@@ -1,0 +1,15 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        key: "mykafkakey"
+        secret: "mykafkasecret"
+    schema_registry:
+      endpoint: "https://sr.confluent.cloud"
+      auth:
+        type: api_key
+        key: "mysrkey"
+        secret: "mysrsecret"

--- a/test-fixtures/yaml_configs/valid/kafka-and-sr.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-and-sr.yaml
@@ -1,0 +1,7 @@
+connections:
+  local:
+    type: direct
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "http://localhost:8081"

--- a/test-fixtures/yaml_configs/valid/kafka-only.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-only.yaml
@@ -1,0 +1,5 @@
+connections:
+  local:
+    type: direct
+    kafka:
+      bootstrap_servers: "localhost:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-auth.yaml
@@ -1,0 +1,9 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        key: "mykafkakey"
+        secret: "mykafkasecret"

--- a/test-fixtures/yaml_configs/valid/kafka-with-interpolated-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-interpolated-auth.yaml
@@ -1,0 +1,9 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      auth:
+        type: api_key
+        key: "${KAFKA_API_KEY}"
+        secret: "${KAFKA_API_SECRET}"

--- a/test-fixtures/yaml_configs/valid/sr-only.yaml
+++ b/test-fixtures/yaml_configs/valid/sr-only.yaml
@@ -1,0 +1,5 @@
+connections:
+  local:
+    type: direct
+    schema_registry:
+      endpoint: "http://localhost:8081"

--- a/test-fixtures/yaml_configs/valid/sr-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/sr-with-auth.yaml
@@ -1,0 +1,9 @@
+connections:
+  production:
+    type: direct
+    schema_registry:
+      endpoint: "https://sr.confluent.cloud"
+      auth:
+        type: api_key
+        key: "mysrkey"
+        secret: "mysrsecret"


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Define api key based auth clause blocks in YAML config  and handle when configuring from env vars. Eventually these blocks will support varying discriminated types (just like we do for connection types), but all we need at this time is api_key support.
- When configuring from env vars, Rotor Zod path-based errors back into the original env var names.

This is a child PR into feat/162-configure-server-from-either-yaml-or-env / [PR-198](https://github.com/confluentinc/mcp-confluent/pull/198).

The maximal yaml config is now:

```
connections:
  my-local:
    type: direct
    kafka:
      bootstrap_servers: "localhost:9092"
      auth:
          type: api_key
          key: kafka_api_key_name
          secret: kafka_api_secret
    schema_registry:
      endpoint: "http://localhost:8081"
      auth:
          type: api_key
          key: sr_api_key_name
          secret: sr_api_secret
```

and now includes support for the additional legacy env vars:
```
    KAFKA_API_KEY=kafka_api_key_name
    KAFKA_API_SECRET=kafka_api_secret
    SCHEMA_REGISTRY_API_KEY=sr_api_key_name
    SCHEMA_REGISTRY_API_SECRET=sr_api_secret
```

-

Reviewer: To read, start with src/config/models.ts, then src/config/index.ts, then look at the new corpus of fixture files showing valid / invalid confgurations.

Closes #165 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
