### PR TITLE
Type-separate OAuthClientManager from the native-Kafka contract

### DIFF
--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -57,58 +57,6 @@ describe("oauth-client-manager.ts", () => {
       });
     });
 
-    describe("getKafkaClient()", () => {
-      it("should throw the OAuth-specific error", () => {
-        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
-        expect(() => cm.getKafkaClient()).toThrow(
-          /Native Kafka client is not available under OAuth/,
-        );
-      });
-    });
-
-    describe("getAdminClient()", () => {
-      it("should reject with the OAuth-specific error", async () => {
-        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
-        await expect(cm.getAdminClient()).rejects.toThrow(
-          /Native Kafka client is not available under OAuth/,
-        );
-      });
-    });
-
-    describe("getProducer()", () => {
-      it("should reject with the OAuth-specific error", async () => {
-        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
-        await expect(cm.getProducer()).rejects.toThrow(
-          /Native Kafka client is not available under OAuth/,
-        );
-      });
-    });
-
-    describe("getConsumer()", () => {
-      it("should reject with the OAuth-specific error", async () => {
-        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
-        await expect(cm.getConsumer()).rejects.toThrow(
-          /Native Kafka client is not available under OAuth/,
-        );
-      });
-    });
-
-    describe("getSchemaRegistryClient()", () => {
-      it("should throw an OAuth-specific error that points to the REST client", () => {
-        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
-        expect(() => cm.getSchemaRegistryClient()).toThrow(
-          /Schema Registry SDK client is not available under OAuth/,
-        );
-      });
-
-      it("should not surface the BaseClientManager api_key-only error message", () => {
-        const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");
-        expect(() => cm.getSchemaRegistryClient()).not.toThrow(
-          /SCHEMA_REGISTRY_API_KEY/,
-        );
-      });
-    });
-
     describe("disconnect()", () => {
       it("should resolve without error (no native clients to clean up)", async () => {
         const cm = new OAuthClientManager(fakeOAuthHolder(), "devel");

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -2,25 +2,19 @@
  * @fileoverview OAuth (bearer-auth) client manager. Wires Confluent Cloud REST
  * surfaces to bearer tokens supplied by an {@link OAuthHolder}; the cloud REST
  * URL is auto-derived from the Auth0 environment via {@link getCloudRestUrlForEnv}.
- * No native Kafka client — those tools are gated off by the `hasKafka` predicate
- * (the synthesized OAuth connection has no `kafka` block); the Kafka methods
- * below throw defensively if they're ever reached.
+ *
+ * Inherits the abstract {@link BaseClientManager} and intentionally adds nothing
+ * native-Kafka-shaped: no broker client, no SASL, no `KafkaJS`/SR-SDK imports.
+ * Native-Kafka tools are gated to direct connections by their predicates and
+ * narrow the runtime's `BaseClientManager` to a `DirectClientManager` via
+ * {@link ServerRuntime.requireDirectClientManager}, so a missing-on-OAuth
+ * Kafka method is a compile-time error rather than a runtime throw.
  */
 
-import { KafkaJS } from "@confluentinc/kafka-javascript";
-import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { BaseClientManager } from "@src/confluent/base-client-manager.js";
-import { type ClientManager } from "@src/confluent/client-manager.js";
 import { getCloudRestUrlForEnv } from "@src/confluent/oauth/auth0-config.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import type { Auth0Environment } from "@src/confluent/oauth/types.js";
-
-const NO_NATIVE_KAFKA_UNDER_OAUTH =
-  "Native Kafka client is not available under OAuth authentication";
-
-const NO_SR_SDK_UNDER_OAUTH =
-  "Schema Registry SDK client is not available under OAuth authentication. " +
-  "Use the Schema Registry REST client (`getConfluentCloudSchemaRegistryRestClient`) instead.";
 
 /**
  * Bearer-auth client manager. Wires every REST surface to the OAuth holder's
@@ -31,10 +25,7 @@ const NO_SR_SDK_UNDER_OAUTH =
  * introduces per-endpoint resolution, and their lazy clients throw at first
  * access if a tool somehow gets enabled with one missing.
  */
-export class OAuthClientManager
-  extends BaseClientManager
-  implements ClientManager
-{
+export class OAuthClientManager extends BaseClientManager {
   constructor(holder: OAuthHolder, env: Auth0Environment) {
     const cpToken = (): string | undefined => holder.getControlPlaneToken();
     const dpToken = (): string | undefined => holder.getDataPlaneToken();
@@ -60,35 +51,6 @@ export class OAuthClientManager
     // Eager construction: surface the cloud REST client at startup so a bad
     // endpoint or middleware wiring fails fast rather than at first tool call.
     this.getConfluentCloudRestClient();
-  }
-
-  /** @inheritdoc */
-  getKafkaClient(): KafkaJS.Kafka {
-    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
-  }
-
-  /** @inheritdoc */
-  async getAdminClient(): Promise<KafkaJS.Admin> {
-    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
-  }
-
-  /** @inheritdoc */
-  async getProducer(): Promise<KafkaJS.Producer> {
-    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
-  }
-
-  /** @inheritdoc */
-  async getConsumer(): Promise<KafkaJS.Consumer> {
-    throw new Error(NO_NATIVE_KAFKA_UNDER_OAUTH);
-  }
-
-  /**
-   * Override the inherited SDK getter so the OAuth-specific error reaches callers
-   * — `BaseClientManager`'s default message tells users to set
-   * `SCHEMA_REGISTRY_API_KEY`/`SECRET`, which is misleading inside an OAuth flow.
-   */
-  override getSchemaRegistryClient(): SchemaRegistryClient {
-    throw new Error(NO_SR_SDK_UNDER_OAUTH);
   }
 
   /** @inheritdoc */

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -4,11 +4,19 @@
  * URL is auto-derived from the Auth0 environment via {@link getCloudRestUrlForEnv}.
  *
  * Inherits the abstract {@link BaseClientManager} and intentionally adds nothing
- * native-Kafka-shaped: no broker client, no SASL, no `KafkaJS`/SR-SDK imports.
- * Native-Kafka tools are gated to direct connections by their predicates and
- * narrow the runtime's `BaseClientManager` to a `DirectClientManager` via
- * {@link ServerRuntime.requireDirectClientManager}, so a missing-on-OAuth
- * Kafka method is a compile-time error rather than a runtime throw.
+ * native-Kafka-shaped: no broker client, no SASL, no `KafkaJS` import. Native
+ * Kafka methods are missing entirely from the class — a call to e.g.
+ * `getAdminClient` is a compile-time error rather than a runtime throw on a
+ * stub. Tool handlers that need them narrow the runtime's `BaseClientManager`
+ * to a `DirectClientManager` via {@link ServerRuntime.requireDirectClientManager},
+ * which (alongside the `hasKafka` predicate that gates those tools off for
+ * OAuth connections in the first place) keeps the path closed end-to-end.
+ *
+ * The Schema Registry SDK is similarly unsupported under OAuth, but its getter
+ * is part of `BaseClientManager`'s contract and stays inherited. A call to
+ * `getSchemaRegistryClient()` therefore still surfaces at runtime as the base
+ * class's existing OAuth-rejection throw — to be revisited once OAuth flows
+ * through the SDK.
  */
 
 import { BaseClientManager } from "@src/confluent/base-client-manager.js";

--- a/src/confluent/tools/handlers/flink/catalog/catalog-resolver.ts
+++ b/src/confluent/tools/handlers/flink/catalog/catalog-resolver.ts
@@ -1,4 +1,4 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
+import { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import env from "@src/env.js";
 
@@ -67,7 +67,7 @@ export interface SchemaMapping {
  * Returns a 1:1 mapping between environment IDs (CATALOG_ID) and friendly names (CATALOG_NAME).
  */
 export async function getCatalogMapping(
-  clientManager: ClientManager,
+  clientManager: BaseClientManager,
   catalogName: string,
   options: {
     organizationId: string;
@@ -127,7 +127,7 @@ export function resolveToCatalogName(
  * Returns a 1:1 mapping between cluster IDs (SCHEMA_ID) and friendly names (SCHEMA_NAME).
  */
 export async function getSchemaMapping(
-  clientManager: ClientManager,
+  clientManager: BaseClientManager,
   catalogName: string,
   options: {
     organizationId: string;

--- a/src/confluent/tools/handlers/flink/diagnostics/metrics-helper.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/metrics-helper.ts
@@ -1,4 +1,4 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
+import { BaseClientManager } from "@src/confluent/base-client-manager.js";
 
 /**
  * Flink statement metrics from the Confluent Cloud Telemetry API.
@@ -104,7 +104,7 @@ const LONG_MIN_VALUE = -9223372036854776000;
  * @returns Aggregated metrics for the statement
  */
 export async function getStatementMetrics(
-  clientManager: ClientManager,
+  clientManager: BaseClientManager,
   options: {
     statementName: string;
     computePoolId: string;
@@ -452,7 +452,7 @@ export function analyzeMetrics(metrics: FlinkStatementMetrics): {
  */
 async function queryTaskMetrics(
   telemetryClient: ReturnType<
-    ClientManager["getConfluentCloudTelemetryRestClient"]
+    BaseClientManager["getConfluentCloudTelemetryRestClient"]
   >,
   options: {
     statementName: string;
@@ -553,7 +553,7 @@ async function queryTaskMetrics(
  */
 async function querySplitMetrics(
   telemetryClient: ReturnType<
-    ClientManager["getConfluentCloudTelemetryRestClient"]
+    BaseClientManager["getConfluentCloudTelemetryRestClient"]
   >,
   options: {
     statementName: string;

--- a/src/confluent/tools/handlers/flink/flink-sql-helper.ts
+++ b/src/confluent/tools/handlers/flink/flink-sql-helper.ts
@@ -1,4 +1,4 @@
-import { ClientManager } from "@src/confluent/client-manager.js";
+import { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export interface FlinkSqlResult {
@@ -33,7 +33,7 @@ function generateStatementName(prefix: string = "mcp-query"): string {
  * then fetches all results.
  */
 export async function executeFlinkSql(
-  clientManager: ClientManager,
+  clientManager: BaseClientManager,
   sql: string,
   options: FlinkSqlOptions,
 ): Promise<FlinkSqlResult> {

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -179,7 +179,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     toolArguments: z.infer<typeof consumeKafkaMessagesArgs>,
     sessionId?: string,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
+    const clientManager = runtime.requireDirectClientManager();
     const { topicNames, maxMessages, timeoutMs, value, key } =
       consumeKafkaMessagesArgs.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -34,7 +34,7 @@ export class CreateTopicsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
+    const clientManager = runtime.requireDirectClientManager();
     const { topics } = createTopicArgs.parse(toolArguments);
     const success = await (
       await clientManager.getAdminClient()

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -22,7 +22,7 @@ export class DeleteTopicsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
+    const clientManager = runtime.requireDirectClientManager();
     const { topicNames } = deleteKafkaTopicsArguments.parse(toolArguments);
     await (
       await clientManager.getAdminClient()

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -21,7 +21,7 @@ export class ListTopicsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     _toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
+    const clientManager = runtime.requireDirectClientManager();
     const topics = await (await clientManager.getAdminClient()).listTopics();
     return this.createResponse(`Kafka topics: ${topics.join(",")}`);
   }

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -115,7 +115,7 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
+    const clientManager = runtime.requireDirectClientManager();
     const { topicName, value, key }: ProduceKafkaMessageArguments =
       produceKafkaMessageArguments.parse(toolArguments);
 

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -198,6 +198,26 @@ describe("ServerRuntime", () => {
     });
   });
 
+  describe("requireDirectClientManager()", () => {
+    it("should return the sole client manager when it is a DirectClientManager", () => {
+      const cm = createMockInstance(DirectClientManager);
+      const runtime = new ServerRuntime(config, { "test-conn": cm });
+      expect(runtime.requireDirectClientManager()).toBe(cm);
+    });
+
+    it("should throw when the sole client manager is not a DirectClientManager (e.g., OAuth)", () => {
+      vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
+      const oauthConfig = new MCPServerConfiguration({
+        connections: { "env-connection": connWith({}) },
+        ccloudOAuth: { type: "ccloud_oauth", env: "stag" },
+      });
+      const runtime = ServerRuntime.fromConfig(oauthConfig);
+      expect(() => runtime.requireDirectClientManager()).toThrow(
+        "Native Kafka tools require a direct (non-OAuth) connection.",
+      );
+    });
+  });
+
   describe("fromConfig()", () => {
     it("should create a DirectClientManager for each connection", () => {
       const twoConnConfig = new MCPServerConfiguration({

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -65,7 +65,7 @@ export class ServerRuntime {
     const cm = this.clientManager;
     if (!(cm instanceof DirectClientManager)) {
       throw new Error(
-        "Native Kafka tools require a direct (api_key) connection.",
+        "Native Kafka tools require a direct (non-OAuth) connection.",
       );
     }
     return cm;

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,6 +1,9 @@
 import { MCPServerConfiguration } from "@src/config/index.js";
-import { type ClientManager } from "@src/confluent/client-manager.js";
-import { constructDirectClientManager } from "@src/confluent/direct-client-manager.js";
+import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import {
+  constructDirectClientManager,
+  DirectClientManager,
+} from "@src/confluent/direct-client-manager.js";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 
@@ -11,7 +14,7 @@ import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
  */
 export class ServerRuntime {
   readonly config: MCPServerConfiguration;
-  readonly clientManagers: Record<string, ClientManager>;
+  readonly clientManagers: Record<string, BaseClientManager>;
   /**
    * The active OAuth holder when the config carries a CCloud OAuth connection.
    * Constructed by {@link ServerRuntime.fromConfig} when `config.getCCloudOAuth()`
@@ -24,7 +27,7 @@ export class ServerRuntime {
 
   constructor(
     config: MCPServerConfiguration,
-    clientManagers: Record<string, ClientManager>,
+    clientManagers: Record<string, BaseClientManager>,
     oauthHolder: OAuthHolder | undefined = undefined,
   ) {
     this.config = config;
@@ -36,7 +39,7 @@ export class ServerRuntime {
    * Convenience accessor for the single-connection period.
    * Remove (or make multi-connection-aware) when issue #151 lands.
    */
-  get clientManager(): ClientManager {
+  get clientManager(): BaseClientManager {
     const managers = Object.values(this.clientManagers);
     if (managers.length === 0) {
       throw new Error("ServerRuntime has no client managers");
@@ -51,13 +54,30 @@ export class ServerRuntime {
     return managers[0]!;
   }
 
+  /**
+   * Narrows the sole client manager to a {@link DirectClientManager} or throws
+   * if the connection is OAuth-backed. Native-Kafka tools call this instead of
+   * {@link clientManager} so a missing-on-OAuth Kafka method is a compile-time
+   * error rather than a runtime throw on a stub. Their `hasKafka` predicates
+   * already gate them off for OAuth connections, so the throw here is defensive.
+   */
+  requireDirectClientManager(): DirectClientManager {
+    const cm = this.clientManager;
+    if (!(cm instanceof DirectClientManager)) {
+      throw new Error(
+        "Native Kafka tools require a direct (api_key) connection.",
+      );
+    }
+    return cm;
+  }
+
   static fromConfig(config: MCPServerConfiguration): ServerRuntime {
     const ccloudOAuth = config.getCCloudOAuth();
     const oauthHolder = ccloudOAuth
       ? OAuthHolder.start(ccloudOAuth.env)
       : undefined;
 
-    // Construct a ClientManager for each connection in the config.
+    // Construct a client manager for each connection in the config.
     // (although currently there will only be one, see `enforceSingleConnectionOnly()`)
     // When OAuth is in play, every connection's manager is bearer-auth-backed by
     // the shared holder; otherwise, fall back to the per-connection direct factory.


### PR DESCRIPTION
## Summary of Changes

- Drop `implements ClientManager` from `OAuthClientManager` and remove the 4 Kafka throw stubs (`getKafkaClient`/`getAdminClient`/`getProducer`/`getConsumer`) plus the SR SDK override. `OAuthClientManager` now only `extends BaseClientManager` — it advertises only the REST + SR-SDK surface it actually provides.
  - Eliminates the type-system lie where the previous design faked five methods to satisfy the wide `ClientManager` interface. Each class's `extends`/`implements` now describes real capability: `DirectClientManager` adds native Kafka and so legitimately satisfies the full `ClientManager`; `OAuthClientManager` adds nothing and doesn't pretend to.
  - Same import-hygiene rule that motivated `BaseClientManager`'s extraction now applies to `OAuthClientManager` — no `KafkaJS`, no `SchemaRegistryClient` imports. The file is purely REST + SR-SDK.
- Add `ServerRuntime.requireDirectClientManager(): DirectClientManager` — `instanceof`-narrows the sole client manager and throws `"Native Kafka tools require a direct (api_key) connection."` otherwise. Single, explicit narrowing point at the runtime boundary.
- Update the 5 native Kafka handlers (`list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages`) to call `runtime.requireDirectClientManager()` instead of `runtime.clientManager`. Their `hasKafka` predicate already gates them off for OAuth connections, so the throw is defensive — but now the type system and the runtime check agree.
- Relax `ServerRuntime.clientManagers: Record<string, BaseClientManager>` (was `Record<string, ClientManager>`) and the `clientManager` getter return type to match. The storage now honestly accepts either a `DirectClientManager` or an `OAuthClientManager`.
- Relax 3 Flink helpers (`flink-sql-helper.ts`, `catalog-resolver.ts`, `metrics-helper.ts`) from `clientManager: ClientManager` to `BaseClientManager` — they only call REST methods, so they don't need the wide type.
- Remove the 5 redundant throw-stub tests from `oauth-client-manager.test.ts` — TypeScript enforces the absence of those methods at compile time, so there's nothing to test at runtime.

### Feature Branch Stack (bcscc/oauth-segregate-direct-client-manager)

- #299
  - #301
    - #306 **(this)**

### Optional: Any additional details or context that should be provided?

- Addresses the same review concern that motivated splitting `BaseClientManager` into its own file in #299: the previous `OAuthClientManager` imported `KafkaJS` and `SchemaRegistryClient` purely to type stubs for capabilities it couldn't deliver. Now the file is import-clean and the type system reflects reality.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Updated existing
- [x] Deleted existing