### PR TITLE
Add new predicate functions and ToolHandler enabledConnectionIds() lifecycle method

### DIFF
--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -1,0 +1,64 @@
+import { type CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  READ_ONLY,
+  type ToolConfig,
+} from "@src/confluent/tools/base-tools.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { EnvVar } from "@src/env-schema.js";
+import { envFactory } from "@tests/factories/env.js";
+import { runtimeWith } from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+class StubHandler extends BaseToolHandler {
+  constructor(private readonly vars: readonly EnvVar[]) {
+    super();
+  }
+
+  getRequiredEnvVars(): readonly EnvVar[] {
+    return this.vars;
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.LIST_TOPICS,
+      description: "stub",
+      inputSchema: {},
+      annotations: READ_ONLY,
+    };
+  }
+
+  handle(): CallToolResult {
+    return this.createResponse("stub");
+  }
+}
+
+describe("BaseToolHandler", () => {
+  describe("enabledConnectionIds()", () => {
+    it("should return the connection ID when all required env vars are present", () => {
+      const handler = new StubHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]);
+      const runtime = runtimeWith(
+        envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
+      );
+      expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
+    });
+
+    it("should return an empty array when a required env var is missing", () => {
+      const handler = new StubHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]);
+      const runtime = runtimeWith(envFactory({ KAFKA_API_KEY: "key" }));
+      expect(handler.enabledConnectionIds(runtime)).toEqual([]);
+    });
+
+    it("should return an empty array when all required env vars are missing", () => {
+      const handler = new StubHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]);
+      const runtime = runtimeWith(envFactory());
+      expect(handler.enabledConnectionIds(runtime)).toEqual([]);
+    });
+
+    it("should return the connection ID when getRequiredEnvVars returns an empty array", () => {
+      const handler = new StubHandler([]);
+      const runtime = runtimeWith(envFactory());
+      expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
+    });
+  });
+});

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -70,7 +70,7 @@ export abstract class BaseToolHandler implements ToolHandler {
    * Used by the enabledConnectionIds() shim; replaced by typed connection predicates
    * when each handler migrates (issue-173 children). Remove once all handlers migrate.
    */
-  abstract getRequiredEnvVars(): readonly EnvVar[];
+  protected abstract getRequiredEnvVars(): readonly EnvVar[];
 
   /**
    * Shim implementation: returns all connection IDs when every required env var is

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -3,6 +3,7 @@ import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { EnvVar } from "@src/env-schema.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { ZodRawShape } from "zod";
 
 /**
@@ -33,15 +34,13 @@ export interface ToolHandler {
   getToolConfig(): ToolConfig;
 
   /**
-   * Returns an array of environment variables required for this tool to function.
+   * Returns the IDs of connections that satisfy this tool's requirements.
+   * A non-empty result means the tool is enabled; empty means disabled.
    *
-   * This method is used to conditionally enable/disable tools based on the availability
-   * of required environment variables. Tools will be disabled if any of their required
-   * environment variables are not set at process startup time.
-   *
-   * @returns Array of environment variable names required by this tool
+   * Override in subclasses with typed connection predicates (issue-173 children).
+   * The default shim in BaseToolHandler delegates to getRequiredEnvVars().
    */
-  getRequiredEnvVars(): readonly EnvVar[];
+  enabledConnectionIds(runtime: ServerRuntime): string[];
 
   /**
    * Returns true if this tool can only be used with Confluent Cloud REST APIs.
@@ -67,15 +66,25 @@ export abstract class BaseToolHandler implements ToolHandler {
   abstract getToolConfig(): ToolConfig;
 
   /**
-   * Return an array of environment variable names required for the operation of this tool.
-   *
-   * Preferable to return a constant array of EnvVars defined in src/env-schema.ts for easier determination
-   * of which tools require which subset of env vars.
-   *
-   * If any of the required environment variables are not set at process
-   * startup time, the tool will be disabled and not returned by the tool loader.
+   * Return the env var names required for this tool.
+   * Used by the enabledConnectionIds() shim; replaced by typed connection predicates
+   * when each handler migrates (issue-173 children). Remove once all handlers migrate.
    */
   abstract getRequiredEnvVars(): readonly EnvVar[];
+
+  /**
+   * Shim implementation: returns all connection IDs when every required env var is
+   * present in runtime.env, otherwise returns [].
+   * Override with typed connection predicates during issue-173 migration.
+   */
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    const missingVars = this.getRequiredEnvVars().filter(
+      (varName) => !runtime.env[varName],
+    );
+    return missingVars.length === 0
+      ? Object.keys(runtime.config.connections)
+      : [];
+  }
 
   /**
    * Default implementation returns false, indicating the tool is not Confluent Cloud only.

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -1,0 +1,156 @@
+import type { DirectConnectionConfig } from "@src/config/index.js";
+import type { ConnectionConfig } from "@src/config/models.js";
+import {
+  connectionIdsWhere,
+  hasConfluentCloud,
+  hasFlink,
+  hasKafka,
+  hasKafkaRest,
+  hasSchemaRegistry,
+  hasTableflow,
+  hasTelemetry,
+} from "@src/confluent/tools/connection-predicates.js";
+import { describe, expect, it } from "vitest";
+
+function conn(
+  fields: Omit<DirectConnectionConfig, "type">,
+): DirectConnectionConfig {
+  return { type: "direct", ...fields };
+}
+
+const KAFKA_CONN = conn({ kafka: { bootstrap_servers: "broker:9092" } });
+const KAFKA_REST_CONN = conn({
+  kafka: { rest_endpoint: "http://kafka-rest:8082" },
+});
+const SCHEMA_REGISTRY_CONN = conn({
+  schema_registry: { endpoint: "http://schema-registry:8081" },
+});
+const CONFLUENT_CLOUD_CONN = conn({
+  confluent_cloud: {
+    endpoint: "https://api.confluent.cloud",
+    auth: { type: "api_key", key: "k", secret: "s" },
+  },
+});
+const FLINK_CONN = conn({
+  flink: {
+    endpoint: "https://flink.confluent.cloud",
+    auth: { type: "api_key", key: "k", secret: "s" },
+    environment_id: "env-abc",
+    organization_id: "org-123",
+    compute_pool_id: "lfcp-xyz",
+  },
+});
+const TELEMETRY_CONN = conn({
+  telemetry: {
+    endpoint: "https://api.telemetry.confluent.cloud",
+    auth: { type: "api_key", key: "k", secret: "s" },
+  },
+});
+const TABLEFLOW_CONN = conn({
+  tableflow: { auth: { type: "api_key", key: "k", secret: "s" } },
+});
+
+describe("connection-predicates.ts", () => {
+  describe("hasKafka()", () => {
+    it("should return true when the kafka block is present", () => {
+      expect(hasKafka(KAFKA_CONN)).toBe(true);
+    });
+
+    it("should return false when the kafka block is absent", () => {
+      expect(hasKafka(SCHEMA_REGISTRY_CONN)).toBe(false);
+    });
+  });
+
+  describe("hasKafkaRest()", () => {
+    it("should return true when kafka.rest_endpoint is present", () => {
+      expect(hasKafkaRest(KAFKA_REST_CONN)).toBe(true);
+    });
+
+    it("should return false when kafka block is absent", () => {
+      expect(hasKafkaRest(SCHEMA_REGISTRY_CONN)).toBe(false);
+    });
+
+    it("should return false when kafka block is present but rest_endpoint is absent", () => {
+      expect(hasKafkaRest(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("hasSchemaRegistry()", () => {
+    it("should return true when the schema_registry block is present", () => {
+      expect(hasSchemaRegistry(SCHEMA_REGISTRY_CONN)).toBe(true);
+    });
+
+    it("should return false when the schema_registry block is absent", () => {
+      expect(hasSchemaRegistry(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("hasConfluentCloud()", () => {
+    it("should return true when the confluent_cloud block is present", () => {
+      expect(hasConfluentCloud(CONFLUENT_CLOUD_CONN)).toBe(true);
+    });
+
+    it("should return false when the confluent_cloud block is absent", () => {
+      expect(hasConfluentCloud(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("hasFlink()", () => {
+    it("should return true when the flink block is present", () => {
+      expect(hasFlink(FLINK_CONN)).toBe(true);
+    });
+
+    it("should return false when the flink block is absent", () => {
+      expect(hasFlink(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("hasTelemetry()", () => {
+    it("should return true when the telemetry block is present", () => {
+      expect(hasTelemetry(TELEMETRY_CONN)).toBe(true);
+    });
+
+    it("should return false when the telemetry block is absent", () => {
+      expect(hasTelemetry(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("hasTableflow()", () => {
+    it("should return true when the tableflow block is present", () => {
+      expect(hasTableflow(TABLEFLOW_CONN)).toBe(true);
+    });
+
+    it("should return false when the tableflow block is absent", () => {
+      expect(hasTableflow(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("connectionIdsWhere()", () => {
+    it("should return an empty array when no connections match the predicate", () => {
+      const connections: Record<string, ConnectionConfig> = {
+        sr: SCHEMA_REGISTRY_CONN,
+      };
+      expect(connectionIdsWhere(connections, hasKafka)).toEqual([]);
+    });
+
+    it("should return the matching connection ID when one connection matches", () => {
+      const connections: Record<string, ConnectionConfig> = {
+        kafka: KAFKA_CONN,
+        sr: SCHEMA_REGISTRY_CONN,
+      };
+      expect(connectionIdsWhere(connections, hasKafka)).toEqual(["kafka"]);
+    });
+
+    it("should return all matching IDs when multiple connections satisfy the predicate", () => {
+      const connections: Record<string, ConnectionConfig> = {
+        kafka1: KAFKA_CONN,
+        kafka2: KAFKA_REST_CONN,
+        sr: SCHEMA_REGISTRY_CONN,
+      };
+      expect(connectionIdsWhere(connections, hasKafka)).toEqual([
+        "kafka1",
+        "kafka2",
+      ]);
+    });
+  });
+});

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -31,7 +31,7 @@ export function hasTableflow(conn: ConnectionConfig): boolean {
 }
 
 export function connectionIdsWhere(
-  connections: Record<string, ConnectionConfig>,
+  connections: Readonly<Record<string, ConnectionConfig>>,
   predicate: ConnectionPredicate,
 ): string[] {
   return Object.entries(connections)

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -1,0 +1,40 @@
+import type { ConnectionConfig } from "@src/config/models.js";
+
+export type ConnectionPredicate = (conn: ConnectionConfig) => boolean;
+
+export function hasKafka(conn: ConnectionConfig): boolean {
+  return conn.kafka !== undefined;
+}
+
+export function hasKafkaRest(conn: ConnectionConfig): boolean {
+  return conn.kafka?.rest_endpoint !== undefined;
+}
+
+export function hasSchemaRegistry(conn: ConnectionConfig): boolean {
+  return conn.schema_registry !== undefined;
+}
+
+export function hasConfluentCloud(conn: ConnectionConfig): boolean {
+  return conn.confluent_cloud !== undefined;
+}
+
+export function hasFlink(conn: ConnectionConfig): boolean {
+  return conn.flink !== undefined;
+}
+
+export function hasTelemetry(conn: ConnectionConfig): boolean {
+  return conn.telemetry !== undefined;
+}
+
+export function hasTableflow(conn: ConnectionConfig): boolean {
+  return conn.tableflow !== undefined;
+}
+
+export function connectionIdsWhere(
+  connections: Record<string, ConnectionConfig>,
+  predicate: ConnectionPredicate,
+): string[] {
+  return Object.entries(connections)
+    .filter(([, conn]) => predicate(conn))
+    .map(([id]) => id);
+}

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
@@ -1,6 +1,8 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topics-handler.js";
+import { envFactory } from "@tests/factories/env.js";
+import { runtimeWith } from "@tests/factories/runtime.js";
 import {
   createMockAdmin,
   createMockInstance,
@@ -25,6 +27,20 @@ describe("list-topics-handler.ts", () => {
         const vars = handler.getRequiredEnvVars();
 
         expect(vars).toEqual(["BOOTSTRAP_SERVERS"]);
+      });
+    });
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID when BOOTSTRAP_SERVERS is set", () => {
+        const runtime = runtimeWith(
+          envFactory({ BOOTSTRAP_SERVERS: "broker:9092" }),
+        );
+        expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
+      });
+
+      it("should return an empty array when BOOTSTRAP_SERVERS is absent", () => {
+        const runtime = runtimeWith(envFactory());
+        expect(handler.enabledConnectionIds(runtime)).toEqual([]);
       });
     });
 

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
@@ -34,6 +34,7 @@ describe("list-topics-handler.ts", () => {
       it("should return the connection ID when BOOTSTRAP_SERVERS is set", () => {
         const runtime = runtimeWith(
           envFactory({ BOOTSTRAP_SERVERS: "broker:9092" }),
+          { kafka: { bootstrap_servers: "broker:9092" } },
         );
         expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
       });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,3 @@
-import { MCPServerConfiguration } from "@src/config/models.js";
-import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { nodeCrypto } from "@src/confluent/node-deps.js";
 import type {
   ToolConfig,
@@ -14,9 +12,8 @@ import {
   outputApiKey,
   outputToolList,
 } from "@src/index.js";
-import { ServerRuntime } from "@src/server-runtime.js";
 import { envFactory } from "@tests/factories/env.js";
-import { createMockInstance } from "@tests/stubs/index.js";
+import { runtimeWith } from "@tests/factories/runtime.js";
 import {
   beforeEach,
   describe,
@@ -28,7 +25,12 @@ import {
 
 function fakeHandler(requiredVars: EnvVar[], isCloudOnly = false): ToolHandler {
   return {
-    getRequiredEnvVars: () => requiredVars,
+    enabledConnectionIds: (runtime) => {
+      const missing = requiredVars.filter((v) => !runtime.env[v]);
+      return missing.length === 0
+        ? Object.keys(runtime.config.connections)
+        : [];
+    },
     isConfluentCloudOnly: () => isCloudOnly,
     getToolConfig: () => ({
       name: ToolName.LIST_TOPICS,
@@ -110,18 +112,6 @@ describe("index.ts", () => {
   });
 
   describe("getToolHandlersToRegister()", () => {
-    // Helper to construct a ServerRuntime with a mocked ClientManager and a customizable
-    // env, since the tool registration logic (currently) depends on env vars.
-    function runtimeWith(env: ReturnType<typeof envFactory>): ServerRuntime {
-      return new ServerRuntime(
-        new MCPServerConfiguration({
-          connections: { default: { type: "direct" } },
-        }),
-        { default: createMockInstance(DefaultClientManager) },
-        env,
-      );
-    }
-
     it("should include a tool when all its required env vars are present", () => {
       vi.spyOn(ToolHandlerRegistry, "getToolHandler").mockReturnValue(
         fakeHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
-import { EnvVar } from "@src/env-schema.js";
 import { initEnv } from "@src/env.js";
 import { logger, setLogLevel } from "@src/logger.js";
 import { generateApiKey, TransportManager } from "@src/mcp/transports/index.js";
@@ -51,16 +50,13 @@ export function getToolHandlersToRegister(
       return;
     }
 
-    const missingVars = handler
-      .getRequiredEnvVars()
-      .filter((varName: EnvVar) => !runtime.env[varName]);
-
-    if (missingVars.length === 0) {
+    const enabledIds = handler.enabledConnectionIds(runtime);
+    if (enabledIds.length > 0) {
       toolHandlers.set(toolName, handler);
       logger.info(`Tool ${toolName} enabled`);
     } else {
       logger.warn(
-        `Tool ${toolName} disabled due to missing environment variables: ${missingVars.join(", ")}`,
+        `Tool ${toolName} disabled; no connections satisfy its requirements`,
       );
     }
   });

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -1,0 +1,29 @@
+import type { DirectConnectionConfig } from "@src/config/index.js";
+import { MCPServerConfiguration } from "@src/config/models.js";
+import { DefaultClientManager } from "@src/confluent/client-manager.js";
+import { ServerRuntime } from "@src/server-runtime.js";
+import { envFactory } from "@tests/factories/env.js";
+import { createMockInstance } from "@tests/stubs/index.js";
+
+/**
+ * Creates a ServerRuntime with a mocked ClientManager and a customizable env.
+ *
+ * Pass `connectionConfig` to populate the connection's service blocks (kafka,
+ * flink, schema_registry, etc.). Tests for `enabledConnectionIds()` should
+ * supply both the relevant env vars (for the current shim) and the matching
+ * service block (for the post-migration predicate), so the test survives the
+ * issue-173 migration without modification.
+ */
+export function runtimeWith(
+  env: ReturnType<typeof envFactory>,
+  connectionConfig: Omit<DirectConnectionConfig, "type"> = {},
+  connectionId = "default",
+): ServerRuntime {
+  return new ServerRuntime(
+    new MCPServerConfiguration({
+      connections: { [connectionId]: { type: "direct", ...connectionConfig } },
+    }),
+    { [connectionId]: createMockInstance(DefaultClientManager) },
+    env,
+  );
+}


### PR DESCRIPTION

# Infrastructure: `connection-predicates.ts` + `enabledConnectionIds()` shim

## Summary of Summary

Create the new ToolHandler lifecycle method `enabledConnectionIds(runtime: ServerRuntime)` which will replace `getRequiredEnvVars()` and tools last common / primary use of knowledge of env vars. Do so by initially implementing `enabledConnectionIds()` in terms of the (only during this transition period) env var payload within `ServerRuntime` by then downcalling into in-every-handler-but-no-longer-treated-as-a public-method `getRequiredEnvVars()` (now is called only by the BaseTool's `enabledConnectionIds()`. Create the module for the predicate functions which will actually assist the real implementations of `enabledConnectionIds()` at either the tool-family level or individual tool handler implementations. See description of #227 and then #173 for more context.

## Summary

- **`src/confluent/tools/connection-predicates.ts`** (new) — `ConnectionPredicate` type and seven named predicate functions (`hasKafka`, `hasKafkaRest`, `hasSchemaRegistry`, `hasConfluentCloud`, `hasFlink`, `hasTelemetry`, `hasTableflow`) over `ConnectionConfig`, plus `connectionIdsWhere(connections, predicate)` helper that filters a connection map to IDs satisfying a predicate.
- **`src/confluent/tools/connection-predicates.test.ts`** (new) — full coverage of every predicate (true and false path each) and `connectionIdsWhere` (empty match, single match, multiple match).
- **`src/confluent/tools/base-tools.ts`** — `getRequiredEnvVars()` removed from the `ToolHandler` interface; it survives as an `abstract` method on `BaseToolHandler` only, serving as the internal hook for the shim. `enabledConnectionIds(runtime: ServerRuntime): string[]` added to both the interface (the new public contract for tool enablement) and `BaseToolHandler` (concrete shim implementation that delegates to `getRequiredEnvVars()` against `runtime.env`). `EnvVar` disappears from the public tool surface entirely. Soon-to-be-removed-entirely `getRequiredEnvVars()` now marked `protected` due to only caller now being in-class-family `enabledConnectionIds()`.
- **`src/confluent/tools/base-tools.test.ts`** (new) — direct unit tests for `enabledConnectionIds()` via a minimal `StubHandler` subclass; covers all-vars-present, one-missing, all-missing, and no-requirements cases.
- **`src/index.ts`** — `getToolHandlersToRegister()` body flipped to call `handler.enabledConnectionIds(runtime)` instead of `handler.getRequiredEnvVars()` against `runtime.env`; `EnvVar` import removed. Disabled-tool log message updated to reflect the connection-centric framing: `"Tool X disabled; no connections satisfy its requirements"`.
- **`src/index.test.ts`** — `fakeHandler` updated to implement `enabledConnectionIds()` (removing the now-absent `getRequiredEnvVars`); local `runtimeWith()` helper removed in favour of the shared factory below.
- **`src/confluent/tools/handlers/kafka/list-topics-handler.test.ts`** — `enabledConnectionIds()` describe block added as a concrete real-handler proof that the shim wires correctly through a genuine `getRequiredEnvVars()` declaration.
- **`tests/factories/runtime.ts`** (new) — `runtimeWith(env, connectionConfig?, connectionId?)` shared test factory, replacing previously duplicated helpers in `index.test.ts` and `base-tools.test.ts`. Accepts an optional `connectionConfig` block so tests can populate service sub-blocks (kafka, flink, etc.) alongside the env, as needed for forward-compatible test writing during the 216–226 migration window.

## Why `getRequiredEnvVars()` was removed from `ToolHandler`

The interface represents the public contract that callers of a handler depend on. `getToolHandlersToRegister()` in `index.ts` was the only non-handler caller, and it now calls `enabledConnectionIds()` instead. With zero external callers remaining, leaving `getRequiredEnvVars()` on the interface would only be noise — and noise that carries `EnvVar` into the public surface, signalling that tool enablement is env-var-centric when it soon won't be. Moving it to `BaseToolHandler` as a protected implementation detail makes the intent clear: it is a shim hook, not a contract.

All existing handler implementations continue to satisfy the abstract requirement on `BaseToolHandler` unchanged — no handler files were touched.

## Why the disabled-tool log message changed

The old message named the specific missing env vars:
`"Tool X disabled due to missing environment variables: KAFKA_API_KEY, KAFKA_API_SECRET"`

`enabledConnectionIds()` returns a `string[]`, not a diagnostic payload, so the missing-var list is no longer available at the call site. More importantly, the old framing is wrong for the world this PR is building toward: once handlers migrate to typed predicates, a tool will be disabled because its required service block is absent from the connection config — not because an env var is missing. The new message:
`"Tool X disabled; no connections satisfy its requirements"`
reads correctly both today and after the migration is complete.

## Manual testing instructions

No functional changes — the same tools enable and disable as before. `npm run test` is the completeness check.

## Relationship to #173 and future domain migration PRs

This is the infrastructure PR (PR 0) described in the incremental migration plan in issue #173. It unblocks the eleven domain migration issues:

| Issue | Domain       |
| ----- | ------------ |
| #216  | billing      |
| #217  | catalog      |
| #218  | clusters     |
| #219  | connect      |
| #220  | environments |
| #221  | flink        |
| #222  | kafka        |
| #223  | metrics      |
| #224  | schema       |
| #225  | search       |
| #226  | tableflow    |

Each of those PRs will, for its domain's handlers:

1. Override `enabledConnectionIds()` with the appropriate one-liner predicate from `connection-predicates.ts`, e.g. `return connectionIdsWhere(runtime.config.connections, hasKafka)`.
2. Delete the `getRequiredEnvVars()` implementation from each handler.
3. Write an `enabledConnectionIds()` test for each handler (see test plan below) — none exist yet outside of `list-topics-handler.test.ts`, which serves as the template.

When the last domain PR lands, `getRequiredEnvVars()`, `runtime.env`, and the `FLINK_REQUIRED_ENV_VARS` / `CCLOUD_CONTROL_PLANE_REQUIRED_ENV_VARS` / etc. constants in `env-schema.ts` are deleted together in the cutover PR, redeclaring `enabledConnectionIds()` as `abstract` in `BaseToolHandler` to enforce that no handler can fall back to a shim that no longer exists.

## Test writing plan for domain migration PRs

The `list-topics-handler.test.ts` `enabledConnectionIds()` block is the template. At the time of writing (shim era), it tests against env vars:

```typescript
it("should return the connection ID when BOOTSTRAP_SERVERS is set", () => {
  const runtime = runtimeWith(envFactory({ BOOTSTRAP_SERVERS: "broker:9092" }));
  expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
});

it("should return an empty array when BOOTSTRAP_SERVERS is absent", () => {
  const runtime = runtimeWith(envFactory());
  expect(handler.enabledConnectionIds(runtime)).toEqual([]);
});
```

When the domain migration PR for kafka (#222) lands, these two tests are updated to test against the connection config instead — and crucially, no env vars are provided, proving the handler no longer consults `runtime.env`:

```typescript
it("should return the connection ID for a connection with a kafka block", () => {
  const runtime = runtimeWith(
    envFactory(), // no env vars needed
    { kafka: { bootstrap_servers: "broker:9092" } }, // predicate checks this
  );
  expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
});

it("should return an empty array for a connection without a kafka block", () => {
  const runtime = runtimeWith(envFactory()); // no env vars, no kafka block
  expect(handler.enabledConnectionIds(runtime)).toEqual([]);
});
```

The `runtimeWith()` factory in `tests/factories/runtime.ts` already accepts the optional `connectionConfig` second argument to support this pattern.

Closes #227.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
