### PR TITLE
Create class ServerRuntime

### DIFF
--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -534,6 +534,7 @@ export const DEFAULT_SERVER_CONFIG = serverConfigSchema.parse({});
  * Parsed output is wrapped in {@link MCPServerConfiguration} by
  * parseYamlConfiguration().
  */
+
 export const mcpConfigSchema = z
   .object({
     connections: z
@@ -542,7 +543,7 @@ export const mcpConfigSchema = z
         connectionConfigSchema,
       )
       .refine(
-        (connections) => Object.keys(connections).length === 1,
+        enforceSingleConnectionOnly,
         "Exactly one connection must be defined (multiple connections not yet supported)",
       ),
     server: serverConfigSchema.default(() => DEFAULT_SERVER_CONFIG),
@@ -557,4 +558,11 @@ export function formatZodIssues(issues: z.ZodError["issues"]): string {
       return path ? `  - ${path}: ${issue.message}` : `  - ${issue.message}`;
     })
     .join("\n");
+}
+
+// Temporary guard: remove when multi-connection support (#151) lands.
+function enforceSingleConnectionOnly(
+  connections: Record<string, unknown>,
+): boolean {
+  return Object.keys(connections).length === 1;
 }

--- a/src/confluent/client-manager.ts
+++ b/src/confluent/client-manager.ts
@@ -6,6 +6,10 @@ import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
 import type { ClientConfig } from "@confluentinc/schemaregistry";
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import {
+  CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
+  type DirectConnectionConfig,
+} from "@src/config/models.js";
+import {
   ConfluentAuth,
   ConfluentEndpoints,
   createAuthMiddleware,
@@ -350,4 +354,65 @@ export class DefaultClientManager
   getSchemaRegistryClient(): SchemaRegistryClient {
     return this.schemaRegistryClient.get();
   }
+}
+
+/**
+ * Constructs a {@link DefaultClientManager} from a single direct connection config.
+ */
+export function constructClientManagerForConnection(
+  conn: DirectConnectionConfig,
+): DefaultClientManager {
+  const kafkaClientConfig: GlobalConfig = {
+    "client.id": "mcp-confluent",
+    ...(conn.kafka?.bootstrap_servers && {
+      "bootstrap.servers": conn.kafka.bootstrap_servers,
+    }),
+    ...(conn.kafka?.auth
+      ? {
+          "security.protocol": "sasl_ssl",
+          "sasl.mechanisms": "PLAIN",
+          "sasl.username": conn.kafka.auth.key,
+          "sasl.password": conn.kafka.auth.secret,
+        }
+      : {}),
+    ...conn.kafka?.extra_properties,
+  };
+
+  return new DefaultClientManager({
+    kafka: kafkaClientConfig,
+    endpoints: {
+      // DefaultClientManager uses this as the Tableflow base URL too (see constructor), so always supply the default.
+      cloud: conn.confluent_cloud?.endpoint ?? CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
+      flink: conn.flink?.endpoint,
+      schemaRegistry: conn.schema_registry?.endpoint,
+      kafka: conn.kafka?.rest_endpoint,
+      telemetry: conn.telemetry?.endpoint,
+    },
+    auth: {
+      cloud: {
+        apiKey: conn.confluent_cloud?.auth.key,
+        apiSecret: conn.confluent_cloud?.auth.secret,
+      },
+      tableflow: {
+        apiKey: conn.tableflow?.auth.key,
+        apiSecret: conn.tableflow?.auth.secret,
+      },
+      flink: {
+        apiKey: conn.flink?.auth.key,
+        apiSecret: conn.flink?.auth.secret,
+      },
+      schemaRegistry: {
+        apiKey: conn.schema_registry?.auth?.key,
+        apiSecret: conn.schema_registry?.auth?.secret,
+      },
+      kafka: {
+        apiKey: conn.kafka?.auth?.key,
+        apiSecret: conn.kafka?.auth?.secret,
+      },
+      telemetry: {
+        apiKey: conn.telemetry?.auth.key,
+        apiSecret: conn.telemetry?.auth.secret,
+      },
+    },
+  });
 }

--- a/src/env-schema.ts
+++ b/src/env-schema.ts
@@ -267,7 +267,7 @@ export type EnvVar = keyof z.infer<typeof combinedSchema>;
 export const TELEMETRY_REQUIRED_ENV_VARS = [
   // Configuring the telemetry client will first look for TELEMETRY_API_KEY/SECRET, then fall back to CONFLUENT_CLOUD_API_KEY/SECRET, so
   // the only absolute required env vars for telemetry are the Confluent Cloud API key/secret.
-  // Likewise, TELEMETRY_ENDPOINT is optional (no default — the fallback is applied in constructDefaultClientManager()).
+  // Likewise, TELEMETRY_ENDPOINT is optional (no default — the fallback is applied in constructClientManagerForConnection()).
 
   // The fallback behavior for the configuration of telemetry
   // in DefaultClientManager indicates that the entire concept

--- a/src/env-schema.ts
+++ b/src/env-schema.ts
@@ -267,7 +267,8 @@ export type EnvVar = keyof z.infer<typeof combinedSchema>;
 export const TELEMETRY_REQUIRED_ENV_VARS = [
   // Configuring the telemetry client will first look for TELEMETRY_API_KEY/SECRET, then fall back to CONFLUENT_CLOUD_API_KEY/SECRET, so
   // the only absolute required env vars for telemetry are the Confluent Cloud API key/secret.
-  // Likewise, TELEMETRY_ENDPOINT is optional (no default — the fallback is applied in constructClientManagerForConnection()).
+  // Likewise, TELEMETRY_ENDPOINT is optional: config/models.ts defaults it to TELEMETRY_DEFAULT_ENDPOINT
+  // and can synthesize a telemetry block entirely from confluent_cloud.auth.
 
   // The fallback behavior for the configuration of telemetry
   // in DefaultClientManager indicates that the entire concept

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,3 @@
-import { type DirectConnectionConfig } from "@src/config/index.js";
 import { MCPServerConfiguration } from "@src/config/models.js";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { nodeCrypto } from "@src/confluent/node-deps.js";
@@ -26,22 +25,6 @@ import {
   type MockInstance,
   vi,
 } from "vitest";
-
-function connWith(
-  fields: Omit<DirectConnectionConfig, "type">,
-): DirectConnectionConfig {
-  return { type: "direct", ...fields };
-}
-
-function runtimeWith(env: ReturnType<typeof envFactory>): ServerRuntime {
-  return new ServerRuntime(
-    new MCPServerConfiguration({
-      connections: { default: connWith({}) },
-    }),
-    { default: createMockInstance(DefaultClientManager) },
-    env,
-  );
-}
 
 function fakeHandler(requiredVars: EnvVar[], isCloudOnly = false): ToolHandler {
   return {
@@ -127,6 +110,18 @@ describe("index.ts", () => {
   });
 
   describe("getToolHandlersToRegister()", () => {
+    // Helper to construct a ServerRuntime with a mocked ClientManager and a customizable
+    // env, since the tool registration logic (currently) depends on env vars.
+    function runtimeWith(env: ReturnType<typeof envFactory>): ServerRuntime {
+      return new ServerRuntime(
+        new MCPServerConfiguration({
+          connections: { default: { type: "direct" } },
+        }),
+        { default: createMockInstance(DefaultClientManager) },
+        env,
+      );
+    }
+
     it("should include a tool when all its required env vars are present", () => {
       vi.spyOn(ToolHandlerRegistry, "getToolHandler").mockReturnValue(
         fakeHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { type DirectConnectionConfig } from "@src/config/index.js";
+import { MCPServerConfiguration } from "@src/config/models.js";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { nodeCrypto } from "@src/confluent/node-deps.js";
 import type {
@@ -10,12 +11,13 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import type { EnvVar } from "@src/env-schema.js";
 import {
-  constructDefaultClientManager,
   getToolHandlersToRegister,
   outputApiKey,
   outputToolList,
 } from "@src/index.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { envFactory } from "@tests/factories/env.js";
+import { createMockInstance } from "@tests/stubs/index.js";
 import {
   beforeEach,
   describe,
@@ -29,6 +31,16 @@ function connWith(
   fields: Omit<DirectConnectionConfig, "type">,
 ): DirectConnectionConfig {
   return { type: "direct", ...fields };
+}
+
+function runtimeWith(env: ReturnType<typeof envFactory>): ServerRuntime {
+  return new ServerRuntime(
+    new MCPServerConfiguration({
+      connections: { default: connWith({}) },
+    }),
+    { default: createMockInstance(DefaultClientManager) },
+    env,
+  );
 }
 
 function fakeHandler(requiredVars: EnvVar[], isCloudOnly = false): ToolHandler {
@@ -123,7 +135,9 @@ describe("index.ts", () => {
       const result = getToolHandlersToRegister(
         [ToolName.LIST_TOPICS],
         false,
-        envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+        runtimeWith(
+          envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+        ),
       );
 
       expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
@@ -138,7 +152,7 @@ describe("index.ts", () => {
         getToolHandlersToRegister(
           [ToolName.LIST_TOPICS],
           false,
-          envFactory(), // no credentials
+          runtimeWith(envFactory()), // no credentials
         ),
       ).toThrow("No tools enabled");
     });
@@ -150,7 +164,9 @@ describe("index.ts", () => {
         getToolHandlersToRegister(
           [], // LIST_TOPICS not in the allowed set
           false,
-          envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+          runtimeWith(
+            envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+          ),
         ),
       ).toThrow("No tools enabled");
 
@@ -169,10 +185,12 @@ describe("index.ts", () => {
         getToolHandlersToRegister(
           [ToolName.LIST_TOPICS],
           true, // cloud tools disabled
-          envFactory({
-            CONFLUENT_CLOUD_API_KEY: "key",
-            CONFLUENT_CLOUD_API_SECRET: "secret",
-          }),
+          runtimeWith(
+            envFactory({
+              CONFLUENT_CLOUD_API_KEY: "key",
+              CONFLUENT_CLOUD_API_SECRET: "secret",
+            }),
+          ),
         ),
       ).toThrow("No tools enabled");
     });
@@ -188,10 +206,12 @@ describe("index.ts", () => {
       const result = getToolHandlersToRegister(
         [ToolName.LIST_TOPICS],
         false,
-        envFactory({
-          CONFLUENT_CLOUD_API_KEY: "key",
-          CONFLUENT_CLOUD_API_SECRET: "secret",
-        }),
+        runtimeWith(
+          envFactory({
+            CONFLUENT_CLOUD_API_KEY: "key",
+            CONFLUENT_CLOUD_API_SECRET: "secret",
+          }),
+        ),
       );
 
       expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
@@ -211,146 +231,13 @@ describe("index.ts", () => {
       const result = getToolHandlersToRegister(
         [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
         false,
-        envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+        runtimeWith(
+          envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+        ),
       );
 
       expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
       expect(result.has(ToolName.CREATE_TOPICS)).toBe(false);
-    });
-  });
-
-  describe("constructDefaultClientManager()", () => {
-    it("should return a DefaultClientManager instance", () => {
-      const manager = constructDefaultClientManager(
-        connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-      );
-      expect(manager).toBeInstanceOf(DefaultClientManager);
-    });
-
-    it("should always set client.id to mcp-confluent", () => {
-      const manager = constructDefaultClientManager(
-        connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-      );
-      expect(manager["kafkaConfig"]["client.id"]).toBe("mcp-confluent");
-    });
-
-    it("should set bootstrap.servers from the kafka block", () => {
-      const manager = constructDefaultClientManager(
-        connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-      );
-      expect(manager["kafkaConfig"]["bootstrap.servers"]).toBe("broker:9092");
-    });
-
-    it("should include SASL config when the kafka block has auth", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          kafka: {
-            bootstrap_servers: "broker:9092",
-            auth: { type: "api_key", key: "the-key", secret: "the-secret" },
-          },
-        }),
-      );
-      expect(manager["kafkaConfig"]["security.protocol"]).toBe("sasl_ssl");
-      expect(manager["kafkaConfig"]["sasl.username"]).toBe("the-key");
-      expect(manager["kafkaConfig"]["sasl.password"]).toBe("the-secret");
-    });
-
-    it("should omit SASL config when the kafka block has no auth", () => {
-      const manager = constructDefaultClientManager(
-        connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-      );
-      expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
-    });
-
-    it("should omit SASL config when there is no kafka block", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          confluent_cloud: {
-            endpoint: "https://api.confluent.cloud",
-            auth: { type: "api_key", key: "k", secret: "s" },
-          },
-        }),
-      );
-      expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
-    });
-
-    it("should spread kafka extra_properties into the GlobalConfig", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          kafka: {
-            bootstrap_servers: "broker:9092",
-            extra_properties: { "socket.timeout.ms": "5000" },
-          },
-        }),
-      );
-      expect(manager["kafkaConfig"]["socket.timeout.ms"]).toBe("5000");
-    });
-
-    it("should set confluentCloudBaseUrl from the confluent_cloud block endpoint", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          confluent_cloud: {
-            endpoint: "https://my.cloud.api",
-            auth: { type: "api_key", key: "k", secret: "s" },
-          },
-        }),
-      );
-      expect(manager["confluentCloudBaseUrl"]).toBe("https://my.cloud.api");
-    });
-
-    it("should set confluentCloudBaseUrl to https://api.confluent.cloud when the block uses the default endpoint", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          confluent_cloud: {
-            endpoint: "https://api.confluent.cloud",
-            auth: { type: "api_key", key: "k", secret: "s" },
-          },
-        }),
-      );
-      expect(manager["confluentCloudBaseUrl"]).toBe(
-        "https://api.confluent.cloud",
-      );
-    });
-
-    it("should default confluentCloudBaseUrl to https://api.confluent.cloud when there is no confluent_cloud block", () => {
-      const manager = constructDefaultClientManager(
-        connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-      );
-      expect(manager["confluentCloudBaseUrl"]).toBe(
-        "https://api.confluent.cloud",
-      );
-    });
-
-    it("should set confluentCloudTableflowBaseUrl to https://api.confluent.cloud when only tableflow is configured", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          tableflow: { auth: { type: "api_key", key: "k", secret: "s" } },
-        }),
-      );
-      expect(manager["confluentCloudTableflowBaseUrl"]).toBe(
-        "https://api.confluent.cloud",
-      );
-    });
-
-    it("should set confluentCloudTelemetryBaseUrl from the telemetry block", () => {
-      const manager = constructDefaultClientManager(
-        connWith({
-          telemetry: {
-            endpoint: "https://my.telemetry.api",
-            auth: { type: "api_key", key: "k", secret: "s" },
-          },
-        }),
-      );
-      expect(manager["confluentCloudTelemetryBaseUrl"]).toBe(
-        "https://my.telemetry.api",
-      );
-    });
-
-    it("should leave confluentCloudTelemetryBaseUrl undefined when there is no telemetry block", () => {
-      const manager = constructDefaultClientManager(
-        connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-      );
-      expect(manager["confluentCloudTelemetryBaseUrl"]).toBeUndefined();
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { GlobalConfig } from "@confluentinc/kafka-javascript";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DisplayedCommandLineUsageError,
@@ -11,21 +10,18 @@ import {
 } from "@src/cli.js";
 import {
   buildConfigFromEnvAndCli,
-  CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
   loadConfigFromYaml,
   MCPServerConfiguration,
-  type DirectConnectionConfig,
 } from "@src/config/index.js";
-import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { EnvVar } from "@src/env-schema.js";
-import type { Environment } from "@src/env.js";
 import { initEnv } from "@src/env.js";
 import { logger, setLogLevel } from "@src/logger.js";
 import { generateApiKey, TransportManager } from "@src/mcp/transports/index.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 
 /**
  * Determine the subset of ToolHandlers to register based on the filtered tool names,
@@ -34,7 +30,7 @@ import { generateApiKey, TransportManager } from "@src/mcp/transports/index.js";
 export function getToolHandlersToRegister(
   filteredToolNames: ToolName[],
   disableConfluentCloudTools: boolean,
-  env: Environment,
+  runtime: ServerRuntime,
 ): Map<ToolName, ToolHandler> {
   const toolHandlers = new Map<ToolName, ToolHandler>();
 
@@ -57,7 +53,7 @@ export function getToolHandlersToRegister(
 
     const missingVars = handler
       .getRequiredEnvVars()
-      .filter((varName: EnvVar) => !env[varName]);
+      .filter((varName: EnvVar) => !runtime.env[varName]);
 
     if (missingVars.length === 0) {
       toolHandlers.set(toolName, handler);
@@ -98,64 +94,6 @@ export function outputToolList(filteredToolNames: ToolName[]): void {
       desc = desc.slice(0, MAX_DESC_LENGTH - 3) + "...";
     }
     console.log(`\x1b[32m${config.name}\x1b[0m: ${desc}`);
-  });
-}
-
-export function constructDefaultClientManager(
-  conn: DirectConnectionConfig,
-): DefaultClientManager {
-  const kafkaClientConfig: GlobalConfig = {
-    "client.id": "mcp-confluent",
-    ...(conn.kafka?.bootstrap_servers && {
-      "bootstrap.servers": conn.kafka.bootstrap_servers,
-    }),
-    ...(conn.kafka?.auth
-      ? {
-          "security.protocol": "sasl_ssl",
-          "sasl.mechanisms": "PLAIN",
-          "sasl.username": conn.kafka.auth.key,
-          "sasl.password": conn.kafka.auth.secret,
-        }
-      : {}),
-    ...conn.kafka?.extra_properties,
-  };
-
-  return new DefaultClientManager({
-    kafka: kafkaClientConfig,
-    endpoints: {
-      // DefaultClientManager uses this as the Tableflow base URL too (see client-manager.ts constructor), so always supply the default.
-      cloud: conn.confluent_cloud?.endpoint ?? CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
-      flink: conn.flink?.endpoint,
-      schemaRegistry: conn.schema_registry?.endpoint,
-      kafka: conn.kafka?.rest_endpoint,
-      telemetry: conn.telemetry?.endpoint,
-    },
-    auth: {
-      cloud: {
-        apiKey: conn.confluent_cloud?.auth.key,
-        apiSecret: conn.confluent_cloud?.auth.secret,
-      },
-      tableflow: {
-        apiKey: conn.tableflow?.auth.key,
-        apiSecret: conn.tableflow?.auth.secret,
-      },
-      flink: {
-        apiKey: conn.flink?.auth.key,
-        apiSecret: conn.flink?.auth.secret,
-      },
-      schemaRegistry: {
-        apiKey: conn.schema_registry?.auth?.key,
-        apiSecret: conn.schema_registry?.auth?.secret,
-      },
-      kafka: {
-        apiKey: conn.kafka?.auth?.key,
-        apiSecret: conn.kafka?.auth?.secret,
-      },
-      telemetry: {
-        apiKey: conn.telemetry?.auth.key,
-        apiSecret: conn.telemetry?.auth.secret,
-      },
-    },
   });
 }
 
@@ -219,9 +157,7 @@ async function main() {
       `${mcpConfig.getConnectionNames().length} connections loaded successfully`,
     );
 
-    const clientManager = constructDefaultClientManager(
-      mcpConfig.getSoleConnection(),
-    );
+    const runtime = ServerRuntime.fromConfig(mcpConfig, env);
 
     const serverVersion = getPackageVersion();
     const server = new McpServer({
@@ -246,7 +182,7 @@ async function main() {
     const toolHandlers = getToolHandlersToRegister(
       filteredToolNames,
       cliOptions.disableConfluentCloudTools ?? false,
-      env,
+      runtime,
     );
 
     logger.info(
@@ -268,7 +204,11 @@ async function main() {
           const sessionId = context?.sessionId;
           const startTime = Date.now();
           try {
-            const result = await handler.handle(clientManager, args, sessionId);
+            const result = await handler.handle(
+              runtime.clientManager,
+              args,
+              sessionId,
+            );
             TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
               toolName: name,
               durationMs: Date.now() - startTime,
@@ -317,7 +257,7 @@ async function main() {
       logger.info("Shutting down...");
       await TelemetryService.getInstance().shutdown();
       await transportManager.stop();
-      await clientManager.disconnect();
+      await runtime.clientManager.disconnect();
       await server.close();
       process.exit(0);
     };

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -1,0 +1,218 @@
+import { type DirectConnectionConfig } from "@src/config/index.js";
+import { MCPServerConfiguration } from "@src/config/models.js";
+import {
+  constructClientManagerForConnection,
+  DefaultClientManager,
+} from "@src/confluent/client-manager.js";
+import { ServerRuntime } from "@src/server-runtime.js";
+import { envFactory } from "@tests/factories/env.js";
+import { createMockInstance } from "@tests/stubs/index.js";
+import { describe, expect, it } from "vitest";
+
+function connWith(
+  fields: Omit<DirectConnectionConfig, "type">,
+): DirectConnectionConfig {
+  return { type: "direct", ...fields };
+}
+
+describe("constructClientManagerForConnection()", () => {
+  it("should return a DefaultClientManager instance", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    );
+    expect(manager).toBeInstanceOf(DefaultClientManager);
+  });
+
+  it("should always set client.id to mcp-confluent", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    );
+    expect(manager["kafkaConfig"]["client.id"]).toBe("mcp-confluent");
+  });
+
+  it("should set bootstrap.servers from the kafka block", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    );
+    expect(manager["kafkaConfig"]["bootstrap.servers"]).toBe("broker:9092");
+  });
+
+  it("should include SASL config when the kafka block has auth", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        kafka: {
+          bootstrap_servers: "broker:9092",
+          auth: { type: "api_key", key: "the-key", secret: "the-secret" },
+        },
+      }),
+    );
+    expect(manager["kafkaConfig"]["security.protocol"]).toBe("sasl_ssl");
+    expect(manager["kafkaConfig"]["sasl.username"]).toBe("the-key");
+    expect(manager["kafkaConfig"]["sasl.password"]).toBe("the-secret");
+  });
+
+  it("should omit SASL config when the kafka block has no auth", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    );
+    expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
+  });
+
+  it("should omit SASL config when there is no kafka block", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        confluent_cloud: {
+          endpoint: "https://api.confluent.cloud",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      }),
+    );
+    expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
+  });
+
+  it("should spread kafka extra_properties into the GlobalConfig", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        kafka: {
+          bootstrap_servers: "broker:9092",
+          extra_properties: { "socket.timeout.ms": "5000" },
+        },
+      }),
+    );
+    expect(manager["kafkaConfig"]["socket.timeout.ms"]).toBe("5000");
+  });
+
+  it("should set confluentCloudBaseUrl from the confluent_cloud block endpoint", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        confluent_cloud: {
+          endpoint: "https://my.cloud.api",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      }),
+    );
+    expect(manager["confluentCloudBaseUrl"]).toBe("https://my.cloud.api");
+  });
+
+  it("should set confluentCloudBaseUrl to https://api.confluent.cloud when the block uses the default endpoint", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        confluent_cloud: {
+          endpoint: "https://api.confluent.cloud",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      }),
+    );
+    expect(manager["confluentCloudBaseUrl"]).toBe(
+      "https://api.confluent.cloud",
+    );
+  });
+
+  it("should default confluentCloudBaseUrl to https://api.confluent.cloud when there is no confluent_cloud block", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    );
+    expect(manager["confluentCloudBaseUrl"]).toBe(
+      "https://api.confluent.cloud",
+    );
+  });
+
+  it("should set confluentCloudTableflowBaseUrl to https://api.confluent.cloud when only tableflow is configured", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        tableflow: { auth: { type: "api_key", key: "k", secret: "s" } },
+      }),
+    );
+    expect(manager["confluentCloudTableflowBaseUrl"]).toBe(
+      "https://api.confluent.cloud",
+    );
+  });
+
+  it("should set confluentCloudTelemetryBaseUrl from the telemetry block", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({
+        telemetry: {
+          endpoint: "https://my.telemetry.api",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      }),
+    );
+    expect(manager["confluentCloudTelemetryBaseUrl"]).toBe(
+      "https://my.telemetry.api",
+    );
+  });
+
+  it("should leave confluentCloudTelemetryBaseUrl undefined when there is no telemetry block", () => {
+    const manager = constructClientManagerForConnection(
+      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    );
+    expect(manager["confluentCloudTelemetryBaseUrl"]).toBeUndefined();
+  });
+});
+
+describe("ServerRuntime", () => {
+  const config = new MCPServerConfiguration({
+    connections: {
+      "test-conn": connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
+    },
+  });
+  const env = envFactory();
+
+  describe("constructor", () => {
+    it("should store config, clientManagers, and env as-is", () => {
+      const cm = createMockInstance(DefaultClientManager);
+      const runtime = new ServerRuntime(config, { "test-conn": cm }, env);
+      expect(runtime.config).toBe(config);
+      expect(runtime.clientManagers).toStrictEqual({ "test-conn": cm });
+      expect(runtime.env).toBe(env);
+    });
+  });
+
+  describe("get clientManager()", () => {
+    it("should return the sole client manager", () => {
+      const cm = createMockInstance(DefaultClientManager);
+      const runtime = new ServerRuntime(config, { "test-conn": cm }, env);
+      expect(runtime.clientManager).toBe(cm);
+    });
+
+    it("should throw when clientManagers is empty", () => {
+      const runtime = new ServerRuntime(config, {}, env);
+      expect(() => runtime.clientManager).toThrow(
+        "ServerRuntime has no client managers",
+      );
+    });
+  });
+
+  describe("fromConfig()", () => {
+    it("should create a DefaultClientManager for each connection", () => {
+      const twoConnConfig = new MCPServerConfiguration({
+        connections: {
+          conn1: connWith({ kafka: { bootstrap_servers: "broker1:9092" } }),
+          conn2: connWith({
+            confluent_cloud: {
+              endpoint: "https://api.confluent.cloud",
+              auth: { type: "api_key", key: "k", secret: "s" },
+            },
+          }),
+        },
+      });
+      const runtime = ServerRuntime.fromConfig(twoConnConfig, env);
+      expect(Object.keys(runtime.clientManagers)).toStrictEqual([
+        "conn1",
+        "conn2",
+      ]);
+      expect(runtime.clientManagers["conn1"]).toBeInstanceOf(
+        DefaultClientManager,
+      );
+      expect(runtime.clientManagers["conn2"]).toBeInstanceOf(
+        DefaultClientManager,
+      );
+    });
+
+    it("should store the config and env on the returned runtime", () => {
+      const runtime = ServerRuntime.fromConfig(config, env);
+      expect(runtime.config).toBe(config);
+      expect(runtime.env).toBe(env);
+    });
+  });
+});

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -181,6 +181,19 @@ describe("ServerRuntime", () => {
         "ServerRuntime has no client managers",
       );
     });
+
+    it("should throw when clientManagers has more than one entry", () => {
+      const cm1 = createMockInstance(DefaultClientManager);
+      const cm2 = createMockInstance(DefaultClientManager);
+      const runtime = new ServerRuntime(
+        config,
+        { conn1: cm1, conn2: cm2 },
+        env,
+      );
+      expect(() => runtime.clientManager).toThrow(
+        "ServerRuntime has multiple client managers",
+      );
+    });
   });
 
   describe("fromConfig()", () => {

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,0 +1,64 @@
+import {
+  MCPServerConfiguration,
+  type DirectConnectionConfig,
+} from "@src/config/index.js";
+import {
+  constructClientManagerForConnection,
+  type ClientManager,
+} from "@src/confluent/client-manager.js";
+import type { Environment } from "@src/env.js";
+
+/**
+ * Aggregate of all runtime state threaded through the server.
+ *
+ * Carries config, per-connection client managers, and (temporarily) the validated
+ * Environment. The `env` field is a shim for the issue-173 migration timeline:
+ * it is read by `getToolHandlersToRegister()` and the `enabledConnectionIds()` shim
+ * in `BaseToolHandler` to check `getRequiredEnvVars()`. Once that migration is
+ * complete and `getRequiredEnvVars()` is deleted, remove `env` from this class.
+ */
+export class ServerRuntime {
+  readonly config: MCPServerConfiguration;
+  readonly clientManagers: Record<string, ClientManager>;
+  /** @deprecated Shim field — remove after issue-173 cutover. */
+  readonly env: Environment;
+
+  constructor(
+    config: MCPServerConfiguration,
+    clientManagers: Record<string, ClientManager>,
+    env: Environment,
+  ) {
+    this.config = config;
+    this.clientManagers = clientManagers;
+    this.env = env;
+  }
+
+  /**
+   * Convenience accessor for the single-connection period.
+   * Remove (or make multi-connection-aware) when issue #151 lands.
+   */
+  get clientManager(): ClientManager {
+    const [id] = Object.keys(this.clientManagers);
+    if (id === undefined) {
+      throw new Error("ServerRuntime has no client managers");
+    }
+    return this.clientManagers[id]!;
+  }
+
+  static fromConfig(
+    config: MCPServerConfiguration,
+    env: Environment,
+  ): ServerRuntime {
+    // Construct a ClientManager for each connection in the config.
+    // (although currently there will only be one, see `enforceSingleConnectionOnly()`)
+
+    const clientManagers = Object.fromEntries(
+      Object.entries(config.connections).map(([id, conn]) => [
+        id,
+        constructClientManagerForConnection(conn as DirectConnectionConfig),
+      ]),
+    );
+    // Wrap in ServerRuntime and return.
+    return new ServerRuntime(config, clientManagers, env);
+  }
+}

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,7 +1,4 @@
-import {
-  MCPServerConfiguration,
-  type DirectConnectionConfig,
-} from "@src/config/index.js";
+import { MCPServerConfiguration } from "@src/config/index.js";
 import {
   constructClientManagerForConnection,
   type ClientManager,
@@ -62,7 +59,7 @@ export class ServerRuntime {
     const clientManagers = Object.fromEntries(
       Object.entries(config.connections).map(([id, conn]) => [
         id,
-        constructClientManagerForConnection(conn as DirectConnectionConfig),
+        constructClientManagerForConnection(conn),
       ]),
     );
     // Wrap in ServerRuntime and return.

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -38,11 +38,18 @@ export class ServerRuntime {
    * Remove (or make multi-connection-aware) when issue #151 lands.
    */
   get clientManager(): ClientManager {
-    const [id] = Object.keys(this.clientManagers);
-    if (id === undefined) {
+    const managers = Object.values(this.clientManagers);
+    if (managers.length === 0) {
       throw new Error("ServerRuntime has no client managers");
     }
-    return this.clientManagers[id]!;
+    if (managers.length > 1) {
+      // enforceSingleConnectionOnly() in config/models.ts should prevent this at parse time;
+      // this guard is the runtime mirror of that constraint.
+      throw new Error(
+        "ServerRuntime has multiple client managers; use clientManagers[id] directly",
+      );
+    }
+    return managers[0]!;
   }
 
   static fromConfig(


### PR DESCRIPTION
# introduce `ServerRuntime`

## Summary

- **`src/server-runtime.ts`** (new) — `ServerRuntime` class carrying `config: MCPServerConfiguration`, `clientManagers: Record<string, ClientManager>`, and `env: Environment` (shim field, scoped to the 173 migration timeline). Includes `get clientManager()` single-connection accessor and `static fromConfig()` factory.
- **`src/confluent/client-manager.ts`** — `constructClientManagerForConnection()` added here (moved from `index.ts`, renamed); its natural home beside `DefaultClientManager` itself, and the location that severs the circular dependency between `server-runtime.ts` (which needs the factory for `fromConfig()`) and `index.ts` (which imports `ServerRuntime`).
- **`src/config/models.ts`** — anonymous single-connection Zod refine predicate extracted and named `enforceSingleConnectionOnly()` for referenceability during the multi-connection transition. This is a constraint which will ultimately be removed, but should be referencable by name.
- **`src/index.ts`** — `constructDefaultClientManager` deleted; `main()` now creates `const runtime = ServerRuntime.fromConfig(mcpConfig, env)` and passes `runtime` to `getToolHandlersToRegister()` (signature updated) and `runtime.clientManager` to `handle()` call sites. In the future, the entire `ServerRuntime` will be passed to `handle()` ()
- **`src/index.test.ts`** — `constructDefaultClientManager` describe block removed (lives in `server-runtime.test.ts`); `runtimeWith()` helper added; `getToolHandlersToRegister()` calls updated to pass a `ServerRuntime`.
- **`src/server-runtime.test.ts`** (new) — full coverage of `constructClientManagerForConnection()` (transplanted tests, renamed), `ServerRuntime` constructor field storage, `get clientManager()` happy/error paths, and `fromConfig()` per-connection manager creation.
- **`src/env-schema.ts`** — one comment updated to reference `constructClientManagerForConnection`.

## Intent for `ServerRuntime`

`ServerRuntime` is the fully-resolved product of `main()`'s startup work: configuration has been parsed and validated, client managers have been constructed for every declared connection, and the result is a single explicitly-passed object that captures everything the server knows about itself at runtime. The long-term intent is for `ServerRuntime` (or per-lifecycle-need scoped subsets of it) to be the sole argument threaded into every tool handler lifecycle method — `handle()`, `enabledConnectionIds()`, and whatever follows — so that handlers can interrogate connection config, access the right client manager, and reason about server state directly passed to it without pining for fjords of globals or accepting an ever growing list of loosely-related parameters. There are too many handlers to keep readjusting their parameter list.

## Why this unblocks #227 and #173

`getToolHandlersToRegister()` now receives a `ServerRuntime` instead of a bare `Environment`. Issue 227 can therefore add `enabledConnectionIds(runtime: ServerRuntime)` to `BaseToolHandler` with a shim that reads `runtime.env` to check `getRequiredEnvVars()` — no globals, no parameter proliferation — and flip the body of `getToolHandlersToRegister()` to call it. The domain migration PRs under 173 then override `enabledConnectionIds()` handler by handler, each one dropping the shim in favour of the typed connection predicates. When the last handler migrates, `runtime.env` and `getRequiredEnvVars()` are deleted together in the cutover PR, and `ServerRuntime` becomes the clean, env-free object it was always meant to be.

## Just a part of existing spelled 229
Issue #229 is specifying a whole bunch of work to be done, including ultimately visiting each tool `handle()`. The issue will be refined to describe that work in separate issues(s), akin to the #173 tree.

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

No functional changes, only refactoring to unblock the future.

Closes #252, reduces the scope of unrefined issue #229.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
