### PR TITLE
Feat/204 model flink in yaml

### DIFF
--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -410,12 +410,10 @@ describe("config/env-config.ts", () => {
         const config = consConfigFromEnv({
           ...baseFlinkEnv,
           ...allRequiredFlinkEnvVars,
-          FLINK_REST_ENDPOINT: "https://flink.confluent.cloud",
           FLINK_ENV_NAME: "my-environment",
           FLINK_DATABASE_NAME: "my-cluster",
         });
         const conn = config.getSoleConnection();
-        expect(conn.flink?.endpoint).toBe("https://flink.confluent.cloud");
         expect(conn.flink?.environment_name).toBe("my-environment");
         expect(conn.flink?.database_name).toBe("my-cluster");
       });
@@ -457,12 +455,7 @@ describe("config/env-config.ts", () => {
         expect(() =>
           consConfigFromEnv({
             ...baseFlinkEnv,
-            ...allRequiredFlinkEnvVars,
-            FLINK_API_KEY: undefined,
-            FLINK_API_SECRET: undefined,
-            FLINK_ENV_ID: undefined,
-            FLINK_ORG_ID: undefined,
-            FLINK_COMPUTE_POOL_ID: undefined,
+            FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
           }),
         ).toThrow(/FLINK_ENV_ID/);
       });

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -64,7 +64,7 @@ describe("config/env-config.ts", () => {
             SCHEMA_REGISTRY_ENDPOINT: undefined,
           }),
         ).toThrow(
-          /At least one of 'kafka', 'schema_registry', 'confluent_cloud', or 'tableflow' must be defined/,
+          /At least one of 'kafka', 'schema_registry', 'confluent_cloud', 'tableflow', or 'flink' must be defined/,
         );
       });
 
@@ -360,6 +360,134 @@ describe("config/env-config.ts", () => {
             TABLEFLOW_API_SECRET: undefined,
           }),
         ).toThrow(/CONFLUENT_CLOUD_API_KEY/);
+      });
+    });
+
+    describe("flink env vars", () => {
+      const baseFlinkEnv = {
+        BOOTSTRAP_SERVERS: undefined,
+        SCHEMA_REGISTRY_ENDPOINT: undefined,
+        KAFKA_API_KEY: undefined,
+        KAFKA_API_SECRET: undefined,
+        SCHEMA_REGISTRY_API_KEY: undefined,
+        SCHEMA_REGISTRY_API_SECRET: undefined,
+        CONFLUENT_CLOUD_REST_ENDPOINT: undefined,
+        CONFLUENT_CLOUD_API_KEY: undefined,
+        CONFLUENT_CLOUD_API_SECRET: undefined,
+        TABLEFLOW_API_KEY: undefined,
+        TABLEFLOW_API_SECRET: undefined,
+      };
+
+      it("should populate flink block when all required fields are set", () => {
+        const config = consConfigFromEnv({
+          ...baseFlinkEnv,
+          FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
+          FLINK_API_KEY: "flinkkey",
+          FLINK_API_SECRET: "flinksecret",
+          FLINK_ENV_ID: "env-abc123",
+          FLINK_ORG_ID: "org-xyz789",
+          FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+          FLINK_ENV_NAME: undefined,
+          FLINK_DATABASE_NAME: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.flink?.endpoint).toBe(
+          "https://flink.us-east-1.aws.confluent.cloud",
+        );
+        expect(conn.flink?.auth).toEqual({
+          type: "api_key",
+          key: "flinkkey",
+          secret: "flinksecret",
+        });
+        expect(conn.flink?.environment_id).toBe("env-abc123");
+        expect(conn.flink?.organization_id).toBe("org-xyz789");
+        expect(conn.flink?.compute_pool_id).toBe("lfcp-pool01");
+      });
+
+      it("should populate all optional fields when provided", () => {
+        const config = consConfigFromEnv({
+          ...baseFlinkEnv,
+          FLINK_API_KEY: "flinkkey",
+          FLINK_API_SECRET: "flinksecret",
+          FLINK_ENV_ID: "env-abc123",
+          FLINK_ORG_ID: "org-xyz789",
+          FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+          FLINK_REST_ENDPOINT: "https://flink.confluent.cloud",
+          FLINK_ENV_NAME: "my-environment",
+          FLINK_DATABASE_NAME: "my-cluster",
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.flink?.endpoint).toBe("https://flink.confluent.cloud");
+        expect(conn.flink?.environment_name).toBe("my-environment");
+        expect(conn.flink?.database_name).toBe("my-cluster");
+      });
+
+      it("should be valid as a standalone block (no kafka, sr, confluent_cloud, or tableflow)", () => {
+        const config = consConfigFromEnv({
+          ...baseFlinkEnv,
+          FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
+          FLINK_API_KEY: "flinkkey",
+          FLINK_API_SECRET: "flinksecret",
+          FLINK_ENV_ID: "env-abc123",
+          FLINK_ORG_ID: "org-xyz789",
+          FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+          FLINK_ENV_NAME: undefined,
+          FLINK_DATABASE_NAME: undefined,
+        });
+        const conn = config.getSoleConnection();
+        expect(conn.flink).toBeDefined();
+        expect(conn.kafka).toBeUndefined();
+        expect(conn.schema_registry).toBeUndefined();
+        expect(conn.confluent_cloud).toBeUndefined();
+        expect(conn.tableflow).toBeUndefined();
+      });
+
+      it("should throw when FLINK_API_KEY is set but FLINK_API_SECRET is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            ...baseFlinkEnv,
+            FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
+            FLINK_API_KEY: "flinkkey",
+            FLINK_API_SECRET: undefined,
+            FLINK_ENV_ID: "env-abc123",
+            FLINK_ORG_ID: "org-xyz789",
+            FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+            FLINK_ENV_NAME: undefined,
+            FLINK_DATABASE_NAME: undefined,
+          }),
+        ).toThrow(/FLINK_API_SECRET/);
+      });
+
+      it("should throw when FLINK_API_SECRET is set but FLINK_API_KEY is missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            ...baseFlinkEnv,
+            FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
+            FLINK_API_KEY: undefined,
+            FLINK_API_SECRET: "flinksecret",
+            FLINK_ENV_ID: "env-abc123",
+            FLINK_ORG_ID: "org-xyz789",
+            FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+            FLINK_ENV_NAME: undefined,
+            FLINK_DATABASE_NAME: undefined,
+          }),
+        ).toThrow(/FLINK_API_KEY/);
+      });
+
+      it("should throw when flink block is triggered but required fields are missing", () => {
+        expect(() =>
+          consConfigFromEnv({
+            ...baseFlinkEnv,
+            FLINK_REST_ENDPOINT: "https://flink.confluent.cloud",
+            FLINK_API_KEY: undefined,
+            FLINK_API_SECRET: undefined,
+            FLINK_ENV_ID: undefined,
+            FLINK_ORG_ID: undefined,
+            FLINK_COMPUTE_POOL_ID: undefined,
+            FLINK_ENV_NAME: undefined,
+            FLINK_DATABASE_NAME: undefined,
+          }),
+        ).toThrow(/FLINK_ENV_ID/);
       });
     });
 

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -378,17 +378,19 @@ describe("config/env-config.ts", () => {
         TABLEFLOW_API_SECRET: undefined,
       };
 
+      const allRequiredFlinkEnvVars = {
+        FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
+        FLINK_API_KEY: "flinkkey",
+        FLINK_API_SECRET: "flinksecret",
+        FLINK_ENV_ID: "env-abc123",
+        FLINK_ORG_ID: "org-xyz789",
+        FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+      } as const;
+
       it("should populate flink block when all required fields are set", () => {
         const config = consConfigFromEnv({
           ...baseFlinkEnv,
-          FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
-          FLINK_API_KEY: "flinkkey",
-          FLINK_API_SECRET: "flinksecret",
-          FLINK_ENV_ID: "env-abc123",
-          FLINK_ORG_ID: "org-xyz789",
-          FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
-          FLINK_ENV_NAME: undefined,
-          FLINK_DATABASE_NAME: undefined,
+          ...allRequiredFlinkEnvVars,
         });
         const conn = config.getSoleConnection();
         expect(conn.flink?.endpoint).toBe(
@@ -407,11 +409,7 @@ describe("config/env-config.ts", () => {
       it("should populate all optional fields when provided", () => {
         const config = consConfigFromEnv({
           ...baseFlinkEnv,
-          FLINK_API_KEY: "flinkkey",
-          FLINK_API_SECRET: "flinksecret",
-          FLINK_ENV_ID: "env-abc123",
-          FLINK_ORG_ID: "org-xyz789",
-          FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
+          ...allRequiredFlinkEnvVars,
           FLINK_REST_ENDPOINT: "https://flink.confluent.cloud",
           FLINK_ENV_NAME: "my-environment",
           FLINK_DATABASE_NAME: "my-cluster",
@@ -425,14 +423,7 @@ describe("config/env-config.ts", () => {
       it("should be valid as a standalone block (no kafka, sr, confluent_cloud, or tableflow)", () => {
         const config = consConfigFromEnv({
           ...baseFlinkEnv,
-          FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
-          FLINK_API_KEY: "flinkkey",
-          FLINK_API_SECRET: "flinksecret",
-          FLINK_ENV_ID: "env-abc123",
-          FLINK_ORG_ID: "org-xyz789",
-          FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
-          FLINK_ENV_NAME: undefined,
-          FLINK_DATABASE_NAME: undefined,
+          ...allRequiredFlinkEnvVars,
         });
         const conn = config.getSoleConnection();
         expect(conn.flink).toBeDefined();
@@ -446,14 +437,8 @@ describe("config/env-config.ts", () => {
         expect(() =>
           consConfigFromEnv({
             ...baseFlinkEnv,
-            FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
-            FLINK_API_KEY: "flinkkey",
+            ...allRequiredFlinkEnvVars,
             FLINK_API_SECRET: undefined,
-            FLINK_ENV_ID: "env-abc123",
-            FLINK_ORG_ID: "org-xyz789",
-            FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
-            FLINK_ENV_NAME: undefined,
-            FLINK_DATABASE_NAME: undefined,
           }),
         ).toThrow(/FLINK_API_SECRET/);
       });
@@ -462,14 +447,8 @@ describe("config/env-config.ts", () => {
         expect(() =>
           consConfigFromEnv({
             ...baseFlinkEnv,
-            FLINK_REST_ENDPOINT: "https://flink.us-east-1.aws.confluent.cloud",
+            ...allRequiredFlinkEnvVars,
             FLINK_API_KEY: undefined,
-            FLINK_API_SECRET: "flinksecret",
-            FLINK_ENV_ID: "env-abc123",
-            FLINK_ORG_ID: "org-xyz789",
-            FLINK_COMPUTE_POOL_ID: "lfcp-pool01",
-            FLINK_ENV_NAME: undefined,
-            FLINK_DATABASE_NAME: undefined,
           }),
         ).toThrow(/FLINK_API_KEY/);
       });
@@ -478,14 +457,12 @@ describe("config/env-config.ts", () => {
         expect(() =>
           consConfigFromEnv({
             ...baseFlinkEnv,
-            FLINK_REST_ENDPOINT: "https://flink.confluent.cloud",
+            ...allRequiredFlinkEnvVars,
             FLINK_API_KEY: undefined,
             FLINK_API_SECRET: undefined,
             FLINK_ENV_ID: undefined,
             FLINK_ORG_ID: undefined,
             FLINK_COMPUTE_POOL_ID: undefined,
-            FLINK_ENV_NAME: undefined,
-            FLINK_DATABASE_NAME: undefined,
           }),
         ).toThrow(/FLINK_ENV_ID/);
       });

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -32,6 +32,15 @@ const ENV_VAR_TO_ZPATH = {
   // Tableflow parameters
   TABLEFLOW_API_KEY: `${CONN}.tableflow.auth.key`,
   TABLEFLOW_API_SECRET: `${CONN}.tableflow.auth.secret`,
+  // Flink parameters
+  FLINK_REST_ENDPOINT: `${CONN}.flink.endpoint`,
+  FLINK_API_KEY: `${CONN}.flink.auth.key`,
+  FLINK_API_SECRET: `${CONN}.flink.auth.secret`,
+  FLINK_ENV_ID: `${CONN}.flink.environment_id`,
+  FLINK_ORG_ID: `${CONN}.flink.organization_id`,
+  FLINK_COMPUTE_POOL_ID: `${CONN}.flink.compute_pool_id`,
+  FLINK_ENV_NAME: `${CONN}.flink.environment_name`,
+  FLINK_DATABASE_NAME: `${CONN}.flink.database_name`,
 } satisfies Partial<Record<keyof Environment, string>>;
 
 /**
@@ -95,6 +104,31 @@ export function consConfigFromEnv(
       env.TABLEFLOW_API_KEY,
       env.TABLEFLOW_API_SECRET,
     );
+  }
+
+  if (
+    env.FLINK_REST_ENDPOINT ||
+    env.FLINK_API_KEY ||
+    env.FLINK_API_SECRET ||
+    env.FLINK_ENV_ID ||
+    env.FLINK_ORG_ID ||
+    env.FLINK_COMPUTE_POOL_ID ||
+    env.FLINK_ENV_NAME ||
+    env.FLINK_DATABASE_NAME
+  ) {
+    connection.flink = {
+      ...(env.FLINK_REST_ENDPOINT && { endpoint: env.FLINK_REST_ENDPOINT }),
+      ...apiKeyAuth(env.FLINK_API_KEY, env.FLINK_API_SECRET),
+      ...(env.FLINK_ENV_ID && { environment_id: env.FLINK_ENV_ID }),
+      ...(env.FLINK_ORG_ID && { organization_id: env.FLINK_ORG_ID }),
+      ...(env.FLINK_COMPUTE_POOL_ID && {
+        compute_pool_id: env.FLINK_COMPUTE_POOL_ID,
+      }),
+      ...(env.FLINK_ENV_NAME && { environment_name: env.FLINK_ENV_NAME }),
+      ...(env.FLINK_DATABASE_NAME && {
+        database_name: env.FLINK_DATABASE_NAME,
+      }),
+    };
   }
 
   const result = mcpConfigSchema.safeParse({

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -136,7 +136,7 @@ describe("config/index.ts", () => {
         /Configuration validation failed/,
       );
       expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /At least one of 'kafka', 'schema_registry', 'confluent_cloud', or 'tableflow' must be defined/,
+        /At least one of 'kafka', 'schema_registry', 'confluent_cloud', 'tableflow', or 'flink' must be defined/,
       );
     });
 

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -58,6 +58,31 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(false);
     });
+
+    it.each(["environment_name", "database_name"])(
+      "should reject flink block with empty string for optional field '%s'",
+      (field) => {
+        const flink = { ...validFlinkBlock, [field]: "" };
+        const result = mcpConfigSchema.safeParse({
+          connections: { production: { type: "direct", flink } },
+        });
+        expect(result.success).toBe(false);
+      },
+    );
+
+    it.each([
+      ["environment_id", "bad-id"],
+      ["compute_pool_id", "bad-id"],
+    ])(
+      "should reject flink block with invalid prefix for '%s'",
+      (field, value) => {
+        const flink = { ...validFlinkBlock, [field]: value };
+        const result = mcpConfigSchema.safeParse({
+          connections: { production: { type: "direct", flink } },
+        });
+        expect(result.success).toBe(false);
+      },
+    );
   });
 
   describe("MCPServerConfiguration", () => {

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,20 +1,19 @@
 import { MCPServerConfiguration, mcpConfigSchema } from "@src/config/models.js";
 import { describe, expect, it } from "vitest";
 
-const validFlinkBlock = {
-  endpoint: "https://flink.us-east-1.aws.confluent.cloud",
-  auth: { type: "api_key" as const, key: "flinkkey", secret: "flinksecret" },
-  environment_id: "env-abc123",
-  organization_id: "org-xyz789",
-  compute_pool_id: "lfcp-pool01",
-};
-
-const directConnection = {
-  type: "direct" as const,
-  kafka: { bootstrap_servers: "localhost:9092" },
-};
-
 describe("config/models.ts", () => {
+  const validFlinkBlock = {
+    endpoint: "https://flink.us-east-1.aws.confluent.cloud",
+    auth: { type: "api_key" as const, key: "flinkkey", secret: "flinksecret" },
+    environment_id: "env-abc123",
+    organization_id: "org-xyz789",
+    compute_pool_id: "lfcp-pool01",
+  };
+
+  const directConnection = {
+    type: "direct" as const,
+    kafka: { bootstrap_servers: "localhost:9092" },
+  };
   describe("mcpConfigSchema", () => {
     it("should reject unknown keys at the document root", () => {
       const result = mcpConfigSchema.safeParse({

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,6 +1,14 @@
 import { MCPServerConfiguration, mcpConfigSchema } from "@src/config/models.js";
 import { describe, expect, it } from "vitest";
 
+const validFlinkBlock = {
+  endpoint: "https://flink.us-east-1.aws.confluent.cloud",
+  auth: { type: "api_key" as const, key: "flinkkey", secret: "flinksecret" },
+  environment_id: "env-abc123",
+  organization_id: "org-xyz789",
+  compute_pool_id: "lfcp-pool01",
+};
+
 const directConnection = {
   type: "direct" as const,
   kafka: { bootstrap_servers: "localhost:9092" },
@@ -13,6 +21,42 @@ describe("config/models.ts", () => {
         conenctions: { local: directConnection },
       });
 
+      expect(result.success).toBe(false);
+    });
+
+    // Add a new case here for each new sub-model block added to directConnectionSchema.
+    it.each([
+      [
+        "confluent_cloud",
+        { endpoint: "https://api.confluent.cloud", bogus: 1 },
+      ],
+      ["kafka", { bootstrap_servers: "broker:9092", bogus: 1 }],
+      ["schema_registry", { endpoint: "https://sr.example.com", bogus: 1 }],
+      [
+        "tableflow",
+        { auth: { type: "api_key", key: "k", secret: "s" }, bogus: 1 },
+      ],
+      ["flink", { ...validFlinkBlock, bogus: 1 }],
+    ])("should reject unknown keys in the %s block", (block, value) => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: { type: "direct", [block]: value } },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("flink block required fields", () => {
+    it.each([
+      "endpoint",
+      "auth",
+      "environment_id",
+      "organization_id",
+      "compute_pool_id",
+    ])("should reject flink block with '%s' omitted", (field) => {
+      const flink = { ...validFlinkBlock, [field]: undefined };
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: { type: "direct", flink } },
+      });
       expect(result.success).toBe(false);
     });
   });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -11,7 +11,7 @@ export type AuthConfig = ApiKeyAuthConfig;
 
 /**
  * Connection configuration for a direct (local/Docker) Kafka cluster.
- * At least one of kafka, schema_registry, confluent_cloud, or tableflow must be present.
+ * At least one of kafka, schema_registry, confluent_cloud, tableflow, or flink must be present.
  */
 export interface DirectConnectionConfig {
   type: "direct";
@@ -168,7 +168,7 @@ const directConnectionSchema = z
         environment_id: z
           .string()
           .trim()
-          .min(1, "flink.environment_id cannot be empty"),
+          .startsWith("env-", "flink.environment_id must start with 'env-'"),
         organization_id: z
           .string()
           .trim()
@@ -176,9 +176,17 @@ const directConnectionSchema = z
         compute_pool_id: z
           .string()
           .trim()
-          .min(1, "flink.compute_pool_id cannot be empty"),
-        environment_name: z.string().trim().optional(),
-        database_name: z.string().trim().optional(),
+          .startsWith("lfcp-", "flink.compute_pool_id must start with 'lfcp-'"),
+        environment_name: z
+          .string()
+          .trim()
+          .min(1, "flink.environment_name cannot be empty")
+          .optional(),
+        database_name: z
+          .string()
+          .trim()
+          .min(1, "flink.database_name cannot be empty")
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -30,6 +30,15 @@ export interface DirectConnectionConfig {
   tableflow?: {
     auth?: AuthConfig;
   };
+  flink?: {
+    endpoint: string;
+    auth: AuthConfig;
+    environment_id: string;
+    organization_id: string;
+    compute_pool_id: string;
+    environment_name?: string;
+    database_name?: string;
+  };
 }
 
 /**
@@ -149,6 +158,30 @@ const directConnectionSchema = z
         message: "tableflow block must contain 'auth'",
       })
       .optional(),
+    flink: z
+      .object({
+        endpoint: z
+          .string()
+          .trim()
+          .check(z.url({ error: "flink.endpoint must be a valid URL" })),
+        auth: authConfigSchema,
+        environment_id: z
+          .string()
+          .trim()
+          .min(1, "flink.environment_id cannot be empty"),
+        organization_id: z
+          .string()
+          .trim()
+          .min(1, "flink.organization_id cannot be empty"),
+        compute_pool_id: z
+          .string()
+          .trim()
+          .min(1, "flink.compute_pool_id cannot be empty"),
+        environment_name: z.string().trim().optional(),
+        database_name: z.string().trim().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -165,12 +198,13 @@ const connectionConfigSchema = z
       !data.kafka &&
       !data.schema_registry &&
       !data.confluent_cloud &&
-      !data.tableflow
+      !data.tableflow &&
+      !data.flink
     ) {
       ctx.addIssue({
         code: "custom",
         message:
-          "At least one of 'kafka', 'schema_registry', 'confluent_cloud', or 'tableflow' must be defined",
+          "At least one of 'kafka', 'schema_registry', 'confluent_cloud', 'tableflow', or 'flink' must be defined",
       });
     }
   });

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -246,21 +246,6 @@ describe("config/yaml-fixtures.test.ts", () => {
       });
       expect(conn.flink?.environment_id).toBe("env-abc123");
     });
-
-    it("should reject a flink block with no fields", () => {
-      expect(() =>
-        loadConfigFromYaml(fixtureFile("invalid/flink-empty.yaml"), NO_ENV),
-      ).toThrow(/Configuration validation failed/);
-    });
-
-    it("should reject a flink block missing required fields", () => {
-      expect(() =>
-        loadConfigFromYaml(
-          fixtureFile("invalid/flink-missing-required-fields.yaml"),
-          NO_ENV,
-        ),
-      ).toThrow(/Configuration validation failed/);
-    });
   });
 
   describe("invalid fixtures", () => {
@@ -324,6 +309,27 @@ describe("config/yaml-fixtures.test.ts", () => {
       expect(() =>
         loadConfigFromYaml(fixtureFile("invalid/auth-empty-key.yaml"), NO_ENV),
       ).toThrow(/auth\.key cannot be empty/);
+    });
+
+    it("should reject a flink block with no fields", () => {
+      expect(() =>
+        loadConfigFromYaml(fixtureFile("invalid/flink-empty.yaml"), NO_ENV),
+      ).toThrow(/flink\.auth/);
+    });
+
+    it("should reject a flink block that has endpoint but is missing other required fields", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/flink-missing-required-fields.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/flink\.auth/);
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/flink-missing-required-fields.yaml"),
+          NO_ENV,
+        ),
+      ).not.toThrow(/flink\.endpoint/);
     });
   });
 });

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -183,6 +183,86 @@ describe("config/yaml-fixtures.test.ts", () => {
     });
   });
 
+  describe("flink fixtures", () => {
+    it("should load flink-with-required-fields with auth and required context fields", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/flink-with-required-fields.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.flink?.auth).toEqual({
+        type: "api_key",
+        key: "myflinkkey",
+        secret: "myflinksecret",
+      });
+      expect(conn.flink?.endpoint).toBe(
+        "https://flink.us-east-1.aws.confluent.cloud",
+      );
+      expect(conn.flink?.environment_id).toBe("env-abc123");
+      expect(conn.flink?.organization_id).toBe("org-xyz789");
+      expect(conn.flink?.compute_pool_id).toBe("lfcp-pool01");
+      expect(conn.flink?.environment_name).toBeUndefined();
+      expect(conn.flink?.database_name).toBeUndefined();
+      expect(conn.kafka).toBeUndefined();
+      expect(conn.schema_registry).toBeUndefined();
+      expect(conn.confluent_cloud).toBeUndefined();
+      expect(conn.tableflow).toBeUndefined();
+    });
+
+    it("should load flink-with-all-fields with every field populated", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/flink-with-all-fields.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.flink?.endpoint).toBe("https://flink.confluent.cloud");
+      expect(conn.flink?.auth).toEqual({
+        type: "api_key",
+        key: "myflinkkey",
+        secret: "myflinksecret",
+      });
+      expect(conn.flink?.environment_id).toBe("env-abc123");
+      expect(conn.flink?.organization_id).toBe("org-xyz789");
+      expect(conn.flink?.compute_pool_id).toBe("lfcp-pool01");
+      expect(conn.flink?.environment_name).toBe("my-environment");
+      expect(conn.flink?.database_name).toBe("my-kafka-cluster");
+    });
+
+    it("should load ccloud-and-flink-with-auth with both blocks populated", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/ccloud-and-flink-with-auth.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.confluent_cloud?.auth).toEqual({
+        type: "api_key",
+        key: "mycloudkey",
+        secret: "mycloudsecret",
+      });
+      expect(conn.flink?.auth).toEqual({
+        type: "api_key",
+        key: "myflinkkey",
+        secret: "myflinksecret",
+      });
+      expect(conn.flink?.environment_id).toBe("env-abc123");
+    });
+
+    it("should reject a flink block with no fields", () => {
+      expect(() =>
+        loadConfigFromYaml(fixtureFile("invalid/flink-empty.yaml"), NO_ENV),
+      ).toThrow(/Configuration validation failed/);
+    });
+
+    it("should reject a flink block missing required fields", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/flink-missing-required-fields.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/Configuration validation failed/);
+    });
+  });
+
   describe("invalid fixtures", () => {
     it("should reject auth block missing secret", () => {
       expect(() =>

--- a/test-fixtures/yaml_configs/invalid/flink-empty.yaml
+++ b/test-fixtures/yaml_configs/invalid/flink-empty.yaml
@@ -1,0 +1,4 @@
+connections:
+  local:
+    type: direct
+    flink: {}

--- a/test-fixtures/yaml_configs/invalid/flink-missing-required-fields.yaml
+++ b/test-fixtures/yaml_configs/invalid/flink-missing-required-fields.yaml
@@ -1,0 +1,5 @@
+connections:
+  local:
+    type: direct
+    flink:
+      endpoint: "https://flink.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/ccloud-and-flink-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-and-flink-with-auth.yaml
@@ -1,0 +1,18 @@
+connections:
+  production:
+    type: direct
+    confluent_cloud:
+      endpoint: "https://api.confluent.cloud"
+      auth:
+        type: api_key
+        key: "mycloudkey"
+        secret: "mycloudsecret"
+    flink:
+      endpoint: "https://flink.confluent.cloud"
+      auth:
+        type: api_key
+        key: "myflinkkey"
+        secret: "myflinksecret"
+      environment_id: "env-abc123"
+      organization_id: "org-xyz789"
+      compute_pool_id: "lfcp-pool01"

--- a/test-fixtures/yaml_configs/valid/flink-with-all-fields.yaml
+++ b/test-fixtures/yaml_configs/valid/flink-with-all-fields.yaml
@@ -1,0 +1,14 @@
+connections:
+  production:
+    type: direct
+    flink:
+      endpoint: "https://flink.confluent.cloud"
+      auth:
+        type: api_key
+        key: "myflinkkey"
+        secret: "myflinksecret"
+      environment_id: "env-abc123"
+      organization_id: "org-xyz789"
+      compute_pool_id: "lfcp-pool01"
+      environment_name: "my-environment"
+      database_name: "my-kafka-cluster"

--- a/test-fixtures/yaml_configs/valid/flink-with-required-fields.yaml
+++ b/test-fixtures/yaml_configs/valid/flink-with-required-fields.yaml
@@ -1,0 +1,12 @@
+connections:
+  production:
+    type: direct
+    flink:
+      endpoint: "https://flink.us-east-1.aws.confluent.cloud"
+      auth:
+        type: api_key
+        key: "myflinkkey"
+        secret: "myflinksecret"
+      environment_id: "env-abc123"
+      organization_id: "org-xyz789"
+      compute_pool_id: "lfcp-pool01"


### PR DESCRIPTION
## Summary of Changes

- Extend `DirectConnectionConfig` and `directConnectionSchema` with a `flink` block containing `endpoint: string`, `auth: AuthConfig`, `environment_id: string`, `organization_id: string`, `compute_pool_id: string` (all required), plus `environment_name?: string` and `database_name?: string` (the last two are optional).
- All required fields are enforced at both the TypeScript type level and the Zod schema level — a present-but-empty or partially-populated `flink` block is rejected. Unlike `confluent_cloud`, `flink.endpoint` has no universal default (Flink REST endpoints are region- and cloud-provider-specific) and is therefore required rather than optional.
- Field naming uses full words throughout: `environment_id`, `organization_id`, `environment_name` — consistent with the rest of the document schema. The legacy env vars (`FLINK_ENV_ID`, `FLINK_ORG_ID`, `FLINK_ENV_NAME`) retain their abbreviated names as they are not part of the YAML surface.
- Extend `consConfigFromEnv()` for eight new env vars: `FLINK_REST_ENDPOINT`, `FLINK_API_KEY`, `FLINK_API_SECRET`, `FLINK_ENV_ID`, `FLINK_ORG_ID`, `FLINK_COMPUTE_POOL_ID`, `FLINK_ENV_NAME`, `FLINK_DATABASE_NAME`. Each maps to its corresponding full-word YAML path in `ENV_VAR_TO_ZPATH`.
- The "at least one block must be defined" guard now accepts `flink` as sufficient on its own.
- `.strict()` applied to the `flink` Zod schema, consistent with all other blocks.

The maximal YAML config is now:

```yaml
connections:
  production:
    type: direct
    confluent_cloud:
      endpoint: "https://api.confluent.cloud"
      auth:
        type: api_key
        key: "my-cloud-key"
        secret: "my-cloud-secret"
    kafka:
      bootstrap_servers: "broker.confluent.cloud:9092"
      auth:
        type: api_key
        key: "my-kafka-key"
        secret: "my-kafka-secret"
    schema_registry:
      endpoint: "https://psrc-abc123.us-east-2.aws.confluent.cloud"
      auth:
        type: api_key
        key: "my-sr-key"
        secret: "my-sr-secret"
    tableflow:
      auth:
        type: api_key
        key: "my-tableflow-key"
        secret: "my-tableflow-secret"
    flink:
      endpoint: "https://flink.us-east-1.aws.confluent.cloud"
      auth:
        type: api_key
        key: "my-flink-key"
        secret: "my-flink-secret"
      environment_id: "env-abc123"
      organization_id: "org-xyz789"
      compute_pool_id: "lfcp-pool01"
      environment_name: "my-environment"
      database_name: "my-kafka-cluster"
```

The additional env vars now supported:

```
FLINK_REST_ENDPOINT=https://flink.us-east-1.aws.confluent.cloud
FLINK_API_KEY=my-flink-key
FLINK_API_SECRET=my-flink-secret
FLINK_ENV_ID=env-abc123
FLINK_ORG_ID=org-xyz789
FLINK_COMPUTE_POOL_ID=lfcp-pool01
FLINK_ENV_NAME=my-environment
FLINK_DATABASE_NAME=my-kafka-cluster
```

Closes #204
Step of #162
Successor to #207

This is a child PR into feat/162-configure-server-from-either-yaml-or-env / https://github.com/confluentinc/mcp-confluent/pull/198.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
