### PR TITLE
Extract reusable handle() test infrastructure; add two POC focused handler suites

### DIFF
--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
@@ -1,0 +1,101 @@
+import { GetFlinkExceptionsHandler } from "@src/confluent/tools/handlers/flink/get-flink-exceptions-handler.js";
+import { initEnv } from "@src/env.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  stubClientGetters,
+  type HandleCase,
+} from "@tests/stubs/index.js";
+import { beforeAll, describe, it } from "vitest";
+
+const FLINK_CONN = {
+  flink: {
+    endpoint: "https://flink.example.com",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+    environment_id: "env-from-config",
+    organization_id: "org-from-config",
+    compute_pool_id: "lfcp-from-config",
+  },
+};
+
+const EXPLICIT_IDS = {
+  organizationId: "org-from-args",
+  environmentId: "env-from-args",
+};
+
+const STATEMENT_NAME = "my-statement";
+
+describe("get-flink-exceptions-handler.ts", () => {
+  describe("GetFlinkExceptionsHandler", () => {
+    const handler = new GetFlinkExceptionsHandler();
+
+    // Required while the handler reads env vars via getEnsuredParam.
+    // Remove after issue #231 migrates those reads to conn.flink config fields.
+    beforeAll(() => {
+      initEnv();
+    });
+
+    describe("handle()", () => {
+      const cases: HandleCase[] = [
+        {
+          label: "throws when statementName is absent",
+          args: {},
+          outcome: { throws: "ZodError" },
+        },
+        {
+          label: "throws when organizationId is absent and not in env",
+          args: { statementName: STATEMENT_NAME },
+          outcome: { throws: "Organization ID is required" },
+        },
+        {
+          label: "throws when environmentId is absent and not in env",
+          args: {
+            statementName: STATEMENT_NAME,
+            organizationId: "org-from-args",
+          },
+          outcome: { throws: "Environment ID is required" },
+        },
+        {
+          label: "resolves with no-exceptions message when data is empty",
+          args: { statementName: STATEMENT_NAME, ...EXPLICIT_IDS },
+          responseData: { data: [] },
+          outcome: {
+            resolves: `No exceptions found for statement '${STATEMENT_NAME}'.`,
+          },
+        },
+        {
+          label: "resolves with exception list when exceptions are present",
+          args: { statementName: STATEMENT_NAME, ...EXPLICIT_IDS },
+          responseData: {
+            data: [{ message: "OOM error" }, { message: "Timeout" }],
+          },
+          outcome: {
+            resolves: `Flink Statement Exceptions for '${STATEMENT_NAME}'`,
+          },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({ args, outcome, responseData }) => {
+          const { clientManager, clientGetters } =
+            stubClientGetters(responseData);
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              FLINK_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+        },
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
@@ -1,0 +1,99 @@
+import { ListFlinkStatementsHandler } from "@src/confluent/tools/handlers/flink/list-flink-statements-handler.js";
+import { initEnv } from "@src/env.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  stubClientGetters,
+  type HandleCase,
+} from "@tests/stubs/index.js";
+import { beforeAll, describe, it } from "vitest";
+
+const FLINK_CONN = {
+  flink: {
+    endpoint: "https://flink.example.com",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+    environment_id: "env-from-config",
+    organization_id: "org-from-config",
+    compute_pool_id: "lfcp-from-config",
+  },
+};
+
+const EXPLICIT_IDS = {
+  organizationId: "org-from-args",
+  environmentId: "env-from-args",
+};
+
+describe("list-flink-statements-handler.ts", () => {
+  describe("ListFlinkStatementsHandler", () => {
+    const handler = new ListFlinkStatementsHandler();
+
+    // Required while the handler reads env vars via getEnsuredParam/Zod defaults.
+    // Remove after issue #231 migrates those reads to conn.flink config fields.
+    beforeAll(() => {
+      initEnv();
+    });
+
+    describe("handle()", () => {
+      const cases: HandleCase[] = [
+        {
+          label: "throws when organizationId is absent and not in env",
+          args: {},
+          outcome: { throws: "Organization ID is required" },
+        },
+        {
+          label: "resolves when required IDs are supplied as explicit args",
+          args: EXPLICIT_IDS,
+          outcome: { resolves: "{}" },
+        },
+        {
+          label: "filters statements client-side by statusPhase",
+          args: {
+            ...EXPLICIT_IDS,
+            statusPhase: "RUNNING",
+          },
+          responseData: {
+            data: [
+              { status: { phase: "RUNNING" } },
+              { status: { phase: "FAILED" } },
+            ],
+          },
+          outcome: { resolves: "Found 1 statement(s) with status 'RUNNING'" },
+        },
+        {
+          label:
+            "reports zero results when no statements match the statusPhase filter",
+          args: {
+            ...EXPLICIT_IDS,
+            statusPhase: "RUNNING",
+          },
+          responseData: {
+            data: [{ status: { phase: "FAILED" } }],
+          },
+          outcome: { resolves: "Found 0 statement(s) with status 'RUNNING'" },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({ args, outcome, responseData }) => {
+          const { clientManager, clientGetters } =
+            stubClientGetters(responseData);
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              FLINK_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+        },
+      );
+    });
+  });
+});

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -11,9 +11,12 @@ import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { createMockInstance } from "@tests/stubs/index.js";
-import { type Mocked, beforeAll, describe, expect, it } from "vitest";
-import { ZodError } from "zod";
+import {
+  assertHandleCase,
+  stubClientGetters,
+  type HandleOutcome,
+} from "@tests/stubs/index.js";
+import { beforeAll, describe, expect, it, type Mocked } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
 
@@ -171,121 +174,6 @@ describe("tool-registry.ts", () => {
       );
     }
 
-    /** Classifies a thrown value into the string used for matching in ZERO_ARG_OUTCOMES. */
-    function classifyThrown(name: string, thrown: unknown): string {
-      if (thrown instanceof ZodError) return "ZodError";
-      if (thrown instanceof Error) return thrown.message;
-      throw new Error(
-        `Wacky -- ${name}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
-      );
-    }
-
-    /**
-     * Wires every client getter on a fresh `Mocked<DefaultClientManager>` to a
-     * two-proxy pair so handler bodies never throw a TypeError before reaching
-     * real logic. Supply `responseData` to push a specific handler past schema
-     * validation into its success branch (defaults to `{}`).
-     *
-     * Returns `{ clientManager, clientGetters }`. `clientGetters` is the canonical
-     * list of all getter mocks; callers use it to assert that at least one was
-     * invoked when a handler resolves successfully.
-     *
-     * (No explicit return type: `clientGetters` is a heterogeneous array of mock
-     * method references whose element type is too verbose to write by hand — inference
-     * is clearer here than annotation would be.)
-     */
-    function stubClientGetters(responseData: unknown = {}) {
-      // Two-proxy setup: callableProxy (function target) handles method chains
-      // and calls; responseProxy (plain-object target) is what async calls
-      // resolve to.
-      let responseProxy: object = {};
-      const callableProxy = new Proxy((() => {}) as () => Promise<object>, {
-        get: (_t, prop) => {
-          if (prop === "then" || prop === "error") return undefined;
-          return callableProxy;
-        },
-        apply: () => Promise.resolve(responseProxy),
-      });
-      responseProxy = new Proxy({} as object, {
-        // Four properties are special-cased:
-        //   `then`            → undefined  (prevents JS treating this as a thenable)
-        //   `error`           → undefined  (openapi-fetch "success" signal)
-        //   `data`            → responseData  (caller-supplied; defaults to {})
-        //   Symbol.iterator   → empty-array iterator (handlers that iterate the
-        //                       resolved value directly get an empty loop, not a
-        //                       TypeError)
-        get: (_t, prop) => {
-          if (prop === "then" || prop === "error") return undefined;
-          if (prop === "data") return responseData;
-          if (prop === Symbol.iterator)
-            return Array.prototype[Symbol.iterator].bind([]);
-          return callableProxy;
-        },
-      });
-      const clientManager = createMockInstance(DefaultClientManager);
-      clientManager.getAdminClient.mockResolvedValue(callableProxy as never);
-      clientManager.getProducer.mockResolvedValue(callableProxy as never);
-      clientManager.getConsumer.mockResolvedValue(callableProxy as never);
-      clientManager.getConfluentCloudFlinkRestClient.mockReturnValue(
-        callableProxy as never,
-      );
-      clientManager.getConfluentCloudRestClient.mockReturnValue(
-        callableProxy as never,
-      );
-      clientManager.getConfluentCloudTableflowRestClient.mockReturnValue(
-        callableProxy as never,
-      );
-      clientManager.getConfluentCloudSchemaRegistryRestClient.mockReturnValue(
-        callableProxy as never,
-      );
-      clientManager.getConfluentCloudKafkaRestClient.mockReturnValue(
-        callableProxy as never,
-      );
-      clientManager.getConfluentCloudTelemetryRestClient.mockReturnValue(
-        callableProxy as never,
-      );
-      clientManager.getSchemaRegistryClient.mockReturnValue(
-        callableProxy as never,
-      );
-      const clientGetters = [
-        clientManager.getAdminClient,
-        clientManager.getProducer,
-        clientManager.getConsumer,
-        clientManager.getConfluentCloudFlinkRestClient,
-        clientManager.getConfluentCloudRestClient,
-        clientManager.getConfluentCloudTableflowRestClient,
-        clientManager.getConfluentCloudSchemaRegistryRestClient,
-        clientManager.getConfluentCloudKafkaRestClient,
-        clientManager.getConfluentCloudTelemetryRestClient,
-        clientManager.getSchemaRegistryClient,
-      ];
-      return { clientManager, clientGetters };
-    }
-
-    type Resolves = {
-      /** Minimal valid API response to feed into the proxy's `data` property.
-       *  Omit to use `{}` (sufficient when the handler just JSON-serialises the
-       *  response); supply `{ data: [] }` or a richer shape to push the handler
-       *  past schema validation into its real success branch. */
-      responseData?: unknown;
-      /** Substring that must appear in the resolved response text. */
-      resolves: string;
-    };
-    type Throws = {
-      /** Same as `Resolves.responseData` — set when the handler needs valid-ish
-       *  data before it reaches the code that throws. */
-      responseData?: unknown;
-      /** Substring that must appear in the thrown error message, or "ZodError"
-       *  to match any ZodError regardless of message. */
-      throws: string;
-    };
-    /** Complete smoke-test specification for one handler: what to feed in
-     *  (`responseData`) and what to expect out (`resolves` / `throws`).
-     *  The string sentinel value triggers a "golden file"-style discovery run:
-     *  the test executes the handler, reports the actual outcome, and asks you
-     *  to paste it in as the recorded expectation. */
-    type HandleSmokeCase = Resolves | Throws | "TODO";
-
     // Reverse map from enum value ("list-topics") → enum key ("LIST_TOPICS"),
     // used to generate helpful copy-paste suggestions in failure messages.
     const TOOL_NAME_TO_KEY = Object.fromEntries(
@@ -299,7 +187,7 @@ describe("tool-registry.ts", () => {
      * Use `"TODO"` as a placeholder — the smoke test will run the handler
      * and report the correct entry to paste in.
      */
-    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, HandleSmokeCase>> = {
+    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, HandleOutcome>> = {
       // Kafka
       [ToolName.LIST_TOPICS]: { resolves: "Kafka topics:" },
       [ToolName.CREATE_TOPICS]: { throws: "ZodError" },
@@ -400,7 +288,7 @@ describe("tool-registry.ts", () => {
       },
     );
 
-    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, HandleSmokeCase][])(
+    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, HandleOutcome][])(
       "%s: handle() should not crash before reaching the ClientManager",
       async (name, outcome) => {
         const responseData =
@@ -409,75 +297,14 @@ describe("tool-registry.ts", () => {
             : undefined;
         const { clientManager, clientGetters } =
           stubClientGetters(responseData);
-
-        const runtime = allServicesRuntime(clientManager);
-
-        const handler = ToolHandlerRegistry.getToolHandler(name);
-
-        // Precondition: { resolves } must carry a real substring, not ""
-        if (typeof outcome === "object" && "resolves" in outcome) {
-          expect(
-            outcome.resolves,
-            `${name}: resolves must be a non-empty substring, not ""`,
-          ).not.toBe("");
-        }
-
-        let result: Awaited<ReturnType<typeof handler.handle>> | undefined;
-        let thrown: unknown;
-        try {
-          result = await handler.handle(runtime, {}, undefined);
-        } catch (err) {
-          thrown = err;
-        }
-
-        // Placeholder sentinel: run completed — report what to replace it with
-        if (outcome === "TODO") {
-          const discovered =
-            thrown === undefined
-              ? `{ resolves: "${result!.content
-                  .map((c) => ("text" in c ? c.text : ""))
-                  .join("")
-                  .slice(0, 60)}" }`
-              : `{ throws: "${classifyThrown(name, thrown)}" }`;
-          throw new Error(
-            `${name}: outcome is TODO — replace with: ${discovered}`,
-          );
-        }
-
-        if (thrown === undefined) {
-          // Outcome table must declare { resolves }, not { throws }
-          expect(
-            typeof outcome === "object" && "resolves" in outcome,
-            `${name}: resolved successfully but outcome specifies { throws }`,
-          ).toBe(true);
-
-          // Response text must contain the declared substring
-          const { resolves } = outcome as Resolves;
-          const responseText = result!.content
-            .map((c) => ("text" in c ? c.text : ""))
-            .join("");
-          expect(
-            responseText,
-            `${name}: response text does not contain expected substring`,
-          ).toContain(resolves);
-
-          // At least one client getter must have been called
-          expect(
-            clientGetters.some((m) => m.mock.calls.length > 0),
-            `${name}: resolved without error but no client getter was called`,
-          ).toBe(true);
-        } else {
-          // Outcome table must declare { throws }, not { resolves }
-          expect(
-            typeof outcome === "object" && "throws" in outcome,
-            `${name}: handler threw but outcome specifies { resolves }`,
-          ).toBe(true);
-
-          expect(
-            classifyThrown(name, thrown),
-            `${name}: unexpected error — update ZERO_ARG_OUTCOMES table with actual`,
-          ).toContain((outcome as Throws).throws);
-        }
+        await assertHandleCase({
+          handler: ToolHandlerRegistry.getToolHandler(name),
+          runtime: allServicesRuntime(clientManager),
+          args: {},
+          outcome,
+          clientGetters,
+          name,
+        });
       },
     );
   });

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -192,13 +192,20 @@ export async function assertHandleCase(options: {
   }
 
   if (outcome === "TODO") {
-    const discovered =
-      thrown === undefined
-        ? `{ resolves: "${result!.content
-            .map((c) => ("text" in c ? c.text : ""))
-            .join("")
-            .slice(0, 60)}" }`
-        : `{ throws: "${classifyThrown(name, thrown)}" }`;
+    let discovered: string;
+    if (thrown !== undefined) {
+      discovered = `{ throws: ${JSON.stringify(classifyThrown(name, thrown))} }`;
+    } else if (result === undefined) {
+      throw new Error(
+        `Wacky -- ${name}: handle() returned undefined instead of a CallToolResult`,
+      );
+    } else {
+      const text = result.content
+        .map((c) => ("text" in c ? c.text : ""))
+        .join("")
+        .slice(0, 60);
+      discovered = `{ resolves: ${JSON.stringify(text)} }`;
+    }
     throw new Error(`${name}: outcome is TODO — replace with: ${discovered}`);
   }
 

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -1,0 +1,237 @@
+import { DefaultClientManager } from "@src/confluent/client-manager.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
+import { expect } from "vitest";
+import { ZodError } from "zod";
+import { createMockInstance } from "./mock-instance.js";
+
+export type Resolves = {
+  /** Minimal valid API response to feed into the proxy's `data` property.
+   *  Omit to use `{}` (sufficient when the handler just JSON-serialises the
+   *  response); supply `{ data: [] }` or a richer shape to push the handler
+   *  past guard checks into its real success branch. */
+  responseData?: unknown;
+  /** Substring that must appear in the resolved response text. */
+  resolves: string;
+};
+
+export type Throws = {
+  /** Same as `Resolves.responseData` — set when the handler needs valid-ish
+   *  data before it reaches the code that throws. */
+  responseData?: unknown;
+  /** Substring that must appear in the thrown error message, or "ZodError"
+   *  to match any ZodError regardless of message. */
+  throws: string;
+};
+
+/** Complete specification for one `handle()` invocation: what to feed in
+ *  (`responseData`) and what to expect out (`resolves` / `throws`).
+ *  The `"TODO"` sentinel triggers discovery mode: the test executes the
+ *  handler, reports the actual outcome, and asks you to paste it in as the
+ *  recorded expectation. */
+export type HandleOutcome = Resolves | Throws | "TODO";
+
+/** The array of client-getter mock functions returned by `stubClientGetters()`.
+ *  Each element is a Vitest mock whose `.mock.calls` records invocations. */
+export type ClientGetters = Array<{ mock: { calls: unknown[] } }>;
+
+/** One entry in an `it.each` handler test suite. Supply `responseData` to push
+ *  the handler past guard checks; omit to use the default `{}` response. */
+export type HandleCase = {
+  label: string;
+  args: Record<string, unknown>;
+  outcome: HandleOutcome;
+  responseData?: unknown;
+};
+
+/** Classifies a thrown value into the string used for matching in HandleOutcome. */
+export function classifyThrown(label: string, thrown: unknown): string {
+  if (thrown instanceof ZodError) return "ZodError";
+  if (thrown instanceof Error) return thrown.message;
+  throw new Error(
+    `Wacky -- ${label}: handler threw a non-Error value: ${JSON.stringify(thrown)}`,
+  );
+}
+
+/**
+ * Wires every client getter on a fresh `Mocked<DefaultClientManager>` to a
+ * two-proxy pair so handler bodies never throw a TypeError before reaching
+ * real logic. Supply `responseData` to push a specific handler past schema
+ * validation into its success branch (defaults to `{}`).
+ *
+ * Returns `{ clientManager, clientGetters }`. `clientGetters` is the
+ * canonical list of all getter mocks; pass it to `assertHandleCase` to
+ * assert that at least one was invoked when a handler resolves successfully.
+ */
+export function stubClientGetters(responseData: unknown = {}) {
+  // Two-proxy setup: callableProxy (function target) handles method chains
+  // and calls; responseProxy (plain-object target) is what async calls
+  // resolve to, modelling the { data, error } shape from openapi-fetch.
+  // Future refinement: accept responseData as an array to support sequential
+  // per-call responses (needed for multi-call handlers). The apply trap would
+  // become index-aware, constructing a fresh responseProxy per invocation.
+  let responseProxy: object = {};
+  const callableProxy = new Proxy((() => {}) as () => Promise<object>, {
+    get: (_t, prop) => {
+      if (prop === "then" || prop === "error") return undefined;
+      return callableProxy;
+    },
+    apply: () => Promise.resolve(responseProxy),
+  });
+  responseProxy = new Proxy({} as object, {
+    // Four properties are special-cased:
+    //   `then`          → undefined  (prevents JS treating this as a thenable)
+    //   `error`         → undefined  (openapi-fetch "success" signal)
+    //   `data`          → responseData  (caller-supplied; defaults to {})
+    //   Symbol.iterator → empty-array iterator (handlers that iterate the
+    //                     resolved value directly get an empty loop, not a TypeError)
+    get: (_t, prop) => {
+      if (prop === "then" || prop === "error") return undefined;
+      if (prop === "data") return responseData;
+      if (prop === Symbol.iterator)
+        return Array.prototype[Symbol.iterator].bind([]);
+      return callableProxy;
+    },
+  });
+
+  const clientManager = createMockInstance(DefaultClientManager);
+  clientManager.getAdminClient.mockResolvedValue(callableProxy as never);
+  clientManager.getProducer.mockResolvedValue(callableProxy as never);
+  clientManager.getConsumer.mockResolvedValue(callableProxy as never);
+  clientManager.getConfluentCloudFlinkRestClient.mockReturnValue(
+    callableProxy as never,
+  );
+  clientManager.getConfluentCloudRestClient.mockReturnValue(
+    callableProxy as never,
+  );
+  clientManager.getConfluentCloudTableflowRestClient.mockReturnValue(
+    callableProxy as never,
+  );
+  clientManager.getConfluentCloudSchemaRegistryRestClient.mockReturnValue(
+    callableProxy as never,
+  );
+  clientManager.getConfluentCloudKafkaRestClient.mockReturnValue(
+    callableProxy as never,
+  );
+  clientManager.getConfluentCloudTelemetryRestClient.mockReturnValue(
+    callableProxy as never,
+  );
+  clientManager.getSchemaRegistryClient.mockReturnValue(callableProxy as never);
+
+  const clientGetters = [
+    clientManager.getAdminClient,
+    clientManager.getProducer,
+    clientManager.getConsumer,
+    clientManager.getConfluentCloudFlinkRestClient,
+    clientManager.getConfluentCloudRestClient,
+    clientManager.getConfluentCloudTableflowRestClient,
+    clientManager.getConfluentCloudSchemaRegistryRestClient,
+    clientManager.getConfluentCloudKafkaRestClient,
+    clientManager.getConfluentCloudTelemetryRestClient,
+    clientManager.getSchemaRegistryClient,
+  ];
+
+  return { clientManager, clientGetters };
+}
+
+/**
+ * Runs `handler.handle(runtime, args)` and asserts the outcome matches the
+ * `HandleOutcome` specification. Designed for both per-handler unit tests
+ * and the global smoke suite.
+ *
+ * @param handler - The handler under test. Only `handle()` is required; pass
+ *   the full handler instance or any `Pick<BaseToolHandler, "handle">`.
+ * @param runtime - The `ServerRuntime` injected into `handle()`. Build it with
+ *   `runtimeWith(connectionConfig, connectionId, clientManager)` so the
+ *   connection shape and mock client are both under test control.
+ * @param args - Tool arguments forwarded to `handle()`. Defaults to `{}`.
+ *   Supply only the fields relevant to the case under test.
+ * @param outcome - What to expect: `{ resolves: substring }` asserts the
+ *   response text contains the substring; `{ throws: substring }` asserts the
+ *   thrown error message contains it (or `"ZodError"` for any `ZodError`);
+ *   the discovery sentinel runs the handler and fails with a copy-paste
+ *   suggestion for the correct entry (see `HandleOutcome`).
+ * @param clientGetters - When supplied, asserts that at least one getter was
+ *   called on a successful resolve, proving the handler reached the client
+ *   layer. Omit in cases that short-circuit before touching the client.
+ *   (Obtain from the `clientGetters` field returned by `stubClientGetters()`.)
+ * @param name - Label prepended to assertion failure messages and used in
+ *   discovery-sentinel output. Defaults to `"(handler)"`.
+ */
+export async function assertHandleCase(options: {
+  handler: Pick<BaseToolHandler, "handle">;
+  runtime: ServerRuntime;
+  args?: Record<string, unknown>;
+  outcome: HandleOutcome;
+  clientGetters?: ClientGetters;
+  name?: string;
+}): Promise<void> {
+  const {
+    handler,
+    runtime,
+    args = {},
+    outcome,
+    clientGetters,
+    name = "(handler)",
+  } = options;
+
+  if (typeof outcome === "object" && "resolves" in outcome) {
+    expect(
+      outcome.resolves,
+      `${name}: resolves must be a non-empty substring, not ""`,
+    ).not.toBe("");
+  }
+
+  let result: CallToolResult | undefined;
+  let thrown: unknown;
+  try {
+    result = await handler.handle(runtime, args, undefined);
+  } catch (err) {
+    thrown = err;
+  }
+
+  if (outcome === "TODO") {
+    const discovered =
+      thrown === undefined
+        ? `{ resolves: "${result!.content
+            .map((c) => ("text" in c ? c.text : ""))
+            .join("")
+            .slice(0, 60)}" }`
+        : `{ throws: "${classifyThrown(name, thrown)}" }`;
+    throw new Error(`${name}: outcome is TODO — replace with: ${discovered}`);
+  }
+
+  if (thrown === undefined) {
+    expect(
+      typeof outcome === "object" && "resolves" in outcome,
+      `${name}: resolved successfully but outcome specifies { throws }`,
+    ).toBe(true);
+
+    const { resolves } = outcome as Resolves;
+    const responseText = result!.content
+      .map((c) => ("text" in c ? c.text : ""))
+      .join("");
+    expect(
+      responseText,
+      `${name}: response text does not contain expected substring`,
+    ).toContain(resolves);
+
+    if (clientGetters) {
+      expect(
+        clientGetters.some((m) => m.mock.calls.length > 0),
+        `${name}: resolved without error but no client getter was called`,
+      ).toBe(true);
+    }
+  } else {
+    expect(
+      typeof outcome === "object" && "throws" in outcome,
+      `${name}: handler threw but outcome specifies { resolves }`,
+    ).toBe(true);
+
+    expect(
+      classifyThrown(name, thrown),
+      `${name}: unexpected error — update outcome with actual`,
+    ).toContain((outcome as Throws).throws);
+  }
+}

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -1,4 +1,14 @@
 export { createMockAdmin, type MockedAdmin } from "./admin.js";
+export {
+  assertHandleCase,
+  classifyThrown,
+  stubClientGetters,
+  type ClientGetters,
+  type HandleCase,
+  type HandleOutcome,
+  type Resolves,
+  type Throws,
+} from "./handler.js";
 export { createMockInstance } from "./mock-instance.js";
 export {
   createFsWrappers,


### PR DESCRIPTION

## Summary of Changes

**TL;DR:** Promotes the two-proxy handler stub machinery out of the smoke test and into `tests/stubs/`, adding typed harness utilities that reduce a per-handler `handle()` test suite to a single `HandleCase[]` array — no repeated assertion logic, no per-case boilerplate. Closes the follow-on noted in PR #295.

Two proof-of-concept `handle()` suites ship with this PR. `list-flink-statements-handler` reaches 88.9% statement and 83.3% branch coverage in 4 cases; `get-flink-exceptions-handler` reaches 85.7% statement coverage in 5 cases. Both suites are pure data tables — label, args, optional `responseData` shape, expected outcome — with zero structural variation between cases. The only lines left uncovered in each are the `if (error)` API-error branches, which the proxy cannot reach because it always resolves `error` as `undefined`; those branches will become testable once the sequential-response extension described in the Future section is implemented.

## Intent

The `tool-registry.test.ts` smoke suite introduced a universal two-proxy `ClientManager` stub and an assertion helper (`assertHandleCase`) that proved useful enough to live somewhere reusable. Without extraction, every focused handler test suite would re-implement the proxy pair, the thrown-vs-resolved discriminator, and the `it.each` wiring independently. Issue #231 and its siblings will touch ~15 Flink handlers; the per-handler cost of writing `handle()` coverage should be "declare a data table," not "copy infrastructure."

## Changes by file category

**`tests/stubs/handler.ts`** (new) — the extracted core. Contains the two-proxy pair (`callableProxy` + `responseProxy`) and all harness types and utilities:

- `stubClientGetters(responseData?)` — wires every `DefaultClientManager` getter mock to the proxy pair; returns `{ clientManager, clientGetters }` for injection into `runtimeWith()` and `assertHandleCase()` respectively
- `assertHandleCase(options)` — runs `handler.handle(runtime, args)` and asserts against a `HandleOutcome` discriminated union; the `"TODO"` sentinel drives a discovery workflow that reports the correct entry to paste in
- `HandleOutcome = Resolves | Throws | "TODO"` — the discriminated union specifying what a case expects
- `HandleCase` — the `it.each` row shape: `{ label, args, outcome, responseData? }`
- `ClientGetters`, `Resolves`, `Throws`, `classifyThrown` — supporting types and utilities

**`tests/stubs/index.ts`** — re-exports all new symbols alongside the existing `admin`, `mock-instance`, `node-deps`, and `stub-handler` exports.

**`src/confluent/tools/tool-registry.test.ts`** — the smoke suite's per-tool assertion loop collapses from ~100 lines to ~8 by consuming the shared utilities. `allServicesRuntime`, `ZERO_ARG_OUTCOMES`, and `TOOL_NAME_TO_KEY` remain local — they are smoke-suite concerns, not general infrastructure.

**`src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts`** (new) — four-case `handle()` suite covering the missing-org-ID guard, successful resolution with explicit args, client-side `statusPhase` filtering with a mixed-phase result set, and the zero-match filter case. The `responseData` field is shaped to push the handler past the API call and into its filtering logic rather than stopping at the guard layer.

**`src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts`** (new) — five-case suite covering Zod validation failure (absent `statementName`), the two sequential `getEnsuredParam` guard failures (org then env), the empty-exceptions success path, and the populated-exceptions success path.

Both new suites carry a `beforeAll(() => { initEnv(); })` with a comment noting it can be removed once issue #231 eliminates the Zod `.default(env.FLINK_*)` and `getEnsuredParam` env reads from the handlers.

## Future

`stubClientGetters` currently returns the same `responseData` for every API call, which is sufficient for handlers that make a single REST call or that are only being tested at the guard layer. Multi-call handlers (`check-health`, `detect-issues`, `read-flink-statement`, `query-profiler`) will eventually need per-call response sequencing. The planned extension: accept `responseData` as an array, making the `apply` trap index-aware and constructing a fresh `responseProxy` per invocation — backward-compatible, localized entirely inside `stubClientGetters`. A comment in the source flags the spot.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
