### PR TITLE
[REPO CONFIG] Pre push hook to run whole repo linting and typescript check

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,15 @@
 #!/usr/bin/env sh
 
+# Run typechecking and linting in parallel, and only allow the push if
+# both succeed.
+
 npm run lint &
-PID_LINT=$!
+LINT_PID=$!
 npm run typecheck &
-PID_TYPE=$!
+TYPE_PID=$!
 
-wait $PID_LINT; EC_LINT=$?
-wait $PID_TYPE; EC_TYPE=$?
+wait $LINT_PID; EC_LINT=$?
+wait $TYPE_PID; EC_TYPE=$?
 
+# Exit with a non-zero code if either linting or typechecking failed.
 [ $EC_LINT -eq 0 ] && [ $EC_TYPE -eq 0 ]

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+npm run lint &
+PID_LINT=$!
+npm run typecheck &
+PID_TYPE=$!
+
+wait $PID_LINT; EC_LINT=$?
+wait $PID_TYPE; EC_TYPE=$?
+
+[ $EC_LINT -eq 0 ] && [ $EC_TYPE -eq 0 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ npm run inspector      # launch MCP inspector for manual testing
 npm run print:schema   # print tool schemas as markdown
 ```
 
-Pre-commit hook runs `npm run format && npm run lint` automatically via Husky.
+Pre-commit hook runs `npm run format && npm run lint` automatically via Husky. Pre-push hook runs `npm run lint && npm run typecheck` across the whole repo.
 
 ## Architecture
 
@@ -72,7 +72,7 @@ Detailed conventions (handler structure, input schema rules, registration checkl
 ## Code Conventions
 
 - ESM modules (`"type": "module"` in package.json); use `.js` extensions in import paths.
-- Prettier + ESLint enforced; pre-commit hook runs both automatically via Husky. `eslint --fix` auto-removes unused imports via `eslint-plugin-unused-imports`, so stale imports left during a migration are cleaned up at commit time without manual intervention.
+- Prettier + ESLint enforced; pre-commit hook runs both automatically via Husky. `eslint --fix` auto-removes unused imports via `eslint-plugin-unused-imports`, so stale imports left during a migration are cleaned up at commit time without manual intervention. Pre-push hook runs full-repo `lint` + `typecheck` so CI failures on those checks are nearly impossible.
 - `noImplicitAny` is disabled in tsconfig due to OpenAPI type resolution issues.
 - REST API calls use `openapi-fetch` with typed paths from the generated schema — prefer this over raw fetch.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ npm run inspector      # launch MCP inspector for manual testing
 npm run print:schema   # print tool schemas as markdown
 ```
 
-Pre-commit hook runs `npm run format && npm run lint` automatically via Husky. Pre-push hook runs `npm run lint && npm run typecheck` across the whole repo.
+Pre-commit hook runs `npx prettier` and `npx eslint` automatically via Husky on staged files only. Pre-push hook runs `npm run lint` and `npm run typecheck` in parallel.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Husky git pre-push hook to run whole-repo typescript and lint check to prevent developerclaude flubs from making it out the door.
- Runs both in parallel then exits clean only if both were clean.

