### PR TITLE
docs: add example YAML config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,17 @@ web_modules/
 .env.production.local
 .env.local
 
+# project-root yaml/yml files are blanket-ignored as a guard against accidentally
+# committing a personal `config.yaml` (or similar) containing credentials. The
+# blanket is root-only — subdirectories (sample_configs/, test-fixtures/,
+# .semaphore/, etc.) are unaffected. To track a NEW yaml/yml file at the repo
+# root, add an explicit `!/your-file.{yaml,yml}` line below.
+/*.yaml
+/*.yml
+!/config.example.yaml
+!/docker-compose.yml
+!/service.yml
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this MCP server will be documented in this file.
 
 - Configuration via YAML file.
   - Details go here eventually.
-- `config.example.yaml` template for YAML-based configuration. Users copy it to `config.yaml` to use; a blanket `/*.{yaml,yml}` `.gitignore` rule (with explicit allow-rules for currently-tracked root files) keeps personal configs and any other accidental root-level yaml out of git.
+- `config.example.yaml` template for YAML-based configuration. Users copy it to `config.yaml` to use; `.gitignore` rules for `/*.yaml` and `/*.yml` (with explicit allow-rules for currently-tracked root files) keep personal configs and any other accidental root-level yaml out of git.
 
 ## 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this MCP server will be documented in this file.
 ### Added
 
 - Configuration via YAML file.
-	- Details go here eventually.
+  - Details go here eventually.
+- `config.example.yaml` template for YAML-based configuration. Users copy it to `config.yaml` to use; a blanket `/*.{yaml,yml}` `.gitignore` rule (with explicit allow-rules for currently-tracked root files) keeps personal configs and any other accidental root-level yaml out of git.
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,17 @@ Flat environment variables can only express a single implicit connection. A YAML
 
 #### Configuration examples
 
-Browse [test-fixtures/yaml_configs/valid/](test-fixtures/yaml_configs/valid/) for working examples covering a range of configurations. These files are executed as part of the test suite on every CI run, so they are always valid and current — use them as your starting point.
+Start from [`config.example.yaml`](config.example.yaml) at the repo root — it is the YAML analogue of `.env.example`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) annotated and wired up with `${VAR}` placeholders so credentials stay in your environment.
+
+Copy it to `config.yaml` at the repo root and the `.gitignore` will keep your filled-in copy out of git — every `*.yaml`/`*.yml` file at the repo root is ignored by default unless explicitly allow-listed, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
+
+```bash
+cp config.example.yaml config.yaml
+# edit config.yaml, then:
+npx @confluentinc/mcp-confluent --config ./config.yaml
+```
+
+For more focused reference snippets, browse [test-fixtures/yaml_configs/valid/](test-fixtures/yaml_configs/valid/) — these files are executed as part of the test suite on every CI run, so they are always valid and current.
 
 #### Env-var interpolation in YAML
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,101 @@
+# Example MCP Confluent Server configuration.
+#
+# Copy this file to `config.yaml` at the repo root (that filename is gitignored
+# so your filled-in credentials stay out of git) and launch the server with:
+#
+#   cp config.example.yaml config.yaml
+#   # edit config.yaml, then:
+#   npx @confluentinc/mcp-confluent --config ./config.yaml
+#
+# Every `${VAR}` and `${VAR:-default}` placeholder is resolved from the process
+# environment at startup, so secrets can stay in your shell or `.env` file
+# rather than the YAML itself. Plain literal values are also fine when you do
+# not need interpolation.
+#
+# Each sub-block under `connections.<name>` is independently optional; remove
+# the ones you do not need. At least one of `kafka`, `schema_registry`,
+# `confluent_cloud`, `flink`, `tableflow`, or `telemetry` must remain.
+
+connections:
+  # Connection name is freeform. Currently exactly one connection is supported,
+  # but the structure is plural so multi-connection support can land later
+  # without a breaking change.
+  default:
+    type: direct
+
+    # --- Kafka ---
+    # `bootstrap_servers` is required for any Kafka client (admin, producer,
+    # consumer). `rest_endpoint` + `cluster_id` + `env_id` are required for
+    # Kafka admin REST operations against Confluent Cloud (topics, configs,
+    # ACLs).
+    kafka:
+      bootstrap_servers: "${KAFKA_BOOTSTRAP_SERVERS:-pkc-xxxxx.us-east-1.aws.confluent.cloud:9092}"
+      auth:
+        type: api_key
+        key: "${KAFKA_API_KEY}"
+        secret: "${KAFKA_API_SECRET}"
+      rest_endpoint: "${KAFKA_REST_ENDPOINT:-https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443}"
+      cluster_id: "${KAFKA_CLUSTER_ID:-lkc-xxxxx}"
+      env_id: "${KAFKA_ENV_ID:-env-xxxxx}"
+      # Optional pass-through librdkafka properties. Must NOT include
+      # `bootstrap.servers`, `sasl.username`, or `sasl.password` — use the
+      # named fields above for those (the schema rejects them here).
+      # extra_properties:
+      #   socket.timeout.ms: "30000"
+      #   debug: "broker,topic"
+
+    # --- Schema Registry ---
+    schema_registry:
+      endpoint: "${SCHEMA_REGISTRY_ENDPOINT:-https://psrc-xxxxx.us-east-2.aws.confluent.cloud}"
+      auth:
+        type: api_key
+        key: "${SCHEMA_REGISTRY_API_KEY}"
+        secret: "${SCHEMA_REGISTRY_API_SECRET}"
+
+    # --- Confluent Cloud control plane ---
+    # Required for tools that hit the Confluent Cloud REST API (environments,
+    # service accounts, connectors, billing, etc.). `endpoint` defaults to
+    # https://api.confluent.cloud when omitted.
+    confluent_cloud:
+      endpoint: "${CONFLUENT_CLOUD_ENDPOINT:-https://api.confluent.cloud}"
+      auth:
+        type: api_key
+        key: "${CONFLUENT_CLOUD_API_KEY}"
+        secret: "${CONFLUENT_CLOUD_API_SECRET}"
+
+    # --- Flink ---
+    # All four of `endpoint`, `auth`, `environment_id`, `organization_id`, and
+    # `compute_pool_id` are required if you include this block.
+    flink:
+      endpoint: "${FLINK_REST_ENDPOINT:-https://flink.us-east-1.aws.confluent.cloud}"
+      auth:
+        type: api_key
+        key: "${FLINK_API_KEY}"
+        secret: "${FLINK_API_SECRET}"
+      organization_id: "${FLINK_ORG_ID}"
+      environment_id: "${FLINK_ENV_ID:-env-xxxxx}"
+      compute_pool_id: "${FLINK_COMPUTE_POOL_ID:-lfcp-xxxxx}"
+      # Optional human-readable labels surfaced to tools / prompts:
+      # environment_name: "${FLINK_ENV_NAME:-production}"
+      # database_name: "${FLINK_DATABASE_NAME:-my-cluster}"
+
+    # --- Tableflow ---
+    # Tableflow tools also need `confluent_cloud` above for environment and
+    # cluster lookups.
+    tableflow:
+      auth:
+        type: api_key
+        key: "${TABLEFLOW_API_KEY}"
+        secret: "${TABLEFLOW_API_SECRET}"
+
+    # --- Telemetry / Metrics ---
+    # If you omit this block entirely, telemetry inherits `confluent_cloud.auth`
+    # and uses the default endpoint (https://api.telemetry.confluent.cloud).
+    # Define this block only when you need to override one of those, e.g. with
+    # a separate metrics-only API key (recommended for least-privilege access).
+    # telemetry:
+    #   endpoint: "${TELEMETRY_ENDPOINT:-https://api.telemetry.confluent.cloud}"
+    #   auth:
+    #     type: api_key
+    #     key: "${TELEMETRY_API_KEY}"
+    #     secret: "${TELEMETRY_API_SECRET}"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -64,7 +64,7 @@ connections:
         secret: "${CONFLUENT_CLOUD_API_SECRET}"
 
     # --- Flink ---
-    # All four of `endpoint`, `auth`, `environment_id`, `organization_id`, and
+    # All five of `endpoint`, `auth`, `environment_id`, `organization_id`, and
     # `compute_pool_id` are required if you include this block.
     flink:
       endpoint: "${FLINK_REST_ENDPOINT:-https://flink.us-east-1.aws.confluent.cloud}"


### PR DESCRIPTION
Mainly to make sure we have the `.env.example` equivalent and documentation, plus the `.gitignore` rule to prevent any accidental commits between now and the time of release.