### PR TITLE
Feat/215 yaml transports and do not track

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,7 +38,7 @@ server:
   # Opt out of anonymous usage analytics.
   # (DO_NOT_TRACK=true in the environment always wins; this field lets you opt
   # out in YAML without needing the env var.)
-  do_not_track: true
+  # do_not_track: true
 
   # HTTP and SSE transport settings. Omit entirely to use all defaults,
   # or when only using the stdio transport.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,17 +22,33 @@
 # When using --config, these replace the corresponding environment variables:
 #   LOG_LEVEL, HTTP_PORT, HTTP_HOST, HTTP_MCP_ENDPOINT_PATH,
 #   SSE_MCP_ENDPOINT_PATH, SSE_MCP_MESSAGE_ENDPOINT_PATH,
-#   MCP_API_KEY, MCP_AUTH_DISABLED, MCP_ALLOWED_HOSTS.
+#   MCP_API_KEY, MCP_AUTH_DISABLED, MCP_ALLOWED_HOSTS, DO_NOT_TRACK.
+# server.transports replaces the --transport CLI flag (the two are mutually
+# exclusive; omit --transport and declare transports here instead).
+# Exception: Env var DO_NOT_TRACK is always honored as a floor — if set in the
+# environment, telemetry is disabled regardless of do_not_track below.
 server:
+  # Transports to start. One or more of: stdio, http, sse. Defaults to [stdio].
+  # (Use server.transports instead of --transport when using --config.)
+  transports: [stdio]
+
   # Logging verbosity. One of: trace, debug, info, warn, error, fatal.
   log_level: "${LOG_LEVEL:-info}"
 
+  # Opt out of anonymous usage analytics.
+  # (DO_NOT_TRACK=true in the environment always wins; this field lets you opt
+  # out in YAML without needing the env var.)
+  do_not_track: true
+
+  # HTTP and SSE transport settings. Omit entirely to use all defaults,
+  # or when only using the stdio transport.
   http:
-    # TCP port and bind address for HTTP/SSE transports.
+    # TCP port and bind address (applies to both http and sse transports).
     port: ${HTTP_PORT:-8080}
     host: "${HTTP_HOST:-127.0.0.1}"
-    # URL paths for each transport endpoint.
+    # URL path for the Streamable HTTP transport endpoint (http transport only).
     mcp_endpoint: "${HTTP_MCP_ENDPOINT_PATH:-/mcp}"
+    # URL paths for the SSE transport endpoints (sse transport only).
     sse_endpoint: "${SSE_MCP_ENDPOINT_PATH:-/sse}"
     sse_message_endpoint: "${SSE_MCP_MESSAGE_ENDPOINT_PATH:-/messages}"
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -379,6 +379,14 @@ describe("cli.ts", () => {
       ).toThrow(/mutually exclusive/);
     });
 
+    it("should throw when both --config and --transport are supplied", () => {
+      expect(() =>
+        parseCliArgs(
+          makeArgs(["--config", "server.yaml", "--transport", "http"]),
+        ),
+      ).toThrow(/mutually exclusive/);
+    });
+
     it("should throw when -k file does not exist", () => {
       resolveSpy.mockReturnValue("/abs/kafka.properties");
       fsMocks.existsSync.mockReturnValue(false);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,6 +109,7 @@ function assertNoConfigConflicts(
   kafkaConfigFile: string | undefined,
   disableAuth: boolean | undefined,
   allowedHosts: string | undefined,
+  transportExplicitlySet: boolean,
 ): void {
   if (!config) return;
   if (kafkaConfigFile) {
@@ -127,6 +128,12 @@ function assertNoConfigConflicts(
     throw new Error(
       "--config and --allowed-hosts are mutually exclusive: " +
         "use server.auth.allowed_hosts in the YAML file instead",
+    );
+  }
+  if (transportExplicitlySet) {
+    throw new Error(
+      "--config and --transport are mutually exclusive: " +
+        "use server.transports in the YAML file instead",
     );
   }
 }
@@ -217,6 +224,7 @@ export function parseCliArgs(argv: string[]): CLIOptions {
       opts.kafkaConfigFile,
       opts.disableAuth,
       opts.allowedHosts,
+      program.getOptionValueSource("transport") === "cli",
     );
 
     // Precedence: CLI > file > undefined

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -42,6 +42,7 @@ function envWith(overrides: Partial<EnvInput> = {}): EnvInput {
     MCP_API_KEY: undefined,
     MCP_AUTH_DISABLED: false,
     MCP_ALLOWED_HOSTS: ["localhost", "127.0.0.1"],
+    DO_NOT_TRACK: false,
     ...overrides,
   };
 }
@@ -680,6 +681,27 @@ describe("config/env-config.ts", () => {
             }),
           ),
         ).toThrow(/MCP_API_KEY.*32/);
+      });
+
+      it("should populate server.do_not_track from DO_NOT_TRACK", () => {
+        const config = buildConfigFromEnvAndCli(
+          envWith({ BOOTSTRAP_SERVERS: "localhost:9092", DO_NOT_TRACK: true }),
+        );
+        expect(config.server.do_not_track).toBe(true);
+      });
+
+      it("should default server.do_not_track to false when DO_NOT_TRACK is not set", () => {
+        const config = buildConfigFromEnvAndCli(
+          envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
+        );
+        expect(config.server.do_not_track).toBe(false);
+      });
+
+      it("should leave server.transports at the schema default [stdio] on the env-var path", () => {
+        const config = buildConfigFromEnvAndCli(
+          envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
+        );
+        expect(config.server.transports).toEqual(["stdio"]);
       });
     });
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -16,8 +16,6 @@ const CONN = `connections.${ENV_CONNECTION_NAME}`;
 /**
  * Maps each environment variable in type Environment (and handled by buildConfigFromEnvAndCli)
  * to its corresponding Zod document path in the manufactured MCPServerConfiguration.
- * The keys drive the Pick<Environment, ...> type of buildConfigFromEnvAndCli, so every
- * env var the function touches must have an entry here.
  */
 const ENV_VAR_TO_ZPATH = {
   // Kafka connection parameters

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -61,6 +61,7 @@ const ENV_VAR_TO_ZPATH = {
   MCP_API_KEY: "server.auth.api_key",
   MCP_AUTH_DISABLED: "server.auth.disabled",
   MCP_ALLOWED_HOSTS: "server.auth.allowed_hosts",
+  DO_NOT_TRACK: "server.do_not_track",
 } satisfies Partial<Record<keyof Environment, string>>;
 
 /**
@@ -386,6 +387,7 @@ function buildFlinkBlock(env: EnvSubset): {
  *     mcp_endpoint: "${HTTP_MCP_ENDPOINT_PATH}"
  *     sse_endpoint: "${SSE_MCP_ENDPOINT_PATH}"
  *     sse_message_endpoint: "${SSE_MCP_MESSAGE_ENDPOINT_PATH}"
+ *   do_not_track: ${DO_NOT_TRACK}
  *   auth:
  *     api_key: "${MCP_API_KEY}"       # omitted when not set
  *     disabled: ${MCP_AUTH_DISABLED}
@@ -398,6 +400,7 @@ function buildServerBlock(
   return {
     server: {
       log_level: env.LOG_LEVEL,
+      do_not_track: env.DO_NOT_TRACK,
       http: {
         port: env.HTTP_PORT,
         host: env.HTTP_HOST,

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -14,8 +14,8 @@ const ENV_CONNECTION_NAME = "env-connection";
 const CONN = `connections.${ENV_CONNECTION_NAME}`;
 
 /**
- * Maps each environment variable name handled by buildConfigFromEnvAndCli to its
- * corresponding Zod document path in the manufactured MCPServerConfiguration.
+ * Maps each environment variable in type Environment (and handled by buildConfigFromEnvAndCli)
+ * to its corresponding Zod document path in the manufactured MCPServerConfiguration.
  * The keys drive the Pick<Environment, ...> type of buildConfigFromEnvAndCli, so every
  * env var the function touches must have an entry here.
  */
@@ -62,7 +62,7 @@ const ENV_VAR_TO_ZPATH = {
   MCP_AUTH_DISABLED: "server.auth.disabled",
   MCP_ALLOWED_HOSTS: "server.auth.allowed_hosts",
   DO_NOT_TRACK: "server.do_not_track",
-} satisfies Partial<Record<keyof Environment, string>>;
+} satisfies Record<keyof Environment, string>;
 
 /**
  * Constructs a single-direct-connection MCPServerConfiguration from environment variables.
@@ -75,7 +75,7 @@ const ENV_VAR_TO_ZPATH = {
  * @throws Error if required environment variables are missing or if validation fails
  */
 function buildConfigFromEnv(
-  env: Pick<Environment, keyof typeof ENV_VAR_TO_ZPATH>,
+  env: Environment,
   authOverrides: Pick<EnvPathCliOverrides, "disableAuth" | "allowedHosts"> = {},
 ): MCPServerConfiguration {
   const connection: Record<string, unknown> = { type: "direct" };
@@ -140,7 +140,7 @@ export interface EnvPathCliOverrides {
  * @param overrides - CLI flag values to merge on top of the env-var-derived config
  */
 export function buildConfigFromEnvAndCli(
-  env: Pick<Environment, keyof typeof ENV_VAR_TO_ZPATH>,
+  env: Environment,
   overrides: EnvPathCliOverrides = {},
 ): MCPServerConfiguration {
   const config = buildConfigFromEnv(env, {
@@ -151,8 +151,6 @@ export function buildConfigFromEnvAndCli(
     config.setKafkaExtraProperties(overrides.kafkaConfig);
   return config;
 }
-
-type EnvSubset = Pick<Environment, keyof typeof ENV_VAR_TO_ZPATH>;
 
 /**
  * Builds the `kafka` connection block from env vars. Triggered when any Kafka-related
@@ -171,7 +169,9 @@ type EnvSubset = Pick<Environment, keyof typeof ENV_VAR_TO_ZPATH>;
  *     key: "${KAFKA_API_KEY}"
  *     secret: "${KAFKA_API_SECRET}"
  */
-function buildKafkaBlock(env: EnvSubset): { kafka: KafkaDirectConfig } | null {
+function buildKafkaBlock(
+  env: Environment,
+): { kafka: KafkaDirectConfig } | null {
   if (
     !env.BOOTSTRAP_SERVERS &&
     !env.KAFKA_API_KEY &&
@@ -214,7 +214,7 @@ function buildKafkaBlock(env: EnvSubset): { kafka: KafkaDirectConfig } | null {
  * to make the complaint that endpoint is required if only the auth var(s) are set.
  */
 function buildSchemaRegistryBlock(
-  env: EnvSubset,
+  env: Environment,
 ): { schema_registry: { endpoint?: string; auth?: AuthConfig } } | null {
   if (
     !env.SCHEMA_REGISTRY_ENDPOINT &&
@@ -249,7 +249,7 @@ function buildSchemaRegistryBlock(
  *     key: "${CONFLUENT_CLOUD_API_KEY}"
  *     secret: "${CONFLUENT_CLOUD_API_SECRET}"
  */
-function buildConfluentCloudBlock(env: EnvSubset) {
+function buildConfluentCloudBlock(env: Environment) {
   if (!env.CONFLUENT_CLOUD_API_KEY && !env.CONFLUENT_CLOUD_API_SECRET)
     return null;
   return {
@@ -277,7 +277,7 @@ function buildConfluentCloudBlock(env: EnvSubset) {
  *     key: "${TABLEFLOW_API_KEY}"
  *     secret: "${TABLEFLOW_API_SECRET}"
  */
-function buildTableflowBlock(env: EnvSubset) {
+function buildTableflowBlock(env: Environment) {
   if (!env.TABLEFLOW_API_KEY && !env.TABLEFLOW_API_SECRET) return null;
   return {
     tableflow: apiKeyAuth(env.TABLEFLOW_API_KEY, env.TABLEFLOW_API_SECRET),
@@ -298,7 +298,7 @@ function buildTableflowBlock(env: EnvSubset) {
  *     secret: "${TELEMETRY_API_SECRET}"
  */
 function buildTelemetryBlock(
-  env: EnvSubset,
+  env: Environment,
 ): { telemetry: { endpoint?: string; auth?: AuthConfig } } | null {
   if (
     !env.TELEMETRY_ENDPOINT &&
@@ -334,7 +334,7 @@ function buildTelemetryBlock(
  *     key: "${FLINK_API_KEY}"
  *     secret: "${FLINK_API_SECRET}"
  */
-function buildFlinkBlock(env: EnvSubset): {
+function buildFlinkBlock(env: Environment): {
   flink: {
     endpoint?: string;
     auth?: AuthConfig;
@@ -394,7 +394,7 @@ function buildFlinkBlock(env: EnvSubset): {
  *     allowed_hosts: ${MCP_ALLOWED_HOSTS}
  */
 function buildServerBlock(
-  env: EnvSubset,
+  env: Environment,
   authOverrides: Pick<EnvPathCliOverrides, "disableAuth" | "allowedHosts"> = {},
 ): { server: Record<string, unknown> } {
   return {

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -484,6 +484,17 @@ describe("config/models.ts", () => {
       expect(result.success).toBe(false);
     });
 
+    it("should reject duplicate entries in server.transports", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { transports: ["http", "http"] },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(formatZodIssues(result.error.issues)).toMatch(/duplicate/i);
+      }
+    });
+
     it("should default server.do_not_track to false when omitted", () => {
       const result = mcpConfigSchema.safeParse({
         connections: { production: validConnection },

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -446,6 +446,64 @@ describe("config/models.ts", () => {
         expect(result.data.server.http.port).toBe(9090);
       }
     });
+
+    it("should default server.transports to [stdio] when omitted", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.server.transports).toEqual(["stdio"]);
+      }
+    });
+
+    it("should accept an explicit server.transports list", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { transports: ["http", "sse"] },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.server.transports).toEqual(["http", "sse"]);
+      }
+    });
+
+    it("should reject an empty server.transports array", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { transports: [] },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject an unknown transport value in server.transports", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { transports: ["grpc"] },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should default server.do_not_track to false when omitted", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.server.do_not_track).toBe(false);
+      }
+    });
+
+    it("should accept server.do_not_track: true", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { do_not_track: true },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.server.do_not_track).toBe(true);
+      }
+    });
   });
 
   describe("confluent_cloud block", () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,5 +1,6 @@
 import { validateBootstrapServers } from "@src/config/validation.js";
 import { logLevels } from "@src/logger.js";
+import { TransportType } from "@src/mcp/transports/types.js";
 import { z } from "zod";
 
 // The following interfaces and types define subcomponents of class MCPServerConfiguration, which represents our entire server configuration.
@@ -110,7 +111,9 @@ export type ConnectionConfig = DirectConnectionConfig;
  * Distinct from connection config, which governs Kafka and Confluent Cloud client behaviour.
  */
 export interface ServerConfig {
+  transports: TransportType[];
   log_level: "fatal" | "error" | "warn" | "info" | "debug" | "trace";
+  do_not_track: boolean;
   http: ServerHttpConfig;
   auth: ServerAuthConfig;
 }
@@ -555,6 +558,14 @@ const serverAuthConfigSchema = z
 // defaults lazily through the schema itself rather than requiring a full literal here.
 const serverConfigSchema = z
   .object({
+    transports: z
+      .array(
+        z.enum(
+          Object.values(TransportType) as [TransportType, ...TransportType[]],
+        ),
+      )
+      .min(1, "server.transports must contain at least one transport")
+      .default([TransportType.STDIO]),
     log_level: z
       .enum(
         Object.keys(logLevels) as [
@@ -563,6 +574,7 @@ const serverConfigSchema = z
         ],
       )
       .default("info"),
+    do_not_track: z.boolean().default(false),
     http: serverHttpConfigSchema.default(() =>
       serverHttpConfigSchema.parse({}),
     ),

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -567,6 +567,9 @@ const serverConfigSchema = z
         ),
       )
       .min(1, "server.transports must contain at least one transport")
+      .refine((arr) => new Set(arr).size === arr.length, {
+        message: "server.transports must not contain duplicate entries",
+      })
       .default(() => [TransportType.STDIO]),
     log_level: z
       .enum(

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -544,7 +544,9 @@ const serverAuthConfigSchema = z
       .min(32, "server.auth.api_key must be at least 32 characters")
       .optional(),
     disabled: z.boolean().default(false),
-    allowed_hosts: z.array(z.string()).default(["localhost", "127.0.0.1"]),
+    allowed_hosts: z
+      .array(z.string())
+      .default(() => ["localhost", "127.0.0.1"]),
   })
   .strict()
   .refine((auth) => !(auth.disabled === true && auth.api_key !== undefined), {
@@ -565,7 +567,7 @@ const serverConfigSchema = z
         ),
       )
       .min(1, "server.transports must contain at least one transport")
-      .default([TransportType.STDIO]),
+      .default(() => [TransportType.STDIO]),
     log_level: z
       .enum(
         Object.keys(logLevels) as [

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -86,7 +86,7 @@ export interface TelemetryDirectConfig {
 }
 
 /**
- * Flink compute-plane connection parameters.
+ * Flink connection parameters.
  * Corresponds to `connections.<name>.flink` in the YAML configuration.
  */
 export interface FlinkDirectConfig {

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -362,6 +362,15 @@ describe("config/yaml-fixtures.test.ts", () => {
       ).toThrow(/Configuration validation failed/);
     });
 
+    it("should reject duplicate entries in server.transports", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/server-transports-duplicate.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/duplicate/i);
+    });
+
     it("should return the YAML do_not_track value even when DO_NOT_TRACK is set in the environment", () => {
       // loadConfigFromYaml does not apply the env-var floor — that is the
       // caller's responsibility (index.ts ORs mcpConfig.server.do_not_track

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -343,6 +343,66 @@ describe("config/yaml-fixtures.test.ts", () => {
         ),
       ).toThrow(/Configuration validation failed/);
     });
+
+    it("should load server.transports and server.do_not_track from YAML", () => {
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-with-server-transports.yaml"),
+        NO_ENV,
+      );
+      expect(config.server.transports).toEqual(["http", "sse"]);
+      expect(config.server.do_not_track).toBe(true);
+    });
+
+    it("should reject an empty server.transports array", () => {
+      expect(() =>
+        loadConfigFromYaml(
+          fixtureFile("invalid/server-transports-empty.yaml"),
+          NO_ENV,
+        ),
+      ).toThrow(/Configuration validation failed/);
+    });
+
+    it("should return the YAML do_not_track value even when DO_NOT_TRACK is set in the environment", () => {
+      // loadConfigFromYaml does not apply the env-var floor — that is the
+      // caller's responsibility (index.ts ORs mcpConfig.server.do_not_track
+      // with env.DO_NOT_TRACK before calling TelemetryService.initialize).
+      const config = loadConfigFromYaml(
+        fixtureFile("valid/kafka-with-server-block.yaml"),
+        { DO_NOT_TRACK: "true" },
+      );
+      expect(config.server.do_not_track).toBe(false);
+    });
+  });
+
+  describe("config.example.yaml", () => {
+    // Prove that the example config can be parsed successfully with a minimal environment providing values for the fields
+    // that it references using ${VAR} interpolation. This ensures the example is a valid config that can be used as a starting
+    // point by users as the codebase evolves.
+
+    // Minimal env: supply values for every ${VAR} placeholder that has no :-default.
+    // Placeholders with defaults (e.g. ${KAFKA_BOOTSTRAP_SERVERS:-pkc-xxxxx...}) resolve
+    // on their own; only the bare auth fields need values to pass schema validation.
+    const EXAMPLE_ENV: Record<string, string> = {
+      KAFKA_API_KEY: "example-kafka-key",
+      KAFKA_API_SECRET: "example-kafka-secret",
+      SCHEMA_REGISTRY_API_KEY: "example-sr-key",
+      SCHEMA_REGISTRY_API_SECRET: "example-sr-secret",
+      CONFLUENT_CLOUD_API_KEY: "example-cloud-key",
+      CONFLUENT_CLOUD_API_SECRET: "example-cloud-secret",
+      FLINK_API_KEY: "example-flink-key",
+      FLINK_API_SECRET: "example-flink-secret",
+      FLINK_ORG_ID: "example-org-id",
+      TABLEFLOW_API_KEY: "example-tableflow-key",
+      TABLEFLOW_API_SECRET: "example-tableflow-secret",
+    };
+
+    const EXAMPLE_FILE = fileURLToPath(
+      new URL("../../config.example.yaml", import.meta.url),
+    );
+
+    it("should parse without error", () => {
+      expect(() => loadConfigFromYaml(EXAMPLE_FILE, EXAMPLE_ENV)).not.toThrow();
+    });
   });
 
   describe("invalid fixtures", () => {

--- a/src/confluent/telemetry.test.ts
+++ b/src/confluent/telemetry.test.ts
@@ -85,9 +85,32 @@ describe("TelemetryService", () => {
     delete process.env.TELEMETRY_WRITE_KEY;
   });
 
+  describe("initialize / getInstance contract", () => {
+    it("should throw when getInstance is called before initialize", () => {
+      expect(() => TelemetryService.getInstance()).toThrow(
+        /initialize\(\) must be called before getInstance\(\)/,
+      );
+    });
+
+    it("should throw when initialize is called a second time", () => {
+      TelemetryService.initialize(false);
+      expect(() => TelemetryService.initialize(false)).toThrow(
+        /already been initialized/,
+      );
+    });
+
+    it("should return the same instance across multiple getInstance calls", () => {
+      TelemetryService.initialize(false);
+      const a = TelemetryService.getInstance();
+      const b = TelemetryService.getInstance();
+      expect(a).toBe(b);
+    });
+  });
+
   describe("activation", () => {
     it("should be enabled when the TELEMETRY_WRITE_KEY env var is set", () => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
+      TelemetryService.initialize(false);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -103,6 +126,7 @@ describe("TelemetryService", () => {
         "TELEMETRY_WRITE_KEY",
         "get",
       ).mockReturnValue("packed-key");
+      TelemetryService.initialize(false);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -122,6 +146,7 @@ describe("TelemetryService", () => {
         "TELEMETRY_WRITE_KEY",
         "get",
       ).mockReturnValue("packed-key");
+      TelemetryService.initialize(false);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -135,6 +160,8 @@ describe("TelemetryService", () => {
     });
 
     it("should be disabled when neither env var nor built-in key is set", () => {
+      TelemetryService.initialize(false);
+
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
         toolName: "list_topics",
@@ -143,9 +170,9 @@ describe("TelemetryService", () => {
       expect(trackStub).not.toHaveBeenCalled();
     });
 
-    it("should be disabled when DO_NOT_TRACK is true, even with a valid write key", () => {
+    it("should be disabled when initialized with doNotTrack: true, even with a valid write key", () => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
-      mockEnv({ DO_NOT_TRACK: true });
+      TelemetryService.initialize(true);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -161,6 +188,7 @@ describe("TelemetryService", () => {
 
     beforeEach(() => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
+      TelemetryService.initialize(false);
       service = TelemetryService.getInstance();
     });
 
@@ -197,9 +225,9 @@ describe("TelemetryService", () => {
       });
     });
 
-    it("should skip identify calls when telemetry is disabled", () => {
+    it("should skip identify calls when initialized with doNotTrack: true", () => {
       TelemetryService["instance"] = undefined;
-      mockEnv({ DO_NOT_TRACK: true });
+      TelemetryService.initialize(true);
 
       const disabled = TelemetryService.getInstance();
       disabled.identify("user-123", { org: "acme" });
@@ -211,6 +239,7 @@ describe("TelemetryService", () => {
   describe("machine ID persistence", () => {
     it("should generate and write a new UUID when no machine-id file exists", () => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
+      TelemetryService.initialize(false);
 
       TelemetryService.getInstance();
 
@@ -225,6 +254,7 @@ describe("TelemetryService", () => {
     it("should reuse an existing UUID when a machine-id file exists", () => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
       readFileSyncStub.mockReturnValue("existing-uuid");
+      TelemetryService.initialize(false);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {});
@@ -239,6 +269,7 @@ describe("TelemetryService", () => {
       mkdirSyncStub.mockImplementation(() => {
         throw new Error("EACCES");
       });
+      TelemetryService.initialize(false);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {});
@@ -252,6 +283,7 @@ describe("TelemetryService", () => {
   describe("shutdown", () => {
     it("should flush the analytics client on shutdown", async () => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
+      TelemetryService.initialize(false);
 
       await TelemetryService.getInstance().shutdown();
 
@@ -260,6 +292,8 @@ describe("TelemetryService", () => {
     });
 
     it("should be a no-op when telemetry is disabled", async () => {
+      TelemetryService.initialize(false);
+
       await TelemetryService.getInstance().shutdown();
 
       expect(closeAndFlushStub).not.toHaveBeenCalled();
@@ -271,6 +305,7 @@ describe("TelemetryService", () => {
 
     beforeEach(() => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
+      TelemetryService.initialize(false);
       service = TelemetryService.getInstance();
     });
 
@@ -330,6 +365,7 @@ describe("TelemetryService", () => {
 
     beforeEach(() => {
       process.env.TELEMETRY_WRITE_KEY = "real-key";
+      TelemetryService.initialize(false);
       service = TelemetryService.getInstance();
     });
 
@@ -367,15 +403,6 @@ describe("TelemetryService", () => {
           }),
         }),
       );
-    });
-  });
-
-  describe("getInstance", () => {
-    it("should return the same instance across multiple calls", () => {
-      const a = TelemetryService.getInstance();
-      const b = TelemetryService.getInstance();
-
-      expect(a).toBe(b);
     });
   });
 });

--- a/src/confluent/telemetry.ts
+++ b/src/confluent/telemetry.ts
@@ -1,6 +1,5 @@
 import {
   buildConfig,
-  config,
   fs,
   os,
   path,
@@ -58,12 +57,11 @@ export class TelemetryService {
   private serverSessionId: string;
   private commonProperties: Record<string, unknown>;
 
-  private constructor() {
+  private constructor(doNotTrack: boolean) {
     // runtime env var can override the build-time value for local dev/testing
     const writeKey =
       process.env.TELEMETRY_WRITE_KEY || buildConfig.TELEMETRY_WRITE_KEY;
-    const disabled = config.env.DO_NOT_TRACK;
-    const enabled = !disabled && !!writeKey;
+    const enabled = !doNotTrack && !!writeKey;
 
     this.machineId = getOrCreateMachineId();
     this.serverSessionId = randomUUID();
@@ -82,9 +80,20 @@ export class TelemetryService {
     }
   }
 
+  static initialize(doNotTrack: boolean): void {
+    if (TelemetryService.instance) {
+      throw new Error(
+        "TelemetryService has already been initialized — initialize() must be called exactly once before getInstance()",
+      );
+    }
+    TelemetryService.instance = new TelemetryService(doNotTrack);
+  }
+
   static getInstance(): TelemetryService {
     if (!TelemetryService.instance) {
-      TelemetryService.instance = new TelemetryService();
+      throw new Error(
+        "TelemetryService.initialize() must be called before getInstance()",
+      );
     }
     return TelemetryService.instance;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,18 @@ async function main() {
 
     setLogLevel(mcpConfig.server.log_level);
 
+    // Transport selection: YAML config is authoritative when --config is used;
+    // CLI flag (or its default) is used on the env-var path.
+    const transports = cliOptions.config
+      ? mcpConfig.server.transports
+      : cliOptions.transports;
+
+    // DO_NOT_TRACK is a cross-tool user preference (consoledonottrack.com);
+    // the env var acts as a floor so it is honored even when --config is used.
+    TelemetryService.initialize(
+      mcpConfig.server.do_not_track || env.DO_NOT_TRACK,
+    );
+
     logger.info(
       `${mcpConfig.getConnectionNames().length} connections loaded successfully`,
     );
@@ -219,7 +231,7 @@ async function main() {
 
     TelemetryService.getInstance().setCommonProperties({
       serverVersion,
-      transportType: cliOptions.transports.join(","),
+      transportType: transports.join(","),
     });
 
     // Capture MCP client info when the handshake completes.
@@ -290,9 +302,9 @@ async function main() {
     });
 
     // Start all transports with a single call
-    logger.info(`Starting transports: ${cliOptions.transports.join(", ")}`);
+    logger.info(`Starting transports: ${transports.join(", ")}`);
     await transportManager.start(
-      cliOptions.transports,
+      transports,
       mcpConfig.server.http.port,
       mcpConfig.server.http.host,
       mcpConfig.server.http.mcp_endpoint,

--- a/test-fixtures/yaml_configs/invalid/server-transports-empty.yaml
+++ b/test-fixtures/yaml_configs/invalid/server-transports-empty.yaml
@@ -1,0 +1,8 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "localhost:9092"
+
+server:
+  transports: []

--- a/test-fixtures/yaml_configs/valid/kafka-with-server-transports.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-server-transports.yaml
@@ -1,0 +1,11 @@
+connections:
+  production:
+    type: direct
+    kafka:
+      bootstrap_servers: "localhost:9092"
+
+server:
+  transports:
+    - http
+    - sse
+  do_not_track: true


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- **`server` block in YAML config** now includes `server.transports`, `server.do_not_track`. Cmdline options `--transport` and `--config` are mutually exclusive so as to prevent discrepancy in configuring transports.

- **`TelemetryService` strict init contract** — `TelemetryService.initialize(doNotTrack)` must now be called before `getInstance()`; both throw if the contract is violated.  Env var`DO_NOT_TRACK` is applied as a floor in `index.ts::main()`(`mcpConfig.server.do_not_track || env.DO_NOT_TRACK`) so the env var wins even on the YAML path, so as to preserve the DO_NOT_TRACK environment variable convention above and beyond this single tool.

- **`ENV_VAR_TO_ZPATH` is now exhaustive** — the map satisfies `Record<keyof Environment, string>` (not `Partial`), so adding a new env var to `env-schema.ts` without a corresponding YAML path entry is a compile error. Parameter types simplified from `Pick<Environment, keyof typeof ENV_VAR_TO_ZPATH>` to `Environment`.

- Adds example configuration syntax in `config.example.yaml` and introduces a new test proving its parsability.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #215.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
