### PR TITLE
Add OAuthClientManager and wire into ServerRuntime

### DIFF
--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -1,0 +1,119 @@
+import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
+import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
+import { describe, expect, it, vi } from "vitest";
+
+function fakeOAuthHolder(): OAuthHolder {
+  return {
+    getControlPlaneToken: () => "cp-token",
+    getDataPlaneToken: () => "dp-token",
+  } as unknown as OAuthHolder;
+}
+
+describe("oauth-client-manager.ts", () => {
+  describe("OAuthClientManager", () => {
+    describe("constructor", () => {
+      it("should derive the cloud REST URL from the Auth0 env (devel)", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        expect(cm["confluentCloudBaseUrl"]).toBe(
+          "https://api.devel.cpdev.cloud",
+        );
+      });
+
+      it("should derive the cloud REST URL from the Auth0 env (stag)", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "stag");
+        expect(cm["confluentCloudBaseUrl"]).toBe(
+          "https://api.stag.cpdev.cloud",
+        );
+      });
+
+      it("should derive the cloud REST URL from the Auth0 env (prod)", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "prod");
+        expect(cm["confluentCloudBaseUrl"]).toBe("https://api.confluent.cloud");
+      });
+
+      it("should reuse the cloud URL for the Tableflow base URL", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "stag");
+        expect(cm["confluentCloudTableflowBaseUrl"]).toBe(
+          cm["confluentCloudBaseUrl"],
+        );
+      });
+
+      it("should leave data-plane endpoints undefined (filled in by a later layer)", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "stag");
+        expect(cm["confluentCloudFlinkBaseUrl"]).toBeUndefined();
+        expect(cm["confluentCloudSchemaRegistryBaseUrl"]).toBeUndefined();
+        expect(cm["confluentCloudKafkaRestBaseUrl"]).toBeUndefined();
+        expect(cm["confluentCloudTelemetryBaseUrl"]).toBeUndefined();
+      });
+
+      it("should eagerly materialize the cloud REST client at startup", () => {
+        const eagerSpy = vi.spyOn(
+          BaseClientManager.prototype,
+          "getConfluentCloudRestClient",
+        );
+        new OAuthClientManager(fakeOAuthHolder(), "stag");
+        expect(eagerSpy).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("getKafkaClient()", () => {
+      it("should throw the OAuth-specific error", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        expect(() => cm.getKafkaClient()).toThrow(
+          /Native Kafka client is not available under OAuth/,
+        );
+      });
+    });
+
+    describe("getAdminClient()", () => {
+      it("should reject with the OAuth-specific error", async () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        await expect(cm.getAdminClient()).rejects.toThrow(
+          /Native Kafka client is not available under OAuth/,
+        );
+      });
+    });
+
+    describe("getProducer()", () => {
+      it("should reject with the OAuth-specific error", async () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        await expect(cm.getProducer()).rejects.toThrow(
+          /Native Kafka client is not available under OAuth/,
+        );
+      });
+    });
+
+    describe("getConsumer()", () => {
+      it("should reject with the OAuth-specific error", async () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        await expect(cm.getConsumer()).rejects.toThrow(
+          /Native Kafka client is not available under OAuth/,
+        );
+      });
+    });
+
+    describe("getSchemaRegistryClient()", () => {
+      it("should throw an OAuth-specific error that points to the REST client", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        expect(() => cm.getSchemaRegistryClient()).toThrow(
+          /Schema Registry SDK client is not available under OAuth/,
+        );
+      });
+
+      it("should not surface the BaseClientManager api_key-only error message", () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        expect(() => cm.getSchemaRegistryClient()).not.toThrow(
+          /SCHEMA_REGISTRY_API_KEY/,
+        );
+      });
+    });
+
+    describe("disconnect()", () => {
+      it("should resolve without error (no native clients to clean up)", async () => {
+        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
+        await expect(cm.disconnect()).resolves.toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import { KafkaJS } from "@confluentinc/kafka-javascript";
+import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { type ClientManager } from "@src/confluent/client-manager.js";
 import { getCloudRestUrlForEnv } from "@src/confluent/oauth/auth0-config.js";
@@ -16,6 +17,10 @@ import type { Auth0Environment } from "@src/confluent/oauth/types.js";
 
 const NO_NATIVE_KAFKA_UNDER_OAUTH =
   "Native Kafka client is not available under OAuth authentication";
+
+const NO_SR_SDK_UNDER_OAUTH =
+  "Schema Registry SDK client is not available under OAuth authentication. " +
+  "Use the Schema Registry REST client (`getConfluentCloudSchemaRegistryRestClient`) instead.";
 
 /**
  * Bearer-auth client manager. Wires every REST surface to the OAuth holder's
@@ -75,6 +80,15 @@ export class OAuthClientManager
   /** @inheritdoc */
   async getConsumer(): Promise<KafkaJS.Consumer> {
     throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
+  }
+
+  /**
+   * Override the inherited SDK getter so the OAuth-specific error reaches callers
+   * — `BaseClientManager`'s default message tells users to set
+   * `SCHEMA_REGISTRY_API_KEY`/`SECRET`, which is misleading inside an OAuth flow.
+   */
+  override getSchemaRegistryClient(): SchemaRegistryClient {
+    throw new Error(NO_SR_SDK_UNDER_OAUTH);
   }
 
   /** @inheritdoc */

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview OAuth (bearer-auth) client manager. Wires Confluent Cloud REST
+ * surfaces to bearer tokens supplied by an {@link OAuthHolder}; the cloud REST
+ * URL is auto-derived from the Auth0 environment via {@link getCloudRestUrlForEnv}.
+ * No native Kafka client — those tools are gated off by the `hasKafka` predicate
+ * (the synthesized OAuth connection has no `kafka` block); the Kafka methods
+ * below throw defensively if they're ever reached.
+ */
+
+import { KafkaJS } from "@confluentinc/kafka-javascript";
+import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import { type ClientManager } from "@src/confluent/client-manager.js";
+import { getCloudRestUrlForEnv } from "@src/confluent/oauth/auth0-config.js";
+import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
+import type { Auth0Environment } from "@src/confluent/oauth/types.js";
+
+const NO_NATIVE_KAFKA_UNDER_OAUTH =
+  "Native Kafka client is not available under OAuth authentication";
+
+/**
+ * Bearer-auth client manager. Wires every REST surface to the OAuth holder's
+ * tokens — control plane (cloud / tableflow / telemetry) reads
+ * {@link OAuthHolder.getControlPlaneToken}; data plane (flink / schema-registry
+ * REST / kafka REST) reads {@link OAuthHolder.getDataPlaneToken}. Cloud REST URL
+ * is auto-derived from the Auth0 env; data-plane endpoints stay unset until T4
+ * introduces per-endpoint resolution, and their lazy clients throw at first
+ * access if a tool somehow gets enabled with one missing.
+ */
+export class OAuthClientManager
+  extends BaseClientManager
+  implements ClientManager
+{
+  constructor(holder: OAuthHolder, env: Auth0Environment) {
+    const cpToken = (): string | undefined => holder.getControlPlaneToken();
+    const dpToken = (): string | undefined => holder.getDataPlaneToken();
+    super({
+      endpoints: {
+        // BaseClientManager re-uses `cloud` for the Tableflow base URL too.
+        cloud: getCloudRestUrlForEnv(env),
+        flink: undefined,
+        schemaRegistry: undefined,
+        kafka: undefined,
+        telemetry: undefined,
+      },
+      auth: {
+        cloud: { type: "oauth", getToken: cpToken },
+        tableflow: { type: "oauth", getToken: cpToken },
+        telemetry: { type: "oauth", getToken: cpToken },
+        flink: { type: "oauth", getToken: dpToken },
+        schemaRegistry: { type: "oauth", getToken: dpToken },
+        kafka: { type: "oauth", getToken: dpToken },
+      },
+    });
+
+    // Eager construction: surface the cloud REST client at startup so a bad
+    // endpoint or middleware wiring fails fast rather than at first tool call.
+    this.getConfluentCloudRestClient();
+  }
+
+  /** @inheritdoc */
+  getKafkaClient(): KafkaJS.Kafka {
+    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
+  }
+
+  /** @inheritdoc */
+  async getAdminClient(): Promise<KafkaJS.Admin> {
+    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
+  }
+
+  /** @inheritdoc */
+  async getProducer(): Promise<KafkaJS.Producer> {
+    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
+  }
+
+  /** @inheritdoc */
+  async getConsumer(): Promise<KafkaJS.Consumer> {
+    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
+  }
+
+  /** @inheritdoc */
+  async disconnect(): Promise<void> {
+    // No native Kafka client to clean up; REST clients have no disconnect.
+  }
+}

--- a/src/confluent/oauth/auth0-config.test.ts
+++ b/src/confluent/oauth/auth0-config.test.ts
@@ -1,5 +1,6 @@
 import {
   getAuth0Config,
+  getCloudRestUrlForEnv,
   OAUTH_CALLBACK_PATH,
   OAUTH_CALLBACK_PORT,
 } from "@src/confluent/oauth/auth0-config.js";
@@ -43,6 +44,24 @@ describe("oauth/auth0-config.ts", () => {
 
       expect(new Set(callbacks).size).toBe(1);
       expect(callbacks[0]).toContain("127.0.0.1:26640");
+    });
+  });
+
+  describe("getCloudRestUrlForEnv", () => {
+    it("should return https://api.devel.cpdev.cloud for devel", () => {
+      expect(getCloudRestUrlForEnv("devel")).toBe(
+        "https://api.devel.cpdev.cloud",
+      );
+    });
+
+    it("should return https://api.stag.cpdev.cloud for stag", () => {
+      expect(getCloudRestUrlForEnv("stag")).toBe(
+        "https://api.stag.cpdev.cloud",
+      );
+    });
+
+    it("should return https://api.confluent.cloud for prod", () => {
+      expect(getCloudRestUrlForEnv("prod")).toBe("https://api.confluent.cloud");
     });
   });
 

--- a/src/confluent/oauth/auth0-config.ts
+++ b/src/confluent/oauth/auth0-config.ts
@@ -13,6 +13,7 @@ const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
     clientId: "D8DV9ee7XrKX4ncAc6vJtBFgIzTMNgoY",
     domain: "login.confluent-dev.io",
     apiUrl: "https://devel.cpdev.cloud",
+    cloudRestUrl: "https://api.devel.cpdev.cloud",
     callbackUrl: OAUTH_CALLBACK_URL,
     scopes: OAUTH_SCOPES,
   },
@@ -20,6 +21,7 @@ const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
     clientId: "adtjckxmHbjddhNK36PvcXIDDbrJUMDH",
     domain: "login-stag.confluent-dev.io",
     apiUrl: "https://stag.cpdev.cloud",
+    cloudRestUrl: "https://api.stag.cpdev.cloud",
     callbackUrl: OAUTH_CALLBACK_URL,
     scopes: OAUTH_SCOPES,
   },
@@ -27,6 +29,7 @@ const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
     clientId: "", // TBD: not yet registered in identity-login-static
     domain: "login.confluent.io",
     apiUrl: "https://confluent.cloud",
+    cloudRestUrl: "https://api.confluent.cloud",
     callbackUrl: OAUTH_CALLBACK_URL,
     scopes: OAUTH_SCOPES,
   },
@@ -34,4 +37,13 @@ const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
 
 export function getAuth0Config(environment: Auth0Environment): Auth0Config {
   return AUTH0_CONFIGS[environment];
+}
+
+/**
+ * Returns the Confluent Cloud REST API base URL for the given Auth0 environment.
+ * Used by {@link OAuthClientManager} to derive the cloud surface's base URL when
+ * the OAuth path doesn't carry an explicit `confluent_cloud.endpoint`.
+ */
+export function getCloudRestUrlForEnv(environment: Auth0Environment): string {
+  return AUTH0_CONFIGS[environment].cloudRestUrl;
 }

--- a/src/confluent/oauth/types.ts
+++ b/src/confluent/oauth/types.ts
@@ -4,6 +4,8 @@ export interface Auth0Config {
   clientId: string;
   domain: string;
   apiUrl: string;
+  /** Confluent Cloud REST API base URL for this environment (e.g. https://api.confluent.cloud for prod). */
+  cloudRestUrl: string;
   callbackUrl: string;
   scopes: string;
 }

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -4,10 +4,18 @@ import {
   constructDirectClientManager,
   DirectClientManager,
 } from "@src/confluent/direct-client-manager.js";
+import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
+
+function fakeOAuthHolder(): OAuthHolder {
+  return {
+    getControlPlaneToken: () => "cp-token",
+    getDataPlaneToken: () => "dp-token",
+  } as unknown as OAuthHolder;
+}
 
 function connWith(
   fields: Omit<DirectConnectionConfig, "type">,
@@ -234,7 +242,7 @@ describe("ServerRuntime", () => {
     });
 
     it("should call OAuthHolder.start and expose oauthHolder when the config has ccloud-oauth", () => {
-      const fakeHolder = {} as OAuthHolder;
+      const fakeHolder = fakeOAuthHolder();
       const startSpy = vi
         .spyOn(OAuthHolder, "start")
         .mockReturnValue(fakeHolder);
@@ -252,6 +260,24 @@ describe("ServerRuntime", () => {
 
       expect(startSpy).toHaveBeenCalledWith("devel");
       expect(runtime.oauthHolder).toBe(fakeHolder);
+    });
+
+    it("should construct OAuthClientManager instances for every connection when ccloud-oauth is set", () => {
+      vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
+      const oauthConfig = new MCPServerConfiguration({
+        connections: {
+          "env-connection": connWith({
+            kafka: { bootstrap_servers: "broker:9092" },
+          }),
+        },
+        ccloudOAuth: { type: "ccloud_oauth", env: "stag" },
+      });
+
+      const runtime = ServerRuntime.fromConfig(oauthConfig);
+
+      expect(runtime.clientManagers["env-connection"]).toBeInstanceOf(
+        OAuthClientManager,
+      );
     });
   });
 });

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,6 +1,7 @@
 import { MCPServerConfiguration } from "@src/config/index.js";
 import { type ClientManager } from "@src/confluent/client-manager.js";
 import { constructDirectClientManager } from "@src/confluent/direct-client-manager.js";
+import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 
 /**
@@ -58,10 +59,14 @@ export class ServerRuntime {
 
     // Construct a ClientManager for each connection in the config.
     // (although currently there will only be one, see `enforceSingleConnectionOnly()`)
+    // When OAuth is in play, every connection's manager is bearer-auth-backed by
+    // the shared holder; otherwise, fall back to the per-connection direct factory.
     const clientManagers = Object.fromEntries(
       Object.entries(config.connections).map(([id, conn]) => [
         id,
-        constructDirectClientManager(conn),
+        oauthHolder && ccloudOAuth
+          ? new OAuthClientManager(oauthHolder, ccloudOAuth.env)
+          : constructDirectClientManager(conn),
       ]),
     );
     return new ServerRuntime(config, clientManagers, oauthHolder);


### PR DESCRIPTION
## Summary of Changes

- Add `OAuthClientManager extends BaseClientManager implements ClientManager` (new file `src/confluent/oauth-client-manager.ts`). Wires every REST surface to bearer tokens supplied by the existing `OAuthHolder` — control-plane (cloud / tableflow / telemetry) reads `getControlPlaneToken()`; data-plane (flink / SR-REST / kafka-REST) reads `getDataPlaneToken()`. Cloud REST URL is auto-derived from the Auth0 environment via the new `getCloudRestUrlForEnv` helper. The constructor eagerly warms the cloud REST client so a bad endpoint or middleware wiring fails fast at startup rather than at first tool call.
  - Native Kafka methods (`getKafkaClient` / `getAdminClient` / `getProducer` / `getConsumer`) throw with an OAuth-specific error. They're gated off by the `hasKafka` predicate (the OAuth synth connection has no `kafka` block) so the throws are defensive.
  - `getSchemaRegistryClient()` is overridden to throw a clearer "use the REST client" message under OAuth, so callers don't get the inherited "configure SCHEMA_REGISTRY_API_KEY" message that's misleading in an OAuth flow.
- Wire `OAuthClientManager` into `ServerRuntime.fromConfig`: when an OAuth connection is detected (`config.getCCloudOAuth()` returns a value), every connection's manager is the bearer-auth-backed `OAuthClientManager` sharing the single holder; otherwise fall back to the per-connection direct factory.
- Extend `Auth0Config` with a `cloudRestUrl` field (devel/stag/prod). `getCloudRestUrlForEnv(env)` exported from `auth0-config.ts`.

### Tests

- New `src/confluent/oauth-client-manager.test.ts` — cloud REST URL derivation per env, Tableflow URL reuse, data-plane endpoints stay undefined, eager cloud-client materialization, native Kafka methods throw, SR SDK getter throws OAuth-specific error, `disconnect()` resolves cleanly.
- Extended `src/server-runtime.test.ts` — asserts `runtime.clientManagers[id]` is an `OAuthClientManager` when `ccloudOAuth` is configured.
- Extended `src/confluent/oauth/auth0-config.test.ts` — covers the new `getCloudRestUrlForEnv` helper across all three envs.

### Feature Branch Stack (bcscc/oauth-298-oauth-client-manager)

- #299
  - #301 **(this)**

Fixes #298

### Optional: Any additional details or context that should be provided?

- `list-billing-costs, list-clusters, list-environments, read-environment, list-connectors, read-connector, delete-connector` now all work when startup using `--oauth`

- **Known limitation, deferred**: when `--oauth --oauth-env=stag` is set together with env vars like `BOOTSTRAP_SERVERS` / `SCHEMA_REGISTRY_*` / `TELEMETRY_*`, those blocks land on the synthesized connection and predicates (`hasKafkaBootstrap`, `hasSchemaRegistry`, `hasTelemetry`) will enable tools whose runtime calls then fail (native Kafka throws, SR SDK throws OAuth-specific error). The fundamental ambiguity (auth source vs. block presence) is what the connection-shape migration resolves — out of scope here.
- **Telemetry endpoint stays unset under OAuth**, intentionally: predicate gating prevents telemetry tools from being enabled under OAuth (no `telemetry` block in the synth connection). Once a future layer lets users supply a telemetry endpoint via YAML for OAuth connections, it'll flow through naturally.
- Four pre-existing observations Copilot raised on this PR were tracked back to behavior that pre-dates the refactor (Lazy.get() not caching, Tableflow URL hardwired, `extra_properties` precedence, `as any` cast on `kafkaJS` config). Those are worth a follow-up cleanup ticket but kept out of this PR to maintain bit-identical direct-connection behavior and keep #298 narrowly focused on OAuth wiring.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing