### PR TITLE
stubClientGetters() expands to support array of stub responses; new BaseToolHandler.resolveParam()

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -144,14 +144,32 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   whose connection has the relevant service block (expect the connection id) and a bare runtime
   without that block (expect `[]`). Helper factories live in `tests/factories/runtime.ts`
   (`flinkRuntime()`, `tableflowRuntime()`, `bareRuntime()`, etc.).
-- Test `handle()` for typical and edge-case inputs. `handle()` now receives a `ServerRuntime`
-  instead of a bare `ClientManager`. Create the mock first, configure it, then inject it into
-  `runtimeWith()` as the third argument:
+- Test `handle()` for typical and edge-case inputs using `stubClientGetters` +
+  `assertHandleCase` from `@tests/stubs/index.js`. The standard three cases per
+  config-backed parameter: (1) throws when arg absent and not in config, (2) resolves
+  using config fallback, (3) resolves using explicit arg. Use `HandleCaseWithConn` to
+  carry a per-case runtime shape (`connectionConfig: {}` for throw cases; domain fixture
+  as default for success cases).
+  - Pass `"DISCOVER"` as the `outcome` sentinel to run the handler and get a copy-paste
+    suggestion for the correct expectation. Replace it before committing.
+  - `stubClientGetters(responseData)` accepts a single element or an array for sequential
+    per-call responses. See its JSDoc for the full element-shape contract (`data`, `response`,
+    `error` keys). The `handle()` now receives a `ServerRuntime`; inject via `runtimeWith()`:
   ```typescript
-  clientManager = createMockInstance(DirectClientManager);
-  clientManager.getSomeClient.mockResolvedValue(...);
-  const runtime = runtimeWith({ kafka: { bootstrap_servers: "..." } }, DEFAULT_CONNECTION_ID, clientManager);
-  handler.handle(runtime, args);
+  const { clientManager, clientGetters } = stubClientGetters({
+    status: { phase: "COMPLETED" },
+  });
+  await assertHandleCase({
+    handler,
+    runtime: runtimeWith(
+      connectionConfig,
+      DEFAULT_CONNECTION_ID,
+      clientManager,
+    ),
+    args,
+    outcome,
+    clientGetters,
+  });
   ```
 - Use `as any` only on partial mock return values (e.g., a mock admin client with only
   `listTopics`), not on the `ClientManager` mock itself; add an eslint-disable comment when needed.

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -68,6 +68,22 @@ export abstract class BaseToolHandler implements ToolHandler {
    */
   abstract enabledConnectionIds(runtime: ServerRuntime): string[];
 
+  /**
+   * Resolves a required string from an explicit tool argument, falling back to
+   * a connection-config value. Throws if neither is present.
+   * `label` is the human-readable field name (e.g. `"Organization ID"`);
+   * the thrown message is `"${label} is required"`.
+   */
+  protected resolveParam(
+    argValue: string | undefined,
+    configValue: string | undefined,
+    label: string,
+  ): string {
+    const resolved = argValue || configValue;
+    if (!resolved) throw new Error(`${label} is required`);
+    return resolved;
+  }
+
   createResponse(
     message: string,
     isError: boolean = false,

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
@@ -1,0 +1,98 @@
+import { DetectIssuesHandler } from "@src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  stubClientGetters,
+  type HandleCase,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+const STATEMENT_NAME = "my-statement";
+
+type HandleCaseWithConn = HandleCase & {
+  connectionConfig?: Parameters<typeof runtimeWith>[0];
+};
+
+describe("detect-issues-handler.ts", () => {
+  describe("DetectIssuesHandler", () => {
+    const handler = new DetectIssuesHandler();
+
+    describe("handle()", () => {
+      const cases: HandleCaseWithConn[] = [
+        {
+          label: "throws ZodError when statementName is absent",
+          args: {},
+          outcome: { throws: "ZodError" },
+        },
+        {
+          label: "reports no issues for a running statement",
+          args: {
+            statementName: STATEMENT_NAME,
+            organizationId: "org-from-args",
+            environmentId: "env-from-args",
+            computePoolId: "lfcp-from-args",
+            includeMetrics: false,
+          },
+          responseData: { status: { phase: "RUNNING" }, data: [] },
+          outcome: {
+            resolves: `No issues detected for statement '${STATEMENT_NAME}'. Statement is running normally.`,
+          },
+        },
+        {
+          label: "detects issues when statement phase is FAILED",
+          args: {
+            statementName: STATEMENT_NAME,
+            organizationId: "org-from-args",
+            environmentId: "env-from-args",
+            computePoolId: "lfcp-from-args",
+            includeMetrics: false,
+          },
+          responseData: {
+            status: { phase: "FAILED", detail: "OOM" },
+            data: [],
+          },
+          outcome: {
+            resolves: `Detected 1 issue(s) for statement '${STATEMENT_NAME}'`,
+          },
+        },
+        {
+          label:
+            "runs metrics branch when includeMetrics is true and reports summary",
+          args: {
+            statementName: STATEMENT_NAME,
+            organizationId: "org-from-args",
+            environmentId: "env-from-args",
+            computePoolId: "lfcp-from-args",
+            includeMetrics: true,
+          },
+          // Call 1: GET statement status; call 2: GET exceptions (reused for
+          // all 13 subsequent telemetry POSTs since it is the last element).
+          responseData: [{ status: { phase: "RUNNING" } }, { data: [] }],
+          outcome: { resolves: "Metrics: No metrics data available" },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({ args, outcome, responseData, connectionConfig = {} }) => {
+          const { clientManager, clientGetters } =
+            stubClientGetters(responseData);
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              connectionConfig,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+        },
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
@@ -4,8 +4,31 @@ import {
   DEFAULT_CONNECTION_ID,
   kafkaRestOnlyRuntime,
   kafkaRestRuntime,
+  runtimeWith,
 } from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  stubClientGetters,
+  type HandleCase,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
+
+const KAFKA_CONN = {
+  kafka: {
+    bootstrap_servers: "broker:9092",
+    rest_endpoint: "https://kafka-rest.example.com",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+    cluster_id: "lkc-from-config",
+  },
+};
+
+const VALID_CONFIGS = [
+  { name: "retention.ms", value: "86400000", operation: "SET" as const },
+];
+
+type HandleCaseWithConn = HandleCase & {
+  connectionConfig?: Parameters<typeof runtimeWith>[0];
+};
 
 describe("alter-topic-config.ts", () => {
   describe("AlterTopicConfigHandler", () => {
@@ -27,6 +50,62 @@ describe("alter-topic-config.ts", () => {
           [],
         );
       });
+    });
+
+    describe("handle()", () => {
+      const cases: HandleCaseWithConn[] = [
+        {
+          label: "throws ZodError when topicName is absent",
+          args: {},
+          outcome: { throws: "ZodError" },
+          connectionConfig: {},
+        },
+        {
+          label: "throws when clusterId is absent and not in connection config",
+          args: { topicName: "my-topic", topicConfigs: VALID_CONFIGS },
+          outcome: { throws: "Kafka Cluster ID is required" },
+          connectionConfig: {},
+        },
+        {
+          label:
+            "uses cluster_id from connection config when clusterId arg is absent",
+          args: { topicName: "my-topic", topicConfigs: VALID_CONFIGS },
+          outcome: { resolves: "Successfully altered topic config" },
+        },
+        {
+          label: "uses clusterId arg over connection config cluster_id",
+          args: {
+            topicName: "my-topic",
+            topicConfigs: VALID_CONFIGS,
+            clusterId: "lkc-from-args",
+          },
+          outcome: { resolves: "Successfully altered topic config" },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({
+          args,
+          outcome,
+          responseData,
+          connectionConfig = KAFKA_CONN,
+        }) => {
+          const { clientManager, clientGetters } =
+            stubClientGetters(responseData);
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              connectionConfig,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+        },
+      );
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -1,4 +1,3 @@
-import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -46,10 +45,11 @@ export class AlterTopicConfigHandler extends BaseToolHandler {
     const clientManager = runtime.clientManager;
     const { clusterId, topicName, topicConfigs, validateOnly } =
       alterTopicConfigArguments.parse(toolArguments);
-    const kafka_cluster_id = getEnsuredParam(
-      "KAFKA_CLUSTER_ID",
-      "Kafka Cluster ID is required",
+    const conn = runtime.config.getSoleConnection();
+    const kafka_cluster_id = this.resolveParam(
       clusterId,
+      conn.kafka?.cluster_id,
+      "Kafka Cluster ID",
     );
 
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
@@ -4,8 +4,27 @@ import {
   DEFAULT_CONNECTION_ID,
   kafkaRestOnlyRuntime,
   kafkaRestRuntime,
+  runtimeWith,
 } from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  stubClientGetters,
+  type HandleCase,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
+
+const KAFKA_CONN = {
+  kafka: {
+    bootstrap_servers: "broker:9092",
+    rest_endpoint: "https://kafka-rest.example.com",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+    cluster_id: "lkc-from-config",
+  },
+};
+
+type HandleCaseWithConn = HandleCase & {
+  connectionConfig?: Parameters<typeof runtimeWith>[0];
+};
 
 describe("get-topic-config.ts", () => {
   describe("GetTopicConfigHandler", () => {
@@ -27,6 +46,58 @@ describe("get-topic-config.ts", () => {
           [],
         );
       });
+    });
+
+    describe("handle()", () => {
+      const cases: HandleCaseWithConn[] = [
+        {
+          label: "throws ZodError when topicName is absent",
+          args: {},
+          outcome: { throws: "ZodError" },
+          connectionConfig: {},
+        },
+        {
+          label: "throws when clusterId is absent and not in connection config",
+          args: { topicName: "my-topic" },
+          outcome: { throws: "Kafka Cluster ID is required" },
+          connectionConfig: {},
+        },
+        {
+          label:
+            "uses cluster_id from connection config when clusterId arg is absent",
+          args: { topicName: "my-topic" },
+          outcome: { resolves: "Topic configuration for 'my-topic'" },
+        },
+        {
+          label: "uses clusterId arg over connection config cluster_id",
+          args: { topicName: "my-topic", clusterId: "lkc-from-args" },
+          outcome: { resolves: "Topic configuration for 'my-topic'" },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({
+          args,
+          outcome,
+          responseData,
+          connectionConfig = KAFKA_CONN,
+        }) => {
+          const { clientManager, clientGetters } =
+            stubClientGetters(responseData);
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              connectionConfig,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+        },
+      );
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -1,4 +1,3 @@
-import { getEnsuredParam } from "@src/confluent/helpers.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -38,10 +37,11 @@ export class GetTopicConfigHandler extends BaseToolHandler {
     const clientManager = runtime.clientManager;
     const { clusterId, topicName } =
       getTopicConfigArguments.parse(toolArguments);
-    const kafka_cluster_id = getEnsuredParam(
-      "KAFKA_CLUSTER_ID",
-      "Kafka Cluster ID is required",
+    const conn = runtime.config.getSoleConnection();
+    const kafka_cluster_id = this.resolveParam(
       clusterId,
+      conn.kafka?.cluster_id,
+      "Kafka Cluster ID",
     );
 
     const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -184,7 +184,7 @@ describe("tool-registry.ts", () => {
      * What each handler produces when called with no arguments against a
      * fully-wired universal client. Use `{ resolves }` when the handler
      * completes and `{ throws }` when it raises before returning.
-     * Use `"TODO"` as a placeholder — the smoke test will run the handler
+     * Use `"DISCOVER"` as a placeholder — the smoke test will run the handler
      * and report the correct entry to paste in.
      */
     const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, HandleOutcome>> = {
@@ -284,7 +284,7 @@ describe("tool-registry.ts", () => {
       (name) => {
         expect(
           name in ZERO_ARG_OUTCOMES,
-          `Add [ToolName.${TOOL_NAME_TO_KEY[name]}]: "TODO" to ZERO_ARG_OUTCOMES, ` +
+          `Add [ToolName.${TOOL_NAME_TO_KEY[name]}]: "DISCOVER" to ZERO_ARG_OUTCOMES, ` +
             `then run: npm test -- src/confluent/tools/tool-registry.test.ts`,
         ).toBe(true);
       },

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -7,18 +7,33 @@ import { ZodError } from "zod";
 import { createMockInstance } from "./mock-instance.js";
 
 export type Resolves = {
-  /** Minimal valid API response to feed into the proxy's `data` property.
-   *  Omit to use `{}` (sufficient when the handler just JSON-serialises the
-   *  response); supply `{ data: [] }` or a richer shape to push the handler
-   *  past guard checks into its real success branch. */
+  /**
+   * Controls what each stubbed API call resolves to. Forwarded directly to
+   * `stubClientGetters()` — see its JSDoc for the full element-shape contract.
+   *
+   * Quick reference:
+   * - Omit (or `{}`) when the handler short-circuits before reading the result.
+   * - Plain object → becomes `(await call()).data`. Match the shape the handler
+   *   reads: e.g. `{ status: { phase: "COMPLETED" }, results: { data: [...] } }`.
+   * - `{ response: { status: N } }` → for handlers that destructure `response`
+   *   (e.g. DELETE endpoints: `const { response } = await client.DELETE(...)`).
+   * - `{ error: { ... } }` → makes `(await call()).error` truthy, triggering
+   *   error-branch code.
+   * - Array of the above → consumed in call order; last element reused when
+   *   the array is exhausted (needed for poll-then-fetch handlers).
+   */
   responseData?: unknown;
   /** Substring that must appear in the resolved response text. */
   resolves: string;
 };
 
 export type Throws = {
-  /** Same as `Resolves.responseData` — set when the handler needs valid-ish
-   *  data before it reaches the code that throws. */
+  /**
+   * Same contract as `Resolves.responseData`. Supply when the handler must
+   * complete one or more successful API calls before reaching the code that
+   * throws (e.g. a handler that fetches data and then validates it).
+   * Omit when the throw happens before any client call.
+   */
   responseData?: unknown;
   /** Substring that must appear in the thrown error message, or "ZodError"
    *  to match any ZodError regardless of message. */
@@ -27,21 +42,24 @@ export type Throws = {
 
 /** Complete specification for one `handle()` invocation: what to feed in
  *  (`responseData`) and what to expect out (`resolves` / `throws`).
- *  The `"TODO"` sentinel triggers discovery mode: the test executes the
- *  handler, reports the actual outcome, and asks you to paste it in as the
- *  recorded expectation. */
-export type HandleOutcome = Resolves | Throws | "TODO";
+ *  Pass `"DISCOVER"` as a sentinel to run the handler, report the actual
+ *  outcome, and get a copy-paste suggestion for the recorded expectation. */
+export type HandleOutcome = Resolves | Throws | "DISCOVER";
 
 /** The array of client-getter mock functions returned by `stubClientGetters()`.
  *  Each element is a Vitest mock whose `.mock.calls` records invocations. */
 export type ClientGetters = Array<{ mock: { calls: unknown[] } }>;
 
-/** One entry in an `it.each` handler test suite. Supply `responseData` to push
- *  the handler past guard checks; omit to use the default `{}` response. */
+/** One entry in an `it.each` handler test suite. */
 export type HandleCase = {
   label: string;
   args: Record<string, unknown>;
   outcome: HandleOutcome;
+  /**
+   * Forwarded to `stubClientGetters()`. Omit for cases that throw or
+   * short-circuit before touching the client. See `Resolves.responseData`
+   * for the element-shape contract and array usage.
+   */
   responseData?: unknown;
 };
 
@@ -56,44 +74,97 @@ export function classifyThrown(label: string, thrown: unknown): string {
 
 /**
  * Wires every client getter on a fresh `Mocked<DirectClientManager>` to a
- * two-proxy pair so handler bodies never throw a TypeError before reaching
- * real logic. Supply `responseData` to push a specific handler past schema
- * validation into its success branch (defaults to `{}`).
+ * two-proxy pair so handler bodies can traverse arbitrary method chains
+ * (`.GET(...)`, `.POST(...)`, `.path(...).method(...)`, etc.) without throwing
+ * a TypeError. Every async call resolves to a proxy that models the
+ * `{ data, error, response }` shape returned by `openapi-fetch`.
  *
- * Returns `{ clientManager, clientGetters }`. `clientGetters` is the
- * canonical list of all getter mocks; pass it to `assertHandleCase` to
- * assert that at least one was invoked when a handler resolves successfully.
+ * ## `responseData` — single value
+ *
+ * Pass a plain object; it becomes `(await call()).data`. Shape it to match
+ * what the handler reads:
+ * ```typescript
+ * // handler does: const { data } = await client.GET(...); data.status.phase
+ * stubClientGetters({ status: { phase: "COMPLETED" }, results: { data: [] } })
+ * ```
+ *
+ * Two special top-level keys override the defaults:
+ * - `response` — surfaced as `(await call()).response`. Use for handlers that
+ *   destructure `response` directly, e.g. DELETE endpoints that check
+ *   `response?.status`:
+ *   ```typescript
+ *   stubClientGetters({ response: { status: 204 } })
+ *   ```
+ * - `error` — surfaced as `(await call()).error`. Use to exercise a handler's
+ *   error branch (`if (error) return this.createResponse(..., true)`):
+ *   ```typescript
+ *   stubClientGetters({ error: { message: "not found" } })
+ *   ```
+ *
+ * ## `responseData` — array of elements
+ *
+ * Pass an array to feed different data to successive calls. Each element
+ * follows the same shape contract above. The last element is reused once the
+ * array is exhausted, so you only need to enumerate the calls that differ:
+ * ```typescript
+ * // handler: POST to create → GET to poll status → GET to fetch results
+ * stubClientGetters([
+ *   {},                                                    // POST (ignored)
+ *   { status: { phase: "COMPLETED" } },                   // GET poll
+ *   { results: { data: [{ COLUMN_NAME: "id" }] } },       // GET results
+ * ])
+ * ```
+ *
+ * Returns `{ clientManager, clientGetters }`. Pass `clientGetters` to
+ * `assertHandleCase` to assert the handler reached the client layer on a
+ * successful resolve.
  */
 export function stubClientGetters(responseData: unknown = {}) {
   // Two-proxy setup: callableProxy (function target) handles method chains
-  // and calls; responseProxy (plain-object target) is what async calls
-  // resolve to, modelling the { data, error } shape from openapi-fetch.
-  // Future refinement: accept responseData as an array to support sequential
-  // per-call responses (needed for multi-call handlers). The apply trap would
-  // become index-aware, constructing a fresh responseProxy per invocation.
-  let responseProxy: object = {};
-  const callableProxy = new Proxy((() => {}) as () => Promise<object>, {
+  // and calls; per-call responseProxies model the { data, error, response }
+  // shape from openapi-fetch. When responseData is an array, each element is
+  // consumed in order; the last element is reused once the array is exhausted.
+  const responses = Array.isArray(responseData) ? responseData : [responseData];
+  if (responses.length === 0)
+    throw new Error("stubClientGetters: responseData array must not be empty");
+  let callIndex = 0;
+
+  const callableProxy: object = new Proxy((() => {}) as () => Promise<object>, {
     get: (_t, prop) => {
       if (prop === "then" || prop === "error") return undefined;
       return callableProxy;
     },
-    apply: () => Promise.resolve(responseProxy),
-  });
-  responseProxy = new Proxy({} as object, {
-    // Four properties are special-cased:
-    //   `then`          → undefined  (prevents JS treating this as a thenable)
-    //   `error`         → undefined  (openapi-fetch "success" signal)
-    //   `data`          → responseData  (caller-supplied; defaults to {})
-    //   Symbol.iterator → empty-array iterator (handlers that iterate the
-    //                     resolved value directly get an empty loop, not a TypeError)
-    get: (_t, prop) => {
-      if (prop === "then" || prop === "error") return undefined;
-      if (prop === "data") return responseData;
-      if (prop === Symbol.iterator)
-        return Array.prototype[Symbol.iterator].bind([]);
-      return callableProxy;
+    apply: () => {
+      const element = responses[Math.min(callIndex++, responses.length - 1)];
+      return Promise.resolve(makeResponseProxy(element));
     },
   });
+
+  function makeResponseProxy(element: unknown): object {
+    const elem =
+      element !== null && typeof element === "object"
+        ? (element as Record<string | symbol, unknown>)
+        : null;
+    return new Proxy({} as object, {
+      // Special-cased properties:
+      //   `then`          → undefined  (prevents JS treating this as a thenable)
+      //   `error`         → element.error if present, else undefined
+      //   `data`          → element  (backward compat: element IS the data)
+      //   `response`      → element.response if present, else callableProxy
+      //   Symbol.iterator → empty-array iterator
+      get: (_t, prop) => {
+        if (prop === "then") return undefined;
+        if (prop === Symbol.iterator)
+          return Array.prototype[Symbol.iterator].bind([]);
+        if (prop === "error")
+          return elem && "error" in elem ? elem["error"] : undefined;
+        if (prop === "data") return element;
+        if (prop === "response")
+          return elem && "response" in elem ? elem["response"] : callableProxy;
+        return callableProxy;
+      },
+    });
+  }
 
   const clientManager = createMockInstance(DirectClientManager);
   clientManager.getAdminClient.mockResolvedValue(callableProxy as never);
@@ -191,7 +262,7 @@ export async function assertHandleCase(options: {
     thrown = err;
   }
 
-  if (outcome === "TODO") {
+  if (outcome === "DISCOVER") {
     let discovered: string;
     if (thrown !== undefined) {
       discovered = `{ throws: ${JSON.stringify(classifyThrown(name, thrown))} }`;
@@ -206,7 +277,9 @@ export async function assertHandleCase(options: {
         .slice(0, 60);
       discovered = `{ resolves: ${JSON.stringify(text)} }`;
     }
-    throw new Error(`${name}: outcome is TODO — replace with: ${discovered}`);
+    throw new Error(
+      `${name}: outcome is "DISCOVER" — replace with: ${discovered}`,
+    );
   }
 
   if (thrown === undefined) {

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -7,18 +7,33 @@ import { ZodError } from "zod";
 import { createMockInstance } from "./mock-instance.js";
 
 export type Resolves = {
-  /** Minimal valid API response to feed into the proxy's `data` property.
-   *  Omit to use `{}` (sufficient when the handler just JSON-serialises the
-   *  response); supply `{ data: [] }` or a richer shape to push the handler
-   *  past guard checks into its real success branch. */
+  /**
+   * Controls what each stubbed API call resolves to. Forwarded directly to
+   * `stubClientGetters()` — see its JSDoc for the full element-shape contract.
+   *
+   * Quick reference:
+   * - Omit (or `{}`) when the handler short-circuits before reading the result.
+   * - Plain object → becomes `(await call()).data`. Match the shape the handler
+   *   reads: e.g. `{ status: { phase: "COMPLETED" }, results: { data: [...] } }`.
+   * - `{ response: { status: N } }` → for handlers that destructure `response`
+   *   (e.g. DELETE endpoints: `const { response } = await client.DELETE(...)`).
+   * - `{ error: { ... } }` → makes `(await call()).error` truthy, triggering
+   *   error-branch code.
+   * - Array of the above → consumed in call order; last element reused when
+   *   the array is exhausted (needed for poll-then-fetch handlers).
+   */
   responseData?: unknown;
   /** Substring that must appear in the resolved response text. */
   resolves: string;
 };
 
 export type Throws = {
-  /** Same as `Resolves.responseData` — set when the handler needs valid-ish
-   *  data before it reaches the code that throws. */
+  /**
+   * Same contract as `Resolves.responseData`. Supply when the handler must
+   * complete one or more successful API calls before reaching the code that
+   * throws (e.g. a handler that fetches data and then validates it).
+   * Omit when the throw happens before any client call.
+   */
   responseData?: unknown;
   /** Substring that must appear in the thrown error message, or "ZodError"
    *  to match any ZodError regardless of message. */
@@ -27,21 +42,24 @@ export type Throws = {
 
 /** Complete specification for one `handle()` invocation: what to feed in
  *  (`responseData`) and what to expect out (`resolves` / `throws`).
- *  The `"TODO"` sentinel triggers discovery mode: the test executes the
- *  handler, reports the actual outcome, and asks you to paste it in as the
- *  recorded expectation. */
-export type HandleOutcome = Resolves | Throws | "TODO";
+ *  Pass `"DISCOVER"` as a sentinel to run the handler, report the actual
+ *  outcome, and get a copy-paste suggestion for the recorded expectation. */
+export type HandleOutcome = Resolves | Throws | "DISCOVER";
 
 /** The array of client-getter mock functions returned by `stubClientGetters()`.
  *  Each element is a Vitest mock whose `.mock.calls` records invocations. */
 export type ClientGetters = Array<{ mock: { calls: unknown[] } }>;
 
-/** One entry in an `it.each` handler test suite. Supply `responseData` to push
- *  the handler past guard checks; omit to use the default `{}` response. */
+/** One entry in an `it.each` handler test suite. */
 export type HandleCase = {
   label: string;
   args: Record<string, unknown>;
   outcome: HandleOutcome;
+  /**
+   * Forwarded to `stubClientGetters()`. Omit for cases that throw or
+   * short-circuit before touching the client. See `Resolves.responseData`
+   * for the element-shape contract and array usage.
+   */
   responseData?: unknown;
 };
 
@@ -56,44 +74,95 @@ export function classifyThrown(label: string, thrown: unknown): string {
 
 /**
  * Wires every client getter on a fresh `Mocked<DirectClientManager>` to a
- * two-proxy pair so handler bodies never throw a TypeError before reaching
- * real logic. Supply `responseData` to push a specific handler past schema
- * validation into its success branch (defaults to `{}`).
+ * two-proxy pair so handler bodies can traverse arbitrary method chains
+ * (`.GET(...)`, `.POST(...)`, `.path(...).method(...)`, etc.) without throwing
+ * a TypeError. Every async call resolves to a proxy that models the
+ * `{ data, error, response }` shape returned by `openapi-fetch`.
  *
- * Returns `{ clientManager, clientGetters }`. `clientGetters` is the
- * canonical list of all getter mocks; pass it to `assertHandleCase` to
- * assert that at least one was invoked when a handler resolves successfully.
+ * ## `responseData` — single value
+ *
+ * Pass a plain object; it becomes `(await call()).data`. Shape it to match
+ * what the handler reads:
+ * ```typescript
+ * // handler does: const { data } = await client.GET(...); data.status.phase
+ * stubClientGetters({ status: { phase: "COMPLETED" }, results: { data: [] } })
+ * ```
+ *
+ * Two special top-level keys override the defaults:
+ * - `response` — surfaced as `(await call()).response`. Use for handlers that
+ *   destructure `response` directly, e.g. DELETE endpoints that check
+ *   `response?.status`:
+ *   ```typescript
+ *   stubClientGetters({ response: { status: 204 } })
+ *   ```
+ * - `error` — surfaced as `(await call()).error`. Use to exercise a handler's
+ *   error branch (`if (error) return this.createResponse(..., true)`):
+ *   ```typescript
+ *   stubClientGetters({ error: { message: "not found" } })
+ *   ```
+ *
+ * ## `responseData` — array of elements
+ *
+ * Pass an array to feed different data to successive calls. Each element
+ * follows the same shape contract above. The last element is reused once the
+ * array is exhausted, so you only need to enumerate the calls that differ:
+ * ```typescript
+ * // handler: POST to create → GET to poll status → GET to fetch results
+ * stubClientGetters([
+ *   {},                                                    // POST (ignored)
+ *   { status: { phase: "COMPLETED" } },                   // GET poll
+ *   { results: { data: [{ COLUMN_NAME: "id" }] } },       // GET results
+ * ])
+ * ```
+ *
+ * Returns `{ clientManager, clientGetters }`. Pass `clientGetters` to
+ * `assertHandleCase` to assert the handler reached the client layer on a
+ * successful resolve.
  */
 export function stubClientGetters(responseData: unknown = {}) {
   // Two-proxy setup: callableProxy (function target) handles method chains
-  // and calls; responseProxy (plain-object target) is what async calls
-  // resolve to, modelling the { data, error } shape from openapi-fetch.
-  // Future refinement: accept responseData as an array to support sequential
-  // per-call responses (needed for multi-call handlers). The apply trap would
-  // become index-aware, constructing a fresh responseProxy per invocation.
-  let responseProxy: object = {};
-  const callableProxy = new Proxy((() => {}) as () => Promise<object>, {
+  // and calls; per-call responseProxies model the { data, error, response }
+  // shape from openapi-fetch. When responseData is an array, each element is
+  // consumed in order; the last element is reused once the array is exhausted.
+  const responses = Array.isArray(responseData) ? responseData : [responseData];
+  let callIndex = 0;
+
+  const callableProxy: object = new Proxy((() => {}) as () => Promise<object>, {
     get: (_t, prop) => {
       if (prop === "then" || prop === "error") return undefined;
       return callableProxy;
     },
-    apply: () => Promise.resolve(responseProxy),
-  });
-  responseProxy = new Proxy({} as object, {
-    // Four properties are special-cased:
-    //   `then`          → undefined  (prevents JS treating this as a thenable)
-    //   `error`         → undefined  (openapi-fetch "success" signal)
-    //   `data`          → responseData  (caller-supplied; defaults to {})
-    //   Symbol.iterator → empty-array iterator (handlers that iterate the
-    //                     resolved value directly get an empty loop, not a TypeError)
-    get: (_t, prop) => {
-      if (prop === "then" || prop === "error") return undefined;
-      if (prop === "data") return responseData;
-      if (prop === Symbol.iterator)
-        return Array.prototype[Symbol.iterator].bind([]);
-      return callableProxy;
+    apply: () => {
+      const element = responses[Math.min(callIndex++, responses.length - 1)];
+      return Promise.resolve(makeResponseProxy(element));
     },
   });
+
+  function makeResponseProxy(element: unknown): object {
+    const elem =
+      element !== null && typeof element === "object"
+        ? (element as Record<string | symbol, unknown>)
+        : null;
+    return new Proxy({} as object, {
+      // Special-cased properties:
+      //   `then`          → undefined  (prevents JS treating this as a thenable)
+      //   `error`         → element.error if present, else undefined
+      //   `data`          → element  (backward compat: element IS the data)
+      //   `response`      → element.response if present, else callableProxy
+      //   Symbol.iterator → empty-array iterator
+      get: (_t, prop) => {
+        if (prop === "then") return undefined;
+        if (prop === Symbol.iterator)
+          return Array.prototype[Symbol.iterator].bind([]);
+        if (prop === "error")
+          return elem && "error" in elem ? elem["error"] : undefined;
+        if (prop === "data") return element;
+        if (prop === "response")
+          return elem && "response" in elem ? elem["response"] : callableProxy;
+        return callableProxy;
+      },
+    });
+  }
 
   const clientManager = createMockInstance(DirectClientManager);
   clientManager.getAdminClient.mockResolvedValue(callableProxy as never);
@@ -191,7 +260,7 @@ export async function assertHandleCase(options: {
     thrown = err;
   }
 
-  if (outcome === "TODO") {
+  if (outcome === "DISCOVER") {
     let discovered: string;
     if (thrown !== undefined) {
       discovered = `{ throws: ${JSON.stringify(classifyThrown(name, thrown))} }`;
@@ -206,7 +275,9 @@ export async function assertHandleCase(options: {
         .slice(0, 60);
       discovered = `{ resolves: ${JSON.stringify(text)} }`;
     }
-    throw new Error(`${name}: outcome is TODO — replace with: ${discovered}`);
+    throw new Error(
+      `${name}: outcome is "DISCOVER" — replace with: ${discovered}`,
+    );
   }
 
   if (thrown === undefined) {


### PR DESCRIPTION
# Stub infrastructure improvement, resolveParam()

## Changes

- **`stubClientGetters()` upgrade** — accepts `responseData` as an array of elements consumed
  in call order (last element reused when exhausted), enabling tests for handlers that make
  multiple sequential client calls. Adds `response` and `error` as first-class keys alongside
  `data`. Single-value callers are unaffected.
- **`"TODO"` → `"DISCOVER"`** sentinel rename in `HandleOutcome` / smoke test — clearer name,
  stops SonarLint S1135 flagging every importer.
- **`resolveParam()`** added to `BaseToolHandler` — canonical arg-over-config fallback with a
  descriptive throw; will replace `getEnsuredParam()` call sites as handlers migrate.
- **`get-topic-config`, `alter-topic-config`** migrated from `getEnsuredParam` to `resolveParam`
  reading `conn.kafka.cluster_id` as fallback; `handle()` tests added for both.
- **`detect-issues-handler` handle() tests** — 4 cases; the `includeMetrics: true` case is the
  first real caller of the array response feature. The handler makes 2 Flink REST calls then 13
  sequential Telemetry POSTs; `stubClientGetters([{ status: { phase: "RUNNING" } }, { data: [] }])`
  feeds distinct data to the first two and reuses the second element for all remaining calls.
- `.claude/rules/unit-tests.md` updated to document the new stub contracts.

## Relationships

Carved out of too-large #307.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
