### PR TITLE
Feat/229 handle() gets runtime, not clientmanage passed now

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -144,8 +144,15 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   whose connection has the relevant service block (expect the connection id) and a bare runtime
   without that block (expect `[]`). Helper factories live in `tests/factories/runtime.ts`
   (`flinkRuntime()`, `tableflowRuntime()`, `bareRuntime()`, etc.).
-- Test `handle()` for typical and edge-case inputs.
-- Stub `ClientManager` methods with `createMockInstance(DefaultClientManager)`.
+- Test `handle()` for typical and edge-case inputs. `handle()` now receives a `ServerRuntime`
+  instead of a bare `ClientManager`. Create the mock first, configure it, then inject it into
+  `runtimeWith()` as the third argument:
+  ```typescript
+  clientManager = createMockInstance(DefaultClientManager);
+  clientManager.getSomeClient.mockResolvedValue(...);
+  const runtime = runtimeWith({ kafka: { bootstrap_servers: "..." } }, DEFAULT_CONNECTION_ID, clientManager);
+  handler.handle(runtime, args);
+  ```
 - Use `as any` only on partial mock return values (e.g., a mock admin client with only
   `listTopics`), not on the `ClientManager` mock itself; add an eslint-disable comment when needed.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.formatOnSave": true,
     "editor.formatOnType": false,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      // "source.organizeImports": "explicit"  // disabled: strips imports mid-edit when Claude Code is writing files
     }
   },
   "[json]": {

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -1,5 +1,4 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -25,7 +24,7 @@ export const DESTRUCTIVE: ToolAnnotations = {
 
 export interface ToolHandler {
   handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
     sessionId?: string,
   ): Promise<CallToolResult> | CallToolResult;
@@ -53,7 +52,7 @@ export interface ToolConfig {
 
 export abstract class BaseToolHandler implements ToolHandler {
   abstract handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
     sessionId?: string,
   ): Promise<CallToolResult> | CallToolResult;

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -76,9 +75,10 @@ type BillingCostsList = z.infer<typeof billingCostsSchema>;
 
 export class ListBillingCostsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { startDate, endDate, pageSize, pageToken } =
       listBillingCostsArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -33,9 +32,10 @@ const addTagToTopicArguments = z.object({
 
 export class AddTagToTopicHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tagAssignments } = addTagToTopicArguments.parse(toolArguments);
 
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -31,9 +30,10 @@ const createTagsArguments = z.object({
 
 export class CreateTopicTagsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tags } = createTagsArguments.parse(toolArguments);
 
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/catalog/delete-tag.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -20,9 +19,10 @@ const deleteTagArguments = z.object({
 
 export class DeleteTagHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tagName } = deleteTagArguments.parse(toolArguments);
 
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/catalog/list-tags.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -14,7 +13,8 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class ListTagsHandler extends BaseToolHandler {
-  async handle(clientManager: ClientManager): Promise<CallToolResult> {
+  async handle(runtime: ServerRuntime): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),
     );

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -34,9 +33,10 @@ const removeTagFromEntityArguments = z.object({
 
 export class RemoveTagFromEntityHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tagName, typeName, qualifiedName } =
       removeTagFromEntityArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -66,9 +65,10 @@ export type Cluster = z.infer<typeof clusterSchema>;
 
 export class ListClustersHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { environmentId } = listClustersArguments.parse(toolArguments);
 
     try {

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -74,9 +73,10 @@ const createConnectorArguments = z.object({
 
 export class CreateConnectorHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName, connectorConfig } =
       createConnectorArguments.parse(toolArguments);
     const environment_id = getEnsuredParam(

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -34,9 +33,10 @@ const deleteConnectorArguments = z.object({
 
 export class DeleteConnectorHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       deleteConnectorArguments.parse(toolArguments);
     const environment_id = getEnsuredParam(

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -32,9 +31,10 @@ const listConnectorArguments = z.object({
 
 export class ListConnectorsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, environmentId } =
       listConnectorArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/connect/read-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/read-connectors-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -37,9 +36,10 @@ const readConnectorArguments = z.object({
 
 export class ReadConnectorHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       readConnectorArguments.parse(toolArguments);
     const environment_id = getEnsuredParam(

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -64,9 +63,10 @@ export type EnvironmentList = z.infer<typeof environmentListSchema>;
 
 export class ListEnvironmentsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { pageToken } = listEnvironmentsArguments.parse(toolArguments);
 
     try {

--- a/src/confluent/tools/handlers/environments/read-environment-handler.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -28,9 +27,10 @@ const readEnvironmentArguments = z.object({
 
 export class ReadEnvironmentHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { environmentId } = readEnvironmentArguments.parse(toolArguments);
 
     try {

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -11,6 +10,7 @@ import {
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const describeTableArguments = z.object({
@@ -52,9 +52,10 @@ const describeTableArguments = z.object({
 
 export class DescribeTableHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       organizationId,
       environmentId,

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -11,6 +10,7 @@ import {
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const getTableInfoArguments = z.object({
@@ -52,9 +52,10 @@ const getTableInfoArguments = z.object({
 
 export class GetTableInfoHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       organizationId,
       environmentId,

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -6,6 +5,7 @@ import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listCatalogsArguments = z.object({
@@ -28,9 +28,10 @@ const listCatalogsArguments = z.object({
 
 export class ListCatalogsHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { organizationId, environmentId, computePoolId } =
       listCatalogsArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -6,6 +5,7 @@ import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listDatabasesArguments = z.object({
@@ -35,9 +35,10 @@ const listDatabasesArguments = z.object({
 
 export class ListDatabasesHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { organizationId, environmentId, computePoolId, catalogName } =
       listDatabasesArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -6,6 +5,7 @@ import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listTablesArguments = z.object({
@@ -42,9 +42,10 @@ const listTablesArguments = z.object({
 
 export class ListTablesHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       organizationId,
       environmentId,

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
@@ -1,10 +1,10 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import env from "@src/env.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -63,9 +63,10 @@ const createFlinkStatementArguments = z.object({
 
 export class CreateFlinkStatementHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       catalogName,
       databaseName,

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -34,9 +34,10 @@ const deleteFlinkStatementArguments = z.object({
 
 export class DeleteFlinkStatementHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { statementName, environmentId, organizationId } =
       deleteFlinkStatementArguments.parse(toolArguments);
     const organization_id = getEnsuredParam(

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -45,9 +45,10 @@ interface HealthStatus {
 
 export class CheckHealthHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { statementName, environmentId, organizationId } =
       checkHealthArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -9,6 +8,7 @@ import {
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import env from "@src/env.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -55,9 +55,10 @@ interface DetectedIssue {
 
 export class DetectIssuesHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       statementName,
       environmentId,

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -113,9 +112,10 @@ const LONG_MIN_VALUE = -9223372036854776000;
 
 export class QueryProfilerHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       statementName,
       environmentId,

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -32,9 +32,10 @@ const getFlinkExceptionsArguments = z.object({
 
 export class GetFlinkExceptionsHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { statementName, environmentId, organizationId } =
       getFlinkExceptionsArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
@@ -1,10 +1,10 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import env from "@src/env.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -50,9 +50,10 @@ const listFlinkStatementsArguments = z.object({
 
 export class ListFlinkStatementsHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       pageSize,
       computePoolId,

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -41,9 +41,10 @@ const readFlinkStatementArguments = z.object({
 
 export class ReadFlinkStatementHandler extends FlinkToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const {
       timeoutInMilliseconds,
       statementName,

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -41,9 +40,10 @@ const alterTopicConfigArguments = z.object({
  */
 export class AlterTopicConfigHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, topicName, topicConfigs, validateOnly } =
       alterTopicConfigArguments.parse(toolArguments);
     const kafka_cluster_id = getEnsuredParam(

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1,7 +1,6 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { KafkaMessage } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
-import { ClientManager } from "@src/confluent/client-manager.js";
 import {
   deserializeMessage,
   getLatestSchemaIfExists,
@@ -176,10 +175,11 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
    * @returns A CallToolResult containing the consumed messages or error information
    */
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: z.infer<typeof consumeKafkaMessagesArgs>,
     sessionId?: string,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { topicNames, maxMessages, timeoutMs, value, key } =
       consumeKafkaMessagesArgs.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -32,9 +31,10 @@ const createTopicArgs = z.object({
 });
 export class CreateTopicsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { topics } = createTopicArgs.parse(toolArguments);
     const success = await (
       await clientManager.getAdminClient()

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -20,9 +19,10 @@ const deleteKafkaTopicsArguments = z.object({
 });
 export class DeleteTopicsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { topicNames } = deleteKafkaTopicsArguments.parse(toolArguments);
     await (
       await clientManager.getAdminClient()

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -33,9 +32,10 @@ const getTopicConfigArguments = z.object({
  */
 export class GetTopicConfigHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, topicName } =
       getTopicConfigArguments.parse(toolArguments);
     const kafka_cluster_id = getEnsuredParam(

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CONNECTION_ID,
   kafkaRestOnlyRuntime,
   kafkaRuntime,
+  runtimeWith,
 } from "@tests/factories/runtime.js";
 import {
   createMockAdmin,
@@ -50,9 +51,16 @@ describe("list-topics-handler.ts", () => {
           new Error("connection refused"),
         );
 
-        await expect(handler.handle(clientManager, {})).rejects.toThrow(
-          "connection refused",
-        );
+        await expect(
+          handler.handle(
+            runtimeWith(
+              { kafka: { bootstrap_servers: "broker:9092" } },
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            {},
+          ),
+        ).rejects.toThrow("connection refused");
       });
     });
   });

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -19,10 +18,11 @@ const listTopicArgs = z.object({
 
 export class ListTopicsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const topics = await (await clientManager.getAdminClient()).listTopics();
     return this.createResponse(`Kafka topics: ${topics.join(",")}`);
   }

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -1,6 +1,5 @@
 import { RecordMetadata } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
-import { ClientManager } from "@src/confluent/client-manager.js";
 import {
   checkSchemaNeeded,
   MessageOptions,
@@ -113,9 +112,10 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
    * @returns A CallToolResult describing the outcome of the produce operation
    */
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { topicName, value, key }: ProduceKafkaMessageArguments =
       produceKafkaMessageArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -145,9 +144,10 @@ const KAFKA_SERVER_METRICS = [
 
 export class ListMetricsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { resource_type } = listMetricsArguments.parse(toolArguments);
 
     try {

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -74,9 +73,10 @@ interface TelemetryResponse {
 
 export class QueryMetricsHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const args = queryMetricsArguments.parse(toolArguments);
     const {
       metric,

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -34,9 +33,10 @@ const deleteSchemaArguments = z.object({
 
 export class DeleteSchemaHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { subject, version, permanent } =
       deleteSchemaArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -1,5 +1,4 @@
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -34,9 +33,10 @@ const listSchemasArguments = z.object({
 
 export class ListSchemasHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { latestOnly, subjectPrefix, deleted } =
       listSchemasArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -29,9 +28,10 @@ const searchTopicsByTagArguments = z.object({
 
 export class SearchTopicsByTagHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { topicTag, limit, offset } =
       searchTopicsByTagArguments.parse(toolArguments);
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
@@ -1,4 +1,3 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -20,9 +19,10 @@ const searchTopicsByNameArguments = z.object({
 
 export class SearchTopicsByNameHandler extends BaseToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { topicName } = searchTopicsByNameArguments.parse(toolArguments);
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),

--- a/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -35,9 +35,10 @@ const createTableflowCatalogIntegrationArguments = z.object({
 
 export class CreateTableFlowCatalogIntegrationHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tableflowCatalogIntegrationConfig } =
       createTableflowCatalogIntegrationArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -23,9 +23,10 @@ const deleteTableflowCatalogIntegrationArguments = z.object({
 
 export class DeleteTableFlowCatalogIntegrationHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { id, environmentId, clusterId } =
       deleteTableflowCatalogIntegrationArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -36,9 +36,10 @@ const listTableFlowCatalogIntegrationsArguments = z.object({
 
 export class ListTableFlowCatalogIntegrationsHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, environmentId } =
       listTableFlowCatalogIntegrationsArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -23,9 +23,10 @@ const readTableflowCatalogIntegrationArguments = z.object({
 
 export class ReadTableFlowCatalogIntegrationHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { id, environmentId, clusterId } =
       readTableflowCatalogIntegrationArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
@@ -1,8 +1,8 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -44,9 +44,10 @@ const updateTableflowCatalogIntegrationArguments = z.object({
 
 export class UpdateTableFlowCatalogIntegrationHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tableflowCatalogIntegrationConfig } =
       updateTableflowCatalogIntegrationArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -1,8 +1,8 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -28,9 +28,10 @@ const listTableFlowRegionsArguments = z.object({
 
 export class ListTableFlowRegionsHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { cloud } = listTableFlowRegionsArguments.parse(toolArguments);
 
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -56,9 +56,10 @@ const createTableflowTopicArguments = z.object({
 
 export class CreateTableFlowTopicHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { tableflowTopicConfig } =
       createTableflowTopicArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -25,9 +25,10 @@ const deleteTableflowTopicArguments = z.object({
 
 export class DeleteTableFlowTopicHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { display_name, environmentId, clusterId } =
       deleteTableflowTopicArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -36,9 +36,10 @@ const listTableFlowTopicArguments = z.object({
 
 export class ListTableFlowTopicsHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { clusterId, environmentId } =
       listTableFlowTopicArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
@@ -1,9 +1,9 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -25,9 +25,10 @@ const readTableflowTopicArguments = z.object({
 
 export class ReadTableFlowTopicHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { display_name, environmentId, clusterId } =
       readTableflowTopicArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
@@ -1,8 +1,8 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
@@ -68,9 +68,10 @@ const updateTableflowTopicArguments = z.object({
 
 export class UpdateTableFlowTopicHandler extends TableflowToolHandler {
   async handle(
-    clientManager: ClientManager,
+    runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
+    const clientManager = runtime.clientManager;
     const { display_name, tableflowTopicConfig } =
       updateTableflowTopicArguments.parse(toolArguments);
 

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -182,44 +182,66 @@ describe("tool-registry.ts", () => {
 
     /**
      * Wires every client getter on a fresh `Mocked<DefaultClientManager>` to a
-     * recursive Proxy: any property access or call on the returned client resolves
-     * to another instance of the same Proxy, so handler bodies never throw a
-     * TypeError before they reach real logic. A TypeError that escapes is therefore
-     * a genuine wiring failure — exactly what the smoke tests check for.
+     * two-proxy pair. `callableProxy` (function target) absorbs any method chain
+     * or call without throwing; every call resolves to `responseProxy`.
+     * `responseProxy` (plain-object target) models the `{ data, error }` shape
+     * returned by openapi-fetch: `error` is `undefined`, and `data` returns
+     * `responseData` — supply a minimal valid shape to push a handler past schema
+     * validation into its real success branch (defaults to `{}`).
+     *
+     * A TypeError that escapes the proxy pair is therefore a genuine wiring
+     * failure — exactly what the smoke tests check for.
      *
      * Returns `{ clientManager, clientGetters }`. `clientGetters` is the canonical
      * list of all getter mocks; callers use it to assert that at least one was
      * invoked when a handler resolves successfully.
      */
-    function stubClientGetters() {
-      const proxy = new Proxy(() => Promise.resolve(proxy), {
+    function stubClientGetters(responseData: unknown = {}) {
+      // Two-proxy setup: callableProxy (function target) handles method chains
+      // and calls; responseProxy (plain-object target) is what async calls
+      // resolve to, giving { data, error } destructuring a real object for `data`.
+      // responseData is returned for the `data` property — callers can supply a
+      // minimal valid shape to push a handler past validation into its success path.
+      let responseProxy: object = {};
+      const callableProxy = new Proxy((() => {}) as () => Promise<object>, {
         get: (_t, prop) => {
           if (prop === "then" || prop === "error") return undefined;
-          return () => Promise.resolve(proxy);
+          return callableProxy;
         },
-        apply: () => Promise.resolve(proxy),
+        apply: () => Promise.resolve(responseProxy),
+      });
+      responseProxy = new Proxy({} as object, {
+        get: (_t, prop) => {
+          if (prop === "then" || prop === "error") return undefined;
+          if (prop === "data") return responseData;
+          return callableProxy;
+        },
       });
       const clientManager = createMockInstance(DefaultClientManager);
-      clientManager.getAdminClient.mockResolvedValue(proxy as never);
-      clientManager.getProducer.mockResolvedValue(proxy as never);
-      clientManager.getConsumer.mockResolvedValue(proxy as never);
+      clientManager.getAdminClient.mockResolvedValue(callableProxy as never);
+      clientManager.getProducer.mockResolvedValue(callableProxy as never);
+      clientManager.getConsumer.mockResolvedValue(callableProxy as never);
       clientManager.getConfluentCloudFlinkRestClient.mockReturnValue(
-        proxy as never,
+        callableProxy as never,
       );
-      clientManager.getConfluentCloudRestClient.mockReturnValue(proxy as never);
+      clientManager.getConfluentCloudRestClient.mockReturnValue(
+        callableProxy as never,
+      );
       clientManager.getConfluentCloudTableflowRestClient.mockReturnValue(
-        proxy as never,
+        callableProxy as never,
       );
       clientManager.getConfluentCloudSchemaRegistryRestClient.mockReturnValue(
-        proxy as never,
+        callableProxy as never,
       );
       clientManager.getConfluentCloudKafkaRestClient.mockReturnValue(
-        proxy as never,
+        callableProxy as never,
       );
       clientManager.getConfluentCloudTelemetryRestClient.mockReturnValue(
-        proxy as never,
+        callableProxy as never,
       );
-      clientManager.getSchemaRegistryClient.mockReturnValue(proxy as never);
+      clientManager.getSchemaRegistryClient.mockReturnValue(
+        callableProxy as never,
+      );
       const clientGetters = [
         clientManager.getAdminClient,
         clientManager.getProducer,
@@ -235,12 +257,29 @@ describe("tool-registry.ts", () => {
       return { clientManager, clientGetters };
     }
 
-    /** Handler resolves: response text contains `resolves`. */
-    type Resolves = { resolves: string };
-    /** Handler throws: "ZodError" or error message contains `throws`. */
-    type Throws = { throws: string };
-    /** Placeholder: run the smoke test to discover and replace with the real outcome. */
-    type ZeroArgOutcome = Resolves | Throws | "TODO";
+    type Resolves = {
+      /** Minimal valid API response to feed into the proxy's `data` property.
+       *  Omit to use `{}` (sufficient when the handler just JSON-serialises the
+       *  response); supply `{ data: [] }` or a richer shape to push the handler
+       *  past schema validation into its real success branch. */
+      responseData?: unknown;
+      /** Substring that must appear in the resolved response text. */
+      resolves: string;
+    };
+    type Throws = {
+      /** Same as `Resolves.responseData` — set when the handler needs valid-ish
+       *  data before it reaches the code that throws. */
+      responseData?: unknown;
+      /** Substring that must appear in the thrown error message, or "ZodError"
+       *  to match any ZodError regardless of message. */
+      throws: string;
+    };
+    /** Complete smoke-test specification for one handler: what to feed in
+     *  (`responseData`) and what to expect out (`resolves` / `throws`).
+     *  The string sentinel value triggers a "golden file"-style discovery run:
+     *  the test executes the handler, reports the actual outcome, and asks you
+     *  to paste it in as the recorded expectation. */
+    type HandleSmokeCase = Resolves | Throws | "TODO";
 
     // Reverse map from enum value ("list-topics") → enum key ("LIST_TOPICS"),
     // used to generate helpful copy-paste suggestions in failure messages.
@@ -255,7 +294,7 @@ describe("tool-registry.ts", () => {
      * Use `"TODO"` as a placeholder — the smoke test will run the handler
      * and report the correct entry to paste in.
      */
-    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, ZeroArgOutcome>> = {
+    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, HandleSmokeCase>> = {
       // Kafka
       [ToolName.LIST_TOPICS]: { resolves: "Kafka topics:" },
       [ToolName.CREATE_TOPICS]: { throws: "ZodError" },
@@ -297,7 +336,7 @@ describe("tool-registry.ts", () => {
       [ToolName.ADD_TAGS_TO_TOPIC]: { throws: "ZodError" },
       [ToolName.LIST_TAGS]: { resolves: "Successfully retrieved tags" },
       // Search
-      [ToolName.SEARCH_TOPICS_BY_TAG]: { resolves: "undefined" },
+      [ToolName.SEARCH_TOPICS_BY_TAG]: { resolves: "{}" },
       [ToolName.SEARCH_TOPICS_BY_NAME]: { throws: "ZodError" },
       // Environments
       [ToolName.LIST_ENVIRONMENTS]: {
@@ -305,7 +344,10 @@ describe("tool-registry.ts", () => {
       },
       [ToolName.READ_ENVIRONMENT]: { throws: "ZodError" },
       // Clusters
-      [ToolName.LIST_CLUSTERS]: { resolves: "Invalid response format" },
+      [ToolName.LIST_CLUSTERS]: {
+        responseData: { data: [] },
+        resolves: "Successfully retrieved 0 clusters",
+      },
       // Tableflow
       [ToolName.CREATE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
       [ToolName.LIST_TABLEFLOW_REGIONS]: { resolves: "Tableflow Regions" },
@@ -326,7 +368,10 @@ describe("tool-registry.ts", () => {
       [ToolName.LIST_BILLING_COSTS]: { throws: "ZodError" },
       // Metrics
       [ToolName.QUERY_METRICS]: { throws: "ZodError" },
-      [ToolName.LIST_METRICS]: { resolves: "No metrics descriptors available" },
+      [ToolName.LIST_METRICS]: {
+        responseData: { data: [] },
+        resolves: "No metrics descriptors available",
+      },
     };
 
     beforeAll(() => {
@@ -345,10 +390,15 @@ describe("tool-registry.ts", () => {
       },
     );
 
-    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, ZeroArgOutcome][])(
+    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, HandleSmokeCase][])(
       "%s: handle() should not crash before reaching the ClientManager",
       async (name, outcome) => {
-        const { clientManager, clientGetters } = stubClientGetters();
+        const responseData =
+          typeof outcome === "object" && "responseData" in outcome
+            ? outcome.responseData
+            : undefined;
+        const { clientManager, clientGetters } =
+          stubClientGetters(responseData);
 
         const runtime = allServicesRuntime(clientManager);
 

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -171,6 +171,15 @@ describe("tool-registry.ts", () => {
       );
     }
 
+    /** Classifies a thrown value into the string used for matching in ZERO_ARG_OUTCOMES. */
+    function classifyThrown(name: string, thrown: unknown): string {
+      if (thrown instanceof ZodError) return "ZodError";
+      if (thrown instanceof Error) return thrown.message;
+      throw new Error(
+        `Wacky -- ${name}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
+      );
+    }
+
     /**
      * Wires every client getter on a fresh `Mocked<DefaultClientManager>` to a
      * recursive Proxy: any property access or call on the returned client resolves
@@ -182,19 +191,10 @@ describe("tool-registry.ts", () => {
      * list of all getter mocks; callers use it to assert that at least one was
      * invoked when a handler resolves successfully.
      */
-    /** Classifies a thrown value into the string used for matching in ZERO_ARG_OUTCOMES. */
-    function classifyThrown(name: string, thrown: unknown): string {
-      if (thrown instanceof ZodError) return "ZodError";
-      if (thrown instanceof Error) return thrown.message;
-      throw new Error(
-        `Wacky -- ${name}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
-      );
-    }
-
     function stubClientGetters() {
       const proxy = new Proxy(() => Promise.resolve(proxy), {
         get: (_t, prop) => {
-          if (prop === "then") return undefined;
+          if (prop === "then" || prop === "error") return undefined;
           return () => Promise.resolve(proxy);
         },
         apply: () => Promise.resolve(proxy),
@@ -295,24 +295,20 @@ describe("tool-registry.ts", () => {
       [ToolName.DELETE_TAG]: { throws: "ZodError" },
       [ToolName.REMOVE_TAG_FROM_ENTITY]: { throws: "ZodError" },
       [ToolName.ADD_TAGS_TO_TOPIC]: { throws: "ZodError" },
-      [ToolName.LIST_TAGS]: { resolves: "Failed to list tags" },
+      [ToolName.LIST_TAGS]: { resolves: "Successfully retrieved tags" },
       // Search
-      [ToolName.SEARCH_TOPICS_BY_TAG]: {
-        resolves: "Failed to search for topics by tag",
-      },
+      [ToolName.SEARCH_TOPICS_BY_TAG]: { resolves: "undefined" },
       [ToolName.SEARCH_TOPICS_BY_NAME]: { throws: "ZodError" },
       // Environments
       [ToolName.LIST_ENVIRONMENTS]: {
-        resolves: "Failed to fetch environments",
+        resolves: "Invalid environment list data",
       },
       [ToolName.READ_ENVIRONMENT]: { throws: "ZodError" },
       // Clusters
-      [ToolName.LIST_CLUSTERS]: { resolves: "Failed to fetch clusters" },
+      [ToolName.LIST_CLUSTERS]: { resolves: "Invalid response format" },
       // Tableflow
       [ToolName.CREATE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
-      [ToolName.LIST_TABLEFLOW_REGIONS]: {
-        resolves: "Failed to list Tableflow regions",
-      },
+      [ToolName.LIST_TABLEFLOW_REGIONS]: { resolves: "Tableflow Regions" },
       [ToolName.LIST_TABLEFLOW_TOPICS]: {
         throws: "Environment ID is required",
       },

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -182,6 +182,15 @@ describe("tool-registry.ts", () => {
      * list of all getter mocks; callers use it to assert that at least one was
      * invoked when a handler resolves successfully.
      */
+    /** Classifies a thrown value into the string used for matching in ZERO_ARG_OUTCOMES. */
+    function classifyThrown(name: string, thrown: unknown): string {
+      if (thrown instanceof ZodError) return "ZodError";
+      if (thrown instanceof Error) return thrown.message;
+      throw new Error(
+        `Wacky -- ${name}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
+      );
+    }
+
     function stubClientGetters() {
       const proxy = new Proxy(() => Promise.resolve(proxy), {
         get: (_t, prop) => {
@@ -230,14 +239,23 @@ describe("tool-registry.ts", () => {
     type Resolves = { resolves: string };
     /** Handler throws: "ZodError" or error message contains `throws`. */
     type Throws = { throws: string };
-    type ZeroArgOutcome = Resolves | Throws;
+    /** Placeholder: run the smoke test to discover and replace with the real outcome. */
+    type ZeroArgOutcome = Resolves | Throws | "TODO";
+
+    // Reverse map from enum value ("list-topics") → enum key ("LIST_TOPICS"),
+    // used to generate helpful copy-paste suggestions in failure messages.
+    const TOOL_NAME_TO_KEY = Object.fromEntries(
+      Object.entries(ToolName).map(([k, v]) => [v, k]),
+    ) as Record<ToolName, string>;
 
     /**
      * What each handler produces when called with no arguments against a
      * fully-wired universal client. Use `{ resolves }` when the handler
      * completes and `{ throws }` when it raises before returning.
+     * Use `"TODO"` as a placeholder — the smoke test will run the handler
+     * and report the correct entry to paste in.
      */
-    const ZERO_ARG_OUTCOMES: Record<ToolName, ZeroArgOutcome> = {
+    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, ZeroArgOutcome>> = {
       // Kafka
       [ToolName.LIST_TOPICS]: { resolves: "Kafka topics:" },
       [ToolName.CREATE_TOPICS]: { throws: "ZodError" },
@@ -319,6 +337,18 @@ describe("tool-registry.ts", () => {
       initEnv();
     });
 
+    // One test per tool — each missing entry is its own failure with a copy-paste fix.
+    it.each(ALL_TOOL_NAMES)(
+      "%s: should have an entry in ZERO_ARG_OUTCOMES",
+      (name) => {
+        expect(
+          name in ZERO_ARG_OUTCOMES,
+          `Add [ToolName.${TOOL_NAME_TO_KEY[name]}]: "TODO" to ZERO_ARG_OUTCOMES, ` +
+            `then run: npm test -- src/confluent/tools/tool-registry.test.ts`,
+        ).toBe(true);
+      },
+    );
+
     it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, ZeroArgOutcome][])(
       "%s: handle() should not crash before reaching the ClientManager",
       async (name, outcome) => {
@@ -329,7 +359,7 @@ describe("tool-registry.ts", () => {
         const handler = ToolHandlerRegistry.getToolHandler(name);
 
         // Precondition: { resolves } must carry a real substring, not ""
-        if ("resolves" in outcome) {
+        if (typeof outcome === "object" && "resolves" in outcome) {
           expect(
             outcome.resolves,
             `${name}: resolves must be a non-empty substring, not ""`,
@@ -344,10 +374,24 @@ describe("tool-registry.ts", () => {
           thrown = err;
         }
 
+        // Placeholder sentinel: run completed — report what to replace it with
+        if (outcome === "TODO") {
+          const discovered =
+            thrown === undefined
+              ? `{ resolves: "${result!.content
+                  .map((c) => ("text" in c ? c.text : ""))
+                  .join("")
+                  .slice(0, 60)}" }`
+              : `{ throws: "${classifyThrown(name, thrown)}" }`;
+          throw new Error(
+            `${name}: outcome is TODO — replace with: ${discovered}`,
+          );
+        }
+
         if (thrown === undefined) {
           // Outcome table must declare { resolves }, not { throws }
           expect(
-            "resolves" in outcome,
+            typeof outcome === "object" && "resolves" in outcome,
             `${name}: resolved successfully but outcome specifies { throws }`,
           ).toBe(true);
 
@@ -367,30 +411,14 @@ describe("tool-registry.ts", () => {
             `${name}: resolved without error but no client getter was called`,
           ).toBe(true);
         } else {
-          // We expect specific error/message to have been thrown.
           // Outcome table must declare { throws }, not { resolves }
           expect(
-            "throws" in outcome,
+            typeof outcome === "object" && "throws" in outcome,
             `${name}: handler threw but outcome specifies { resolves }`,
           ).toBe(true);
 
-          // Classify the thrown value into a comparable string
-          let actual: string;
-          if (thrown instanceof ZodError) {
-            // We don't care about which exact ZodError it is, because
-            // that's determined by the ordering of zod refinements in the handler, which is an
-            // internal detail.
-            actual = "ZodError";
-          } else if (thrown instanceof Error) {
-            actual = thrown.message;
-          } else {
-            throw new Error(
-              `Wacky -- ${name}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
-            );
-          }
-
           expect(
-            actual,
+            classifyThrown(name, thrown),
             `${name}: unexpected error — update ZERO_ARG_OUTCOMES table with actual`,
           ).toContain((outcome as Throws).throws);
         }

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -189,6 +189,10 @@ describe("tool-registry.ts", () => {
      * Returns `{ clientManager, clientGetters }`. `clientGetters` is the canonical
      * list of all getter mocks; callers use it to assert that at least one was
      * invoked when a handler resolves successfully.
+     *
+     * (No explicit return type: `clientGetters` is a heterogeneous array of mock
+     * method references whose element type is too verbose to write by hand — inference
+     * is clearer here than annotation would be.)
      */
     function stubClientGetters(responseData: unknown = {}) {
       // Two-proxy setup: callableProxy (function target) handles method chains

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -1,3 +1,4 @@
+import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import {
   CREATE_UPDATE,
   DESTRUCTIVE,
@@ -5,7 +6,14 @@ import {
 } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
-import { describe, expect, it } from "vitest";
+import { initEnv } from "@src/env.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import { createMockInstance } from "@tests/stubs/index.js";
+import { type Mocked, beforeAll, describe, expect, it } from "vitest";
+import { ZodError } from "zod";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
 
@@ -122,5 +130,271 @@ describe("tool-registry.ts", () => {
         }
       });
     });
+  });
+
+  describe("handle() smoke tests", () => {
+    /**
+     * Builds a `ServerRuntime` with every service block populated, injecting
+     * `clientManager` so callers can verify which client getters were invoked.
+     */
+    function allServicesRuntime(clientManager: Mocked<DefaultClientManager>) {
+      return runtimeWith(
+        {
+          kafka: {
+            bootstrap_servers: "broker:9092",
+            rest_endpoint: "https://rest.example.com",
+            auth: { type: "api_key", key: "k", secret: "s" },
+          },
+          flink: {
+            endpoint: "https://flink.example.com",
+            auth: { type: "api_key", key: "k", secret: "s" },
+            environment_id: "env-1",
+            organization_id: "org-1",
+            compute_pool_id: "pool-1",
+          },
+          schema_registry: {
+            endpoint: "https://sr.example.com",
+            auth: { type: "api_key", key: "k", secret: "s" },
+          },
+          confluent_cloud: {
+            endpoint: "https://api.confluent.cloud",
+            auth: { type: "api_key", key: "k", secret: "s" },
+          },
+          tableflow: { auth: { type: "api_key", key: "k", secret: "s" } },
+          telemetry: {
+            endpoint: "https://telemetry.example.com",
+            auth: { type: "api_key", key: "k", secret: "s" },
+          },
+        },
+        DEFAULT_CONNECTION_ID,
+        clientManager,
+      );
+    }
+
+    /**
+     * Wires every client getter on a fresh `Mocked<DefaultClientManager>` to a
+     * recursive Proxy: any property access or call on the returned client resolves
+     * to another instance of the same Proxy, so handler bodies never throw a
+     * TypeError before they reach real logic. A TypeError that escapes is therefore
+     * a genuine wiring failure — exactly what the smoke tests check for.
+     *
+     * Returns `{ clientManager, clientGetters }`. `clientGetters` is the canonical
+     * list of all getter mocks; callers use it to assert that at least one was
+     * invoked when a handler resolves successfully.
+     */
+    function stubClientGetters() {
+      const proxy = new Proxy(() => Promise.resolve(proxy), {
+        get: (_t, prop) => {
+          if (prop === "then") return undefined;
+          return () => Promise.resolve(proxy);
+        },
+        apply: () => Promise.resolve(proxy),
+      });
+      const clientManager = createMockInstance(DefaultClientManager);
+      clientManager.getAdminClient.mockResolvedValue(proxy as never);
+      clientManager.getProducer.mockResolvedValue(proxy as never);
+      clientManager.getConsumer.mockResolvedValue(proxy as never);
+      clientManager.getConfluentCloudFlinkRestClient.mockReturnValue(
+        proxy as never,
+      );
+      clientManager.getConfluentCloudRestClient.mockReturnValue(proxy as never);
+      clientManager.getConfluentCloudTableflowRestClient.mockReturnValue(
+        proxy as never,
+      );
+      clientManager.getConfluentCloudSchemaRegistryRestClient.mockReturnValue(
+        proxy as never,
+      );
+      clientManager.getConfluentCloudKafkaRestClient.mockReturnValue(
+        proxy as never,
+      );
+      clientManager.getConfluentCloudTelemetryRestClient.mockReturnValue(
+        proxy as never,
+      );
+      clientManager.getSchemaRegistryClient.mockReturnValue(proxy as never);
+      const clientGetters = [
+        clientManager.getAdminClient,
+        clientManager.getProducer,
+        clientManager.getConsumer,
+        clientManager.getConfluentCloudFlinkRestClient,
+        clientManager.getConfluentCloudRestClient,
+        clientManager.getConfluentCloudTableflowRestClient,
+        clientManager.getConfluentCloudSchemaRegistryRestClient,
+        clientManager.getConfluentCloudKafkaRestClient,
+        clientManager.getConfluentCloudTelemetryRestClient,
+        clientManager.getSchemaRegistryClient,
+      ];
+      return { clientManager, clientGetters };
+    }
+
+    /** Handler resolves: response text contains `resolves`. */
+    type Resolves = { resolves: string };
+    /** Handler throws: "ZodError" or error message contains `throws`. */
+    type Throws = { throws: string };
+    type ZeroArgOutcome = Resolves | Throws;
+
+    /**
+     * What each handler produces when called with no arguments against a
+     * fully-wired universal client. Use `{ resolves }` when the handler
+     * completes and `{ throws }` when it raises before returning.
+     */
+    const ZERO_ARG_OUTCOMES: Record<ToolName, ZeroArgOutcome> = {
+      // Kafka
+      [ToolName.LIST_TOPICS]: { resolves: "Kafka topics:" },
+      [ToolName.CREATE_TOPICS]: { throws: "ZodError" },
+      [ToolName.DELETE_TOPICS]: { throws: "ZodError" },
+      [ToolName.PRODUCE_MESSAGE]: { throws: "ZodError" },
+      [ToolName.CONSUME_MESSAGES]: { throws: "ZodError" },
+      [ToolName.ALTER_TOPIC_CONFIG]: { throws: "ZodError" },
+      [ToolName.GET_TOPIC_CONFIG]: { throws: "ZodError" },
+      // Schema Registry
+      [ToolName.LIST_SCHEMAS]: { resolves: "Failed to list schemas" },
+      [ToolName.DELETE_SCHEMA]: { throws: "ZodError" },
+      // Flink
+      [ToolName.LIST_FLINK_STATEMENTS]: {
+        throws: "Organization ID is required",
+      },
+      [ToolName.CREATE_FLINK_STATEMENT]: { throws: "ZodError" },
+      [ToolName.READ_FLINK_STATEMENT]: { throws: "ZodError" },
+      [ToolName.DELETE_FLINK_STATEMENTS]: { throws: "ZodError" },
+      [ToolName.GET_FLINK_STATEMENT_EXCEPTIONS]: { throws: "ZodError" },
+      [ToolName.CHECK_FLINK_STATEMENT_HEALTH]: { throws: "ZodError" },
+      [ToolName.DETECT_FLINK_STATEMENT_ISSUES]: { throws: "ZodError" },
+      [ToolName.GET_FLINK_STATEMENT_PROFILE]: { throws: "ZodError" },
+      [ToolName.LIST_FLINK_CATALOGS]: { throws: "Organization ID is required" },
+      [ToolName.LIST_FLINK_DATABASES]: {
+        throws: "Organization ID is required",
+      },
+      [ToolName.LIST_FLINK_TABLES]: { throws: "Organization ID is required" },
+      [ToolName.DESCRIBE_FLINK_TABLE]: { throws: "ZodError" },
+      [ToolName.GET_FLINK_TABLE_INFO]: { throws: "ZodError" },
+      // Connect
+      [ToolName.LIST_CONNECTORS]: { throws: "Environment ID is required" },
+      [ToolName.READ_CONNECTOR]: { throws: "ZodError" },
+      [ToolName.CREATE_CONNECTOR]: { throws: "ZodError" },
+      [ToolName.DELETE_CONNECTOR]: { throws: "ZodError" },
+      // Catalog
+      [ToolName.CREATE_TOPIC_TAGS]: { throws: "ZodError" },
+      [ToolName.DELETE_TAG]: { throws: "ZodError" },
+      [ToolName.REMOVE_TAG_FROM_ENTITY]: { throws: "ZodError" },
+      [ToolName.ADD_TAGS_TO_TOPIC]: { throws: "ZodError" },
+      [ToolName.LIST_TAGS]: { resolves: "Failed to list tags" },
+      // Search
+      [ToolName.SEARCH_TOPICS_BY_TAG]: {
+        resolves: "Failed to search for topics by tag",
+      },
+      [ToolName.SEARCH_TOPICS_BY_NAME]: { throws: "ZodError" },
+      // Environments
+      [ToolName.LIST_ENVIRONMENTS]: {
+        resolves: "Failed to fetch environments",
+      },
+      [ToolName.READ_ENVIRONMENT]: { throws: "ZodError" },
+      // Clusters
+      [ToolName.LIST_CLUSTERS]: { resolves: "Failed to fetch clusters" },
+      // Tableflow
+      [ToolName.CREATE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
+      [ToolName.LIST_TABLEFLOW_REGIONS]: {
+        resolves: "Failed to list Tableflow regions",
+      },
+      [ToolName.LIST_TABLEFLOW_TOPICS]: {
+        throws: "Environment ID is required",
+      },
+      [ToolName.READ_TABLEFLOW_TOPIC]: { throws: "ZodError" },
+      [ToolName.UPDATE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
+      [ToolName.DELETE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
+      [ToolName.CREATE_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
+      [ToolName.LIST_TABLEFLOW_CATALOG_INTEGRATIONS]: {
+        throws: "Environment ID is required",
+      },
+      [ToolName.READ_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
+      [ToolName.UPDATE_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
+      [ToolName.DELETE_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
+      // Billing
+      [ToolName.LIST_BILLING_COSTS]: { throws: "ZodError" },
+      // Metrics
+      [ToolName.QUERY_METRICS]: { throws: "ZodError" },
+      [ToolName.LIST_METRICS]: { resolves: "No metrics descriptors available" },
+    };
+
+    beforeAll(() => {
+      initEnv();
+    });
+
+    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, ZeroArgOutcome][])(
+      "%s: handle() should not crash before reaching the ClientManager",
+      async (name, outcome) => {
+        const { clientManager, clientGetters } = stubClientGetters();
+
+        const runtime = allServicesRuntime(clientManager);
+
+        const handler = ToolHandlerRegistry.getToolHandler(name);
+
+        // Precondition: { resolves } must carry a real substring, not ""
+        if ("resolves" in outcome) {
+          expect(
+            outcome.resolves,
+            `${name}: resolves must be a non-empty substring, not ""`,
+          ).not.toBe("");
+        }
+
+        let result: Awaited<ReturnType<typeof handler.handle>> | undefined;
+        let thrown: unknown;
+        try {
+          result = await handler.handle(runtime, {}, undefined);
+        } catch (err) {
+          thrown = err;
+        }
+
+        if (thrown === undefined) {
+          // Outcome table must declare { resolves }, not { throws }
+          expect(
+            "resolves" in outcome,
+            `${name}: resolved successfully but outcome specifies { throws }`,
+          ).toBe(true);
+
+          // Response text must contain the declared substring
+          const { resolves } = outcome as Resolves;
+          const responseText = result!.content
+            .map((c) => ("text" in c ? c.text : ""))
+            .join("");
+          expect(
+            responseText,
+            `${name}: response text does not contain expected substring`,
+          ).toContain(resolves);
+
+          // At least one client getter must have been called
+          expect(
+            clientGetters.some((m) => m.mock.calls.length > 0),
+            `${name}: resolved without error but no client getter was called`,
+          ).toBe(true);
+        } else {
+          // We expect specific error/message to have been thrown.
+          // Outcome table must declare { throws }, not { resolves }
+          expect(
+            "throws" in outcome,
+            `${name}: handler threw but outcome specifies { resolves }`,
+          ).toBe(true);
+
+          // Classify the thrown value into a comparable string
+          let actual: string;
+          if (thrown instanceof ZodError) {
+            // We don't care about which exact ZodError it is, because
+            // that's determined by the ordering of zod refinements in the handler, which is an
+            // internal detail.
+            actual = "ZodError";
+          } else if (thrown instanceof Error) {
+            actual = thrown.message;
+          } else {
+            throw new Error(
+              `Wacky -- ${name}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
+            );
+          }
+
+          expect(
+            actual,
+            `${name}: unexpected error — update ZERO_ARG_OUTCOMES table with actual`,
+          ).toContain((outcome as Throws).throws);
+        }
+      },
+    );
   });
 });

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -182,15 +182,9 @@ describe("tool-registry.ts", () => {
 
     /**
      * Wires every client getter on a fresh `Mocked<DefaultClientManager>` to a
-     * two-proxy pair. `callableProxy` (function target) absorbs any method chain
-     * or call without throwing; every call resolves to `responseProxy`.
-     * `responseProxy` (plain-object target) models the `{ data, error }` shape
-     * returned by openapi-fetch: `error` is `undefined`, and `data` returns
-     * `responseData` — supply a minimal valid shape to push a handler past schema
-     * validation into its real success branch (defaults to `{}`).
-     *
-     * A TypeError that escapes the proxy pair is therefore a genuine wiring
-     * failure — exactly what the smoke tests check for.
+     * two-proxy pair so handler bodies never throw a TypeError before reaching
+     * real logic. Supply `responseData` to push a specific handler past schema
+     * validation into its success branch (defaults to `{}`).
      *
      * Returns `{ clientManager, clientGetters }`. `clientGetters` is the canonical
      * list of all getter mocks; callers use it to assert that at least one was
@@ -199,9 +193,7 @@ describe("tool-registry.ts", () => {
     function stubClientGetters(responseData: unknown = {}) {
       // Two-proxy setup: callableProxy (function target) handles method chains
       // and calls; responseProxy (plain-object target) is what async calls
-      // resolve to, giving { data, error } destructuring a real object for `data`.
-      // responseData is returned for the `data` property — callers can supply a
-      // minimal valid shape to push a handler past validation into its success path.
+      // resolve to.
       let responseProxy: object = {};
       const callableProxy = new Proxy((() => {}) as () => Promise<object>, {
         get: (_t, prop) => {
@@ -211,9 +203,18 @@ describe("tool-registry.ts", () => {
         apply: () => Promise.resolve(responseProxy),
       });
       responseProxy = new Proxy({} as object, {
+        // Four properties are special-cased:
+        //   `then`            → undefined  (prevents JS treating this as a thenable)
+        //   `error`           → undefined  (openapi-fetch "success" signal)
+        //   `data`            → responseData  (caller-supplied; defaults to {})
+        //   Symbol.iterator   → empty-array iterator (handlers that iterate the
+        //                       resolved value directly get an empty loop, not a
+        //                       TypeError)
         get: (_t, prop) => {
           if (prop === "then" || prop === "error") return undefined;
           if (prop === "data") return responseData;
+          if (prop === Symbol.iterator)
+            return Array.prototype[Symbol.iterator].bind([]);
           return callableProxy;
         },
       });
@@ -304,7 +305,7 @@ describe("tool-registry.ts", () => {
       [ToolName.ALTER_TOPIC_CONFIG]: { throws: "ZodError" },
       [ToolName.GET_TOPIC_CONFIG]: { throws: "ZodError" },
       // Schema Registry
-      [ToolName.LIST_SCHEMAS]: { resolves: "Failed to list schemas" },
+      [ToolName.LIST_SCHEMAS]: { resolves: "{}" },
       [ToolName.DELETE_SCHEMA]: { throws: "ZodError" },
       // Flink
       [ToolName.LIST_FLINK_STATEMENTS]: {
@@ -340,7 +341,12 @@ describe("tool-registry.ts", () => {
       [ToolName.SEARCH_TOPICS_BY_NAME]: { throws: "ZodError" },
       // Environments
       [ToolName.LIST_ENVIRONMENTS]: {
-        resolves: "Invalid environment list data",
+        responseData: {
+          api_version: "org/v2",
+          kind: "EnvironmentList",
+          data: [],
+        },
+        resolves: "Successfully retrieved 0 environments",
       },
       [ToolName.READ_ENVIRONMENT]: { throws: "ZodError" },
       // Clusters

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,11 +196,7 @@ async function main() {
           const sessionId = context?.sessionId;
           const startTime = Date.now();
           try {
-            const result = await handler.handle(
-              runtime.clientManager,
-              args,
-              sessionId,
-            );
+            const result = await handler.handle(runtime, args, sessionId);
             TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
               toolName: name,
               durationMs: Date.now() - startTime,

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,7 +1,6 @@
-import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { runtimeWith } from "@tests/factories/runtime.js";
 import { createTestServer, TestServerContext } from "@tests/server.js";
-import { createMockInstance } from "@tests/stubs/index.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
@@ -14,7 +13,7 @@ describe("MCP server", () => {
 
   beforeEach(async () => {
     // registers all tools by default
-    ctx = await createTestServer(createMockInstance(DefaultClientManager));
+    ctx = await createTestServer(runtimeWith());
   });
 
   afterEach(() => ctx.shutdown());

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -3,6 +3,7 @@ import { MCPServerConfiguration } from "@src/config/models.js";
 import { DefaultClientManager } from "@src/confluent/client-manager.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
+import type { Mocked } from "vitest";
 
 /** Connection ID used by the named runtime factories and their default single-connection runtimes. */
 export const DEFAULT_CONNECTION_ID = "default";
@@ -16,12 +17,15 @@ export const DEFAULT_CONNECTION_ID = "default";
 export function runtimeWith(
   connectionConfig: Omit<DirectConnectionConfig, "type"> = {},
   connectionId = DEFAULT_CONNECTION_ID,
+  clientManager: Mocked<DefaultClientManager> = createMockInstance(
+    DefaultClientManager,
+  ),
 ): ServerRuntime {
   return new ServerRuntime(
     new MCPServerConfiguration({
       connections: { [connectionId]: { type: "direct", ...connectionConfig } },
     }),
-    { [connectionId]: createMockInstance(DefaultClientManager) },
+    { [connectionId]: clientManager },
   );
 }
 

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -1,10 +1,10 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ClientManager } from "@src/confluent/client-manager.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 
 export interface TestServerContext {
   server: McpServer;
@@ -19,13 +19,12 @@ export interface TestServerContext {
  * Spins up an {@link McpServer} and {@link Client} connected via
  * {@link InMemoryTransport} for protocol-level integration tests.
  *
- * @param clientManager - (Stubbed) {@link ClientManager} injected into every
- *   tool handler
+ * @param runtime - {@link ServerRuntime} injected into every tool handler
  * @param toolNames - (Optional) Subset of tools to register (defaults to all
  *   {@link ToolName} values)
  */
 export async function createTestServer(
-  clientManager: ClientManager,
+  runtime: ServerRuntime,
   toolNames?: ToolName[],
 ): Promise<TestServerContext> {
   // ensure the env proxy is initialized so Zod .default() callbacks
@@ -45,7 +44,7 @@ export async function createTestServer(
       toolName as string,
       { description: config.description, inputSchema: config.inputSchema },
       async (args, context) => {
-        return await handler.handle(clientManager, args, context?.sessionId);
+        return await handler.handle(runtime, args, context?.sessionId);
       },
     );
   }

--- a/tests/stubs/stub-handler.ts
+++ b/tests/stubs/stub-handler.ts
@@ -1,4 +1,3 @@
-import type { ClientManager } from "@src/confluent/client-manager.js";
 import type { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -32,7 +31,7 @@ export class StubHandler extends BaseToolHandler {
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
   handle(
-    _clientManager: ClientManager,
+    _runtime: ServerRuntime,
     _toolArguments: Record<string, unknown> | undefined,
     _sessionId?: string,
   ): CallToolResult {


### PR DESCRIPTION
## Summary of Changes

Widen the contract between the MCP server and its tool handlers: `handle()` now receives the full `ServerRuntime` instead of a single `ClientManager`. This is a prerequisite for two upcoming capabilities:

- **Multi-connection support** — when multiple connections are configured, tools will gain an explicit invocation parameter indicating which connection to operate against; `runtime` gives handlers access to the full connection map needed to resolve that parameter to a client.
- **OAuth / Confluent Cloud unified connection** — a single CCloud-via-OAuth connection provides access to every resource the user owns across services. This will likely require a different client abstraction than `ClientManager`; having `runtime` in the signature gives handlers a place to receive it without another interface change.

The `const clientManager = runtime.clientManager;` shim construct in each handler preserves all existing handler bodies unchanged. It is the seam that will be removed as multi-connection and OAuth routing are implemented in follow-on tickets.

## Changes by file category

  1. **`src/confluent/tools/base-tools.ts`** — `ToolHandler` interface and `BaseToolHandler` abstract class: `handle(clientManager, ...)` → `handle(runtime, ...)`.

  2. **`src/index.ts`** — single call site updated to pass `runtime` instead of `runtime.clientManager`.


  3. **`tests/factories/runtime.ts`** — `runtimeWith()` gains an optional third argument to inject a pre-configured `Mocked<DefaultClientManager>`, so handler tests that call `handle()` directly can still control the mock client without constructing a full runtime from scratch.

  4. **`tests/server.ts` + `src/mcp/server.test.ts`** — in-process MCP test harness updated to pass a `ServerRuntime` rather than a bare `ClientManager`.

  5. **`tests/stubs/stub-handler.ts`** — `StubHandler.handle()` signature updated to match the new interface.

  6. **`.claude/rules/unit-tests.md`** — handler test pattern documentation updated to show the `runtimeWith(..., clientManager)` call shape.

  7. **50 concrete handler classes** (`handlers/billing`, `catalog`, `clusters`, `connect`, `environments`, `flink/**`, `kafka`, `metrics`, `schema`, `search`, `tableflow/**`) — purely mechanical: signature updated, `const clientManager = runtime.clientManager;` added as first body line. No logic changes.

## Smoke test suite

`tool-registry.test.ts` gains an exhaustive `handle()` smoke test that drives every registered handler with empty arguments against a fully-wired universal-proxy `ClientManager`, lifting overall line coverage from 37% to 50.19%. Each handler's expected outcome is declared in a `Partial<Record<ToolName, HandleSmokeCase>>` table — typed as a discriminated union of `{ resolves: string }` and `{ throws: string }` — with a parameterized completeness check that gives each missing tool its own failing test. Handler invocation is separated from assertions, and a precondition guard prevents empty-string `resolves` placeholders from masquerading as real assertions.

When a developer adds a new tool and forgets the table, a named test fails with the exact line to paste in (`[ToolName.FOO]: "TODO"`). Replacing the placeholder with `"TODO"` and re-running the tests drives the handler against the universal client and reports the correct entry to substitute — a "golden file"-style discovery workflow that guides the developer to a passing state without requiring them to read any documentation.

The universal client is a **two-proxy pair** rather than a single recursive proxy. `callableProxy` (function target) absorbs any method chain or call without throwing; every async call resolves to `responseProxy` (plain-object target), which models the `{ data, error }` shape returned by openapi-fetch: `error` is always `undefined` (i.e. "no API error"), and `data` returns the per-entry `responseData` value. This means handlers now advance past the `if (error)` guard and into their success-path code rather than immediately returning error messages. Two handlers — `list-clusters` and `list-available-metrics` — supply `{ data: [] }` as `responseData` and reach their genuine success branch with no error handling involved. The `responseData` field is optional and defaults to `{}`; remaining entries that stop at Zod validation or a guard check are left as-is for a future sitting.

> **Follow-on:** `stubClientGetters` and its two-proxy pair could be promoted out of the smoke-test `describe` block and into `tests/stubs/` or `tests/factories/`, where individual handler unit tests can import and reuse it. Supplying a realistic `responseData` shape eliminates the need to manually stub the full `pathBasedClient["/endpoint"].GET({params})` call chain in per-tool tests — replacing five lines of mock wiring with one.

---

_Miles to go before we sleep — significant design, planning, and implementation work remains before the single-connection shim construct can be removed from the handler bodies._


### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- No feature changes.
- Closes #229 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
