### PR TITLE
update CI pipeline run lint+typecheck before build+test in the same job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,23 +27,14 @@ global_job_config:
       - cache store npm-cache-$(checksum package-lock.json) ~/.npm
 
 blocks:
-  - name: "Static Analysis"
-    dependencies: []
-    task:
-      jobs:
-        - name: "ESLint"
-          commands:
-            - npm run lint
-        - name: "TypeScript"
-          commands:
-            - npm run typecheck
-
   - name: "Build & Test"
-    dependencies: ["Static Analysis"]
+    dependencies: []
     task:
       jobs:
         - name: "Build & Test"
           commands:
+            - npm run lint
+            - npm run typecheck
             - npm run build
             - npm run test:coverage
       epilogue:


### PR DESCRIPTION
No need to run these two separately considering the total job time is 10x what the actual commands themselves take -- note the `Total Time` at the top of each screenshot compared to the time in the highlighted rows:
- lint
    <img width="608" height="214" alt="image" src="https://github.com/user-attachments/assets/7d4adfc4-b540-4680-a0a2-c10af909fd76" />

- typecheck
    <img width="598" height="192" alt="image" src="https://github.com/user-attachments/assets/841c8563-2dc0-4caa-b34e-1c8d7faf6efd" />

So this PR sticks them all in the same `Build & Test` job to resolve some lingering bottlenecks:
- waiting for a Semaphore agent to be available
- waiting for the Node setup
- waiting for cache restoration

While we lose some of the original block-level status reporting, triage here is generally easier and worth the overall workflow speedup. 

Now:
<img width="825" height="354" alt="image" src="https://github.com/user-attachments/assets/7d2fad01-296d-4b72-a4e0-61fe18291f1a" />
