### PR TITLE
feat(oauth): classify refresh errors and retry transient failures

### DIFF
--- a/src/confluent/oauth/auth-context.test.ts
+++ b/src/confluent/oauth/auth-context.test.ts
@@ -2,6 +2,7 @@ import { nodeFetch } from "@src/confluent/node-deps.js";
 import { AuthContext } from "@src/confluent/oauth/auth-context.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 import {
+  MAX_CONSECUTIVE_TRANSIENT_FAILURES,
   REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
   REFRESH_TOKEN_IDLE_LIFETIME_MS,
 } from "@src/confluent/oauth/token-lifetimes.js";
@@ -472,7 +473,7 @@ describe("oauth/auth-context.ts", () => {
         const ctx = await newLoggedInContext(fetchStub);
         // 50 generic 500s back-to-back. Each refresh() call consumes one fetch
         // (phase 1 fails and we return before phase 2).
-        for (let i = 0; i < 50; i++) {
+        for (let i = 0; i < MAX_CONSECUTIVE_TRANSIENT_FAILURES; i++) {
           fetchStub
             .onCall(3 + i)
             .resolves(new Response("server error", { status: 500 }));

--- a/src/confluent/oauth/auth-context.test.ts
+++ b/src/confluent/oauth/auth-context.test.ts
@@ -413,6 +413,157 @@ describe("oauth/auth-context.ts", () => {
         expect(ctx.getDataPlaneToken()).toBeUndefined();
       });
     });
+
+    describe("error classification", () => {
+      it("should record a transient error on a generic phase-1 failure", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        fetchStub
+          .onCall(3)
+          .resolves(new Response("server error", { status: 500 }));
+
+        await ctx.refresh();
+
+        const err = ctx.getErrors().tokenRefresh;
+        expect(err).toBeDefined();
+        expect(err!.isTransient).toBe(true);
+        expect(
+          ctx.shouldAttemptRefresh(
+            internals(ctx).controlPlaneExpiresAt - 10_000,
+          ),
+        ).toBe(true);
+      });
+
+      it("should record a non-transient error when the refresh token is revoked", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        fetchStub
+          .onCall(3)
+          .resolves(
+            new Response(
+              '{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}',
+              { status: 400 },
+            ),
+          );
+
+        await ctx.refresh();
+
+        const err = ctx.getErrors().tokenRefresh;
+        expect(err).toBeDefined();
+        expect(err!.isTransient).toBe(false);
+        // Scheduler must now skip this context even when CP is due.
+        expect(
+          ctx.shouldAttemptRefresh(
+            internals(ctx).controlPlaneExpiresAt - 10_000,
+          ),
+        ).toBe(false);
+      });
+
+      it("should record a non-transient error on invalid_grant without the revoked-token message", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        fetchStub
+          .onCall(3)
+          .resolves(new Response('{"error":"invalid_grant"}', { status: 400 }));
+
+        await ctx.refresh();
+
+        expect(ctx.getErrors().tokenRefresh!.isTransient).toBe(false);
+      });
+
+      it("should promote to non-transient after MAX_CONSECUTIVE_TRANSIENT_FAILURES", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        // 50 generic 500s back-to-back. Each refresh() call consumes one fetch
+        // (phase 1 fails and we return before phase 2).
+        for (let i = 0; i < 50; i++) {
+          fetchStub
+            .onCall(3 + i)
+            .resolves(new Response("server error", { status: 500 }));
+          await ctx.refresh();
+        }
+
+        const err = ctx.getErrors().tokenRefresh;
+        expect(err).toBeDefined();
+        expect(err!.isTransient).toBe(false);
+      });
+
+      it("should clear the recorded error and reset the counter on a successful refresh", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        // First refresh fails transiently.
+        fetchStub
+          .onCall(3)
+          .resolves(new Response("server error", { status: 500 }));
+        await ctx.refresh();
+        expect(ctx.getErrors().tokenRefresh!.isTransient).toBe(true);
+
+        // Next refresh succeeds.
+        stubSuccessfulChain(
+          fetchStub,
+          4,
+          "new-refresh",
+          "new-id",
+          "new-cp",
+          "new-dp",
+        );
+        await ctx.refresh();
+
+        expect(ctx.getErrors().tokenRefresh).toBeUndefined();
+        // Counter reset is observable via the classifier: a new generic failure
+        // should be classified transient, not cascade from the prior counter.
+        fetchStub
+          .onCall(7)
+          .resolves(new Response("server error", { status: 500 }));
+        await ctx.refresh();
+        expect(ctx.getErrors().tokenRefresh!.isTransient).toBe(true);
+      });
+
+      it("should retry CP once on transient failure and succeed", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        stubAuth0OkAt(fetchStub, 3, "new-refresh", "new-id");
+        fetchStub
+          .onCall(4)
+          .resolves(new Response("bad gateway", { status: 502 }));
+        stubCpOkAt(fetchStub, 5, "retry-cp");
+        stubDpOkAt(fetchStub, 6, "new-dp");
+
+        await ctx.refresh();
+
+        expect(ctx.getControlPlaneToken()).toBe("retry-cp");
+        expect(ctx.getDataPlaneToken()).toBe("new-dp");
+        expect(ctx.getErrors().tokenRefresh).toBeUndefined();
+      });
+
+      it("should retry DP once on transient failure and succeed", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        stubAuth0OkAt(fetchStub, 3, "new-refresh", "new-id");
+        stubCpOkAt(fetchStub, 4, "new-cp");
+        fetchStub
+          .onCall(5)
+          .resolves(new Response("bad gateway", { status: 502 }));
+        stubDpOkAt(fetchStub, 6, "retry-dp");
+
+        await ctx.refresh();
+
+        expect(ctx.getDataPlaneToken()).toBe("retry-dp");
+        expect(ctx.getErrors().tokenRefresh).toBeUndefined();
+      });
+
+      it("should not retry phase-2 when the error is a known non-transient signal", async () => {
+        const ctx = await newLoggedInContext(fetchStub);
+        stubAuth0OkAt(fetchStub, 3, "new-refresh", "new-id");
+        fetchStub
+          .onCall(4)
+          .resolves(
+            new Response(
+              '{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}',
+              { status: 400 },
+            ),
+          );
+
+        await ctx.refresh();
+
+        // Only the first CP call should have fired — no retry.
+        expect(fetchStub.callCount).toBe(5);
+        expect(ctx.getErrors().tokenRefresh!.isTransient).toBe(false);
+      });
+    });
   });
 
   describe("startRefreshLoop / stopRefreshLoop", () => {

--- a/src/confluent/oauth/auth-context.ts
+++ b/src/confluent/oauth/auth-context.ts
@@ -108,7 +108,7 @@ export class AuthContext {
   }
 
   /**
-   * Snapshot of recorded auth-lifecycle errors. Consumers check this to decide
+   * Readonly view of current auth-lifecycle errors. Consumers check this to decide
    * whether to prompt re-auth (when a non-transient error has been flagged).
    */
   getErrors(): Readonly<AuthErrors> {

--- a/src/confluent/oauth/auth-context.ts
+++ b/src/confluent/oauth/auth-context.ts
@@ -1,5 +1,9 @@
 import { generateOpaqueToken } from "@src/confluent/oauth/crypto-utils.js";
 import {
+  type AuthErrors,
+  hasNonTransientError,
+} from "@src/confluent/oauth/errors.js";
+import {
   exchangeControlPlaneForDataPlaneToken,
   exchangeIdTokenForControlPlaneToken,
   exchangeRefreshTokenForAuth0Tokens,
@@ -10,14 +14,31 @@ import {
   CONTROL_PLANE_TOKEN_LIFETIME_MS,
   DATA_PLANE_TOKEN_LIFETIME_MS,
   DEFAULT_REFRESH_INTERVAL_MS,
+  MAX_CONSECUTIVE_TRANSIENT_FAILURES,
   REFRESH_TOKEN_IDLE_LIFETIME_MS,
 } from "@src/confluent/oauth/token-lifetimes.js";
 import type {
   Auth0Config,
   Auth0TokenResponse,
   ConfluentTokenSet,
+  ControlPlaneTokenResponse,
 } from "@src/confluent/oauth/types.js";
 import { logger } from "@src/logger.js";
+
+/** Substrings that mark a refresh error as permanently non-recoverable. */
+const NON_TRANSIENT_ERROR_SIGNALS = [
+  "Unknown or invalid refresh token.",
+  '"error":"invalid_grant"',
+  '"error":"invalid_client"',
+  '"error":"unauthorized_client"',
+] as const;
+
+function isKnownNonTransient(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return NON_TRANSIENT_ERROR_SIGNALS.some((signal) =>
+    error.message.includes(signal),
+  );
+}
 
 /**
  * Owns one user's Confluent OAuth lifecycle — token state plus the
@@ -30,6 +51,8 @@ export class AuthContext {
   private cleared = false;
   private refreshInterval: ReturnType<typeof setInterval> | null = null;
   private inflightRefresh: Promise<void> | null = null;
+  private errors: AuthErrors = {};
+  private failedRefreshAttempts = 0;
 
   private constructor(
     private readonly auth0Config: Auth0Config,
@@ -83,6 +106,14 @@ export class AuthContext {
     return this.internalTokens.dataPlaneToken;
   }
 
+  /**
+   * Snapshot of recorded auth-lifecycle errors. Consumers check this to decide
+   * whether to prompt re-auth (when a non-transient error has been flagged).
+   */
+  getErrors(): Readonly<AuthErrors> {
+    return this.errors;
+  }
+
   /** True when the refresh token is no longer usable (expired or cleared). */
   refreshTokenExpired(now: number = Date.now()): boolean {
     if (this.cleared) return true;
@@ -94,11 +125,12 @@ export class AuthContext {
 
   /**
    * Pure predicate: should the refresh loop call `refresh()` on this context
-   * right now? True when the refresh token is still live and the CP token is
-   * within the refresh window.
+   * right now? True when the refresh token is still live, no non-transient
+   * error has been recorded, and the CP token is within the refresh window.
    */
   shouldAttemptRefresh(now: number = Date.now()): boolean {
     if (this.refreshTokenExpired(now)) return false;
+    if (hasNonTransientError(this.errors)) return false;
     return (
       this.internalTokens.controlPlaneExpiresAt - now <=
       CONTROL_PLANE_REFRESH_WINDOW_MS
@@ -136,10 +168,7 @@ export class AuthContext {
         this.internalTokens.refreshToken,
       );
     } catch (error) {
-      logger.error(
-        { error },
-        "Auth0 refresh failed; keeping the context's current token state for next tick",
-      );
+      this.recordRefreshError(error);
       return;
     }
     // clear() may have fired while the rotation was in flight — the refresh
@@ -160,15 +189,38 @@ export class AuthContext {
     }));
 
     try {
-      const cpResponse = await exchangeIdTokenForControlPlaneToken(
-        this.auth0Config.apiUrl,
-        auth0Response.id_token,
-      );
+      // Phase 2 is safe to retry and both the CP and DP exchanges accept bearer
+      // tokens without marking them consumed. A retry after a transient 5xx just
+      // creates a fresh CP/DP session; any orphaned session from a lost-in-transit first
+      // response expires naturally within its short TTL.
+      let cpResponse: ControlPlaneTokenResponse;
+      try {
+        cpResponse = await exchangeIdTokenForControlPlaneToken(
+          this.auth0Config.apiUrl,
+          auth0Response.id_token,
+        );
+      } catch (error) {
+        if (isKnownNonTransient(error)) throw error;
+        cpResponse = await exchangeIdTokenForControlPlaneToken(
+          this.auth0Config.apiUrl,
+          auth0Response.id_token,
+        );
+      }
       if (this.cleared) return;
-      const dpResponse = await exchangeControlPlaneForDataPlaneToken(
-        this.auth0Config.apiUrl,
-        cpResponse.token,
-      );
+
+      let dpResponse;
+      try {
+        dpResponse = await exchangeControlPlaneForDataPlaneToken(
+          this.auth0Config.apiUrl,
+          cpResponse.token,
+        );
+      } catch (error) {
+        if (isKnownNonTransient(error)) throw error;
+        dpResponse = await exchangeControlPlaneForDataPlaneToken(
+          this.auth0Config.apiUrl,
+          cpResponse.token,
+        );
+      }
       if (this.cleared) return;
 
       this.updateTokens((prev) => ({
@@ -178,11 +230,41 @@ export class AuthContext {
         dataPlaneToken: dpResponse.token,
         dataPlaneExpiresAt: rotationTime + DATA_PLANE_TOKEN_LIFETIME_MS,
       }));
+      // Full success — clear any prior transient error state.
+      this.errors = { ...this.errors, tokenRefresh: undefined };
+      this.failedRefreshAttempts = 0;
       logger.debug("Token set refreshed successfully");
     } catch (error) {
+      this.recordRefreshError(error);
+    }
+  }
+
+  /**
+   * Records a refresh failure on the context. A failure is transient unless
+   * its message matches a known-permanent signal, or the consecutive failure
+   * counter hits {@link MAX_CONSECUTIVE_TRANSIENT_FAILURES}. A non-transient
+   * record flips `shouldAttemptRefresh` to `false` until the context is
+   * cleared / re-authenticated.
+   */
+  private recordRefreshError(error: unknown): void {
+    this.failedRefreshAttempts += 1;
+    const isTransient =
+      this.failedRefreshAttempts < MAX_CONSECUTIVE_TRANSIENT_FAILURES &&
+      !isKnownNonTransient(error);
+    const message = error instanceof Error ? error.message : String(error);
+    this.errors = {
+      ...this.errors,
+      tokenRefresh: { message, isTransient },
+    };
+    if (isTransient) {
+      logger.warn(
+        { error, attempts: this.failedRefreshAttempts },
+        "Transient refresh error; will retry next tick",
+      );
+    } else {
       logger.error(
-        { error },
-        "CP/DP exchange failed; rotated refresh token preserved for next tick",
+        { error, attempts: this.failedRefreshAttempts },
+        "Non-transient refresh error; scheduler will skip until re-auth",
       );
     }
   }

--- a/src/confluent/oauth/auth-context.ts
+++ b/src/confluent/oauth/auth-context.ts
@@ -22,6 +22,7 @@ import type {
   Auth0TokenResponse,
   ConfluentTokenSet,
   ControlPlaneTokenResponse,
+  DataPlaneTokenResponse,
 } from "@src/confluent/oauth/types.js";
 import { logger } from "@src/logger.js";
 
@@ -208,7 +209,7 @@ export class AuthContext {
       }
       if (this.cleared) return;
 
-      let dpResponse;
+      let dpResponse: DataPlaneTokenResponse;
       try {
         dpResponse = await exchangeControlPlaneForDataPlaneToken(
           this.auth0Config.apiUrl,

--- a/src/confluent/oauth/errors.ts
+++ b/src/confluent/oauth/errors.ts
@@ -9,9 +9,8 @@ export interface AuthError {
 }
 
 /**
- * Record of auth-lifecycle errors — one optional entry per phase. Shape
- * parallels IntelliJ's `CCloudOAuthErrors.AuthErrors` for the phases that fit
- * our model. `signIn` is intentionally omitted: sign-in failures throw from
+ * Record of auth-lifecycle errors — one optional entry per phase.
+ * `signIn` is intentionally omitted: sign-in failures throw from
  * {@link AuthContext.newFromInitialLogin} before any context exists, so they
  * have no instance on which to be stored.
  */

--- a/src/confluent/oauth/errors.ts
+++ b/src/confluent/oauth/errors.ts
@@ -1,0 +1,34 @@
+/** A single auth-lifecycle error with transience flag. */
+export interface AuthError {
+  message: string;
+  /**
+   * True if expected to resolve on retry. False means the scheduler stops
+   * retrying until the context is cleared or re-authenticated.
+   */
+  isTransient: boolean;
+}
+
+/**
+ * Record of auth-lifecycle errors — one optional entry per phase. Shape
+ * parallels IntelliJ's `CCloudOAuthErrors.AuthErrors` for the phases that fit
+ * our model. `signIn` is intentionally omitted: sign-in failures throw from
+ * {@link AuthContext.newFromInitialLogin} before any context exists, so they
+ * have no instance on which to be stored.
+ */
+export interface AuthErrors {
+  /** Populated when a token refresh attempt fails. */
+  tokenRefresh?: AuthError;
+  /**
+   * Populated when an active token health check fails. Not set today;
+   * reserved for a follow-up that adds a `/api/check_jwt` probe.
+   */
+  authStatusCheck?: AuthError;
+}
+
+/** True if any recorded error is flagged non-transient. */
+export function hasNonTransientError(errors: AuthErrors): boolean {
+  return (
+    errors.tokenRefresh?.isTransient === false ||
+    errors.authStatusCheck?.isTransient === false
+  );
+}

--- a/src/confluent/oauth/token-lifetimes.ts
+++ b/src/confluent/oauth/token-lifetimes.ts
@@ -17,5 +17,5 @@ export const CONTROL_PLANE_REFRESH_WINDOW_MS = 30 * 1000;
 export const DEFAULT_REFRESH_INTERVAL_MS =
   CONTROL_PLANE_TOKEN_LIFETIME_MS - CONTROL_PLANE_REFRESH_WINDOW_MS;
 
-/** Consecutive refresh failures tolerated before the context is flagged as permanently failed. */
+/** Failure count at which the auth context is flagged as permanently failed. */
 export const MAX_CONSECUTIVE_TRANSIENT_FAILURES = 50;

--- a/src/confluent/oauth/token-lifetimes.ts
+++ b/src/confluent/oauth/token-lifetimes.ts
@@ -16,3 +16,6 @@ export const CONTROL_PLANE_REFRESH_WINDOW_MS = 30 * 1000;
 /** Default auto-refresh interval — CP lifetime minus the refresh window. */
 export const DEFAULT_REFRESH_INTERVAL_MS =
   CONTROL_PLANE_TOKEN_LIFETIME_MS - CONTROL_PLANE_REFRESH_WINDOW_MS;
+
+/** Consecutive refresh failures tolerated before the context is flagged as permanently failed. */
+export const MAX_CONSECUTIVE_TRANSIENT_FAILURES = 50;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-  Classifies OAuth refresh failures as transient vs non-transient, retries transient phase-2 exchanges inline, and records lifecycle errors on the AuthContext so the scheduler can skip permanently-failed sessions.

Closes #195 

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
