### PR TITLE
MINOR: combine build+test jobs to speed up CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,11 +38,11 @@ blocks:
           commands:
             - npm run typecheck
 
-  - name: "Build & Test"
+  - name: "Test"
     dependencies: ["Static Analysis"]
     task:
       jobs:
-        - name: "Build & Test"
+        - name: "Test"
           commands:
             - npm run build
             - npm run test:coverage

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,20 +38,13 @@ blocks:
           commands:
             - npm run typecheck
 
-  - name: "Build"
+  - name: "Build & Test"
     dependencies: ["Static Analysis"]
     task:
       jobs:
-        - name: "Build"
+        - name: "Build & Test"
           commands:
             - npm run build
-
-  - name: "Test"
-    dependencies: ["Build"]
-    task:
-      jobs:
-        - name: "Test"
-          commands:
             - npm run test:coverage
       epilogue:
         always:


### PR DESCRIPTION
The individual jobs themselves are fast enough, so we don't need to split them up and incur more wait time while dealing with pre- and post-job operations.