### PR TITLE
chore: update claude+Copilot instructions based on YAML config migration progress [ci skip]

### DIFF
--- a/.claude/rules/tool-handlers.md
+++ b/.claude/rules/tool-handlers.md
@@ -1,0 +1,98 @@
+---
+paths:
+  - "src/confluent/tools/**/*.ts"
+---
+
+# MCP Tool Handler Conventions
+
+## Handler Structure
+
+Every tool handler follows this pattern:
+
+1. **Pick a base class:**
+   - If a domain subclass exists (e.g., `FlinkToolHandler`, `TableflowToolHandler` under `handlers/<domain>/`), extend it. The subclass already implements `enabledConnectionIds()` for the whole domain, so you don't repeat the predicate per tool.
+   - Otherwise extend `BaseToolHandler` from `@src/confluent/tools/base-tools.js` directly and implement `enabledConnectionIds()` yourself. If a domain has more than one tool with the same predicate, introduce a domain subclass first and extend that.
+2. **Implement these methods (skip `enabledConnectionIds` if you inherited it):**
+   - `getToolConfig()` → returns `{ name: ToolName, description: string, inputSchema: zodSchema.shape, annotations: ToolAnnotations }`. Use one of the shared annotation constants exported from `base-tools.ts`: `READ_ONLY`, `CREATE_UPDATE`, or `DESTRUCTIVE` (don't construct ad-hoc instances).
+   - `handle(clientManager, toolArguments, sessionId?)` → returns `Promise<CallToolResult>`.
+   - `enabledConnectionIds(runtime: ServerRuntime)` → returns `string[]` of connection ids whose YAML satisfies a predicate from `connection-predicates.ts`. The canonical body is a one-liner: `return connectionIdsWhere(runtime.config.connections, hasFoo);`. An empty result disables the tool.
+
+## Input Schema
+
+- Define a Zod object schema as a `const` above the class (e.g., `const listTopicArgs = z.object({...})`)
+- Pass `.shape` (not the schema itself) to `inputSchema` in `getToolConfig()`
+- Use `.describe()` on every field — these descriptions surface to the AI assistant as tool parameter docs
+
+## Response Pattern
+
+- Use `this.createResponse(message, isError, _meta?)` inherited from `BaseToolHandler`
+- `_meta` is an optional object for structured data the AI can use beyond the text message
+- Parse `toolArguments` with the Zod schema at the top of `handle()` for validation
+
+## Registration Checklist
+
+When adding a new tool, touch exactly three files (plus optionally a fourth):
+
+1. `src/confluent/tools/tool-name.ts` — add enum entry (e.g., `MY_TOOL = "my-tool"`)
+2. `src/confluent/tools/handlers/<domain>/my-tool-handler.ts` — create handler class
+3. `src/confluent/tools/tool-registry.ts` — import handler and add `[ToolName.MY_TOOL, new MyToolHandler()]` to the `ToolHandlerRegistry.handlers` map
+4. (Only if needed) `src/confluent/tools/connection-predicates.ts` — add a new predicate if no existing one expresses the tool's requirement
+
+## Connection Predicates
+
+Tool enablement is decided by inspecting which **service blocks** are present in each `ConnectionConfig` (Kafka, Flink, Schema Registry, Confluent Cloud, Tableflow, Telemetry). Predicates in `connection-predicates.ts` express those checks as pure functions; `connectionIdsWhere(connections, predicate)` walks `runtime.config.connections` and returns the matching ids.
+
+- A tool whose predicate matches zero connections is automatically disabled.
+- A tool with no service-specific requirement (a rare case) returns `Object.keys(runtime.config.connections)` directly.
+- Cloud-only-ness is expressed as `hasConfluentCloud` (or a conjunction like `hasCCloudCatalogSupport`), not a separate boolean override.
+- New predicates should be additive and pure; they read the YAML/config shape only.
+
+## File Organization
+
+Handlers live under `src/confluent/tools/handlers/<domain>/`:
+
+```
+handlers/
+├── billing/      # billing API
+├── catalog/      # tags, catalog search
+├── clusters/     # cluster management
+├── connect/      # connectors
+├── environments/ # environment CRUD
+├── flink/        # Flink SQL + catalog/ + diagnostics/ (flink-tool-handler.ts is the domain base)
+├── kafka/        # topics, produce, consume, config
+├── metrics/      # telemetry metric discovery + query
+├── schema/       # Schema Registry
+├── search/       # topic search
+└── tableflow/    # Tableflow topics + catalog/ (tableflow-tool-handler.ts is the domain base)
+```
+
+## Import Conventions
+
+- Use `@src/` path alias for all internal imports
+- Use `.js` extensions on import paths (ESM requirement)
+- Standard imports for a handler that extends `BaseToolHandler` directly:
+  ```typescript
+  import { ClientManager } from "@src/confluent/client-manager.js";
+  import { CallToolResult } from "@src/confluent/schema.js";
+  import {
+    BaseToolHandler,
+    READ_ONLY,
+    ToolConfig,
+  } from "@src/confluent/tools/base-tools.js";
+  import {
+    connectionIdsWhere,
+    hasSchemaRegistry,
+  } from "@src/confluent/tools/connection-predicates.js";
+  import { ToolName } from "@src/confluent/tools/tool-name.js";
+  import { ServerRuntime } from "@src/server-runtime.js";
+  import { z } from "zod";
+  ```
+- For a handler that extends a domain subclass, drop `BaseToolHandler`, the predicate imports, and `ServerRuntime` (the subclass owns those):
+  ```typescript
+  import { ClientManager } from "@src/confluent/client-manager.js";
+  import { CallToolResult } from "@src/confluent/schema.js";
+  import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+  import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
+  import { ToolName } from "@src/confluent/tools/tool-name.js";
+  import { z } from "zod";
+  ```

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -158,5 +158,3 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   `@tests/factories/runtime.js`: `bareRuntime()`, `kafkaRuntime()`, `flinkRuntime()`,
   `tableflowRuntime()`, `schemaRegistryRuntime()`, `confluentCloudRuntime()`,
   `telemetryRuntime()`, etc. For uncommon shapes, use `runtimeWith(connectionConfig?, connectionId?)` (both args optional; `connectionId` defaults to `"default"`).
-- Integration tests (`*.integration.test.ts`) default to real I/O; stub selectively. Unit tests
-  default to stubbed dependencies via `vi.spyOn` and the `node-deps.ts` namespace pattern.

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -139,14 +139,24 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
 
 ## Handler Tests
 
-- Test config (`getToolConfig()`), required env vars (`getRequiredEnvVars()`), and behavior (`handle()`)
-- Stub `ClientManager` methods with `createMockInstance(DefaultClientManager)`
+- Test `getToolConfig()` (name, description, input schema, annotations).
+- Test `enabledConnectionIds(runtime)` against representative `ServerRuntime` fixtures: a runtime
+  whose connection has the relevant service block (expect the connection id) and a bare runtime
+  without that block (expect `[]`). Helper factories live in `tests/factories/runtime.ts`
+  (`flinkRuntime()`, `tableflowRuntime()`, `bareRuntime()`, etc.).
+- Test `handle()` for typical and edge-case inputs.
+- Stub `ClientManager` methods with `createMockInstance(DefaultClientManager)`.
 - Use `as any` only on partial mock return values (e.g., a mock admin client with only
-  `listTopics`), not on the `ClientManager` mock itself — add an eslint-disable comment when needed
+  `listTopics`), not on the `ClientManager` mock itself; add an eslint-disable comment when needed.
 
-## Environment Proxy
+## Test Server & Runtime Fixtures
 
-- `createTestServer()` calls `initEnv()` automatically so Zod `.default()` callbacks in tool
-  schemas don't throw
-- For handler-only tests that don't use `createTestServer()`, call `initEnv()` in `beforeAll` if
-  the handler's Zod schema references `env.*` in `.default()` callbacks
+- `createTestServer(clientManager, toolNames?)` from `@tests/server.js` boots a real `McpServer`
+  with all tools (or a passed subset) wired to a stubbed `ClientManager` over `InMemoryTransport`.
+  Use it for protocol-level integration tests.
+- For `enabledConnectionIds()` tests, build a `ServerRuntime` via the named factories in
+  `@tests/factories/runtime.js`: `bareRuntime()`, `kafkaRuntime()`, `flinkRuntime()`,
+  `tableflowRuntime()`, `schemaRegistryRuntime()`, `confluentCloudRuntime()`,
+  `telemetryRuntime()`, etc. For uncommon shapes, use `runtimeWith(env, connectionConfig)`.
+- Integration tests (`*.integration.test.ts`) default to real I/O; stub selectively. Unit tests
+  default to stubbed dependencies via `vi.spyOn` and the `node-deps.ts` namespace pattern.

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -157,6 +157,6 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
 - For `enabledConnectionIds()` tests, build a `ServerRuntime` via the named factories in
   `@tests/factories/runtime.js`: `bareRuntime()`, `kafkaRuntime()`, `flinkRuntime()`,
   `tableflowRuntime()`, `schemaRegistryRuntime()`, `confluentCloudRuntime()`,
-  `telemetryRuntime()`, etc. For uncommon shapes, use `runtimeWith(env, connectionConfig)`.
+  `telemetryRuntime()`, etc. For uncommon shapes, use `runtimeWith(connectionConfig?, connectionId?)` (both args optional; `connectionId` defaults to `"default"`).
 - Integration tests (`*.integration.test.ts`) default to real I/O; stub selectively. Unit tests
   default to stubbed dependencies via `vi.spyOn` and the `node-deps.ts` namespace pattern.

--- a/.claude/skills/mcp-docs/SKILL.md
+++ b/.claude/skills/mcp-docs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: mcp-docs
+description:
+  Use when the user asks about Model Context Protocol details (protocol spec, transports,
+  authorization, tools/resources/prompts, sampling/elicitation/roots, server/client concepts,
+  extensions, or SDK usage). Triggers on phrases like "MCP spec", "MCP transport",
+  "streamable HTTP", "MCP authorization", "list_tools", "initialize handshake", "MCP SDK",
+  "@modelcontextprotocol/sdk", or "how does MCP X".
+allowed-tools:
+  - WebFetch
+  - WebSearch
+  - Read
+  - Grep
+---
+
+# MCP Protocol Documentation Lookup
+
+Look up Model Context Protocol (MCP) documentation from modelcontextprotocol.io.
+
+## Instructions
+
+You are looking up MCP protocol documentation to answer a question or guide implementation.
+
+### Step 1: Fetch the documentation index
+
+Fetch the machine-readable index at `https://modelcontextprotocol.io/llms.txt`. This lists all ~90
+documentation pages with titles and URLs. Use it to identify which page(s) are relevant to the
+question.
+
+### Step 2: Fetch the relevant page(s)
+
+Append `.md` to page URLs for cleaner markdown content. For example:
+
+- `https://modelcontextprotocol.io/docs/learn/architecture.md`
+- `https://modelcontextprotocol.io/specification/2025-11-25/server/tools.md`
+
+Fetch only the pages needed to answer the question — typically 1-3 pages.
+
+### Step 3: Cross-reference with our codebase
+
+When relevant, use Read and Grep to cross-reference the documentation with our implementation in
+`src/` to provide concrete, project-specific guidance.
+
+## Documentation Tiers
+
+Use these categories to prioritize which pages to fetch:
+
+- **Specification** (`/specification/2025-11-25/...`) — Protocol-level details: transports,
+  lifecycle, tools, resources, prompts, pagination, logging. Prioritize for questions about MCP
+  server implementation, protocol behavior, or message formats.
+
+- **Develop guides** (`/docs/develop/...`) — Building servers/clients, connecting local/remote
+  servers. Prioritize for integration, setup, or "how do I build..." questions.
+
+- **Learn** (`/docs/learn/...`) — Architecture, core concepts, server/client roles. Prioritize for
+  conceptual or "how does MCP work" questions.
+
+- **SDK** (`/docs/sdk.md`) — SDK reference. Relevant when working with `@modelcontextprotocol/sdk`
+  APIs.
+
+- **Extensions** (`/extensions/...`) — Auth, application support, client compatibility matrix.
+  Relevant for auth and transport questions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,8 +8,8 @@ assistants. The tool surface splits into two groups:
 - **Kafka-protocol tools** that work against any Apache Kafka®-compatible cluster or Schema
   Registry (e.g., topic CRUD, producing and consuming messages, schema management).
 - **Confluent Cloud-specific tools** that wrap CCloud REST APIs (e.g., Flink, Tableflow,
-  billing), automatically disabled when no `confluent_cloud` block is present in the connection
-  config (YAML) or when the corresponding environment variables are not set.
+  billing), enabled only when the relevant service block (`confluent_cloud:`, `flink:`,
+  `tableflow:`) is present in a connection's YAML config.
 
 Built with TypeScript, Node.js ≥22, and the `@modelcontextprotocol/sdk`. Ships as an npm package
 and a Docker image; supports stdio, Streamable HTTP, and (for backwards compatibility with older
@@ -23,24 +23,38 @@ this codebase. Author-facing guidance (how to scaffold a tool, run the inspector
 
 ### Entry flow
 
-At startup the server parses CLI arguments, loads and validates configuration, constructs the
-shared client manager, builds the set of enabled tools, registers them, and starts the configured
-transports.
+At startup: `parseCliArgs()` → `buildConfigFromEnvAndCli()` (resolves a single
+`MCPServerConfiguration` from either a YAML file via `-c <path>` or legacy env vars + CLI args)
+→ `ServerRuntime.fromConfig()` constructs one `DefaultClientManager` per connection → iterates
+`ToolName` enum to build the enabled tool set → registers tools on `McpServer` → starts transports.
 
-**Tools are auto-enabled/disabled** at startup based on the available configuration: each handler
-implements `enabledConnectionIds()` using typed predicates (e.g., `hasConfluentCloud`,
-`hasSchemaRegistry`) to declare which connections it can serve; the server only registers tools
-for connections that satisfy the predicate.
+**Tools are auto-enabled/disabled** at startup based on which service blocks are present in each
+connection's resolved config (which can come from a YAML file or, for backwards compatibility
+during the migration, from env vars + CLI args). Each handler declares its requirement via
+`enabledConnectionIds(runtime)`, which returns the ids of connections that satisfy a predicate
+from `src/confluent/tools/connection-predicates.ts`. An empty result disables the tool.
 
 ### Key layers
 
+- **`src/config/`** — Configuration core. `models.ts` defines `MCPServerConfiguration` (a Zod
+  schema with per-service connection blocks: `kafka`, `flink`, `schema_registry`,
+  `confluent_cloud`, `tableflow`, `telemetry`). `env-config.ts` exports
+  `buildConfigFromEnvAndCli()`, the single entry point that resolves config from YAML or env vars.
+
 - **`src/confluent/tools/`** — Tool system core:
   - `tool-name.ts` — `ToolName` enum; every tool has an entry here.
-  - `base-tools.ts` — `BaseToolHandler` abstract class all handlers extend.
+  - `base-tools.ts` — `BaseToolHandler` abstract class all handlers extend (directly or via a
+    domain subclass like `FlinkToolHandler` or `TableflowToolHandler`).
+  - `connection-predicates.ts` — predicate vocabulary handlers use to express enablement:
+    `hasKafka`, `hasFlink`, `hasSchemaRegistry`, `hasConfluentCloud`, `hasTableflow`,
+    `hasTelemetry`, `hasKafkaRestWithAuth`, and conjunctions like `hasCCloudCatalogSupport`.
+    `connectionIdsWhere(connections, predicate)` is the canonical way to call them.
   - `tool-registry.ts` — `ToolHandlerRegistry.handlers` maps `ToolName` → handler instance.
     Wiring must be complete here for a tool to exist.
   - `handlers/<domain>/` — organized by service (e.g., `kafka/`, `schema/`, `flink/`); new
-    handlers go under the matching domain or a new one if no fit exists.
+    handlers go under the matching domain or a new one if no fit exists. Some domains expose an
+    intermediate base class (e.g., `flink-tool-handler.ts`, `tableflow-tool-handler.ts`) that
+    implements `enabledConnectionIds()` once for the whole domain.
 
 - **`src/confluent/client-manager.ts`** — `DefaultClientManager` holds lazily-initialized Kafka
   clients (admin/producer/consumer via `@confluentinc/kafka-javascript`) and typed `openapi-fetch`
@@ -57,10 +71,6 @@ for connections that satisfy the predicate.
 
 - **`src/mcp/transports/`** — stdio, HTTP (Streamable HTTP), and SSE transports built on Fastify.
   HTTP/SSE support API-key auth and DNS rebinding protection.
-
-- **Server configuration** — loaded and schema-validated at startup into a typed object. Each
-  handler's declared configuration dependencies resolve against this object, and that resolution
-  determines which tools the server exposes.
 
 ### Path aliases and module format
 
@@ -96,14 +106,18 @@ and how the AI assistant uses the tool. Reviewers should verify each of these:
   enforcement. Pick the one that matches the tool's actual behavior, but don't treat `READ_ONLY`
   as a safety guarantee — the implementation still has to avoid mutations.
 - **Input schema** should always be provided to `getToolConfig()`. For tools with parameters,
-  use a Zod object schema's `.shape` and make sure each field has a `.describe()` call (those
-  descriptions surface to the AI assistant as parameter docs). For tools with no parameters,
-  provide an empty object (`inputSchema: {}`), not omit the field.
-- **Config dependencies** drive auto-enablement: each handler declares what configuration it
-  needs, and the server skips exposing tools whose requirements aren't satisfied. A missing
-  declaration silently breaks the tool on servers where that config isn't set — it registers,
-  then fails at call time with a confusing error. Check that declared dependencies match what the
-  handler actually reads.
+  use a Zod object schema's `.shape`. Every field must have a `.describe()` call; those
+  descriptions surface as parameter docs to the AI client and are a review blocker if missing.
+  For tools with no parameters, provide an empty object (`inputSchema: {}`), not omit the field.
+- **`enabledConnectionIds(runtime)`** drives auto-enablement. A missing or incorrect
+  implementation silently misconfigures the tool: it may register on a server that doesn't
+  support it, or be disabled on one that does. Verify two things: (1) the predicate selected from
+  `connection-predicates.ts` actually matches the service blocks the handler reads; (2) if a
+  domain subclass exists (e.g., `FlinkToolHandler`, `TableflowToolHandler`), the handler extends
+  it rather than reimplementing the same predicate. Multiple handlers in the same domain with
+  the same predicate and no shared subclass are a candidate for extracting a domain base class.
+- **New predicates** in `connection-predicates.ts` are rare. Before accepting one, verify no
+  existing predicate (or conjunction) covers the case.
 
 ### 3. Type safety
 
@@ -186,17 +200,18 @@ coverage output, etc. are already excluded via `.gitignore` and won't appear in 
 - Formatting and import ordering are owned by Prettier + `prettier-plugin-organize-imports`, which
   run in the Husky pre-commit hook. Don't comment on whitespace, quote style, or import order.
 - Focus reviews on logic, architecture, testing, and the checkpoints above.
-- We have competent CICD checks enforcing linting, typescript type checks, and running of the test
-  suite. When reviewing, do not bother considering if a change "might fail the build" — if it does,
-  it will be caught and will be fixed before merging.
+- We have competent CI/CD checks enforcing linting, TypeScript type-checks, and the test suite.
+  When reviewing, do not bother flagging that a change "might fail the build"; if it does, CI
+  will catch it and the author will fix it before merge.
 
 ## Review checklist
 
 Before approving, confirm:
 
 - [ ] New tools touch all three registration points (`ToolName` enum, handler file,
-      `ToolHandlerRegistry.handlers`), and the handler's declared config dependencies reflect
-      what it actually reads.
+      `ToolHandlerRegistry.handlers`). `enabledConnectionIds()` uses the correct predicate from
+      `connection-predicates.ts` (or inherits it from a domain subclass). All input schema fields
+      have `.describe()` calls.
 - [ ] No `any` types introduced; types come from `openapi-schema.d.ts` where applicable.
 - [ ] Error paths surface actionable messages; exceptions are logged or rethrown, never swallowed.
 - [ ] New external I/O is stubbable (routed through `node-deps.ts` or typed API clients).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,9 +24,10 @@ this codebase. Author-facing guidance (how to scaffold a tool, run the inspector
 
 ### Entry flow
 
-At startup: `parseCliArgs()` → `buildConfigFromEnvAndCli()` (resolves a single
-`MCPServerConfiguration` from either a YAML file via `-c <path>` or legacy env vars + CLI args)
-→ `ServerRuntime.fromConfig()` constructs one `DefaultClientManager` per connection → iterates
+At startup: `parseCliArgs()` → `initEnv()` → branch on whether `-c <path>` was supplied:
+`loadConfigFromYaml(path, process.env)` for the YAML path, or `buildConfigFromEnvAndCli(env, ...)`
+for the legacy env+CLI path. Both return a single `MCPServerConfiguration`. Then
+`ServerRuntime.fromConfig()` constructs one `DefaultClientManager` per connection → iterates
 `ToolName` enum to build the enabled tool set → registers tools on `McpServer` → starts transports.
 
 **Tools are auto-enabled/disabled** at startup based on which service blocks are present in each
@@ -39,8 +40,10 @@ from `src/confluent/tools/connection-predicates.ts`. An empty result disables th
 
 - **`src/config/`** — Configuration core. `models.ts` defines `MCPServerConfiguration` (a Zod
   schema with per-service connection blocks: `kafka`, `flink`, `schema_registry`,
-  `confluent_cloud`, `tableflow`, `telemetry`). `env-config.ts` exports
-  `buildConfigFromEnvAndCli()`, the single entry point that resolves config from YAML or env vars.
+  `confluent_cloud`, `tableflow`, `telemetry`). `index.ts` exposes `loadConfigFromYaml()` for
+  the `-c <path>` branch (parsing, `${VAR}` interpolation via `interpolation.ts`, and Zod
+  validation). `env-config.ts` exports `buildConfigFromEnvAndCli()` for the legacy env-var + CLI
+  path. Both return an `MCPServerConfiguration`.
 
 - **`src/confluent/tools/`** — Tool system core:
   - `tool-name.ts` — `ToolName` enum; every tool has an entry here.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,8 @@ assistants. The tool surface splits into two groups:
   Registry (e.g., topic CRUD, producing and consuming messages, schema management).
 - **Confluent Cloud-specific tools** that wrap CCloud REST APIs (e.g., Flink, Tableflow,
   billing), enabled only when the relevant service block (`confluent_cloud:`, `flink:`,
-  `tableflow:`) is present in a connection's YAML config.
+  `tableflow:`) is present in a connection's resolved config (from YAML or, during the
+  migration, legacy env vars + CLI args).
 
 Built with TypeScript, Node.js ≥22, and the `@modelcontextprotocol/sdk`. Ships as an npm package
 and a Docker image; supports stdio, Streamable HTTP, and (for backwards compatibility with older

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,25 +30,28 @@ Pre-commit hook runs `npm run format && npm run lint` automatically via Husky.
 
 ### Entry Point & Startup Flow
 
-`src/index.ts` → `parseCliArgs()` → `initEnv()` (Zod-validated env vars) → creates `DefaultClientManager` → iterates `ToolName` enum to build enabled tool set → registers tools on `McpServer` → starts transports.
+`src/index.ts` → `parseCliArgs()` → `buildConfigFromEnvAndCli()` (re-exported via `src/config/index.ts`, resolves a single `MCPServerConfiguration` from either a YAML file or env vars + CLI args, see issue #151) → `ServerRuntime.fromConfig()` constructs a `DefaultClientManager` per connection → iterates `ToolName` enum to build enabled tool set → registers tools on `McpServer` → starts transports.
 
-Tools are **auto-enabled/disabled** based on which service blocks are present in the connection config (YAML) or the corresponding environment variables (set directly or via a `.env` file). Each handler implements `enabledConnectionIds()` using typed predicates from `connection-predicates.ts` to declare which connections it can serve.
+Tools are **auto-enabled/disabled** based on which **service blocks** are present in each connection (e.g., a tool requiring `flink` is enabled iff some connection's resolved config has a `flink:` block). The connection's blocks come from YAML when one is supplied via `-c <path>`; otherwise they're synthesized from env vars + CLI args for backwards compatibility during the migration. Each handler declares its requirement via `enabledConnectionIds(runtime)`, which returns the ids of connections satisfying a predicate from `src/confluent/tools/connection-predicates.ts`. An empty result disables the tool. Domain-wide gating (e.g., all Flink tools) lives on intermediate base classes such as `FlinkToolHandler`.
 
 ### Key Layers
 
+- **`src/config/`** — Configuration core. `models.ts` defines `MCPServerConfiguration` (a Zod schema with per-service connection blocks: `kafka`, `flink`, `schema_registry`, `confluent_cloud`, `tableflow`, `telemetry`). `env-config.ts` exports `buildConfigFromEnvAndCli()` (re-exported from `index.ts`), the single entry point that produces a config from either a YAML file (`-c <path>`) or env vars + CLI args. `interpolation.ts` handles `${VAR}` interpolation inside YAML.
+
 - **`src/confluent/tools/`** — Tool system core:
   - `tool-name.ts` — `ToolName` enum; add new entries here when creating tools.
-  - `base-tools.ts` — `BaseToolHandler` abstract class all handlers extend.
+  - `base-tools.ts` — `BaseToolHandler` abstract class all handlers extend (directly or via a domain subclass like `FlinkToolHandler`).
+  - `connection-predicates.ts` — `hasKafka`, `hasFlink`, `hasSchemaRegistry`, etc., plus `connectionIdsWhere(connections, predicate)`. The vocabulary handlers use to express their enablement requirement.
   - `tool-registry.ts` — `ToolHandlerRegistry.handlers` map: `ToolName` → handler instance. Wire new tools here.
-  - `handlers/<domain>/` — Organized by Confluent service (kafka, flink, connect, catalog, schema, tableflow, billing, search).
+  - `handlers/<domain>/` — Organized by Confluent service (kafka, flink, connect, catalog, schema, tableflow, billing, search, metrics, environments, clusters). Some domains expose an intermediate base class (e.g., `flink-tool-handler.ts`) that implements `enabledConnectionIds()` once for the whole domain.
 
-- **`src/confluent/client-manager.ts`** — `DefaultClientManager` holds lazily-initialized Kafka clients (admin, producer, consumer via `@confluentinc/kafka-javascript`) and typed REST clients (`openapi-fetch`) for each Confluent Cloud API surface.
+- **`src/confluent/client-manager.ts`** — `DefaultClientManager` holds lazily-initialized Kafka clients (admin, producer, consumer via `@confluentinc/kafka-javascript`) and typed REST clients (`openapi-fetch`) for each Confluent Cloud API surface. One instance per connection, constructed from a `ConnectionConfig` (not directly from env vars).
 
 - **`src/confluent/openapi-schema.d.ts`** — Generated types from `openapi.json` using `openapi-typescript`. Provides type-safe REST calls throughout the codebase.
 
 - **`src/mcp/transports/`** — Transport layer supporting stdio, HTTP (Streamable HTTP), and SSE. `TransportManager` orchestrates startup/shutdown. HTTP/SSE transports use Fastify and support API key auth + DNS rebinding protection.
 
-- **`src/env-schema.ts`** — Zod schema defining all environment variables with defaults and validation. Merged from required (`envSchema`) and optional (`configSchema`) sections.
+- **`src/env-schema.ts`** — Zod schema for the legacy env-var path. Still consulted when no YAML file is provided, but the configuration that flows through the rest of the app is the resolved `MCPServerConfiguration` from `src/config/`, not the raw env. Slated to shrink as the YAML migration completes (see issue #151 and follow-ups).
 
 - **`src/confluent/middleware.ts`** — Auth middleware injected into `openapi-fetch` clients for Confluent Cloud API authentication.
 
@@ -58,9 +61,11 @@ Tools are **auto-enabled/disabled** based on which service blocks are present in
 
 ## Adding a New Tool
 
+Detailed conventions (handler structure, input schema rules, registration checklist, predicate selection) live in `.claude/rules/tool-handlers.md`, which auto-loads when you edit `src/confluent/tools/**/*.ts`. The high-level shape:
+
 1. Add entry to `ToolName` enum in `src/confluent/tools/tool-name.ts`.
-2. Create handler class extending `BaseToolHandler` in `src/confluent/tools/handlers/<domain>/`.
-3. Implement `getToolConfig()` (name, description, Zod input schema), `handle()`, and `enabledConnectionIds()` (use predicates from `connection-predicates.ts`).
+2. Create handler class in `src/confluent/tools/handlers/<domain>/`. Extend the domain subclass if one exists (e.g., `FlinkToolHandler`); otherwise extend `BaseToolHandler` directly and implement `enabledConnectionIds(runtime)` using a predicate from `connection-predicates.ts`.
+3. Implement `getToolConfig()` (name, description, Zod input schema, `annotations`) and `handle()`.
 4. Register the handler in the `ToolHandlerRegistry.handlers` map in `src/confluent/tools/tool-registry.ts`.
 5. If the tool calls a new Confluent Cloud REST endpoint, add it to `openapi.json` and regenerate types with `npm run generate:openapi-types`. Commit the updated `src/confluent/openapi-schema.d.ts` alongside the `openapi.json` change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,13 @@ Pre-commit hook runs `npm run format && npm run lint` automatically via Husky.
 
 ### Entry Point & Startup Flow
 
-`src/index.ts` → `parseCliArgs()` → `buildConfigFromEnvAndCli()` (re-exported via `src/config/index.ts`, resolves a single `MCPServerConfiguration` from either a YAML file or env vars + CLI args, see issue #151) → `ServerRuntime.fromConfig()` constructs a `DefaultClientManager` per connection → iterates `ToolName` enum to build enabled tool set → registers tools on `McpServer` → starts transports.
+`src/index.ts` → `parseCliArgs()` → `initEnv()` → branch on `cliOptions.config`: when `-c <path>` is supplied, `loadConfigFromYaml(path, process.env)` parses + interpolates + validates the YAML; otherwise `buildConfigFromEnvAndCli(env, ...)` synthesizes the same `MCPServerConfiguration` shape from env vars + CLI args (legacy path, see issue #151). Both branches converge into `ServerRuntime.fromConfig()`, which constructs a `DefaultClientManager` per connection → iterates `ToolName` enum to build enabled tool set → registers tools on `McpServer` → starts transports.
 
 Tools are **auto-enabled/disabled** based on which **service blocks** are present in each connection (e.g., a tool requiring `flink` is enabled iff some connection's resolved config has a `flink:` block). The connection's blocks come from YAML when one is supplied via `-c <path>`; otherwise they're synthesized from env vars + CLI args for backwards compatibility during the migration. Each handler declares its requirement via `enabledConnectionIds(runtime)`, which returns the ids of connections satisfying a predicate from `src/confluent/tools/connection-predicates.ts`. An empty result disables the tool. Domain-wide gating (e.g., all Flink tools) lives on intermediate base classes such as `FlinkToolHandler`.
 
 ### Key Layers
 
-- **`src/config/`** — Configuration core. `models.ts` defines `MCPServerConfiguration` (a Zod schema with per-service connection blocks: `kafka`, `flink`, `schema_registry`, `confluent_cloud`, `tableflow`, `telemetry`). `env-config.ts` exports `buildConfigFromEnvAndCli()` (re-exported from `index.ts`), the single entry point that produces a config from either a YAML file (`-c <path>`) or env vars + CLI args. `interpolation.ts` handles `${VAR}` interpolation inside YAML.
+- **`src/config/`** — Configuration core. `models.ts` defines `MCPServerConfiguration` (a Zod schema with per-service connection blocks: `kafka`, `flink`, `schema_registry`, `confluent_cloud`, `tableflow`, `telemetry`). `index.ts` exposes `loadConfigFromYaml()` for the `-c <path>` branch (parsing, `${VAR}` interpolation via `interpolation.ts`, Zod validation). `env-config.ts` exports `buildConfigFromEnvAndCli()` for the legacy env-var + CLI path. Both produce an `MCPServerConfiguration`.
 
 - **`src/confluent/tools/`** — Tool system core:
   - `tool-name.ts` — `ToolName` enum; add new entries here when creating tools.


### PR DESCRIPTION
Many changes have been applied to the server config and underlying logic over the past couple of weeks, and our current "AI guidance" has drifted, so this PR is catching up to some of the most recent changes by removing outdated references like `getRequiredEnvVars` in favor of the new config and related expectations.

Some QoL extras:
- new `mcp-docs` skill to help look up [MCP documentation](https://modelcontextprotocol.io/docs)
- new `tool-handlers` rule for finer guidance that doesn't need to go in `CLAUDE.md`