### PR TITLE
Migrate billing and catalog handlers to enabledConnectionIds()

### DIFF
--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -7,7 +7,10 @@ import {
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import type { EnvVar } from "@src/env-schema.js";
 import { envFactory } from "@tests/factories/env.js";
-import { runtimeWith } from "@tests/factories/runtime.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
 
 class StubHandler extends BaseToolHandler {
@@ -40,7 +43,9 @@ describe("BaseToolHandler", () => {
       const runtime = runtimeWith(
         envFactory({ KAFKA_API_KEY: "key", KAFKA_API_SECRET: "secret" }),
       );
-      expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
+      expect(handler.enabledConnectionIds(runtime)).toEqual([
+        DEFAULT_CONNECTION_ID,
+      ]);
     });
 
     it("should return an empty array when a required env var is missing", () => {
@@ -58,7 +63,30 @@ describe("BaseToolHandler", () => {
     it("should return the connection ID when getRequiredEnvVars returns an empty array", () => {
       const handler = new StubHandler([]);
       const runtime = runtimeWith(envFactory());
-      expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
+      expect(handler.enabledConnectionIds(runtime)).toEqual([
+        DEFAULT_CONNECTION_ID,
+      ]);
+    });
+
+    it("should throw when neither enabledConnectionIds nor getRequiredEnvVars is overridden", () => {
+      class BareHandler extends BaseToolHandler {
+        getToolConfig(): ToolConfig {
+          return {
+            name: ToolName.LIST_TOPICS,
+            description: "bare",
+            inputSchema: {},
+            annotations: READ_ONLY,
+          };
+        }
+        handle(): CallToolResult {
+          return this.createResponse("bare");
+        }
+      }
+      expect(() =>
+        new BareHandler().enabledConnectionIds(runtimeWith(envFactory())),
+      ).toThrow(
+        "BareHandler must override enabledConnectionIds() or implement getRequiredEnvVars()",
+      );
     });
   });
 });

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -69,6 +69,10 @@ describe("BaseToolHandler", () => {
     });
 
     it("should throw when neither enabledConnectionIds nor getRequiredEnvVars is overridden", () => {
+      // Exists only during the issue-173 transition: once enabledConnectionIds() is abstract,
+      // the compiler enforces this and the runtime throw (and this test) can be deleted.
+      // A class is required (not a plain ToolHandler object) so that constructor.name
+      // appears in the thrown message, proving the error identifies the offending handler.
       class BareHandler extends BaseToolHandler {
         getToolConfig(): ToolConfig {
           return {

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -34,11 +34,13 @@ export interface ToolHandler {
   getToolConfig(): ToolConfig;
 
   /**
-   * Returns the IDs of connections that satisfy this tool's requirements.
-   * A non-empty result means the tool is enabled; empty means disabled.
+   * Returns the IDs of connections that satisfy this tool's service requirements.
+   * A non-empty result enables the tool; an empty result disables it. Implementations
+   * should return a subset of the keys in runtime.config.connections.
    *
-   * Override in subclasses with typed connection predicates (issue-173 children).
-   * The default shim in BaseToolHandler delegates to getRequiredEnvVars().
+   * Each handler is intended to implement this by applying the appropriate predicate from
+   * connection-predicates.ts via connectionIdsWhere(), e.g.:
+   *   return connectionIdsWhere(runtime.config.connections, hasKafka);
    */
   enabledConnectionIds(runtime: ServerRuntime): string[];
 
@@ -70,14 +72,21 @@ export abstract class BaseToolHandler implements ToolHandler {
    * Used by the enabledConnectionIds() shim; replaced by typed connection predicates
    * when each handler migrates (issue-173 children). Remove once all handlers migrate.
    */
-  protected abstract getRequiredEnvVars(): readonly EnvVar[];
+  protected getRequiredEnvVars(): readonly EnvVar[] {
+    throw new Error(
+      `${this.constructor.name} must override enabledConnectionIds() or implement getRequiredEnvVars()`,
+    );
+  }
 
   /**
-   * Shim implementation: returns all connection IDs when every required env var is
-   * present in runtime.env, otherwise returns [].
-   * Override with typed connection predicates during issue-173 migration.
+   * Determines which configured connections can serve this tool by inspecting
+   * their service blocks. If returns an empty array, the tool is disabled.
+   *
+   * The canonical implementation is a one-liner:
+   *   return connectionIdsWhere(runtime.config.connections, some-predicate-function);
    */
   enabledConnectionIds(runtime: ServerRuntime): string[] {
+    // Shim: delegates to getRequiredEnvVars() until all handlers migrate (issue-173).
     const missingVars = this.getRequiredEnvVars().filter(
       (varName) => !runtime.env[varName],
     );

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -1,0 +1,25 @@
+import { ListBillingCostsHandler } from "@src/confluent/tools/handlers/billing/list-billing-costs-handler.js";
+import {
+  bareRuntime,
+  confluentCloudRuntime,
+  DEFAULT_CONNECTION_ID,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+describe("list-billing-costs-handler.ts", () => {
+  describe("ListBillingCostsHandler", () => {
+    const handler = new ListBillingCostsHandler();
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID for a connection with a confluent_cloud block", () => {
+        expect(handler.enabledConnectionIds(confluentCloudRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
+      });
+
+      it("should return an empty array for a connection without a confluent_cloud block", () => {
+        expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -5,12 +5,13 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
-  CCLOUD_CONTROL_PLANE_REQUIRED_ENV_VARS,
-  EnvVar,
-} from "@src/env-schema.js";
+  connectionIdsWhere,
+  hasConfluentCloud,
+} from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -213,8 +214,8 @@ Pagination:${metadata.total_size ? `\n  Total Items: ${metadata.total_size}` : "
     };
   }
 
-  getRequiredEnvVars(): readonly EnvVar[] {
-    return CCLOUD_CONTROL_PLANE_REQUIRED_ENV_VARS;
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return connectionIdsWhere(runtime.config.connections, hasConfluentCloud);
   }
 
   isConfluentCloudOnly(): boolean {

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.test.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.test.ts
@@ -1,0 +1,25 @@
+import { AddTagToTopicHandler } from "@src/confluent/tools/handlers/catalog/add-tags-to-topic.js";
+import {
+  bareRuntime,
+  DEFAULT_CONNECTION_ID,
+  schemaRegistryRuntime,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+describe("add-tags-to-topic.ts", () => {
+  describe("AddTagToTopicHandler", () => {
+    const handler = new AddTagToTopicHandler();
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID for a connection with a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(schemaRegistryRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
+      });
+
+      it("should return an empty array for a connection without a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
@@ -5,11 +5,12 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
-  CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS,
-  EnvVar,
-} from "@src/env-schema.js";
+  connectionIdsWhere,
+  hasSchemaRegistry,
+} from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -67,8 +68,8 @@ export class AddTagToTopicHandler extends BaseToolHandler {
     };
   }
 
-  getRequiredEnvVars(): readonly EnvVar[] {
-    return CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS;
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
   }
 
   isConfluentCloudOnly(): boolean {

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.test.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.test.ts
@@ -1,0 +1,25 @@
+import { CreateTopicTagsHandler } from "@src/confluent/tools/handlers/catalog/create-topic-tags.js";
+import {
+  bareRuntime,
+  DEFAULT_CONNECTION_ID,
+  schemaRegistryRuntime,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+describe("create-topic-tags.ts", () => {
+  describe("CreateTopicTagsHandler", () => {
+    const handler = new CreateTopicTagsHandler();
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID for a connection with a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(schemaRegistryRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
+      });
+
+      it("should return an empty array for a connection without a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.ts
@@ -5,11 +5,12 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
-  CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS,
-  EnvVar,
-} from "@src/env-schema.js";
+  connectionIdsWhere,
+  hasSchemaRegistry,
+} from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -71,8 +72,8 @@ export class CreateTopicTagsHandler extends BaseToolHandler {
     };
   }
 
-  getRequiredEnvVars(): readonly EnvVar[] {
-    return CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS;
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
   }
 
   isConfluentCloudOnly(): boolean {

--- a/src/confluent/tools/handlers/catalog/delete-tag.test.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.test.ts
@@ -1,0 +1,25 @@
+import { DeleteTagHandler } from "@src/confluent/tools/handlers/catalog/delete-tag.js";
+import {
+  bareRuntime,
+  DEFAULT_CONNECTION_ID,
+  schemaRegistryRuntime,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+describe("delete-tag.ts", () => {
+  describe("DeleteTagHandler", () => {
+    const handler = new DeleteTagHandler();
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID for a connection with a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(schemaRegistryRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
+      });
+
+      it("should return an empty array for a connection without a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/delete-tag.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.ts
@@ -5,11 +5,12 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
-  CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS,
-  EnvVar,
-} from "@src/env-schema.js";
+  connectionIdsWhere,
+  hasSchemaRegistry,
+} from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -58,8 +59,8 @@ export class DeleteTagHandler extends BaseToolHandler {
     };
   }
 
-  getRequiredEnvVars(): readonly EnvVar[] {
-    return CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS;
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
   }
 
   isConfluentCloudOnly(): boolean {

--- a/src/confluent/tools/handlers/catalog/list-tags.test.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.test.ts
@@ -1,0 +1,25 @@
+import { ListTagsHandler } from "@src/confluent/tools/handlers/catalog/list-tags.js";
+import {
+  bareRuntime,
+  DEFAULT_CONNECTION_ID,
+  schemaRegistryRuntime,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+describe("list-tags.ts", () => {
+  describe("ListTagsHandler", () => {
+    const handler = new ListTagsHandler();
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID for a connection with a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(schemaRegistryRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
+      });
+
+      it("should return an empty array for a connection without a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/list-tags.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.ts
@@ -5,11 +5,12 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
-  CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS,
-  EnvVar,
-} from "@src/env-schema.js";
+  connectionIdsWhere,
+  hasSchemaRegistry,
+} from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class ListTagsHandler extends BaseToolHandler {
@@ -41,8 +42,8 @@ export class ListTagsHandler extends BaseToolHandler {
     };
   }
 
-  getRequiredEnvVars(): readonly EnvVar[] {
-    return CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS;
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
   }
 
   isConfluentCloudOnly(): boolean {

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.test.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.test.ts
@@ -1,0 +1,25 @@
+import { RemoveTagFromEntityHandler } from "@src/confluent/tools/handlers/catalog/remove-tag-from-entity.js";
+import {
+  bareRuntime,
+  DEFAULT_CONNECTION_ID,
+  schemaRegistryRuntime,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+describe("remove-tag-from-entity.ts", () => {
+  describe("RemoveTagFromEntityHandler", () => {
+    const handler = new RemoveTagFromEntityHandler();
+
+    describe("enabledConnectionIds()", () => {
+      it("should return the connection ID for a connection with a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(schemaRegistryRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
+      });
+
+      it("should return an empty array for a connection without a schema_registry block", () => {
+        expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
@@ -5,11 +5,12 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
-  CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS,
-  EnvVar,
-} from "@src/env-schema.js";
+  connectionIdsWhere,
+  hasSchemaRegistry,
+} from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -75,8 +76,8 @@ export class RemoveTagFromEntityHandler extends BaseToolHandler {
     };
   }
 
-  getRequiredEnvVars(): readonly EnvVar[] {
-    return CCLOUD_SCHEMA_REGISTRY_REQUIRED_ENV_VARS;
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
   }
 
   isConfluentCloudOnly(): boolean {

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
@@ -2,7 +2,10 @@ import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topics-handler.js";
 import { envFactory } from "@tests/factories/env.js";
-import { runtimeWith } from "@tests/factories/runtime.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
 import {
   createMockAdmin,
   createMockInstance,
@@ -36,7 +39,9 @@ describe("list-topics-handler.ts", () => {
           envFactory({ BOOTSTRAP_SERVERS: "broker:9092" }),
           { kafka: { bootstrap_servers: "broker:9092" } },
         );
-        expect(handler.enabledConnectionIds(runtime)).toEqual(["default"]);
+        expect(handler.enabledConnectionIds(runtime)).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
       });
 
       it("should return an empty array when BOOTSTRAP_SERVERS is absent", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -202,6 +202,23 @@ describe("index.ts", () => {
       expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
     });
 
+    it("should throw when enabledConnectionIds returns an ID not present in the config", () => {
+      vi.spyOn(ToolHandlerRegistry, "getToolHandler").mockReturnValue({
+        ...fakeHandler([]),
+        enabledConnectionIds: () => ["nonexistent-connection"],
+      });
+
+      expect(() =>
+        getToolHandlersToRegister(
+          [ToolName.LIST_TOPICS],
+          false,
+          runtimeWith(envFactory()),
+        ),
+      ).toThrow(
+        "Tool list-topics: enabledConnectionIds() returned unknown connection ID(s): nonexistent-connection",
+      );
+    });
+
     it("should include only the tool whose env vars are satisfied when tools have mixed satisfaction", () => {
       const listHandler = fakeHandler(["KAFKA_API_KEY", "KAFKA_API_SECRET"]);
       const createHandler = fakeHandler(["FLINK_API_KEY", "FLINK_API_SECRET"]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export function getToolHandlersToRegister(
   runtime: ServerRuntime,
 ): Map<ToolName, ToolHandler> {
   const toolHandlers = new Map<ToolName, ToolHandler>();
+  const knownIds = new Set(Object.keys(runtime.config.connections));
 
   Object.values(ToolName).forEach((toolName) => {
     // Skip names that are not in the filtered list of tool names provided.
@@ -51,6 +52,12 @@ export function getToolHandlersToRegister(
     }
 
     const enabledIds = handler.enabledConnectionIds(runtime);
+    const unknownIds = enabledIds.filter((id) => !knownIds.has(id));
+    if (unknownIds.length > 0) {
+      throw new Error(
+        `Tool ${toolName}: enabledConnectionIds() returned unknown connection ID(s): ${unknownIds.join(", ")}`,
+      );
+    }
     if (enabledIds.length > 0) {
       toolHandlers.set(toolName, handler);
       logger.info(`Tool ${toolName} enabled`);

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -5,19 +5,24 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { envFactory } from "@tests/factories/env.js";
 import { createMockInstance } from "@tests/stubs/index.js";
 
+/** Connection ID used by the named runtime factories and their default single-connection runtimes. */
+export const DEFAULT_CONNECTION_ID = "default";
+
 /**
  * Creates a ServerRuntime with a mocked ClientManager and a customizable env.
  *
  * Pass `connectionConfig` to populate the connection's service blocks (kafka,
- * flink, schema_registry, etc.). Tests for `enabledConnectionIds()` should
- * supply both the relevant env vars (for the current shim) and the matching
- * service block (for the post-migration predicate), so the test survives the
- * issue-173 migration without modification.
+ * flink, schema_registry, etc.).
+ *
+ * For `enabledConnectionIds()` tests on handlers still using the shim (not yet
+ * migrated to predicate form), supply matching env vars so the shim path passes.
+ * For migrated handlers, env vars are irrelevant — prefer the named factory
+ * functions (`bareRuntime()`, `schemaRegistryRuntime()`, etc.) which omit them.
  */
 export function runtimeWith(
   env: ReturnType<typeof envFactory>,
   connectionConfig: Omit<DirectConnectionConfig, "type"> = {},
-  connectionId = "default",
+  connectionId = DEFAULT_CONNECTION_ID,
 ): ServerRuntime {
   return new ServerRuntime(
     new MCPServerConfiguration({
@@ -26,4 +31,26 @@ export function runtimeWith(
     { [connectionId]: createMockInstance(DefaultClientManager) },
     env,
   );
+}
+
+/** Runtime with no service blocks — used as the disabled case in enabledConnectionIds() tests. */
+export function bareRuntime(): ServerRuntime {
+  return runtimeWith(envFactory());
+}
+
+/** Runtime with a schema_registry block — used by catalog and schema handler tests. */
+export function schemaRegistryRuntime(): ServerRuntime {
+  return runtimeWith(envFactory(), {
+    schema_registry: { endpoint: "https://schema-registry.example.com" },
+  });
+}
+
+/** Runtime with a confluent_cloud block — used by billing, clusters, connect, environments, and search handler tests. */
+export function confluentCloudRuntime(): ServerRuntime {
+  return runtimeWith(envFactory(), {
+    confluent_cloud: {
+      endpoint: "https://api.confluent.cloud",
+      auth: { type: "api_key", key: "k", secret: "s" },
+    },
+  });
 }


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Migrate billing and catalog tool handlers to `enabledConnectionIds()` predicate style implementation for determining tool enablement based on the `ServerRuntime` instance, not env vars.
- Harden `getToolHandlersToRegister()` against handlers returning unknown connection IDs.
- Establish new tests + fixtures for the  `enabledConnectionIds()`-backed implementations, easily and minimally replicatable to future tool families as per #173
- Closes #216, #217.
- No feature changes, just refactoring toward completely weaning off of env vars.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
