### PR TITLE
Add connector-scoped metrics tools

### DIFF
--- a/src/confluent/tools/handlers/connect/list-connector-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connector-metrics-handler.test.ts
@@ -1,0 +1,80 @@
+import { DefaultClientManager } from "@src/confluent/client-manager.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
+import { ListConnectorMetricsHandler } from "@src/confluent/tools/handlers/connect/list-connector-metrics-handler.js";
+import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { TELEMETRY_REQUIRED_ENV_VARS } from "@src/env-schema.js";
+import { createMockInstance } from "@tests/stubs/index.js";
+import { describe, expect, it, vi } from "vitest";
+
+describe("list-connector-metrics-handler.ts", () => {
+  describe("ListConnectorMetricsHandler", () => {
+    describe("getToolConfig()", () => {
+      it("should return LIST_CONNECTOR_METRICS with READ_ONLY annotations", () => {
+        const handler = new ListConnectorMetricsHandler();
+        const config = handler.getToolConfig();
+
+        expect(config.name).toBe(ToolName.LIST_CONNECTOR_METRICS);
+        expect(config.annotations).toBe(READ_ONLY);
+        expect(config.description).toContain("connector");
+      });
+    });
+
+    describe("getRequiredEnvVars()", () => {
+      it("should return TELEMETRY_REQUIRED_ENV_VARS", () => {
+        const handler = new ListConnectorMetricsHandler();
+
+        expect(handler.getRequiredEnvVars()).toBe(TELEMETRY_REQUIRED_ENV_VARS);
+      });
+    });
+
+    describe("isConfluentCloudOnly()", () => {
+      it("should return true", () => {
+        const handler = new ListConnectorMetricsHandler();
+
+        expect(handler.isConfluentCloudOnly()).toBe(true);
+      });
+    });
+
+    describe("handle()", () => {
+      it("should delegate to ListMetricsHandler with resource_type connector", async () => {
+        const handler = new ListConnectorMetricsHandler();
+        const clientManager = createMockInstance(DefaultClientManager);
+        const innerHandle = vi
+          .spyOn(handler["inner"] as ListMetricsHandler, "handle")
+          .mockResolvedValue({
+            content: [{ type: "text", text: "stub" }],
+            isError: false,
+          });
+
+        const result = await handler.handle(clientManager, {});
+
+        expect(innerHandle).toHaveBeenCalledOnce();
+        expect(innerHandle).toHaveBeenCalledWith(clientManager, {
+          resource_type: "connector",
+        });
+        expect(result).toEqual({
+          content: [{ type: "text", text: "stub" }],
+          isError: false,
+        });
+      });
+
+      it("should pass resource_type connector regardless of provided arguments", async () => {
+        const handler = new ListConnectorMetricsHandler();
+        const clientManager = createMockInstance(DefaultClientManager);
+        const innerHandle = vi
+          .spyOn(handler["inner"] as ListMetricsHandler, "handle")
+          .mockResolvedValue({
+            content: [{ type: "text", text: "stub" }],
+            isError: false,
+          });
+
+        await handler.handle(clientManager, { resource_type: "kafka" });
+
+        expect(innerHandle).toHaveBeenCalledWith(clientManager, {
+          resource_type: "connector",
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/connect/list-connector-metrics-handler.ts
+++ b/src/confluent/tools/handlers/connect/list-connector-metrics-handler.ts
@@ -1,0 +1,43 @@
+import { ClientManager } from "@src/confluent/client-manager.js";
+import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  READ_ONLY,
+  ToolConfig,
+} from "@src/confluent/tools/base-tools.js";
+import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { EnvVar, TELEMETRY_REQUIRED_ENV_VARS } from "@src/env-schema.js";
+import { z } from "zod";
+
+const listConnectorMetricsArguments = z.object({});
+
+export class ListConnectorMetricsHandler extends BaseToolHandler {
+  private inner = new ListMetricsHandler();
+
+  async handle(
+    clientManager: ClientManager,
+    toolArguments: Record<string, unknown> | undefined,
+  ): Promise<CallToolResult> {
+    listConnectorMetricsArguments.parse(toolArguments ?? {});
+    return this.inner.handle(clientManager, { resource_type: "connector" });
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.LIST_CONNECTOR_METRICS,
+      description:
+        "List Confluent Cloud connector metrics available from the Telemetry API. Equivalent to list-available-metrics with resource_type=connector.",
+      inputSchema: listConnectorMetricsArguments.shape,
+      annotations: READ_ONLY,
+    };
+  }
+
+  getRequiredEnvVars(): readonly EnvVar[] {
+    return TELEMETRY_REQUIRED_ENV_VARS;
+  }
+
+  isConfluentCloudOnly(): boolean {
+    return true;
+  }
+}

--- a/src/confluent/tools/handlers/connect/query-connector-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/query-connector-metrics-handler.test.ts
@@ -1,0 +1,158 @@
+import { DefaultClientManager } from "@src/confluent/client-manager.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
+import { QueryConnectorMetricsHandler } from "@src/confluent/tools/handlers/connect/query-connector-metrics-handler.js";
+import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { TELEMETRY_REQUIRED_ENV_VARS } from "@src/env-schema.js";
+import { createMockInstance } from "@tests/stubs/index.js";
+import { describe, expect, it, vi } from "vitest";
+
+describe("query-connector-metrics-handler.ts", () => {
+  describe("QueryConnectorMetricsHandler", () => {
+    describe("getToolConfig()", () => {
+      it("should return QUERY_CONNECTOR_METRICS with READ_ONLY annotations", () => {
+        const handler = new QueryConnectorMetricsHandler();
+        const config = handler.getToolConfig();
+
+        expect(config.name).toBe(ToolName.QUERY_CONNECTOR_METRICS);
+        expect(config.annotations).toBe(READ_ONLY);
+        expect(config.description).toContain("connector");
+      });
+    });
+
+    describe("getRequiredEnvVars()", () => {
+      it("should return TELEMETRY_REQUIRED_ENV_VARS", () => {
+        const handler = new QueryConnectorMetricsHandler();
+
+        expect(handler.getRequiredEnvVars()).toBe(TELEMETRY_REQUIRED_ENV_VARS);
+      });
+    });
+
+    describe("isConfluentCloudOnly()", () => {
+      it("should return true", () => {
+        const handler = new QueryConnectorMetricsHandler();
+
+        expect(handler.isConfluentCloudOnly()).toBe(true);
+      });
+    });
+
+    describe("handle()", () => {
+      it("should delegate to QueryMetricsHandler with auto-injected connector filter", async () => {
+        const handler = new QueryConnectorMetricsHandler();
+        const clientManager = createMockInstance(DefaultClientManager);
+        const innerHandle = vi
+          .spyOn(handler["inner"] as QueryMetricsHandler, "handle")
+          .mockResolvedValue({
+            content: [{ type: "text", text: "stub" }],
+            isError: false,
+          });
+
+        const result = await handler.handle(clientManager, {
+          connectorId: "lcc-abc123",
+          metric: "io.confluent.kafka.connect/sent_records",
+        });
+
+        expect(innerHandle).toHaveBeenCalledOnce();
+        expect(innerHandle).toHaveBeenCalledWith(
+          clientManager,
+          expect.objectContaining({
+            metric: "io.confluent.kafka.connect/sent_records",
+            filter: { "resource.connector.id": "lcc-abc123" },
+          }),
+        );
+        const callArgs = innerHandle.mock.calls[0]![1] as Record<
+          string,
+          unknown
+        >;
+        expect(callArgs).not.toHaveProperty("connectorId");
+        expect(result).toEqual({
+          content: [{ type: "text", text: "stub" }],
+          isError: false,
+        });
+      });
+
+      it("should preserve user-provided filter keys and merge in resource.connector.id", async () => {
+        const handler = new QueryConnectorMetricsHandler();
+        const clientManager = createMockInstance(DefaultClientManager);
+        const innerHandle = vi
+          .spyOn(handler["inner"] as QueryMetricsHandler, "handle")
+          .mockResolvedValue({
+            content: [{ type: "text", text: "stub" }],
+            isError: false,
+          });
+
+        await handler.handle(clientManager, {
+          connectorId: "lcc-abc123",
+          metric: "io.confluent.kafka.connect/sent_records",
+          filter: { "resource.environment.id": "env-xyz" },
+        });
+
+        expect(innerHandle).toHaveBeenCalledWith(
+          clientManager,
+          expect.objectContaining({
+            filter: {
+              "resource.environment.id": "env-xyz",
+              "resource.connector.id": "lcc-abc123",
+            },
+          }),
+        );
+      });
+
+      it("should override user-provided resource.connector.id with the connectorId arg", async () => {
+        const handler = new QueryConnectorMetricsHandler();
+        const clientManager = createMockInstance(DefaultClientManager);
+        const innerHandle = vi
+          .spyOn(handler["inner"] as QueryMetricsHandler, "handle")
+          .mockResolvedValue({
+            content: [{ type: "text", text: "stub" }],
+            isError: false,
+          });
+
+        await handler.handle(clientManager, {
+          connectorId: "lcc-correct",
+          metric: "io.confluent.kafka.connect/sent_records",
+          filter: { "resource.connector.id": "lcc-stale" },
+        });
+
+        const callArgs = innerHandle.mock.calls[0]![1] as {
+          filter: Record<string, string>;
+        };
+        expect(callArgs.filter["resource.connector.id"]).toBe("lcc-correct");
+      });
+
+      it("should forward optional fields like interval, granularity, group_by", async () => {
+        const handler = new QueryConnectorMetricsHandler();
+        const clientManager = createMockInstance(DefaultClientManager);
+        const innerHandle = vi
+          .spyOn(handler["inner"] as QueryMetricsHandler, "handle")
+          .mockResolvedValue({
+            content: [{ type: "text", text: "stub" }],
+            isError: false,
+          });
+
+        await handler.handle(clientManager, {
+          connectorId: "lcc-abc123",
+          metric: "io.confluent.kafka.connect/sent_records",
+          interval: "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
+          granularity: "PT5M",
+          group_by: ["metric.task_id"],
+          aggregation: "AVG",
+          limit: 50,
+        });
+
+        expect(innerHandle).toHaveBeenCalledWith(
+          clientManager,
+          expect.objectContaining({
+            metric: "io.confluent.kafka.connect/sent_records",
+            interval: "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
+            granularity: "PT5M",
+            group_by: ["metric.task_id"],
+            aggregation: "AVG",
+            limit: 50,
+            filter: { "resource.connector.id": "lcc-abc123" },
+          }),
+        );
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/connect/query-connector-metrics-handler.ts
+++ b/src/confluent/tools/handlers/connect/query-connector-metrics-handler.ts
@@ -1,0 +1,105 @@
+import { ClientManager } from "@src/confluent/client-manager.js";
+import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  READ_ONLY,
+  ToolConfig,
+} from "@src/confluent/tools/base-tools.js";
+import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { EnvVar, TELEMETRY_REQUIRED_ENV_VARS } from "@src/env-schema.js";
+import { z } from "zod";
+
+const queryConnectorMetricsArguments = z.object({
+  connectorId: z
+    .string()
+    .describe("Confluent Cloud connector resource ID, e.g. 'lcc-abc123'."),
+  metric: z
+    .string()
+    .describe(
+      'The connector metric name to query. Common Connector metrics: "io.confluent.kafka.connect/sent_records", "io.confluent.kafka.connect/received_records", "io.confluent.kafka.connect/dead_letter_queue_records". Use list-connector-metrics first to discover valid metric names.',
+    ),
+  dataset: z
+    .enum(["cloud"])
+    .default("cloud")
+    .describe("The metrics dataset to query.")
+    .optional(),
+  aggregation: z
+    .enum(["SUM", "MAX", "AVG", "MIN", "COUNT"])
+    .default("SUM")
+    .describe("Aggregation function to apply to the metric values.")
+    .optional(),
+  filter: z
+    .record(z.string(), z.string())
+    .describe(
+      'Additional key-value pairs to filter results. The "resource.connector.id" filter is auto-injected from connectorId; pass additional filters here as needed (e.g. "resource.environment.id").',
+    )
+    .optional(),
+  granularity: z
+    .enum(["PT1M", "PT5M", "PT15M", "PT30M", "PT1H", "P1D", "ALL"])
+    .default("PT1M")
+    .describe(
+      "Time granularity for the metric data points. Defaults to PT1M. Use PT1M or PT5M for intervals under a few hours, PT1H for day-scale queries, P1D for multi-day queries.",
+    )
+    .optional(),
+  interval: z
+    .string()
+    .describe(
+      'Time range as two ISO 8601 timestamps separated by "/". Example: "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z". Must include both start and end timestamps. Defaults to the last 1 hour if omitted. Do NOT pass a duration like "PT1H" — always use "start/end" format.',
+    )
+    .optional(),
+  group_by: z
+    .array(z.string())
+    .describe(
+      "Label keys to group results by. Returns separate time series for each group.",
+    )
+    .optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(1000)
+    .default(100)
+    .describe("Maximum number of data points to return (max 1000).")
+    .optional(),
+});
+
+export class QueryConnectorMetricsHandler extends BaseToolHandler {
+  private inner = new QueryMetricsHandler();
+
+  async handle(
+    clientManager: ClientManager,
+    toolArguments: Record<string, unknown> | undefined,
+  ): Promise<CallToolResult> {
+    const { connectorId, filter, ...rest } =
+      queryConnectorMetricsArguments.parse(toolArguments);
+
+    const mergedFilter: Record<string, string> = {
+      ...(filter ?? {}),
+      "resource.connector.id": connectorId,
+    };
+
+    return this.inner.handle(clientManager, {
+      ...rest,
+      filter: mergedFilter,
+    });
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.QUERY_CONNECTOR_METRICS,
+      description:
+        "Query metrics for a specific connector from the Telemetry API. Auto-injects resource.connector.id filter; pass other filters/group_by as needed. Use list-connector-metrics first to discover valid metric names.",
+      inputSchema: queryConnectorMetricsArguments.shape,
+      annotations: READ_ONLY,
+    };
+  }
+
+  getRequiredEnvVars(): readonly EnvVar[] {
+    return TELEMETRY_REQUIRED_ENV_VARS;
+  }
+
+  isConfluentCloudOnly(): boolean {
+    return true;
+  }
+}

--- a/src/confluent/tools/tool-name.ts
+++ b/src/confluent/tools/tool-name.ts
@@ -21,6 +21,8 @@ export enum ToolName {
   READ_CONNECTOR = "read-connector",
   CREATE_CONNECTOR = "create-connector",
   DELETE_CONNECTOR = "delete-connector",
+  LIST_CONNECTOR_METRICS = "list-connector-metrics",
+  QUERY_CONNECTOR_METRICS = "query-connector-metrics",
   SEARCH_TOPICS_BY_TAG = "search-topics-by-tag",
   SEARCH_TOPICS_BY_NAME = "search-topics-by-name",
   CREATE_TOPIC_TAGS = "create-topic-tags",

--- a/src/confluent/tools/tool-registry.ts
+++ b/src/confluent/tools/tool-registry.ts
@@ -8,7 +8,9 @@ import { RemoveTagFromEntityHandler } from "@src/confluent/tools/handlers/catalo
 import { ListClustersHandler } from "@src/confluent/tools/handlers/clusters/list-clusters-handler.js";
 import { CreateConnectorHandler } from "@src/confluent/tools/handlers/connect/create-connector-handler.js";
 import { DeleteConnectorHandler } from "@src/confluent/tools/handlers/connect/delete-connector-handler.js";
+import { ListConnectorMetricsHandler } from "@src/confluent/tools/handlers/connect/list-connector-metrics-handler.js";
 import { ListConnectorsHandler } from "@src/confluent/tools/handlers/connect/list-connectors-handler.js";
+import { QueryConnectorMetricsHandler } from "@src/confluent/tools/handlers/connect/query-connector-metrics-handler.js";
 import { ReadConnectorHandler } from "@src/confluent/tools/handlers/connect/read-connectors-handler.js";
 import { ListEnvironmentsHandler } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
 import { ReadEnvironmentHandler } from "@src/confluent/tools/handlers/environments/read-environment-handler.js";
@@ -76,6 +78,8 @@ export class ToolHandlerRegistry {
     [ToolName.LIST_CONNECTORS, new ListConnectorsHandler()],
     [ToolName.READ_CONNECTOR, new ReadConnectorHandler()],
     [ToolName.CREATE_CONNECTOR, new CreateConnectorHandler()],
+    [ToolName.LIST_CONNECTOR_METRICS, new ListConnectorMetricsHandler()],
+    [ToolName.QUERY_CONNECTOR_METRICS, new QueryConnectorMetricsHandler()],
     [ToolName.SEARCH_TOPICS_BY_TAG, new SearchTopicsByTagHandler()],
     [ToolName.CREATE_TOPIC_TAGS, new CreateTopicTagsHandler()],
     [ToolName.DELETE_TAG, new DeleteTagHandler()],


### PR DESCRIPTION
## Summary

Adds two thin wrapper tools that scope the existing telemetry tools to the connector resource type, giving the model a discoverable connector-specific surface for metrics:

- **list-connector-metrics** — delegates to `ListMetricsHandler` with `resource_type: "connector"`. No args. Returns the descriptor list filtered to connector metrics (e.g. `io.confluent.kafka.connect/sent_records`, `received_records`, `dead_letter_queue_records`).
- **query-connector-metrics** — mirrors `QueryMetricsHandler`'s Zod schema (so `metric`, `interval`, `granularity`, `aggregation`, `group_by`, `limit`, `dataset`, `filter` all pass through) and adds a required `connectorId` arg. Internally merges `{ "resource.connector.id": connectorId }` into the filter before delegating.

Both tools require `TELEMETRY_REQUIRED_ENV_VARS` and are `isConfluentCloudOnly: true`. Implemented via composition (private `inner` handler instance) so the typed Telemetry path stays canonical.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npx vitest run` passes (531 tests; 12 colocated tests added)
- [ ] Reviewer: confirm `tool-name.ts` adds exactly 2 entries; `tool-registry.ts` adds 2 imports + 2 map entries
- [ ] Reviewer: confirm `query-connector-metrics-handler.ts` merge order — user-provided `filter["resource.connector.id"]` is overridden by the `connectorId` arg (consistent with the model's most explicit signal winning)
- [ ] Manual: invoke `list-connector-metrics` and confirm the output is filtered to `resource_type=connector`
- [ ] Manual: invoke `query-connector-metrics` against a real connector with `metric: "io.confluent.kafka.connect/sent_records"`, confirm a non-empty time-series

Assisted-by: Claude Code