### PR TITLE
MINOR: update `.env.example` with missing recently-introduced env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,9 +50,11 @@ TABLEFLOW_API_SECRET=""
 
 # -----------------------------------------------------------------------------
 # Telemetry / Metrics API (Confluent Cloud)
-# Optional. When unset, falls back to CONFLUENT_CLOUD_API_KEY /
-# CONFLUENT_CLOUD_API_SECRET. Set these only when you want to use a
-# separate (e.g. least-privilege, metrics-only) API key.
+# Optional. TELEMETRY_API_KEY / TELEMETRY_API_SECRET fall back to
+# CONFLUENT_CLOUD_API_KEY / CONFLUENT_CLOUD_API_SECRET when unset.
+# TELEMETRY_ENDPOINT defaults to https://api.telemetry.confluent.cloud.
+# Set these only when you want to use a separate (e.g. least-privilege,
+# metrics-only) API key.
 # -----------------------------------------------------------------------------
 # TELEMETRY_ENDPOINT="https://api.telemetry.confluent.cloud"
 # TELEMETRY_API_KEY=""

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ TABLEFLOW_API_KEY=""
 TABLEFLOW_API_SECRET=""
 
 # -----------------------------------------------------------------------------
+# Telemetry / Metrics API (Confluent Cloud)
+# Optional. When unset, falls back to CONFLUENT_CLOUD_API_KEY /
+# CONFLUENT_CLOUD_API_SECRET. Set these only when you want to use a
+# separate (e.g. least-privilege, metrics-only) API key.
+# -----------------------------------------------------------------------------
+# TELEMETRY_ENDPOINT="https://api.telemetry.confluent.cloud"
+# TELEMETRY_API_KEY=""
+# TELEMETRY_API_SECRET=""
+
+# -----------------------------------------------------------------------------
 # MCP Server Settings
 # -----------------------------------------------------------------------------
 # LOG_LEVEL="info"                          # trace, debug, info, warn, error, fatal
@@ -57,6 +67,14 @@ TABLEFLOW_API_SECRET=""
 # HTTP_MCP_ENDPOINT_PATH="/mcp"             # HTTP endpoint path
 # SSE_MCP_ENDPOINT_PATH="/sse"              # SSE endpoint path
 # SSE_MCP_MESSAGE_ENDPOINT_PATH="/messages" # SSE message endpoint path
+
+# -----------------------------------------------------------------------------
+# Anonymous Usage Analytics
+# This MCP server's own anonymous-usage opt-out (unrelated to the
+# TELEMETRY_* block above, which configures the Confluent Cloud Metrics API).
+# See README "Telemetry" section for what is collected.
+# -----------------------------------------------------------------------------
+# DO_NOT_TRACK=true
 
 # -----------------------------------------------------------------------------
 # MCP Server Authentication (required for HTTP/SSE transports)


### PR DESCRIPTION
Already available in the `config.example.yaml`, but was missing here for env var users.