### PR TITLE
Delay eslint import revising from vscode save to pre-commit hook (or explicit `lint:fix` invocation)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.formatOnSave": true,
     "editor.formatOnType": false,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      // "source.organizeImports": "explicit"  // disabled: strips imports mid-edit when Claude Code is writing files; ESLint handles removal at commit time
     }
   },
   "[json]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,7 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.formatOnType": false,
-    "editor.codeActionsOnSave": {
-      // "source.organizeImports": "explicit"  // disabled: strips imports mid-edit when Claude Code is writing files; ESLint handles removal at commit time
-    }
+    "editor.formatOnType": false
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Detailed conventions (handler structure, input schema rules, registration checkl
 ## Code Conventions
 
 - ESM modules (`"type": "module"` in package.json); use `.js` extensions in import paths.
-- Prettier + ESLint enforced; pre-commit hook runs both automatically via Husky.
+- Prettier + ESLint enforced; pre-commit hook runs both automatically via Husky. `eslint --fix` auto-removes unused imports via `eslint-plugin-unused-imports`, so stale imports left during a migration are cleaned up at commit time without manual intervention.
 - `noImplicitAny` is disabled in tsconfig due to OpenAPI type resolution issues.
 - REST API calls use `openapi-fetch` with typed paths from the generated schema — prefer this over raw fetch.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,8 +23,9 @@ export default [
     },
     rules: {
       // Hand unused-variable/import detection to unused-imports, which adds
-      // auto-fix support for import removal. Disabling the TS rule avoids
-      // double-reporting the same violation on every unused import binding.
+      // auto-fix support for import removal. Disabling both the core and TS
+      // rules avoids double-reporting on JS and TS files respectively.
+      "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "unused-imports/no-unused-imports": "error",
       "unused-imports/no-unused-vars": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import pluginJs from "@eslint/js";
 import eslintConfigPrettier from "eslint-config-prettier";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import unusedImports from "eslint-plugin-unused-imports";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
@@ -16,4 +17,25 @@ export default [
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
   eslintPluginPrettierRecommended,
+  {
+    plugins: {
+      "unused-imports": unusedImports,
+    },
+    rules: {
+      // Hand unused-variable/import detection to unused-imports, which adds
+      // auto-fix support for import removal. Disabling the TS rule avoids
+      // double-reporting the same violation on every unused import binding.
+      "@typescript-eslint/no-unused-vars": "off",
+      "unused-imports/no-unused-imports": "error",
+      "unused-imports/no-unused-vars": [
+        "error",
+        {
+          vars: "all",
+          varsIgnorePattern: "^_",
+          args: "after-used",
+          argsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.5.1",
+        "eslint-plugin-unused-imports": "^4.4.1",
         "globals": "^16.2.0",
         "husky": "^9.1.7",
         "openapi-typescript": "^7.8.0",
@@ -5590,6 +5591,22 @@
           "optional": true
         },
         "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
+      "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^10.0.0 || ^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",
+    "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "openapi-typescript": "^7.8.0",

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -20,8 +20,7 @@ const listTopicArgs = z.object({
 export class ListTopicsHandler extends BaseToolHandler {
   async handle(
     clientManager: ClientManager,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    toolArguments: Record<string, unknown>,
+    _toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const topics = await (await clientManager.getAdminClient()).listTopics();
     return this.createResponse(`Kafka topics: ${topics.join(",")}`);

--- a/tests/stubs/stub-handler.ts
+++ b/tests/stubs/stub-handler.ts
@@ -30,13 +30,11 @@ export class StubHandler extends BaseToolHandler {
     };
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   handle(
     _clientManager: ClientManager,
     _toolArguments: Record<string, unknown> | undefined,
     _sessionId?: string,
   ): CallToolResult {
-    /* eslint-enable @typescript-eslint/no-unused-vars */
     return this.createResponse("stub");
   }
 


### PR DESCRIPTION
**TL;DR:** Moves unused-import cleanup out of the editor (VS Code's `source.organizeImports`, which fires destructively on every save) and into the pre-commit ESLint run, where `eslint --fix` removes stale imports safely and automatically. To drive the cleanup manually at any time: `npm run lint:fix`.

## Problem

`source.organizeImports: "explicit"` in `.vscode/settings.json` fires TypeScript's Organize Imports action on every save — including saves triggered by Claude Code VS Code Extension's edit hook. This strips imports it considers unused between edits, causing a "linter battle" during multi-file migrations.

## Changes

- **`.vscode/settings.json`** — remove `source.organizeImports: "explicit"` and its enclosing `editor.codeActionsOnSave` block
- **`eslint.config.mjs` + `package.json`** — add `eslint-plugin-unused-imports`; the existing pre-commit `eslint --fix` now auto-removes genuinely stale imports
- **`CLAUDE.md`** — note that `eslint --fix` is self-healing on unused imports

Both `no-unused-vars` (core) and `@typescript-eslint/no-unused-vars` are disabled in favour of `unused-imports/no-unused-vars`: identical enforcement, adds auto-fix, no double-reporting on JS or TS files. Not a coverage regression.

Two incidental cleanups: `eslint-disable` suppression comments in `stub-handler.ts` and `list-topics-handler.ts` that were working around the now-replaced rule.

## Future

`eslint-plugin-simple-import-sort` was prototyped and dropped from this PR: it enforces a consistent import order on `--fix` but touches nearly every file in the repo on first application. That rewrite deserves its own PR with an explicit "this will be a large mechanical diff" warning so reviewers know what they're looking at.
