### PR TITLE
Handle extra kafka configs in yaml mutually exclusively from -k file …

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -352,6 +352,17 @@ describe("cli.ts", () => {
       ]);
     });
 
+    it("should throw when both --config and --kafka-config-file are supplied", () => {
+      resolveStub.returns("/abs/kafka.properties");
+      fsStubs.existsSync.returns(true);
+
+      expect(() =>
+        parseCliArgs(
+          makeArgs(["--config", "server.yaml", "-k", "kafka.properties"]),
+        ),
+      ).toThrow(/mutually exclusive/);
+    });
+
     it("should throw when -k file does not exist", () => {
       resolveStub.returns("/abs/kafka.properties");
       fsStubs.existsSync.returns(false);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ export interface CLIOptions {
   blockTools?: string[];
   listTools?: boolean;
   disableConfluentCloudTools?: boolean;
-  kafkaConfig: KeyValuePairObject;
+  kafkaConfig?: KeyValuePairObject;
   disableAuth?: boolean;
   allowedHosts?: string[];
   generateKey?: boolean;
@@ -185,6 +185,13 @@ export function parseCliArgs(argv: string[]): CLIOptions {
   try {
     const opts = program.parse(argv).opts();
 
+    if (opts.config && opts.kafkaConfigFile) {
+      throw new Error(
+        "--config and --kafka-config-file are mutually exclusive: " +
+          "use kafka.extra_properties in the YAML file instead of -k",
+      );
+    }
+
     // Precedence: CLI > file > undefined
     let allowTools: string[] | undefined = undefined;
     let blockTools: string[] | undefined = undefined;
@@ -198,10 +205,6 @@ export function parseCliArgs(argv: string[]): CLIOptions {
     } else if (opts.blockToolsFile) {
       blockTools = readFileLines(opts.blockToolsFile);
     }
-    let kafkaConfig: KeyValuePairObject = {};
-    if (opts.kafkaConfigFile) {
-      kafkaConfig = parsePropertiesFile(opts.kafkaConfigFile);
-    }
     return {
       envFile: opts.envFile,
       config: opts.config,
@@ -212,7 +215,9 @@ export function parseCliArgs(argv: string[]): CLIOptions {
       blockTools,
       listTools: !!opts.listTools,
       disableConfluentCloudTools: !!opts.disableConfluentCloudTools,
-      kafkaConfig: kafkaConfig,
+      kafkaConfig: opts.kafkaConfigFile
+        ? parsePropertiesFile(opts.kafkaConfigFile)
+        : undefined,
       disableAuth: !!opts.disableAuth,
       allowedHosts: opts.allowedHosts
         ? opts.allowedHosts

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -436,6 +436,23 @@ describe("config/models.ts", () => {
       });
 
       it.each([
+        ["bootstrap.servers", { "bootstrap.servers": "" }],
+        ["sasl.username", { "sasl.username": "" }],
+        ["sasl.password", { "sasl.password": "" }],
+      ])(
+        "should throw when protected key '%s' is present but empty",
+        (key, props) => {
+          const config = new MCPServerConfiguration({
+            connections: {
+              local: { type: "direct", kafka: { bootstrap_servers: "b:9092" } },
+            },
+          });
+
+          expect(() => config.setKafkaExtraProperties(props)).toThrow(key);
+        },
+      );
+
+      it.each([
         [{ "sasl.username": "k-key" }, "sasl.password"],
         [{ "sasl.password": "k-secret" }, "sasl.username"],
       ])(

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,4 +1,8 @@
-import { MCPServerConfiguration, mcpConfigSchema } from "@src/config/models.js";
+import {
+  KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
+  MCPServerConfiguration,
+  mcpConfigSchema,
+} from "@src/config/models.js";
 import { describe, expect, it } from "vitest";
 
 describe("config/models.ts", () => {
@@ -149,6 +153,43 @@ describe("config/models.ts", () => {
     });
   });
 
+  describe("kafka extra_properties", () => {
+    const baseKafka = { bootstrap_servers: "broker:9092" };
+
+    it("should accept extra_properties with non-protected keys", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: {
+          production: {
+            type: "direct",
+            kafka: {
+              ...baseKafka,
+              extra_properties: {
+                "socket.timeout.ms": "30000",
+                debug: "broker",
+              },
+            },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it.each([...KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS])(
+      "should reject extra_properties containing protected key '%s'",
+      (key) => {
+        const result = mcpConfigSchema.safeParse({
+          connections: {
+            production: {
+              type: "direct",
+              kafka: { ...baseKafka, extra_properties: { [key]: "value" } },
+            },
+          },
+        });
+        expect(result.success).toBe(false);
+      },
+    );
+  });
+
   describe("telemetry block", () => {
     it("should accept telemetry block with auth only", () => {
       const result = mcpConfigSchema.safeParse({
@@ -231,6 +272,167 @@ describe("config/models.ts", () => {
         });
 
         expect(config.getConnectionNames()).toEqual(["local", "staging"]);
+      });
+    });
+
+    describe("setKafkaExtraProperties", () => {
+      it("should set extra_properties on an existing kafka block", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              kafka: { bootstrap_servers: "broker:9092" },
+            },
+          },
+        });
+
+        config.setKafkaExtraProperties({ "socket.timeout.ms": "5000" });
+
+        expect(config.getSoleConnection().kafka?.extra_properties).toEqual({
+          "socket.timeout.ms": "5000",
+        });
+      });
+
+      it("should throw when extra_properties is already defined in configuration", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              kafka: {
+                bootstrap_servers: "broker:9092",
+                extra_properties: { debug: "all" },
+              },
+            },
+          },
+        });
+
+        expect(() =>
+          config.setKafkaExtraProperties({ "socket.timeout.ms": "5000" }),
+        ).toThrow(/already defined/);
+      });
+
+      it("should construct a kafka block with bootstrap_servers when none existed", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              confluent_cloud: {
+                auth: { type: "api_key", key: "k", secret: "s" },
+              },
+            },
+          },
+        });
+
+        config.setKafkaExtraProperties({ "bootstrap.servers": "broker:9092" });
+
+        expect(config.getSoleConnection().kafka?.bootstrap_servers).toBe(
+          "broker:9092",
+        );
+        expect(
+          config.getSoleConnection().kafka?.extra_properties,
+        ).toBeUndefined();
+      });
+
+      it("should construct a kafka block with auth when sasl.username and sasl.password are both present", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              confluent_cloud: {
+                auth: { type: "api_key", key: "k", secret: "s" },
+              },
+            },
+          },
+        });
+
+        config.setKafkaExtraProperties({
+          "bootstrap.servers": "broker:9092",
+          "sasl.username": "mykey",
+          "sasl.password": "mysecret",
+        });
+
+        const kafka = config.getSoleConnection().kafka;
+        expect(kafka?.bootstrap_servers).toBe("broker:9092");
+        expect(kafka?.auth).toEqual({
+          type: "api_key",
+          key: "mykey",
+          secret: "mysecret",
+        });
+        expect(kafka?.extra_properties).toBeUndefined();
+      });
+
+      it("should put non-protected keys into extra_properties when constructing a kafka block from scratch", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              confluent_cloud: {
+                auth: { type: "api_key", key: "k", secret: "s" },
+              },
+            },
+          },
+        });
+
+        config.setKafkaExtraProperties({
+          "bootstrap.servers": "broker:9092",
+          "socket.timeout.ms": "30000",
+        });
+
+        const kafka = config.getSoleConnection().kafka;
+        expect(kafka?.bootstrap_servers).toBe("broker:9092");
+        expect(kafka?.extra_properties).toEqual({
+          "socket.timeout.ms": "30000",
+        });
+      });
+
+      it("should override bootstrap_servers from env vars when -k provides bootstrap.servers", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              kafka: { bootstrap_servers: "env-broker:9092" },
+            },
+          },
+        });
+
+        config.setKafkaExtraProperties({
+          "bootstrap.servers": "k-broker:9092",
+        });
+
+        expect(config.getSoleConnection().kafka?.bootstrap_servers).toBe(
+          "k-broker:9092",
+        );
+        expect(
+          config.getSoleConnection().kafka?.extra_properties,
+        ).toBeUndefined();
+      });
+
+      it("should override auth from env vars when -k provides sasl credentials", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              kafka: {
+                bootstrap_servers: "broker:9092",
+                auth: { type: "api_key", key: "env-key", secret: "env-secret" },
+              },
+            },
+          },
+        });
+
+        config.setKafkaExtraProperties({
+          "sasl.username": "k-key",
+          "sasl.password": "k-secret",
+        });
+
+        expect(config.getSoleConnection().kafka?.auth).toEqual({
+          type: "api_key",
+          key: "k-key",
+          secret: "k-secret",
+        });
+        expect(
+          config.getSoleConnection().kafka?.extra_properties,
+        ).toBeUndefined();
       });
     });
 

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -452,6 +452,40 @@ describe("config/models.ts", () => {
           );
         },
       );
+
+      it("should throw when no kafka block exists and props contain no connectivity field", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              confluent_cloud: {
+                auth: { type: "api_key", key: "k", secret: "s" },
+              },
+            },
+          },
+        });
+
+        expect(() =>
+          config.setKafkaExtraProperties({ "socket.timeout.ms": "5000" }),
+        ).toThrow("bootstrap.servers");
+      });
+
+      it("should throw when no kafka block exists and props are empty", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            local: {
+              type: "direct",
+              confluent_cloud: {
+                auth: { type: "api_key", key: "k", secret: "s" },
+              },
+            },
+          },
+        });
+
+        expect(() => config.setKafkaExtraProperties({})).toThrow(
+          "bootstrap.servers",
+        );
+      });
     });
 
     describe("getSoleConnection", () => {

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -434,6 +434,24 @@ describe("config/models.ts", () => {
           config.getSoleConnection().kafka?.extra_properties,
         ).toBeUndefined();
       });
+
+      it.each([
+        [{ "sasl.username": "k-key" }, "sasl.password"],
+        [{ "sasl.password": "k-secret" }, "sasl.username"],
+      ])(
+        "should throw when only one SASL credential is present",
+        (props, missingKey) => {
+          const config = new MCPServerConfiguration({
+            connections: {
+              local: { type: "direct", kafka: { bootstrap_servers: "b:9092" } },
+            },
+          });
+
+          expect(() => config.setKafkaExtraProperties(props)).toThrow(
+            missingKey,
+          );
+        },
+      );
     });
 
     describe("getSoleConnection", () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -270,8 +270,8 @@ const directConnectionSchema = z
         extra_properties: z
           .record(z.string(), z.string())
           .superRefine((props, ctx) => {
-            const found = KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS.filter(
-              (k) => k in props,
+            const found = KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS.filter((k) =>
+              Object.hasOwn(props, k),
             );
             if (found.length > 0) {
               ctx.addIssue({

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -133,8 +133,16 @@ export class MCPServerConfiguration {
   setKafkaExtraProperties(props: Record<string, string>): void {
     const conn = this.getSoleConnection();
 
+    for (const key of KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS) {
+      if (Object.hasOwn(props, key) && props[key] === "") {
+        throw new Error(
+          `--kafka-config-file: ${key} is present but empty — provide a non-empty value or omit the key`,
+        );
+      }
+    }
+
     if (!conn.kafka) {
-      if (!props["bootstrap.servers"]) {
+      if (!Object.hasOwn(props, "bootstrap.servers")) {
         throw new Error(
           "--kafka-config-file: no kafka block is configured and props do not include bootstrap.servers — cannot establish a Kafka connection",
         );
@@ -148,8 +156,8 @@ export class MCPServerConfiguration {
       );
     }
 
-    const hasSaslUser = !!props["sasl.username"];
-    const hasSaslPass = !!props["sasl.password"];
+    const hasSaslUser = Object.hasOwn(props, "sasl.username");
+    const hasSaslPass = Object.hasOwn(props, "sasl.password");
     if (hasSaslUser !== hasSaslPass) {
       throw new Error(
         "--kafka-config-file: sasl.username and sasl.password must both be present or both be absent",
@@ -158,14 +166,14 @@ export class MCPServerConfiguration {
 
     const protectedSet = new Set<string>(KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS);
 
-    if (props["bootstrap.servers"]) {
+    if (Object.hasOwn(props, "bootstrap.servers")) {
       conn.kafka.bootstrap_servers = props["bootstrap.servers"];
     }
-    if (props["sasl.username"] && props["sasl.password"]) {
+    if (hasSaslUser && hasSaslPass) {
       conn.kafka.auth = {
         type: "api_key",
-        key: props["sasl.username"],
-        secret: props["sasl.password"],
+        key: props["sasl.username"]!,
+        secret: props["sasl.password"]!,
       };
     }
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -143,6 +143,14 @@ export class MCPServerConfiguration {
       );
     }
 
+    const hasSaslUser = !!props["sasl.username"];
+    const hasSaslPass = !!props["sasl.password"];
+    if (hasSaslUser !== hasSaslPass) {
+      throw new Error(
+        "--kafka-config-file: sasl.username and sasl.password must both be present or both be absent",
+      );
+    }
+
     const protectedSet = new Set<string>(KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS);
 
     if (props["bootstrap.servers"]) {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -31,6 +31,7 @@ export interface KafkaDirectConfig {
   rest_endpoint?: string;
   cluster_id?: string;
   env_id?: string;
+  extra_properties?: Record<string, string>;
 }
 
 /** Subcomponent of DirectConnectionConfig describing Schema Registry connection parameters */
@@ -108,9 +109,78 @@ export class MCPServerConfiguration {
   getConnectionNames(): string[] {
     return Object.keys(this.connections).sort((a, b) => a.localeCompare(b));
   }
+
+  /**
+   * Absorbs `-k` / `--kafka-config-file` properties into the kafka block so that all
+   * config is consolidated in MCPServerConfiguration before client construction.
+   *
+   * Only valid in the legacy env-var codepath (`consConfigFromEnv`). YAML-configured
+   * connections must not use this method — the `--config` and `--kafka-config-file` flags
+   * are mutually exclusive and enforced at CLI parse time.
+   *
+   * Protected keys (`bootstrap.servers`, `sasl.username`, `sasl.password`) are always
+   * promoted into their corresponding named fields, overriding any env-var-derived values
+   * already present. All other keys go into `extra_properties`. This ensures the resulting
+   * MCPServerConfiguration is self-consistent: named fields hold the authoritative values
+   * with CLI arguments taking precedence over environment variables, matching the intended
+   * precedence order.
+   *
+   * Creates a kafka block if none exists, so that `-k` alone (without any Kafka env vars)
+   * is sufficient to configure the client.
+   *
+   * Throws if `extra_properties` is already set — guards against double-application.
+   */
+  setKafkaExtraProperties(props: Record<string, string>): void {
+    const conn = this.getSoleConnection();
+
+    if (!conn.kafka) {
+      conn.kafka = {};
+    }
+
+    if (conn.kafka.extra_properties !== undefined) {
+      throw new Error(
+        "Cannot apply --kafka-config-file: kafka.extra_properties is already defined in configuration",
+      );
+    }
+
+    const protectedSet = new Set<string>(KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS);
+
+    if (props["bootstrap.servers"]) {
+      conn.kafka.bootstrap_servers = props["bootstrap.servers"];
+    }
+    if (props["sasl.username"] && props["sasl.password"]) {
+      conn.kafka.auth = {
+        type: "api_key",
+        key: props["sasl.username"],
+        secret: props["sasl.password"],
+      };
+    }
+
+    const remaining = Object.fromEntries(
+      Object.entries(props).filter(([k]) => !protectedSet.has(k)),
+    );
+    if (Object.keys(remaining).length > 0) {
+      conn.kafka.extra_properties = remaining;
+    }
+  }
 }
 
 /* And now, Zod schemas for validation of MCPServerConfiguration and contained objects. */
+
+/**
+ * librdkafka property keys that have named YAML equivalents and must not appear in
+ * `extra_properties`. Authoring them there is an error in YAML-configured connections;
+ * use `bootstrap_servers` or the `auth` block instead.
+ *
+ * Note: this restriction applies only to YAML-authored configs. The `-k` /
+ * `--kafka-config-file` CLI flag is a higher-precedence override mechanism and is
+ * permitted to supply these keys (env vars are always lowest precedence).
+ */
+export const KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS = [
+  "bootstrap.servers",
+  "sasl.username",
+  "sasl.password",
+] as const;
 
 const apiKeyAuthSchema = z
   .object({
@@ -175,6 +245,20 @@ const directConnectionSchema = z
           .string()
           .trim()
           .startsWith("env-", "kafka.env_id must start with 'env-'")
+          .optional(),
+        extra_properties: z
+          .record(z.string(), z.string())
+          .superRefine((props, ctx) => {
+            const found = KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS.filter(
+              (k) => k in props,
+            );
+            if (found.length > 0) {
+              ctx.addIssue({
+                code: "custom",
+                message: `extra_properties must not include ${found.join(", ")} — use the named YAML fields (bootstrap_servers, auth) instead`,
+              });
+            }
+          })
           .optional(),
       })
       .strict()

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -134,6 +134,11 @@ export class MCPServerConfiguration {
     const conn = this.getSoleConnection();
 
     if (!conn.kafka) {
+      if (!props["bootstrap.servers"]) {
+        throw new Error(
+          "--kafka-config-file: no kafka block is configured and props do not include bootstrap.servers — cannot establish a Kafka connection",
+        );
+      }
       conn.kafka = {};
     }
 

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -183,6 +183,22 @@ describe("config/yaml-fixtures.test.ts", () => {
     });
   });
 
+  describe("kafka extra_properties fixtures", () => {
+    it("should load kafka-with-extra-properties and parse the extra_properties block", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-with-extra-properties.yaml"),
+        NO_ENV,
+      );
+      const conn = config.getSoleConnection();
+      expect(conn.kafka?.bootstrap_servers).toBe("broker.confluent.cloud:9092");
+      expect(conn.kafka?.extra_properties).toEqual({
+        "socket.timeout.ms": "30000",
+        "ssl.ca.location": "/etc/ssl/certs/ca-certificates.crt",
+        debug: "broker,topic",
+      });
+    });
+  });
+
   describe("kafka REST metadata fixtures", () => {
     it("should load kafka-with-rest-metadata with all three metadata fields", () => {
       const config = loadConfigFromYaml(
@@ -392,6 +408,26 @@ describe("config/yaml-fixtures.test.ts", () => {
           NO_ENV,
         ),
       ).toThrow(/kafka\.env_id must start with 'env-'/);
+    });
+
+    it("should reject kafka extra_properties containing a protected key", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/kafka-extra-properties-protected-key.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/bootstrap\.servers/);
+    });
+
+    it("should reject kafka extra_properties containing protected auth keys", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile(
+            "invalid/kafka-extra-properties-protected-auth-keys.yaml",
+          ),
+          NO_ENV,
+        ),
+      ).toThrow(/sasl\.(username|password)/);
     });
 
     it("should reject a flink block that has endpoint but is missing other required fields", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,10 @@ async function main() {
     } else {
       mcpConfig = consConfigFromEnv(env);
 
+      if (cliOptions.kafkaConfig) {
+        mcpConfig.setKafkaExtraProperties(cliOptions.kafkaConfig);
+      }
+
       // TODO(issue #151): Use config to construct connection manager instead of env vars
       logger.warn(
         "MCPServerConfiguration constructed from environment variables, but it is not applied yet; startup still uses" +

--- a/test-fixtures/yaml_configs/invalid/kafka-extra-properties-protected-auth-keys.yaml
+++ b/test-fixtures/yaml_configs/invalid/kafka-extra-properties-protected-auth-keys.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      extra_properties:
+        sasl.username: "myapikey"
+        sasl.password: "myapisecret"

--- a/test-fixtures/yaml_configs/invalid/kafka-extra-properties-protected-key.yaml
+++ b/test-fixtures/yaml_configs/invalid/kafka-extra-properties-protected-key.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      extra_properties:
+        bootstrap.servers: "other-broker.confluent.cloud:9092"
+        socket.timeout.ms: "30000"

--- a/test-fixtures/yaml_configs/valid/kafka-with-extra-properties.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-extra-properties.yaml
@@ -1,0 +1,9 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "broker.confluent.cloud:9092"
+      extra_properties:
+        socket.timeout.ms: "30000"
+        ssl.ca.location: "/etc/ssl/certs/ca-certificates.crt"
+        debug: "broker,topic"

--- a/tests/factories/cli-options.ts
+++ b/tests/factories/cli-options.ts
@@ -3,7 +3,7 @@ import { TransportType } from "@src/mcp/transports/types.js";
 
 const BASE_CLI_OPTIONS: CLIOptions = {
   transports: [TransportType.STDIO],
-  kafkaConfig: {},
+
   envFile: undefined,
   config: undefined,
   allowTools: undefined,


### PR DESCRIPTION
## Summary of Changes

TL; DR: Extend `MCPServerConfiguration` to carry the kafka extra options, deal with the possible overlap between these options and our explicitly defined yaml keys differently depending if configuring from YAML or configuring from the legacy env vars, because nothing is easy. Read the ticket (#211) for more details. The end goal here is to set us up to be able to make the call to `constructDefaultClientManager()` ONLY with the `MCPServerConfiguration`, and that all of its need of env var and cmdline arg triage has happened cleanly already.

- Add `extra_properties?: Record<string, string>` to `KafkaDirectConfig` and the corresponding Zod schema, allowing arbitrary librdkafka client properties to be passed through a YAML `kafka` block without requiring a dedicated named field for each one:

  ```yaml
  connections:
    production:
      type: direct
      kafka:
        bootstrap_servers: "broker.confluent.cloud:9092"
        extra_properties:
          socket.timeout.ms: "30000"
          ssl.ca.location: "/etc/ssl/certs/ca-certificates.crt"
          debug: "broker,topic"
  ```

- Export `KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS` — the set `["bootstrap.servers", "sasl.username", "sasl.password"]`. These keys have named YAML equivalents (`bootstrap_servers`, `auth`) and must not appear in `extra_properties`; the Zod schema rejects them at parse time with an explicit error message directing the author to the correct field.

- Add `MCPServerConfiguration.setKafkaExtraProperties(props)` — used exclusively by the legacy env-var codepath (`consConfigFromEnv`) to absorb `-k` / `--kafka-config-file` properties into the `MCPServerConfiguration` after construction. Protected keys are promoted to their corresponding named fields (with CLI-supplied values overriding any env-var-derived ones, matching the intended precedence order); all remaining keys go into `extra_properties`. Throws if `extra_properties` is already set to prevent double-application. Creates the `kafka` block if none exists, so `-k` alone is sufficient to configure the client.

- `--config` and `--kafka-config-file` (`-k`) are now mutually exclusive, enforced at CLI parse time. YAML-configured connections express extra Kafka properties via `kafka.extra_properties` in the YAML file itself; the `-k` flag is a legacy env-var-path concern only. This is for both 'single source of values' while we support just a single connection, and then for total sanity when we begin to deal with multiple connections (which might need separate extra property sets).

- `CLIOptions.kafkaConfig` tightened from `KeyValuePairObject` (always defaulted to `{}`) to `KeyValuePairObject | undefined`, making absence of the flag explicit rather than indistinguishable from an empty file.


Closes #211  (successor to issue #205)
Step of #162 (nearing the end!)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
