### PR TITLE
chore(CI): move Docker image scan to dedicated pipeline, rename Test job

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@ src/generated
 # Confluent Cloud API spec; keep upstream formatting so spec bumps
 # don't mix with prettier whitespace churn.
 openapi.json
+# servicebot requires single-quoted task descriptions; prettier's
+# singleQuote=false silently breaks them, so don't format this file.
+service.yml

--- a/.semaphore/docker-image-scan.yml
+++ b/.semaphore/docker-image-scan.yml
@@ -1,0 +1,26 @@
+version: v1.0
+name: Docker Image Scan
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-2
+
+execution_time_limit:
+  hours: 1
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+
+blocks:
+  - name: "Docker Image Scan"
+    dependencies: []
+    task:
+      jobs:
+        - name: "Trivy Scan"
+          commands:
+            - docker build -t mcp-confluent:${SEMAPHORE_GIT_SHA:0:7} .
+            # fail the job only on CRITICAL vulnerabilities
+            - trivy image --exit-code 1 --severity CRITICAL mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
+            # report HIGH and MEDIUM vulnerabilities but don't fail the job
+            - trivy image --severity HIGH,MEDIUM mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -56,18 +56,6 @@ blocks:
             - sem-version java 17
             - emit-sonarqube-data --run_only_sonar_scan --enable_sonarqube_enterprise
 
-  - name: "Docker Image Scan"
-    dependencies: ["Static Analysis"]
-    task:
-      jobs:
-        - name: "Trivy Scan"
-          commands:
-            - docker build -t mcp-confluent:${SEMAPHORE_GIT_SHA:0:7} .
-            # fail the job only on CRITICAL vulnerabilities
-            - trivy image --exit-code 1 --severity CRITICAL mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
-            # report HIGH and MEDIUM vulnerabilities but don't fail the job
-            - trivy image --severity HIGH,MEDIUM mcp-confluent:${SEMAPHORE_GIT_SHA:0:7}
-
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,11 +38,11 @@ blocks:
           commands:
             - npm run typecheck
 
-  - name: "Test"
+  - name: "Build & Test"
     dependencies: ["Static Analysis"]
     task:
       jobs:
-        - name: "Test"
+        - name: "Build & Test"
           commands:
             - npm run build
             - npm run test:coverage

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,3 +62,7 @@ after_pipeline:
       - name: Publish Test Results
         commands:
           - test-results gen-pipeline-report || true
+
+promotions:
+  - name: Docker Image Scan
+    pipeline_file: docker-image-scan.yml

--- a/service.yml
+++ b/service.yml
@@ -59,3 +59,8 @@ semaphore:
           required: false
           default_value: 'main'
           description: 'The branch to audit and base the PR against. Defaults to main; override for release branches like v1.2.x.'
+    - name: scheduled-docker-image-scan
+      branch: main
+      pipeline_file: .semaphore/docker-image-scan.yml
+      scheduled: true
+      at: "0 12 * * *" # Daily at 12:00 UTC


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/mcp-confluent/pull/283:
- `Test` job renamed to `Build & Test` for accuracy
- Docker image scan via Trivy is now moved out of the default (PR) pipeline to speed up overall run time, and is instead a daily scheduled Semaphore task that can optionally be run as a manual promotion (e.g. for a PR)