### PR TITLE
chore(local dev): update default `.vscode/launch.json` for YAML-first config [ci skip]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,30 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug MCP Server",
+      "name": "Debug MCP Server (ENV)",
       "type": "node",
       "request": "launch",
       "runtimeVersion": "22",
       "program": "${workspaceFolder}/dist/index.js",
       "args": ["--env-file", ".env", "--transport", "http", "--disable-auth"],
+      "env": {
+        "HTTP_PORT": "18080",
+        "LOG_PRETTY": "true",
+        "LOG_LEVEL": "debug"
+      },
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "sourceMaps": true,
+      "console": "integratedTerminal",
+      "preLaunchTask": "build",
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"]
+    },
+    {
+      "name": "Debug MCP Server (YAML)",
+      "type": "node",
+      "request": "launch",
+      "runtimeVersion": "22",
+      "program": "${workspaceFolder}/dist/index.js",
+      "args": ["--env-file", ".env", "--config", "config.yaml"],
       "env": {
         "HTTP_PORT": "18080",
         "LOG_PRETTY": "true",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,34 +2,14 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug MCP Server (ENV)",
+      "name": "Debug MCP Server",
       "type": "node",
       "request": "launch",
       "runtimeVersion": "22",
       "program": "${workspaceFolder}/dist/index.js",
-      "args": ["--env-file", ".env", "--transport", "http", "--disable-auth"],
+      "args": ["--config", "config.yaml", "--env-file", ".env"],
       "env": {
-        "HTTP_PORT": "18080",
-        "LOG_PRETTY": "true",
-        "LOG_LEVEL": "debug"
-      },
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "sourceMaps": true,
-      "console": "integratedTerminal",
-      "preLaunchTask": "build",
-      "skipFiles": ["<node_internals>/**", "**/node_modules/**"]
-    },
-    {
-      "name": "Debug MCP Server (YAML)",
-      "type": "node",
-      "request": "launch",
-      "runtimeVersion": "22",
-      "program": "${workspaceFolder}/dist/index.js",
-      "args": ["--env-file", ".env", "--config", "config.yaml"],
-      "env": {
-        "HTTP_PORT": "18080",
-        "LOG_PRETTY": "true",
-        "LOG_LEVEL": "debug"
+        "LOG_PRETTY": "true"
       },
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "sourceMaps": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,15 +7,23 @@
       "request": "launch",
       "runtimeVersion": "22",
       "program": "${workspaceFolder}/dist/index.js",
-      "args": ["--config", "config.yaml", "--env-file", ".env"],
+      "args": [
+        "--config",
+        "config.yaml"
+      ],
       "env": {
         "LOG_PRETTY": "true"
       },
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
       "sourceMaps": true,
       "console": "integratedTerminal",
       "preLaunchTask": "build",
-      "skipFiles": ["<node_internals>/**", "**/node_modules/**"]
+      "skipFiles": [
+        "<node_internals>/**",
+        "**/node_modules/**"
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "type": "node",
       "request": "launch",
       "runtimeVersion": "22",
+      "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/dist/index.js",
       "args": [
         "--config",


### PR DESCRIPTION
Sample `config.yaml` to get started (also reference [`config.example.yaml`](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml)):
```yaml
server:
  transports: [http]
  http:
    port: 18080
  auth:
    disabled: true

connections:
  default:
    type: direct

    # whatever tool group configs you want enabled
```

Now that most of the dust has settled migrating from the .env to the YAML based configs, it appears server startup errors appear as expected:
- missing service block configs:
    <img width="1042" height="362" alt="image" src="https://github.com/user-attachments/assets/1c1407b9-3372-4687-b107-ab87fb6a3c15" />
- invalid config:
    <img width="728" height="196" alt="image" src="https://github.com/user-attachments/assets/0a3d481b-839d-445b-a47e-94fb08846311" />

