### PR TITLE
Yaml config for ccloud control plane api key and endpoint, and tableflow api key.

### DIFF
--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -64,7 +64,7 @@ describe("config/env-config.ts", () => {
             SCHEMA_REGISTRY_ENDPOINT: undefined,
           }),
         ).toThrow(
-          /At least one of 'kafka' or 'schema_registry' must be defined/,
+          /At least one of 'kafka', 'schema_registry', 'confluent_cloud', or 'tableflow' must be defined/,
         );
       });
 
@@ -208,6 +208,11 @@ describe("config/env-config.ts", () => {
             KAFKA_API_SECRET: "mysecret",
             SCHEMA_REGISTRY_API_KEY: undefined,
             SCHEMA_REGISTRY_API_SECRET: undefined,
+            CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+            CONFLUENT_CLOUD_API_KEY: undefined,
+            CONFLUENT_CLOUD_API_SECRET: undefined,
+            TABLEFLOW_API_KEY: undefined,
+            TABLEFLOW_API_SECRET: undefined,
           }),
         ).toThrow(/BOOTSTRAP_SERVERS/);
       });
@@ -221,8 +226,221 @@ describe("config/env-config.ts", () => {
             KAFKA_API_SECRET: undefined,
             SCHEMA_REGISTRY_API_KEY: "srkey",
             SCHEMA_REGISTRY_API_SECRET: "srsecret",
+            CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+            CONFLUENT_CLOUD_API_KEY: undefined,
+            CONFLUENT_CLOUD_API_SECRET: undefined,
+            TABLEFLOW_API_KEY: undefined,
+            TABLEFLOW_API_SECRET: undefined,
           }),
         ).toThrow(/SCHEMA_REGISTRY_ENDPOINT/);
+      });
+    });
+
+    describe("confluent_cloud env vars", () => {
+      it("should populate confluent_cloud auth when key and secret are set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+          CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+          CONFLUENT_CLOUD_API_KEY: "cckey",
+          CONFLUENT_CLOUD_API_SECRET: "ccsecret",
+          TABLEFLOW_API_KEY: undefined,
+          TABLEFLOW_API_SECRET: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.confluent_cloud?.auth).toEqual({
+          type: "api_key",
+          key: "cckey",
+          secret: "ccsecret",
+        });
+        expect(conn.confluent_cloud?.endpoint).toBeUndefined();
+      });
+
+      it("should populate confluent_cloud endpoint when only CONFLUENT_CLOUD_REST_ENDPOINT is set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+          CONFLUENT_CLOUD_REST_ENDPOINT: "https://custom.confluent.cloud",
+          CONFLUENT_CLOUD_API_KEY: undefined,
+          CONFLUENT_CLOUD_API_SECRET: undefined,
+          TABLEFLOW_API_KEY: undefined,
+          TABLEFLOW_API_SECRET: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.confluent_cloud?.endpoint).toBe(
+          "https://custom.confluent.cloud",
+        );
+        expect(conn.confluent_cloud?.auth).toBeUndefined();
+      });
+
+      it("should populate both endpoint and auth when all three CCloud vars are set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+          CONFLUENT_CLOUD_REST_ENDPOINT: "https://custom.confluent.cloud",
+          CONFLUENT_CLOUD_API_KEY: "cckey",
+          CONFLUENT_CLOUD_API_SECRET: "ccsecret",
+          TABLEFLOW_API_KEY: undefined,
+          TABLEFLOW_API_SECRET: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.confluent_cloud?.endpoint).toBe(
+          "https://custom.confluent.cloud",
+        );
+        expect(conn.confluent_cloud?.auth).toEqual({
+          type: "api_key",
+          key: "cckey",
+          secret: "ccsecret",
+        });
+      });
+
+      it("should be valid as a standalone block (no kafka or schema_registry)", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+          CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+          CONFLUENT_CLOUD_API_KEY: "cckey",
+          CONFLUENT_CLOUD_API_SECRET: "ccsecret",
+          TABLEFLOW_API_KEY: undefined,
+          TABLEFLOW_API_SECRET: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.confluent_cloud?.auth).toBeDefined();
+        expect(conn.kafka).toBeUndefined();
+        expect(conn.schema_registry).toBeUndefined();
+      });
+
+      it("should throw when CONFLUENT_CLOUD_API_KEY is set but CONFLUENT_CLOUD_API_SECRET is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+            CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+            CONFLUENT_CLOUD_API_KEY: "cckey",
+            CONFLUENT_CLOUD_API_SECRET: undefined,
+            TABLEFLOW_API_KEY: undefined,
+            TABLEFLOW_API_SECRET: undefined,
+          }),
+        ).toThrow(/CONFLUENT_CLOUD_API_SECRET/);
+      });
+
+      it("should throw when CONFLUENT_CLOUD_API_SECRET is set but CONFLUENT_CLOUD_API_KEY is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+            CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+            CONFLUENT_CLOUD_API_KEY: undefined,
+            CONFLUENT_CLOUD_API_SECRET: "ccsecret",
+            TABLEFLOW_API_KEY: undefined,
+            TABLEFLOW_API_SECRET: undefined,
+          }),
+        ).toThrow(/CONFLUENT_CLOUD_API_KEY/);
+      });
+    });
+
+    describe("tableflow env vars", () => {
+      it("should populate tableflow auth when key and secret are set", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+          CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+          CONFLUENT_CLOUD_API_KEY: undefined,
+          CONFLUENT_CLOUD_API_SECRET: undefined,
+          TABLEFLOW_API_KEY: "tfkey",
+          TABLEFLOW_API_SECRET: "tfsecret",
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.tableflow?.auth).toEqual({
+          type: "api_key",
+          key: "tfkey",
+          secret: "tfsecret",
+        });
+      });
+
+      it("should be valid as a standalone block (no kafka, sr, or confluent_cloud)", () => {
+        const config = consConfigFromEnv({
+          BOOTSTRAP_SERVERS: undefined,
+          SCHEMA_REGISTRY_ENDPOINT: undefined,
+          KAFKA_API_KEY: undefined,
+          KAFKA_API_SECRET: undefined,
+          SCHEMA_REGISTRY_API_KEY: undefined,
+          SCHEMA_REGISTRY_API_SECRET: undefined,
+          CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+          CONFLUENT_CLOUD_API_KEY: undefined,
+          CONFLUENT_CLOUD_API_SECRET: undefined,
+          TABLEFLOW_API_KEY: "tfkey",
+          TABLEFLOW_API_SECRET: "tfsecret",
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.tableflow?.auth).toBeDefined();
+        expect(conn.kafka).toBeUndefined();
+        expect(conn.schema_registry).toBeUndefined();
+        expect(conn.confluent_cloud).toBeUndefined();
+      });
+
+      it("should throw when TABLEFLOW_API_KEY is set but TABLEFLOW_API_SECRET is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+            CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+            CONFLUENT_CLOUD_API_KEY: undefined,
+            CONFLUENT_CLOUD_API_SECRET: undefined,
+            TABLEFLOW_API_KEY: "tfkey",
+            TABLEFLOW_API_SECRET: undefined,
+          }),
+        ).toThrow(/TABLEFLOW_API_SECRET/);
+      });
+
+      it("should throw when TABLEFLOW_API_SECRET is set but TABLEFLOW_API_KEY is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            BOOTSTRAP_SERVERS: undefined,
+            SCHEMA_REGISTRY_ENDPOINT: undefined,
+            KAFKA_API_KEY: undefined,
+            KAFKA_API_SECRET: undefined,
+            SCHEMA_REGISTRY_API_KEY: undefined,
+            SCHEMA_REGISTRY_API_SECRET: undefined,
+            CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+            CONFLUENT_CLOUD_API_KEY: undefined,
+            CONFLUENT_CLOUD_API_SECRET: undefined,
+            TABLEFLOW_API_KEY: undefined,
+            TABLEFLOW_API_SECRET: "tfsecret",
+          }),
+        ).toThrow(/TABLEFLOW_API_KEY/);
       });
     });
   });

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -25,6 +25,13 @@ const ENV_VAR_TO_ZPATH = {
   SCHEMA_REGISTRY_ENDPOINT: `${CONN}.schema_registry.endpoint`,
   SCHEMA_REGISTRY_API_KEY: `${CONN}.schema_registry.auth.key`,
   SCHEMA_REGISTRY_API_SECRET: `${CONN}.schema_registry.auth.secret`,
+  // Confluent Cloud control plane parameters
+  CONFLUENT_CLOUD_REST_ENDPOINT: `${CONN}.confluent_cloud.endpoint`,
+  CONFLUENT_CLOUD_API_KEY: `${CONN}.confluent_cloud.auth.key`,
+  CONFLUENT_CLOUD_API_SECRET: `${CONN}.confluent_cloud.auth.secret`,
+  // Tableflow parameters
+  TABLEFLOW_API_KEY: `${CONN}.tableflow.auth.key`,
+  TABLEFLOW_API_SECRET: `${CONN}.tableflow.auth.secret`,
 } satisfies Partial<Record<keyof Environment, string>>;
 
 /**
@@ -43,16 +50,12 @@ export function consConfigFromEnv(
   const connection: Record<string, unknown> = { type: "direct" };
 
   if (env.BOOTSTRAP_SERVERS || env.KAFKA_API_KEY || env.KAFKA_API_SECRET) {
-    const kafka: Record<string, unknown> = {};
-    if (env.BOOTSTRAP_SERVERS) kafka.bootstrap_servers = env.BOOTSTRAP_SERVERS;
-    if (env.KAFKA_API_KEY || env.KAFKA_API_SECRET) {
-      kafka.auth = {
-        type: "api_key",
-        key: env.KAFKA_API_KEY,
-        secret: env.KAFKA_API_SECRET,
-      };
-    }
-    connection.kafka = kafka;
+    connection.kafka = {
+      ...(env.BOOTSTRAP_SERVERS && {
+        bootstrap_servers: env.BOOTSTRAP_SERVERS,
+      }),
+      ...apiKeyAuth(env.KAFKA_API_KEY, env.KAFKA_API_SECRET),
+    };
   }
 
   if (
@@ -60,17 +63,38 @@ export function consConfigFromEnv(
     env.SCHEMA_REGISTRY_API_KEY ||
     env.SCHEMA_REGISTRY_API_SECRET
   ) {
-    const sr: Record<string, unknown> = {};
-    if (env.SCHEMA_REGISTRY_ENDPOINT)
-      sr.endpoint = env.SCHEMA_REGISTRY_ENDPOINT;
-    if (env.SCHEMA_REGISTRY_API_KEY || env.SCHEMA_REGISTRY_API_SECRET) {
-      sr.auth = {
-        type: "api_key",
-        key: env.SCHEMA_REGISTRY_API_KEY,
-        secret: env.SCHEMA_REGISTRY_API_SECRET,
-      };
-    }
-    connection.schema_registry = sr;
+    connection.schema_registry = {
+      ...(env.SCHEMA_REGISTRY_ENDPOINT && {
+        endpoint: env.SCHEMA_REGISTRY_ENDPOINT,
+      }),
+      ...apiKeyAuth(
+        env.SCHEMA_REGISTRY_API_KEY,
+        env.SCHEMA_REGISTRY_API_SECRET,
+      ),
+    };
+  }
+
+  if (
+    env.CONFLUENT_CLOUD_REST_ENDPOINT ||
+    env.CONFLUENT_CLOUD_API_KEY ||
+    env.CONFLUENT_CLOUD_API_SECRET
+  ) {
+    connection.confluent_cloud = {
+      ...(env.CONFLUENT_CLOUD_REST_ENDPOINT && {
+        endpoint: env.CONFLUENT_CLOUD_REST_ENDPOINT,
+      }),
+      ...apiKeyAuth(
+        env.CONFLUENT_CLOUD_API_KEY,
+        env.CONFLUENT_CLOUD_API_SECRET,
+      ),
+    };
+  }
+
+  if (env.TABLEFLOW_API_KEY || env.TABLEFLOW_API_SECRET) {
+    connection.tableflow = apiKeyAuth(
+      env.TABLEFLOW_API_KEY,
+      env.TABLEFLOW_API_SECRET,
+    );
   }
 
   const result = mcpConfigSchema.safeParse({
@@ -87,6 +111,15 @@ export function consConfigFromEnv(
   }
 
   return new MCPServerConfiguration(result.data);
+}
+
+/** Returns an `{ auth: ... }` spread object when either credential is present, empty object otherwise. */
+function apiKeyAuth(
+  key: string | undefined,
+  secret: string | undefined,
+): Record<string, unknown> {
+  if (!key && !secret) return {};
+  return { auth: { type: "api_key", key, secret } };
 }
 
 /**

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -136,7 +136,7 @@ describe("config/index.ts", () => {
         /Configuration validation failed/,
       );
       expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /At least one of 'kafka' or 'schema_registry' must be defined/,
+        /At least one of 'kafka', 'schema_registry', 'confluent_cloud', or 'tableflow' must be defined/,
       );
     });
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -103,6 +103,10 @@ const directConnectionSchema = z
         auth: authConfigSchema.optional(),
       })
       .strict()
+      .refine((cc) => cc.endpoint !== undefined || cc.auth !== undefined, {
+        message:
+          "confluent_cloud block must contain at least 'endpoint' or 'auth'",
+      })
       .optional(),
     kafka: z
       .object({
@@ -141,6 +145,9 @@ const directConnectionSchema = z
         auth: authConfigSchema.optional(),
       })
       .strict()
+      .refine((tf) => tf.auth !== undefined, {
+        message: "tableflow block must contain 'auth'",
+      })
       .optional(),
   })
   .strict();

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -15,16 +15,16 @@ export type AuthConfig = ApiKeyAuthConfig;
  */
 export interface DirectConnectionConfig {
   type: "direct";
+  confluent_cloud?: {
+    endpoint?: string;
+    auth?: AuthConfig;
+  };
   kafka?: {
     bootstrap_servers: string;
     auth?: AuthConfig;
   };
   schema_registry?: {
     endpoint: string;
-    auth?: AuthConfig;
-  };
-  confluent_cloud?: {
-    endpoint?: string;
     auth?: AuthConfig;
   };
   tableflow?: {
@@ -91,6 +91,19 @@ const authConfigSchema = z.discriminatedUnion("type", [apiKeyAuthSchema]);
 const directConnectionSchema = z
   .object({
     type: z.literal("direct"),
+    confluent_cloud: z
+      .object({
+        endpoint: z
+          .string()
+          .trim()
+          .check(
+            z.url({ error: "confluent_cloud.endpoint must be a valid URL" }),
+          )
+          .optional(),
+        auth: authConfigSchema.optional(),
+      })
+      .strict()
+      .optional(),
     kafka: z
       .object({
         bootstrap_servers: z
@@ -119,19 +132,6 @@ const directConnectionSchema = z
           .check(
             z.url({ error: "schema_registry.endpoint must be a valid URL" }),
           ),
-        auth: authConfigSchema.optional(),
-      })
-      .strict()
-      .optional(),
-    confluent_cloud: z
-      .object({
-        endpoint: z
-          .string()
-          .trim()
-          .check(
-            z.url({ error: "confluent_cloud.endpoint must be a valid URL" }),
-          )
-          .optional(),
         auth: authConfigSchema.optional(),
       })
       .strict()

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -11,7 +11,7 @@ export type AuthConfig = ApiKeyAuthConfig;
 
 /**
  * Connection configuration for a direct (local/Docker) Kafka cluster.
- * At least one of kafka or schema_registry must be present.
+ * At least one of kafka, schema_registry, confluent_cloud, or tableflow must be present.
  */
 export interface DirectConnectionConfig {
   type: "direct";
@@ -21,6 +21,13 @@ export interface DirectConnectionConfig {
   };
   schema_registry?: {
     endpoint: string;
+    auth?: AuthConfig;
+  };
+  confluent_cloud?: {
+    endpoint?: string;
+    auth?: AuthConfig;
+  };
+  tableflow?: {
     auth?: AuthConfig;
   };
 }
@@ -116,6 +123,25 @@ const directConnectionSchema = z
       })
       .strict()
       .optional(),
+    confluent_cloud: z
+      .object({
+        endpoint: z
+          .string()
+          .trim()
+          .check(
+            z.url({ error: "confluent_cloud.endpoint must be a valid URL" }),
+          )
+          .optional(),
+        auth: authConfigSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    tableflow: z
+      .object({
+        auth: authConfigSchema.optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -127,10 +153,17 @@ const connectionConfigSchema = z
   // superRefine is placed here (after the union) rather than on directConnectionSchema
   // because wrapping a ZodObject in ZodEffects breaks z.discriminatedUnion's discriminant lookup.
   .superRefine((data, ctx) => {
-    if (data.type === "direct" && !data.kafka && !data.schema_registry) {
+    if (
+      data.type === "direct" &&
+      !data.kafka &&
+      !data.schema_registry &&
+      !data.confluent_cloud &&
+      !data.tableflow
+    ) {
       ctx.addIssue({
         code: "custom",
-        message: "At least one of 'kafka' or 'schema_registry' must be defined",
+        message:
+          "At least one of 'kafka', 'schema_registry', 'confluent_cloud', or 'tableflow' must be defined",
       });
     }
   });

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -226,6 +226,20 @@ describe("config/yaml-fixtures.test.ts", () => {
       ).toThrow(/auth/);
     });
 
+    it("should reject a tableflow block with no auth", () => {
+      expect(() =>
+        loadConfigFromYaml(fixtureFile("invalid/tableflow-empty.yaml"), NO_ENV),
+      ).toThrow(/tableflow block must contain 'auth'/);
+    });
+
+    it("should reject a confluent_cloud block with neither endpoint nor auth", () => {
+      expect(() =>
+        loadConfigFromYaml(fixtureFile("invalid/ccloud-empty.yaml"), NO_ENV),
+      ).toThrow(
+        /confluent_cloud block must contain at least 'endpoint' or 'auth'/,
+      );
+    });
+
     it("should include a descriptive field path in error messages for empty key", () => {
       expect(() =>
         loadConfigFromYaml(fixtureFile("invalid/auth-empty-key.yaml"), NO_ENV),

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -111,6 +111,78 @@ describe("config/yaml-fixtures.test.ts", () => {
     });
   });
 
+  describe("confluent_cloud and tableflow fixtures", () => {
+    it("should load ccloud-with-auth with auth and no endpoint", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/ccloud-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.confluent_cloud?.auth).toEqual({
+        type: "api_key",
+        key: "mycloudkey",
+        secret: "mycloudsecret",
+      });
+      expect(conn.confluent_cloud?.endpoint).toBeUndefined();
+      expect(conn.kafka).toBeUndefined();
+      expect(conn.schema_registry).toBeUndefined();
+      expect(conn.tableflow).toBeUndefined();
+    });
+
+    it("should load ccloud-with-endpoint-and-auth with both fields populated", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/ccloud-with-endpoint-and-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.confluent_cloud?.endpoint).toBe(
+        "https://custom.confluent.cloud",
+      );
+      expect(conn.confluent_cloud?.auth).toEqual({
+        type: "api_key",
+        key: "mycloudkey",
+        secret: "mycloudsecret",
+      });
+    });
+
+    it("should load tableflow-with-auth with auth block", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/tableflow-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.tableflow?.auth).toEqual({
+        type: "api_key",
+        key: "mytableflowkey",
+        secret: "mytableflowsecret",
+      });
+      expect(conn.kafka).toBeUndefined();
+      expect(conn.schema_registry).toBeUndefined();
+      expect(conn.confluent_cloud).toBeUndefined();
+    });
+
+    it("should load ccloud-and-tableflow-with-auth with both blocks populated", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/ccloud-and-tableflow-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.confluent_cloud?.endpoint).toBe(
+        "https://api.confluent.cloud",
+      );
+      expect(conn.confluent_cloud?.auth).toEqual({
+        type: "api_key",
+        key: "mycloudkey",
+        secret: "mycloudsecret",
+      });
+      expect(conn.tableflow?.auth).toEqual({
+        type: "api_key",
+        key: "mytableflowkey",
+        secret: "mytableflowsecret",
+      });
+    });
+  });
+
   describe("invalid fixtures", () => {
     it("should reject auth block missing secret", () => {
       expect(() =>

--- a/test-fixtures/yaml_configs/invalid/ccloud-empty.yaml
+++ b/test-fixtures/yaml_configs/invalid/ccloud-empty.yaml
@@ -1,0 +1,4 @@
+connections:
+  local:
+    type: direct
+    confluent_cloud: {}

--- a/test-fixtures/yaml_configs/invalid/tableflow-empty.yaml
+++ b/test-fixtures/yaml_configs/invalid/tableflow-empty.yaml
@@ -1,0 +1,4 @@
+connections:
+  local:
+    type: direct
+    tableflow: {}

--- a/test-fixtures/yaml_configs/valid/ccloud-and-tableflow-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-and-tableflow-with-auth.yaml
@@ -1,0 +1,14 @@
+connections:
+  production:
+    type: direct
+    confluent_cloud:
+      endpoint: "https://api.confluent.cloud"
+      auth:
+        type: api_key
+        key: "mycloudkey"
+        secret: "mycloudsecret"
+    tableflow:
+      auth:
+        type: api_key
+        key: "mytableflowkey"
+        secret: "mytableflowsecret"

--- a/test-fixtures/yaml_configs/valid/ccloud-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-with-auth.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    confluent_cloud:
+      auth:
+        type: api_key
+        key: "mycloudkey"
+        secret: "mycloudsecret"

--- a/test-fixtures/yaml_configs/valid/ccloud-with-endpoint-and-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-with-endpoint-and-auth.yaml
@@ -1,0 +1,9 @@
+connections:
+  production:
+    type: direct
+    confluent_cloud:
+      endpoint: "https://custom.confluent.cloud"
+      auth:
+        type: api_key
+        key: "mycloudkey"
+        secret: "mycloudsecret"

--- a/test-fixtures/yaml_configs/valid/tableflow-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/tableflow-with-auth.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    tableflow:
+      auth:
+        type: api_key
+        key: "mytableflowkey"
+        secret: "mytableflowsecret"


### PR DESCRIPTION
## Summary of Changes

- Extend `DirectConnectionConfig` and `directConnectionSchema` with `confluent_cloud` (`endpoint?: string`, `auth?: AuthConfig`) and `tableflow` (`auth: AuthConfig`) blocks. `confluent_cloud` is ordered first as it will be referenced by multiple subcomponents; `tableflow` is last.
- `tableflow` carries no endpoint — it piggybacks CCloud infrastructure. Its `auth` is required in both the TypeScript type and the Zod schema. In a forthcoming change, `constructDefaultClientManager()` will additionally accept a `confluent_cloud.auth` credential as a substitute when constructing the Tableflow client, but that fallback is a runtime concern — the config layer requires explicit `tableflow.auth` when a `tableflow` block is present.
- A present-but-empty `confluent_cloud: {}` block (omitting both `endpoint` and `auth`) is rejected as degenerate; likewise `tableflow` without `auth` is rejected.
- `CONFLUENT_CLOUD_REST_ENDPOINT` no longer carries a Zod schema default; the fallback to `https://api.confluent.cloud` is applied in `constructDefaultClientManager()` at the point of use.
- Extend `consConfigFromEnv()` for five new env vars: `CONFLUENT_CLOUD_API_KEY`, `CONFLUENT_CLOUD_API_SECRET`, `CONFLUENT_CLOUD_REST_ENDPOINT`, `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET`.
- The "at least one block must be defined" guard now accepts `confluent_cloud` or `tableflow` as sufficient on their own.

The maximal YAML config is now:

```yaml
connections:
  production:
    type: direct
    confluent_cloud:
      endpoint: "https://api.confluent.cloud"
      auth:
        type: api_key
        key: cloud_api_key
        secret: cloud_api_secret
    kafka:
      bootstrap_servers: "broker.confluent.cloud:9092"
      auth:
        type: api_key
        key: kafka_api_key
        secret: kafka_api_secret
    schema_registry:
      endpoint: "https://sr.confluent.cloud"
      auth:
        type: api_key
        key: sr_api_key
        secret: sr_api_secret
    tableflow:
      auth:
        type: api_key
        key: tableflow_api_key
        secret: tableflow_api_secret
```

And the additional env vars now supported:

```
CONFLUENT_CLOUD_REST_ENDPOINT=https://api.confluent.cloud
CONFLUENT_CLOUD_API_KEY=cloud_api_key
CONFLUENT_CLOUD_API_SECRET=cloud_api_secret
TABLEFLOW_API_KEY=tableflow_api_key
TABLEFLOW_API_SECRET=tableflow_api_secret
```

Closes #203
Linear followup to #202
Step of #162

This is a child PR into feat/162-configure-server-from-either-yaml-or-env / https://github.com/confluentinc/mcp-confluent/pull/198.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
