### PR TITLE
Promote OAuth to a ConnectionConfig variant

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -420,81 +420,81 @@ describe("cli.ts", () => {
     );
 
     describe("--oauth flags", () => {
-      it("should parse --oauth and --oauth-env into cliOptions", () => {
+      it("should parse --oauth alone with developmentEnv undefined", () => {
+        const result = parseCliArgs(["node", "mcp-confluent", "--oauth"]);
+        expect(result.oauth).toBe(true);
+        expect(result.developmentEnv).toBeUndefined();
+      });
+
+      it("should parse --oauth with --development-env=devel", () => {
         const result = parseCliArgs([
           "node",
           "mcp-confluent",
           "--oauth",
-          "--oauth-env",
+          "--development-env",
           "devel",
         ]);
         expect(result.oauth).toBe(true);
-        expect(result.oauthEnv).toBe("devel");
+        expect(result.developmentEnv).toBe("devel");
       });
 
-      it("should accept stag and prod for --oauth-env", () => {
+      it("should accept stag and prod for --development-env", () => {
         expect(
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--oauth-env",
+            "--development-env",
             "stag",
-          ]).oauthEnv,
+          ]).developmentEnv,
         ).toBe("stag");
         expect(
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--oauth-env",
+            "--development-env",
             "prod",
-          ]).oauthEnv,
+          ]).developmentEnv,
         ).toBe("prod");
       });
 
-      it("should reject --oauth without --oauth-env", () => {
+      it("should reject --development-env without --oauth", () => {
         expect(() =>
-          parseCliArgs(["node", "mcp-confluent", "--oauth"]),
-        ).toThrow(/--oauth-env/);
+          parseCliArgs(["node", "mcp-confluent", "--development-env", "devel"]),
+        ).toThrow(/--development-env requires --oauth/);
       });
 
-      it("should reject --oauth-env without --oauth", () => {
-        expect(() =>
-          parseCliArgs(["node", "mcp-confluent", "--oauth-env", "devel"]),
-        ).toThrow(/--oauth-env requires --oauth/);
-      });
-
-      it("should reject --oauth-env with an unknown environment", () => {
+      it("should reject --development-env with an unknown value", () => {
         expect(() =>
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--oauth-env",
+            "--development-env",
             "bogus",
           ]),
         ).toThrow();
       });
 
-      it("should reject --oauth combined with --config", () => {
+      it("should accept --oauth combined with --config", () => {
+        // The unconditional --oauth + --config mutex is removed; an actual conflict
+        // (YAML declaring its own oauth connection) is detected post-load.
         expect(() =>
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--oauth-env",
-            "devel",
             "--config",
             "/tmp/foo.yaml",
           ]),
-        ).toThrow(/oauth.*config|config.*oauth/i);
+        ).not.toThrow();
       });
 
-      it("should leave oauth and oauthEnv undefined when neither flag is set", () => {
+      it("should leave oauth and developmentEnv undefined when neither flag is set", () => {
         const result = parseCliArgs(["node", "mcp-confluent"]);
         expect(result.oauth).toBeUndefined();
-        expect(result.oauthEnv).toBeUndefined();
+        expect(result.developmentEnv).toBeUndefined();
       });
     });
   });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -477,9 +477,10 @@ describe("cli.ts", () => {
         ).toThrow();
       });
 
-      it("should accept --oauth combined with --config", () => {
-        // The unconditional --oauth + --config mutex is removed; an actual conflict
-        // (YAML declaring its own oauth connection) is detected post-load.
+      it("should accept --oauth combined with --config at parse time", () => {
+        // parseCliArgs no longer rejects the combination — the actual rejection
+        // (in either the YAML-has-OAuth or YAML-is-direct-only shape) is
+        // detected post-load in main(), where the parsed YAML is available.
         expect(() =>
           parseCliArgs([
             "node",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -420,67 +420,67 @@ describe("cli.ts", () => {
     );
 
     describe("--oauth flags", () => {
-      it("should parse --oauth alone with developmentEnv undefined", () => {
+      it("should parse --oauth alone with ccloudEnv undefined", () => {
         const result = parseCliArgs(["node", "mcp-confluent", "--oauth"]);
         expect(result.oauth).toBe(true);
-        expect(result.developmentEnv).toBeUndefined();
+        expect(result.ccloudEnv).toBeUndefined();
       });
 
-      it("should parse --oauth with --development-env=devel", () => {
+      it("should parse --oauth with --ccloud-env=devel", () => {
         const result = parseCliArgs([
           "node",
           "mcp-confluent",
           "--oauth",
-          "--development-env",
+          "--ccloud-env",
           "devel",
         ]);
         expect(result.oauth).toBe(true);
-        expect(result.developmentEnv).toBe("devel");
+        expect(result.ccloudEnv).toBe("devel");
       });
 
-      it("should accept stag and prod for --development-env", () => {
+      it("should accept stag and prod for --ccloud-env", () => {
         expect(
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--development-env",
+            "--ccloud-env",
             "stag",
-          ]).developmentEnv,
+          ]).ccloudEnv,
         ).toBe("stag");
         expect(
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--development-env",
+            "--ccloud-env",
             "prod",
-          ]).developmentEnv,
+          ]).ccloudEnv,
         ).toBe("prod");
       });
 
-      it("should reject --development-env without --oauth", () => {
+      it("should reject --ccloud-env without --oauth", () => {
         expect(() =>
-          parseCliArgs(["node", "mcp-confluent", "--development-env", "devel"]),
-        ).toThrow(/--development-env requires --oauth/);
+          parseCliArgs(["node", "mcp-confluent", "--ccloud-env", "devel"]),
+        ).toThrow(/--ccloud-env requires --oauth/);
       });
 
-      it("should reject --development-env with an unknown value", () => {
+      it("should reject --ccloud-env with an unknown value", () => {
         expect(() =>
           parseCliArgs([
             "node",
             "mcp-confluent",
             "--oauth",
-            "--development-env",
+            "--ccloud-env",
             "bogus",
           ]),
         ).toThrow();
       });
 
-      it("should accept --oauth combined with --config at parse time", () => {
-        // parseCliArgs no longer rejects the combination — the actual rejection
-        // (in either the YAML-has-OAuth or YAML-is-direct-only shape) is
-        // detected post-load in main(), where the parsed YAML is available.
+      it("should reject --oauth combined with --config at parse time", () => {
+        // The check fires at parse time so a malformed YAML can't mask the
+        // friendlier "--oauth and --config cannot be combined" message
+        // behind a generic YAML parse error.
         expect(() =>
           parseCliArgs([
             "node",
@@ -489,13 +489,13 @@ describe("cli.ts", () => {
             "--config",
             "/tmp/foo.yaml",
           ]),
-        ).not.toThrow();
+        ).toThrow(/--oauth and --config cannot be combined/);
       });
 
-      it("should leave oauth and developmentEnv undefined when neither flag is set", () => {
+      it("should leave oauth and ccloudEnv undefined when neither flag is set", () => {
         const result = parseCliArgs(["node", "mcp-confluent"]);
         expect(result.oauth).toBeUndefined();
-        expect(result.developmentEnv).toBeUndefined();
+        expect(result.ccloudEnv).toBeUndefined();
       });
     });
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export interface CLIOptions {
   allowedHosts?: string[];
   generateKey?: boolean;
   oauth?: boolean;
-  oauthEnv?: "devel" | "stag" | "prod";
+  developmentEnv?: "devel" | "stag" | "prod";
 }
 
 /**
@@ -210,13 +210,15 @@ export function parseCliArgs(argv: string[]): CLIOptions {
       "--generate-key",
       "Generate a secure API key for MCP_API_KEY and print it to stdout, then exit. Use this to set MCP_API_KEY in your .env file.",
     )
-    .option("--oauth", "Enable OAuth (PKCE) auth against Confluent Cloud")
+    .option(
+      "--oauth",
+      "Enable OAuth (PKCE) auth against Confluent Cloud (defaults to prod)",
+    )
     .addOption(
-      new Option("--oauth-env <env>", "Auth0 environment for --oauth").choices([
-        "devel",
-        "stag",
-        "prod",
-      ] as const),
+      new Option(
+        "--development-env <env>",
+        "Override the Auth0 environment for --oauth (devel/stag/prod). Defaults to prod when omitted.",
+      ).choices(["devel", "stag", "prod"] as const),
     )
     .allowExcessArguments(false)
     .exitOverride();
@@ -232,16 +234,8 @@ export function parseCliArgs(argv: string[]): CLIOptions {
       program.getOptionValueSource("transport") === "cli",
     );
 
-    if (opts.oauth && !opts.oauthEnv) {
-      throw new Error("--oauth requires --oauth-env <devel|stag|prod>");
-    }
-    if (opts.oauthEnv && !opts.oauth) {
-      throw new Error("--oauth-env requires --oauth");
-    }
-    if (opts.oauth && opts.config) {
-      throw new Error(
-        "--oauth and --config are mutually exclusive in this release; YAML-driven OAuth is tracked as a follow-up",
-      );
+    if (opts.developmentEnv && !opts.oauth) {
+      throw new Error("--development-env requires --oauth");
     }
 
     // Precedence: CLI > file > undefined
@@ -277,7 +271,7 @@ export function parseCliArgs(argv: string[]): CLIOptions {
         : undefined,
       generateKey: !!opts.generateKey,
       oauth: opts.oauth,
-      oauthEnv: opts.oauthEnv,
+      developmentEnv: opts.developmentEnv,
     };
   } catch (error: unknown) {
     if (

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export interface CLIOptions {
   allowedHosts?: string[];
   generateKey?: boolean;
   oauth?: boolean;
-  developmentEnv?: "devel" | "stag" | "prod";
+  ccloudEnv?: "devel" | "stag" | "prod";
 }
 
 /**
@@ -216,7 +216,7 @@ export function parseCliArgs(argv: string[]): CLIOptions {
     )
     .addOption(
       new Option(
-        "--development-env <env>",
+        "--ccloud-env <env>",
         "Override the Auth0 environment for --oauth (devel/stag/prod). Defaults to prod when omitted.",
       ).choices(["devel", "stag", "prod"] as const),
     )
@@ -234,8 +234,13 @@ export function parseCliArgs(argv: string[]): CLIOptions {
       program.getOptionValueSource("transport") === "cli",
     );
 
-    if (opts.developmentEnv && !opts.oauth) {
-      throw new Error("--development-env requires --oauth");
+    if (opts.ccloudEnv && !opts.oauth) {
+      throw new Error("--ccloud-env requires --oauth");
+    }
+    if (opts.oauth && opts.config) {
+      throw new Error(
+        "--oauth and --config cannot be combined: declare OAuth as a connection inside the YAML (type: oauth) instead of passing --oauth",
+      );
     }
 
     // Precedence: CLI > file > undefined
@@ -271,7 +276,7 @@ export function parseCliArgs(argv: string[]): CLIOptions {
         : undefined,
       generateKey: !!opts.generateKey,
       oauth: opts.oauth,
-      developmentEnv: opts.developmentEnv,
+      ccloudEnv: opts.ccloudEnv,
     };
   } catch (error: unknown) {
     if (

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1034,7 +1034,7 @@ describe("config/env-config.ts", () => {
       ).toThrow(/MCP_AUTH_DISABLED.*MCP_API_KEY/);
     });
 
-    describe("oauth connection synthesis", () => {
+    describe("--oauth flag", () => {
       it("should produce a single direct connection when --oauth is not set", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1035,7 +1035,7 @@ describe("config/env-config.ts", () => {
     });
 
     describe("ccloudOAuth", () => {
-      it("should leave ccloudOAuth undefined when neither flag is set", () => {
+      it("should leave ccloudOAuth undefined when --oauth is not set", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
           {},
@@ -1043,28 +1043,29 @@ describe("config/env-config.ts", () => {
         expect(config.getCCloudOAuth()).toBeUndefined();
       });
 
-      it("should populate ccloudOAuth when oauth and oauthEnv are set", () => {
+      it("should default development_env to prod when --oauth is set without --development-env", () => {
+        const config = buildConfigFromEnvAndCli(
+          envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
+          { oauth: true },
+        );
+        expect(config.getCCloudOAuth()).toEqual({
+          type: "ccloud_oauth",
+          env: "prod",
+        });
+      });
+
+      it("should propagate developmentEnv into ccloudOAuth when both flags are set", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
           {
             oauth: true,
-            oauthEnv: "devel",
+            developmentEnv: "devel",
           },
         );
         expect(config.getCCloudOAuth()).toEqual({
           type: "ccloud_oauth",
           env: "devel",
         });
-      });
-
-      it("should leave ccloudOAuth undefined when oauth is set but oauthEnv is not", () => {
-        // Defensive: parseCliArgs would reject this combination, but the env-config
-        // builder must not silently invent an env value.
-        const config = buildConfigFromEnvAndCli(
-          envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
-          { oauth: true },
-        );
-        expect(config.getCCloudOAuth()).toBeUndefined();
       });
     });
   });

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1044,19 +1044,19 @@ describe("config/env-config.ts", () => {
         expect(conn.type).toBe("direct");
       });
 
-      it("should produce an OAuth connection with development_env=prod when --oauth is alone", () => {
+      it("should produce an OAuth connection with ccloud_env=prod when --oauth is alone", () => {
         const config = buildConfigFromEnvAndCli(envWith({}), { oauth: true });
         const conn = config.getSoleConnection();
-        expect(conn).toEqual({ type: "oauth", development_env: "prod" });
+        expect(conn).toEqual({ type: "oauth", ccloud_env: "prod" });
       });
 
-      it("should propagate developmentEnv into the OAuth connection", () => {
+      it("should propagate ccloudEnv into the OAuth connection", () => {
         const config = buildConfigFromEnvAndCli(envWith({}), {
           oauth: true,
-          developmentEnv: "stag",
+          ccloudEnv: "stag",
         });
         const conn = config.getSoleConnection();
-        expect(conn).toEqual({ type: "oauth", development_env: "stag" });
+        expect(conn).toEqual({ type: "oauth", ccloud_env: "stag" });
       });
 
       it("should ignore api-key env vars when --oauth is set", () => {
@@ -1068,10 +1068,10 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_KEY: "k",
             CONFLUENT_CLOUD_API_SECRET: "s",
           }),
-          { oauth: true, developmentEnv: "devel" },
+          { oauth: true, ccloudEnv: "devel" },
         );
         const conn = config.getSoleConnection();
-        expect(conn).toEqual({ type: "oauth", development_env: "devel" });
+        expect(conn).toEqual({ type: "oauth", ccloud_env: "devel" });
       });
     });
   });

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1034,38 +1034,44 @@ describe("config/env-config.ts", () => {
       ).toThrow(/MCP_AUTH_DISABLED.*MCP_API_KEY/);
     });
 
-    describe("ccloudOAuth", () => {
-      it("should leave ccloudOAuth undefined when --oauth is not set", () => {
+    describe("oauth connection synthesis", () => {
+      it("should produce a single direct connection when --oauth is not set", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
           {},
         );
-        expect(config.getCCloudOAuth()).toBeUndefined();
+        const conn = config.getSoleConnection();
+        expect(conn.type).toBe("direct");
       });
 
-      it("should default development_env to prod when --oauth is set without --development-env", () => {
-        const config = buildConfigFromEnvAndCli(
-          envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
-          { oauth: true },
-        );
-        expect(config.getCCloudOAuth()).toEqual({
-          type: "ccloud_oauth",
-          env: "prod",
-        });
+      it("should produce an OAuth connection with development_env=prod when --oauth is alone", () => {
+        const config = buildConfigFromEnvAndCli(envWith({}), { oauth: true });
+        const conn = config.getSoleConnection();
+        expect(conn).toEqual({ type: "oauth", development_env: "prod" });
       });
 
-      it("should propagate developmentEnv into ccloudOAuth when both flags are set", () => {
-        const config = buildConfigFromEnvAndCli(
-          envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
-          {
-            oauth: true,
-            developmentEnv: "devel",
-          },
-        );
-        expect(config.getCCloudOAuth()).toEqual({
-          type: "ccloud_oauth",
-          env: "devel",
+      it("should propagate developmentEnv into the OAuth connection", () => {
+        const config = buildConfigFromEnvAndCli(envWith({}), {
+          oauth: true,
+          developmentEnv: "stag",
         });
+        const conn = config.getSoleConnection();
+        expect(conn).toEqual({ type: "oauth", development_env: "stag" });
+      });
+
+      it("should ignore api-key env vars when --oauth is set", () => {
+        // OAuth is a top-level switch; the connections record carries a single OAuth
+        // entry regardless of which api-key env vars happen to be present.
+        const config = buildConfigFromEnvAndCli(
+          envWith({
+            BOOTSTRAP_SERVERS: "broker:9092",
+            CONFLUENT_CLOUD_API_KEY: "k",
+            CONFLUENT_CLOUD_API_SECRET: "s",
+          }),
+          { oauth: true, developmentEnv: "devel" },
+        );
+        const conn = config.getSoleConnection();
+        expect(conn).toEqual({ type: "oauth", development_env: "devel" });
       });
     });
   });

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -58,7 +58,7 @@ describe("config/env-config.ts", () => {
           }),
         );
 
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.type).toBe("direct");
         expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
         expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
@@ -77,7 +77,7 @@ describe("config/env-config.ts", () => {
           envWith({ BOOTSTRAP_SERVERS: "broker1:9092,broker2:9092" }),
         );
 
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.bootstrap_servers).toBe("broker1:9092,broker2:9092");
         expect(conn.schema_registry).toBeUndefined();
       });
@@ -87,7 +87,7 @@ describe("config/env-config.ts", () => {
           envWith({ SCHEMA_REGISTRY_ENDPOINT: "https://sr.example.com:8081" }),
         );
 
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.schema_registry?.endpoint).toBe(
           "https://sr.example.com:8081",
         );
@@ -128,7 +128,7 @@ describe("config/env-config.ts", () => {
             KAFKA_API_SECRET: "mysecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.auth).toEqual({
           type: "api_key",
           key: "mykey",
@@ -144,7 +144,7 @@ describe("config/env-config.ts", () => {
             SCHEMA_REGISTRY_API_SECRET: "srsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.schema_registry?.auth).toEqual({
           type: "api_key",
           key: "srkey",
@@ -163,7 +163,7 @@ describe("config/env-config.ts", () => {
             SCHEMA_REGISTRY_API_SECRET: "srsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.auth).toEqual({
           type: "api_key",
           key: "kafkakey",
@@ -267,7 +267,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.confluent_cloud?.auth).toEqual({
           type: "api_key",
           key: "cckey",
@@ -285,7 +285,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_REST_ENDPOINT: "https://custom.confluent.cloud",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.confluent_cloud).toBeUndefined();
       });
 
@@ -297,7 +297,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.confluent_cloud?.endpoint).toBe(
           "https://custom.confluent.cloud",
         );
@@ -315,7 +315,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.confluent_cloud?.auth).toBeDefined();
         expect(conn.kafka).toBeUndefined();
         expect(conn.schema_registry).toBeUndefined();
@@ -352,7 +352,7 @@ describe("config/env-config.ts", () => {
         const config = buildConfigFromEnvAndCli(
           envWith(allRequiredFlinkEnvVars),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.flink?.endpoint).toBe(
           "https://flink.us-east-1.aws.confluent.cloud",
         );
@@ -374,7 +374,7 @@ describe("config/env-config.ts", () => {
             FLINK_DATABASE_NAME: "my-cluster",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.flink?.environment_name).toBe("my-environment");
         expect(conn.flink?.database_name).toBe("my-cluster");
       });
@@ -383,7 +383,7 @@ describe("config/env-config.ts", () => {
         const config = buildConfigFromEnvAndCli(
           envWith(allRequiredFlinkEnvVars),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.flink).toBeDefined();
         expect(conn.kafka).toBeUndefined();
         expect(conn.schema_registry).toBeUndefined();
@@ -431,7 +431,7 @@ describe("config/env-config.ts", () => {
               "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.rest_endpoint).toBe(
           "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
         );
@@ -444,7 +444,7 @@ describe("config/env-config.ts", () => {
             KAFKA_CLUSTER_ID: "lkc-abc123",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.cluster_id).toBe("lkc-abc123");
       });
 
@@ -455,7 +455,7 @@ describe("config/env-config.ts", () => {
             KAFKA_ENV_ID: "env-xyz789",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.env_id).toBe("env-xyz789");
       });
 
@@ -469,7 +469,7 @@ describe("config/env-config.ts", () => {
             KAFKA_ENV_ID: "env-xyz789",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.rest_endpoint).toBe(
           "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
         );
@@ -495,7 +495,7 @@ describe("config/env-config.ts", () => {
               "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.kafka?.rest_endpoint).toBe(
           "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
         );
@@ -511,7 +511,7 @@ describe("config/env-config.ts", () => {
             TABLEFLOW_API_SECRET: "tfsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.tableflow?.auth).toEqual({
           type: "api_key",
           key: "tfkey",
@@ -526,7 +526,7 @@ describe("config/env-config.ts", () => {
             TABLEFLOW_API_SECRET: "tfsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.tableflow?.auth).toBeDefined();
         expect(conn.kafka).toBeUndefined();
         expect(conn.schema_registry).toBeUndefined();
@@ -727,7 +727,7 @@ describe("config/env-config.ts", () => {
             TELEMETRY_API_SECRET: "telsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.telemetry).toEqual({
           endpoint: "https://custom.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "telkey", secret: "telsecret" },
@@ -741,7 +741,7 @@ describe("config/env-config.ts", () => {
             TELEMETRY_API_SECRET: "telsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.telemetry).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "telkey", secret: "telsecret" },
@@ -766,7 +766,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.telemetry).toEqual({
           endpoint: "https://custom.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "cckey", secret: "ccsecret" },
@@ -780,7 +780,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.telemetry).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "cckey", secret: "ccsecret" },
@@ -794,7 +794,7 @@ describe("config/env-config.ts", () => {
             TELEMETRY_API_SECRET: "telsecret",
           }),
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getSoleDirectConnection();
         expect(conn.telemetry?.endpoint).toBe(
           "https://api.telemetry.confluent.cloud",
         );
@@ -836,7 +836,7 @@ describe("config/env-config.ts", () => {
         "localhost",
         "127.0.0.1",
       ]);
-      expect(config.getSoleConnection().kafka?.bootstrap_servers).toBe(
+      expect(config.getSoleDirectConnection().kafka?.bootstrap_servers).toBe(
         "localhost:9092",
       );
     });
@@ -873,7 +873,7 @@ describe("config/env-config.ts", () => {
         envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
         { kafkaConfig: { "ssl.ca.location": "/etc/ssl/certs/ca.pem" } },
       );
-      expect(config.getSoleConnection().kafka?.extra_properties).toEqual({
+      expect(config.getSoleDirectConnection().kafka?.extra_properties).toEqual({
         "ssl.ca.location": "/etc/ssl/certs/ca.pem",
       });
     });
@@ -883,7 +883,7 @@ describe("config/env-config.ts", () => {
         envWith({ BOOTSTRAP_SERVERS: "original:9092" }),
         { kafkaConfig: { "bootstrap.servers": "override:9092" } },
       );
-      expect(config.getSoleConnection().kafka?.bootstrap_servers).toBe(
+      expect(config.getSoleDirectConnection().kafka?.bootstrap_servers).toBe(
         "override:9092",
       );
     });
@@ -896,11 +896,11 @@ describe("config/env-config.ts", () => {
         }),
         { kafkaConfig: { "bootstrap.servers": "broker:9092" } },
       );
-      expect(config.getSoleConnection().kafka?.bootstrap_servers).toBe(
+      expect(config.getSoleDirectConnection().kafka?.bootstrap_servers).toBe(
         "broker:9092",
       );
       expect(
-        config.getSoleConnection().kafka?.extra_properties,
+        config.getSoleDirectConnection().kafka?.extra_properties,
       ).toBeUndefined();
     });
 
@@ -918,7 +918,7 @@ describe("config/env-config.ts", () => {
           },
         },
       );
-      const kafka = config.getSoleConnection().kafka;
+      const kafka = config.getSoleDirectConnection().kafka;
       expect(kafka?.bootstrap_servers).toBe("broker:9092");
       expect(kafka?.auth).toEqual({
         type: "api_key",
@@ -941,7 +941,7 @@ describe("config/env-config.ts", () => {
           },
         },
       );
-      const kafka = config.getSoleConnection().kafka;
+      const kafka = config.getSoleDirectConnection().kafka;
       expect(kafka?.bootstrap_servers).toBe("broker:9092");
       expect(kafka?.extra_properties).toEqual({ "socket.timeout.ms": "30000" });
     });
@@ -960,7 +960,7 @@ describe("config/env-config.ts", () => {
           },
         },
       );
-      const kafka = config.getSoleConnection().kafka;
+      const kafka = config.getSoleDirectConnection().kafka;
       expect(kafka?.auth).toEqual({
         type: "api_key",
         key: "k-key",

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -77,17 +77,17 @@ function buildConfigFromEnv(
   env: Environment,
   authOverrides: Pick<EnvPathCliOverrides, "disableAuth" | "allowedHosts"> = {},
   kafkaConfig?: KeyValuePairObject,
-  oauth?: { developmentEnv?: "devel" | "stag" | "prod" },
+  oauth?: { ccloudEnv?: "devel" | "stag" | "prod" },
 ): MCPServerConfiguration {
   // OAuth path: synthesize a single OAuth-typed connection. No surface blocks,
-  // no auth fields. development_env defaults to "prod" via the schema.
+  // no auth fields. ccloud_env defaults to "prod" via the schema.
   if (oauth) {
     const rawDocument: Record<string, unknown> = {
       connections: {
         [ENV_CONNECTION_NAME]: {
           type: "oauth",
-          ...(oauth.developmentEnv && {
-            development_env: oauth.developmentEnv,
+          ...(oauth.ccloudEnv && {
+            ccloud_env: oauth.ccloudEnv,
           }),
         },
       },
@@ -166,7 +166,7 @@ export interface EnvPathCliOverrides {
   allowedHosts?: string[];
   kafkaConfig?: KeyValuePairObject;
   oauth?: boolean;
-  developmentEnv?: "devel" | "stag" | "prod";
+  ccloudEnv?: "devel" | "stag" | "prod";
 }
 
 /**
@@ -189,7 +189,7 @@ export function buildConfigFromEnvAndCli(
       allowedHosts: overrides.allowedHosts,
     },
     overrides.kafkaConfig,
-    overrides.oauth ? { developmentEnv: overrides.developmentEnv } : undefined,
+    overrides.oauth ? { ccloudEnv: overrides.ccloudEnv } : undefined,
   );
 }
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -1,6 +1,5 @@
 import {
   type AuthConfig,
-  type CCloudOAuthConfig,
   type KafkaDirectConfig,
   formatZodIssues,
   KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
@@ -78,8 +77,31 @@ function buildConfigFromEnv(
   env: Environment,
   authOverrides: Pick<EnvPathCliOverrides, "disableAuth" | "allowedHosts"> = {},
   kafkaConfig?: KeyValuePairObject,
-  ccloudOAuth?: CCloudOAuthConfig,
+  oauth?: { developmentEnv?: "devel" | "stag" | "prod" },
 ): MCPServerConfiguration {
+  // OAuth path: synthesize a single OAuth-typed connection. No surface blocks,
+  // no auth fields. development_env defaults to "prod" via the schema.
+  if (oauth) {
+    const rawDocument: Record<string, unknown> = {
+      connections: {
+        [ENV_CONNECTION_NAME]: {
+          type: "oauth",
+          ...(oauth.developmentEnv && {
+            development_env: oauth.developmentEnv,
+          }),
+        },
+      },
+      ...buildServerBlock(env, authOverrides),
+    };
+    const result = mcpConfigSchema.safeParse(rawDocument);
+    if (!result.success) {
+      throw new Error(
+        `Failed to construct OAuth MCPServerConfiguration:\n${formatZodIssues(result.error.issues)}`,
+      );
+    }
+    return new MCPServerConfiguration(result.data);
+  }
+
   const connection: Record<string, unknown> = { type: "direct" };
 
   // Each connection builder returns { <blockKey>: { ...fields } } or null — the key is owned
@@ -129,7 +151,7 @@ function buildConfigFromEnv(
     );
   }
 
-  return new MCPServerConfiguration({ ...result.data, ccloudOAuth });
+  return new MCPServerConfiguration(result.data);
 }
 
 /** CLI flags that may override values in the env-var config path. */
@@ -154,14 +176,6 @@ export function buildConfigFromEnvAndCli(
   env: Environment,
   overrides: EnvPathCliOverrides = {},
 ): MCPServerConfiguration {
-  // --oauth alone → defaults to prod. --development-env only takes effect when --oauth is set
-  // (parseCliArgs enforces this); defensively default the env here too.
-  const ccloudOAuth: CCloudOAuthConfig | undefined = overrides.oauth
-    ? {
-        type: "ccloud_oauth" as const,
-        env: overrides.developmentEnv ?? "prod",
-      }
-    : undefined;
   return buildConfigFromEnv(
     env,
     {
@@ -169,7 +183,7 @@ export function buildConfigFromEnvAndCli(
       allowedHosts: overrides.allowedHosts,
     },
     overrides.kafkaConfig,
-    ccloudOAuth,
+    overrides.oauth ? { developmentEnv: overrides.developmentEnv } : undefined,
   );
 }
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -95,8 +95,14 @@ function buildConfigFromEnv(
     };
     const result = mcpConfigSchema.safeParse(rawDocument);
     if (!result.success) {
+      // Server-config validation can still fail on the OAuth path
+      // (e.g., MCP_API_KEY length / disabled+api_key conflict). Run the
+      // env-var humanizer so users see env-var names, not schema paths.
+      const formattedIssues = humanizeEnvConfigPaths(
+        formatZodIssues(result.error.issues),
+      );
       throw new Error(
-        `Failed to construct OAuth MCPServerConfiguration:\n${formatZodIssues(result.error.issues)}`,
+        `Failed to construct OAuth MCPServerConfiguration from environment variables:\n${formattedIssues}`,
       );
     }
     return new MCPServerConfiguration(result.data);

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -132,13 +132,13 @@ function buildConfigFromEnv(
   return new MCPServerConfiguration({ ...result.data, ccloudOAuth });
 }
 
-/** CLI flags that may override values in the env-var config path. Mutually exclusive with --config (YAML path). */
+/** CLI flags that may override values in the env-var config path. */
 export interface EnvPathCliOverrides {
   disableAuth?: boolean;
   allowedHosts?: string[];
   kafkaConfig?: KeyValuePairObject;
   oauth?: boolean;
-  oauthEnv?: "devel" | "stag" | "prod";
+  developmentEnv?: "devel" | "stag" | "prod";
 }
 
 /**
@@ -154,10 +154,14 @@ export function buildConfigFromEnvAndCli(
   env: Environment,
   overrides: EnvPathCliOverrides = {},
 ): MCPServerConfiguration {
-  const ccloudOAuth: CCloudOAuthConfig | undefined =
-    overrides.oauth && overrides.oauthEnv
-      ? { type: "ccloud_oauth" as const, env: overrides.oauthEnv }
-      : undefined;
+  // --oauth alone → defaults to prod. --development-env only takes effect when --oauth is set
+  // (parseCliArgs enforces this); defensively default the env here too.
+  const ccloudOAuth: CCloudOAuthConfig | undefined = overrides.oauth
+    ? {
+        type: "ccloud_oauth" as const,
+        env: overrides.developmentEnv ?? "prod",
+      }
+    : undefined;
   return buildConfigFromEnv(
     env,
     {

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -303,34 +303,34 @@ describe("config/index.ts", () => {
 
       expect(config.getSoleConnection()).toEqual({
         type: "oauth",
-        development_env: "prod",
+        ccloud_env: "prod",
       });
     });
 
-    it("should parse an explicit oauth development_env value", () => {
+    it("should parse an explicit oauth ccloud_env value", () => {
       const yamlContent = `connections:
   stag-oauth:
     type: "oauth"
-    development_env: "stag"
+    ccloud_env: "stag"
 `;
 
       const config = parseYamlConfiguration(yamlContent, {});
 
       expect(config.getSoleConnection()).toEqual({
         type: "oauth",
-        development_env: "stag",
+        ccloud_env: "stag",
       });
     });
 
-    it("should reject an oauth connection with an unknown development_env", () => {
+    it("should reject an oauth connection with an unknown ccloud_env", () => {
       const yamlContent = `connections:
   bad-oauth:
     type: "oauth"
-    development_env: "bogus"
+    ccloud_env: "bogus"
 `;
 
       expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /development_env/,
+        /ccloud_env/,
       );
     });
 

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -293,6 +293,47 @@ describe("config/index.ts", () => {
       expect(conn.kafka).toBeUndefined();
     });
 
+    it("should parse a minimal oauth connection and apply the prod default", () => {
+      const yamlContent = `connections:
+  prod-oauth:
+    type: "oauth"
+`;
+
+      const config = parseYamlConfiguration(yamlContent, {});
+
+      expect(config.getSoleConnection()).toEqual({
+        type: "oauth",
+        development_env: "prod",
+      });
+    });
+
+    it("should parse an explicit oauth development_env value", () => {
+      const yamlContent = `connections:
+  stag-oauth:
+    type: "oauth"
+    development_env: "stag"
+`;
+
+      const config = parseYamlConfiguration(yamlContent, {});
+
+      expect(config.getSoleConnection()).toEqual({
+        type: "oauth",
+        development_env: "stag",
+      });
+    });
+
+    it("should reject an oauth connection with an unknown development_env", () => {
+      const yamlContent = `connections:
+  bad-oauth:
+    type: "oauth"
+    development_env: "bogus"
+`;
+
+      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
+        /development_env/,
+      );
+    });
+
     it("should interpolate ${VAR} references using provided env before Zod validation", () => {
       const yamlContent = `connections:
   local:

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -19,7 +19,10 @@ describe("config/index.ts", () => {
       bootstrap_servers: "localhost:9092"
 `;
 
-      const conn = parseYamlConfiguration(yamlContent, {}).getSoleConnection();
+      const conn = parseYamlConfiguration(
+        yamlContent,
+        {},
+      ).getSoleDirectConnection();
 
       expect(conn.type).toBe("direct");
       expect(conn.kafka!.bootstrap_servers).toBe("localhost:9092");
@@ -36,7 +39,10 @@ describe("config/index.ts", () => {
       endpoint: "http://localhost:8081"
 `;
 
-      const conn = parseYamlConfiguration(yamlContent, {}).getSoleConnection();
+      const conn = parseYamlConfiguration(
+        yamlContent,
+        {},
+      ).getSoleDirectConnection();
 
       expect(conn.schema_registry).toBeDefined();
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
@@ -50,7 +56,10 @@ describe("config/index.ts", () => {
       bootstrap_servers: "broker1:9092,broker2:9092,broker3:9092"
 `;
 
-      const conn = parseYamlConfiguration(yamlContent, {}).getSoleConnection();
+      const conn = parseYamlConfiguration(
+        yamlContent,
+        {},
+      ).getSoleDirectConnection();
 
       expect(conn.kafka!.bootstrap_servers).toBe(
         "broker1:9092,broker2:9092,broker3:9092",
@@ -264,7 +273,7 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      expect(config.getSoleConnection().schema_registry?.endpoint).toBe(
+      expect(config.getSoleDirectConnection().schema_registry?.endpoint).toBe(
         "https://schema-registry.example.com:8081",
       );
     });
@@ -279,7 +288,7 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       expect(conn.kafka).toBeUndefined();
     });
@@ -299,7 +308,7 @@ describe("config/index.ts", () => {
         SR_URL: "http://localhost:8081",
       });
 
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka!.bootstrap_servers).toBe("broker1:9092");
       expect(conn.schema_registry!.endpoint).toBe("http://localhost:8081");
     });
@@ -418,7 +427,7 @@ describe("config/index.ts", () => {
 
       const config = loadConfigFromYaml("/path/to/config.yaml", {});
 
-      expect(config.getSoleConnection().kafka!.bootstrap_servers).toBe(
+      expect(config.getSoleDirectConnection().kafka!.bootstrap_servers).toBe(
         "localhost:9092",
       );
     });
@@ -437,7 +446,7 @@ describe("config/index.ts", () => {
         BOOTSTRAP_SERVERS: "broker1:9092",
       });
 
-      expect(config.getSoleConnection().kafka!.bootstrap_servers).toBe(
+      expect(config.getSoleDirectConnection().kafka!.bootstrap_servers).toBe(
         "broker1:9092",
       );
     });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,6 +13,7 @@ export {
   CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
   MCPServerConfiguration,
   type DirectConnectionConfig,
+  type OAuthConnectionConfig,
 } from "@src/config/models.js";
 
 /**

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,11 +1,7 @@
-import type {
-  CCloudOAuthConfig,
-  DirectConnectionConfig,
-} from "@src/config/models.js";
+import type { DirectConnectionConfig } from "@src/config/models.js";
 import {
   KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
   MCPServerConfiguration,
-  ccloudOAuthConfigSchema,
   formatZodIssues,
   mcpConfigSchema,
 } from "@src/config/models.js";
@@ -675,87 +671,6 @@ describe("config/models.ts", () => {
           /Multiple connections defined/,
         );
       });
-    });
-
-    describe("getCCloudOAuth()", () => {
-      it("should return undefined when no oauth config is supplied", () => {
-        const config = new MCPServerConfiguration({
-          connections: {},
-        });
-        expect(config.getCCloudOAuth()).toBeUndefined();
-      });
-
-      it("should return the supplied config", () => {
-        const oauth: CCloudOAuthConfig = { type: "ccloud_oauth", env: "stag" };
-        const config = new MCPServerConfiguration({
-          connections: {},
-          ccloudOAuth: oauth,
-        });
-        expect(config.getCCloudOAuth()).toEqual(oauth);
-      });
-
-      it("should not expose ccloudOAuth as an enumerable property", () => {
-        const config = new MCPServerConfiguration({
-          connections: {},
-          ccloudOAuth: { type: "ccloud_oauth", env: "devel" },
-        });
-        // Private fields should not appear on Object.keys.
-        expect(Object.keys(config)).not.toContain("ccloudOAuth");
-        expect(Object.keys(config)).not.toContain("#ccloudOAuth");
-      });
-    });
-  });
-
-  describe("ccloudOAuthConfigSchema", () => {
-    it("should accept a valid devel config", () => {
-      const result = ccloudOAuthConfigSchema.safeParse({
-        type: "ccloud_oauth",
-        env: "devel",
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it("should accept stag and prod environments", () => {
-      expect(
-        ccloudOAuthConfigSchema.safeParse({ type: "ccloud_oauth", env: "stag" })
-          .success,
-      ).toBe(true);
-      expect(
-        ccloudOAuthConfigSchema.safeParse({ type: "ccloud_oauth", env: "prod" })
-          .success,
-      ).toBe(true);
-    });
-
-    it("should reject an unknown env value", () => {
-      const result = ccloudOAuthConfigSchema.safeParse({
-        type: "ccloud_oauth",
-        env: "bogus",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject a wrong discriminator", () => {
-      const result = ccloudOAuthConfigSchema.safeParse({
-        type: "direct",
-        env: "devel",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject when env is missing", () => {
-      const result = ccloudOAuthConfigSchema.safeParse({
-        type: "ccloud_oauth",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject unknown extra keys", () => {
-      const result = ccloudOAuthConfigSchema.safeParse({
-        type: "ccloud_oauth",
-        env: "devel",
-        clientId: "should-not-be-here",
-      });
-      expect(result.success).toBe(false);
     });
   });
 

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -687,7 +687,7 @@ describe("config/models.ts", () => {
       it("should throw when the sole connection is OAuth-typed", () => {
         const config = new MCPServerConfiguration({
           connections: {
-            "env-connection": { type: "oauth", development_env: "devel" },
+            "env-connection": { type: "oauth", ccloud_env: "devel" },
           },
         });
 
@@ -707,7 +707,7 @@ describe("config/models.ts", () => {
   });
 
   describe("oauth connection arm", () => {
-    it("should default development_env to 'prod' when omitted", () => {
+    it("should default ccloud_env to 'prod' when omitted", () => {
       const result = mcpConfigSchema.safeParse({
         connections: { foo: { type: "oauth" } },
       });
@@ -715,23 +715,23 @@ describe("config/models.ts", () => {
       if (result.success) {
         expect(result.data.connections.foo).toEqual({
           type: "oauth",
-          development_env: "prod",
+          ccloud_env: "prod",
         });
       }
     });
 
-    it("should accept explicit devel/stag/prod for development_env", () => {
+    it("should accept explicit devel/stag/prod for ccloud_env", () => {
       for (const env of ["devel", "stag", "prod"] as const) {
         const result = mcpConfigSchema.safeParse({
-          connections: { foo: { type: "oauth", development_env: env } },
+          connections: { foo: { type: "oauth", ccloud_env: env } },
         });
         expect(result.success).toBe(true);
       }
     });
 
-    it("should reject an unknown development_env value", () => {
+    it("should reject an unknown ccloud_env value", () => {
       const result = mcpConfigSchema.safeParse({
-        connections: { foo: { type: "oauth", development_env: "bogus" } },
+        connections: { foo: { type: "oauth", ccloud_env: "bogus" } },
       });
       expect(result.success).toBe(false);
     });
@@ -739,7 +739,7 @@ describe("config/models.ts", () => {
     it("should reject unknown extra keys on the oauth arm", () => {
       const result = mcpConfigSchema.safeParse({
         connections: {
-          foo: { type: "oauth", development_env: "devel", clientId: "x" },
+          foo: { type: "oauth", ccloud_env: "devel", clientId: "x" },
         },
       });
       expect(result.success).toBe(false);

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,4 +1,7 @@
-import type { CCloudOAuthConfig } from "@src/config/models.js";
+import type {
+  CCloudOAuthConfig,
+  DirectConnectionConfig,
+} from "@src/config/models.js";
 import {
   KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
   MCPServerConfiguration,
@@ -219,7 +222,13 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.connections["production"]?.telemetry).toEqual({
+        expect(
+          (
+            result.data.connections["production"] as
+              | DirectConnectionConfig
+              | undefined
+          )?.telemetry,
+        ).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "k", secret: "s" },
         });
@@ -257,7 +266,13 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.connections["production"]?.telemetry).toEqual({
+        expect(
+          (
+            result.data.connections["production"] as
+              | DirectConnectionConfig
+              | undefined
+          )?.telemetry,
+        ).toEqual({
           endpoint: "https://custom.telemetry.example.com",
           auth: { type: "api_key", key: "cckey", secret: "ccsecret" },
         });
@@ -278,7 +293,13 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.connections["production"]?.telemetry).toEqual({
+        expect(
+          (
+            result.data.connections["production"] as
+              | DirectConnectionConfig
+              | undefined
+          )?.telemetry,
+        ).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "k", secret: "s" },
         });
@@ -298,7 +319,13 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.connections["production"]?.telemetry).toEqual({
+        expect(
+          (
+            result.data.connections["production"] as
+              | DirectConnectionConfig
+              | undefined
+          )?.telemetry,
+        ).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "cckey", secret: "ccsecret" },
         });
@@ -546,7 +573,13 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.connections["production"]?.confluent_cloud).toEqual({
+        expect(
+          (
+            result.data.connections["production"] as
+              | DirectConnectionConfig
+              | undefined
+          )?.confluent_cloud,
+        ).toEqual({
           endpoint: "https://api.confluent.cloud",
           auth: { type: "api_key", key: "k", secret: "s" },
         });
@@ -568,7 +601,11 @@ describe("config/models.ts", () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(
-          result.data.connections["production"]?.confluent_cloud?.endpoint,
+          (
+            result.data.connections["production"] as
+              | DirectConnectionConfig
+              | undefined
+          )?.confluent_cloud?.endpoint,
         ).toBe("https://custom.confluent.cloud");
       }
     });
@@ -719,6 +756,61 @@ describe("config/models.ts", () => {
         clientId: "should-not-be-here",
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe("oauth connection arm of mcpConfigSchema", () => {
+    it("should default development_env to 'prod' when omitted", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { foo: { type: "oauth" } },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.connections.foo).toEqual({
+          type: "oauth",
+          development_env: "prod",
+        });
+      }
+    });
+
+    it("should accept explicit devel/stag/prod for development_env", () => {
+      for (const env of ["devel", "stag", "prod"] as const) {
+        const result = mcpConfigSchema.safeParse({
+          connections: { foo: { type: "oauth", development_env: env } },
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("should reject an unknown development_env value", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { foo: { type: "oauth", development_env: "bogus" } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject unknown extra keys on the oauth arm", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: {
+          foo: { type: "oauth", development_env: "devel", clientId: "x" },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should not spread direct-arm fields onto an oauth connection", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { foo: { type: "oauth" } },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const conn = result.data.connections.foo as unknown as Record<
+          string,
+          unknown
+        >;
+        expect(conn).not.toHaveProperty("confluent_cloud");
+        expect(conn).not.toHaveProperty("telemetry");
+      }
     });
   });
 });

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -672,6 +672,38 @@ describe("config/models.ts", () => {
         );
       });
     });
+
+    describe("getSoleDirectConnection", () => {
+      it("should return the connection narrowed to direct when sole connection is direct", () => {
+        const config = new MCPServerConfiguration({
+          connections: { local: directConnection },
+        });
+
+        const conn = config.getSoleDirectConnection();
+        expect(conn).toBe(directConnection);
+        expect(conn.type).toBe("direct");
+      });
+
+      it("should throw when the sole connection is OAuth-typed", () => {
+        const config = new MCPServerConfiguration({
+          connections: {
+            "env-connection": { type: "oauth", development_env: "devel" },
+          },
+        });
+
+        expect(() => config.getSoleDirectConnection()).toThrow(
+          /Expected sole connection to be a direct connection; got type "oauth"/,
+        );
+      });
+
+      it("should propagate the underlying getSoleConnection throw on zero connections", () => {
+        const config = new MCPServerConfiguration({ connections: {} });
+
+        expect(() => config.getSoleDirectConnection()).toThrow(
+          /No connections defined/,
+        );
+      });
+    });
   });
 
   describe("oauth connection arm", () => {

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -674,7 +674,7 @@ describe("config/models.ts", () => {
     });
   });
 
-  describe("oauth connection arm of mcpConfigSchema", () => {
+  describe("oauth connection arm", () => {
     it("should default development_env to 'prod' when omitted", () => {
       const result = mcpConfigSchema.safeParse({
         connections: { foo: { type: "oauth" } },

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -41,6 +41,22 @@ export interface CCloudOAuthConfig {
 }
 
 /**
+ * OAuth (PKCE) connection variant. Peer arm of {@link DirectConnectionConfig}
+ * inside the `ConnectionConfig` discriminated union. The CCloud REST URL is
+ * derived from `development_env` via `getCloudRestUrlForEnv` inside
+ * `OAuthClientManager`. No service blocks; OAuth-eligible tools auto-enable
+ * via the `isOAuth` predicate, and resource IDs that direct connections supply
+ * via blocks must be passed as tool arguments under OAuth.
+ *
+ * `development_env` defaults to "prod" via the schema; only Confluent staff
+ * testing against devel/stag set it explicitly.
+ */
+export interface OAuthConnectionConfig {
+  readonly type: "oauth";
+  readonly development_env: "devel" | "stag" | "prod";
+}
+
+/**
  * API key credential pair used throughout connection sub-configs.
  * Corresponds to `auth` blocks nested under each service in `connections.<name>`.
  */
@@ -118,7 +134,7 @@ export interface FlinkDirectConfig {
  * Union of all connection types (future-proof discriminated union).
  * Currently only supports "direct" type.
  */
-export type ConnectionConfig = DirectConnectionConfig;
+export type ConnectionConfig = DirectConnectionConfig | OAuthConnectionConfig;
 
 /**
  * MCP server operational settings — transport, auth, and logging.
@@ -214,6 +230,22 @@ export class MCPServerConfiguration {
 
     // must be exactly one connection at this point, so return it.
     return this.connections[connectionNames[0]!]!;
+  }
+
+  /**
+   * Returns the sole connection narrowed to {@link DirectConnectionConfig}, throwing
+   * if it is OAuth-typed. Use from callers that need to read service-block fields
+   * (e.g., `kafka.cluster_id`, `flink.environment_id`) — the throw replaces what
+   * would otherwise be a `conn.type === "direct"` guard at every read site.
+   */
+  getSoleDirectConnection(): DirectConnectionConfig {
+    const conn = this.getSoleConnection();
+    if (conn.type !== "direct") {
+      throw new Error(
+        `Expected sole connection to be a direct connection; got type "${conn.type}"`,
+      );
+    }
+    return conn;
   }
 
   getConnectionNames(): string[] {
@@ -407,11 +439,19 @@ const directConnectionSchema = z
 export const CONFLUENT_CLOUD_DEFAULT_ENDPOINT = "https://api.confluent.cloud";
 const TELEMETRY_DEFAULT_ENDPOINT = "https://api.telemetry.confluent.cloud";
 
+/** Zod schema for the OAuth (PKCE) connection arm. */
+const oauthConnectionSchema = z
+  .object({
+    type: z.literal("oauth"),
+    development_env: z.enum(["devel", "stag", "prod"]).default("prod"),
+  })
+  .strict();
+
 /**
- * Discriminated union of all connection types (currently just direct).
+ * Discriminated union of all connection types: direct (api-key) and oauth (PKCE).
  */
 const connectionConfigSchema = z
-  .discriminatedUnion("type", [directConnectionSchema])
+  .discriminatedUnion("type", [directConnectionSchema, oauthConnectionSchema])
   // superRefine calls are placed here (after the union) rather than on directConnectionSchema
   // because wrapping a ZodObject in ZodEffects breaks z.discriminatedUnion's discriminant lookup.
   .superRefine((data, ctx) => {
@@ -451,6 +491,9 @@ const connectionConfigSchema = z
     }
   })
   .transform((data): ConnectionConfig => {
+    // OAuth connections carry no service blocks — pass through untouched so the
+    // direct-arm telemetry/cc resolution below doesn't spread `undefined` onto them.
+    if (data.type !== "direct") return data;
     // Resolve the raw (optional-field) telemetry input into a fully-populated
     // TelemetryDirectConfig or undefined, applying two normalisation rules:
     //   1. If telemetry.auth is absent, fall back to confluent_cloud.auth.

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -28,18 +28,18 @@ export interface DirectConnectionConfig {
 /**
  * OAuth (PKCE) connection variant. Peer arm of {@link DirectConnectionConfig}
  * inside the `ConnectionConfig` discriminated union. The CCloud REST URL is
- * derived from `development_env` via `getCloudRestUrlForEnv` inside
+ * derived from `ccloud_env` via `getCloudRestUrlForEnv` inside
  * `OAuthClientManager`. No service blocks; OAuth-eligible tools auto-enable
  * because `hasConfluentCloud` widens to return `true` for OAuth connections
  * (see `connection-predicates.ts`). Resource IDs that direct connections
  * supply via blocks must be passed as tool arguments under OAuth.
  *
- * `development_env` defaults to "prod" via the schema; only Confluent staff
+ * `ccloud_env` defaults to "prod" via the schema; only Confluent staff
  * testing against devel/stag set it explicitly.
  */
 export interface OAuthConnectionConfig {
   readonly type: "oauth";
-  readonly development_env: "devel" | "stag" | "prod";
+  readonly ccloud_env: "devel" | "stag" | "prod";
 }
 
 /**
@@ -409,7 +409,7 @@ const TELEMETRY_DEFAULT_ENDPOINT = "https://api.telemetry.confluent.cloud";
 const oauthConnectionSchema = z
   .object({
     type: z.literal("oauth"),
-    development_env: z.enum(["devel", "stag", "prod"]).default("prod"),
+    ccloud_env: z.enum(["devel", "stag", "prod"]).default("prod"),
   })
   .strict();
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -30,8 +30,9 @@ export interface DirectConnectionConfig {
  * inside the `ConnectionConfig` discriminated union. The CCloud REST URL is
  * derived from `development_env` via `getCloudRestUrlForEnv` inside
  * `OAuthClientManager`. No service blocks; OAuth-eligible tools auto-enable
- * via the `isOAuth` predicate, and resource IDs that direct connections supply
- * via blocks must be passed as tool arguments under OAuth.
+ * because `hasConfluentCloud` widens to return `true` for OAuth connections
+ * (see `connection-predicates.ts`). Resource IDs that direct connections
+ * supply via blocks must be passed as tool arguments under OAuth.
  *
  * `development_env` defaults to "prod" via the schema; only Confluent staff
  * testing against devel/stag set it explicitly.
@@ -116,8 +117,7 @@ export interface FlinkDirectConfig {
 }
 
 /**
- * Union of all connection types (future-proof discriminated union).
- * Currently only supports "direct" type.
+ * Discriminated union of all connection variants: direct (api-key) and oauth (PKCE).
  */
 export type ConnectionConfig = DirectConnectionConfig | OAuthConnectionConfig;
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -26,21 +26,6 @@ export interface DirectConnectionConfig {
 }
 
 /**
- * Connection-shaped configuration for a Confluent Cloud OAuth (PKCE) connection.
- * Peer to {@link DirectConnectionConfig}. For now this is held as a private
- * optional field on {@link MCPServerConfiguration} (see `#ccloudOAuth`); the
- * connections-record migration moves it into `connections` as a second member
- * of the discriminated `ConnectionConfig` union.
- *
- * Endpoints derive from `env` via the Auth0 environment table — the only data
- * needed to drive the PKCE flow and resolve REST base URLs.
- */
-export interface CCloudOAuthConfig {
-  readonly type: "ccloud_oauth";
-  readonly env: "devel" | "stag" | "prod";
-}
-
-/**
  * OAuth (PKCE) connection variant. Peer arm of {@link DirectConnectionConfig}
  * inside the `ConnectionConfig` discriminated union. The CCloud REST URL is
  * derived from `development_env` via `getCloudRestUrlForEnv` inside
@@ -181,34 +166,15 @@ export class MCPServerConfiguration {
   readonly connections: Readonly<Record<string, ConnectionConfig>>;
   /** MCP server operational settings. Corresponds to the `server` block at the root of the YAML configuration. */
   readonly server: ServerConfig;
-  /**
-   * CCloud OAuth connection config, when configured via `--oauth` /
-   * `--oauth-env` on the env-var pathway. Held outside the `connections`
-   * record because the single-connection guard prohibits a second entry;
-   * the connections-record migration will move it inside the record and
-   * remove both this private field and {@link MCPServerConfiguration.getCCloudOAuth}.
-   */
-  readonly #ccloudOAuth: CCloudOAuthConfig | undefined;
 
   constructor(data: {
     connections: Record<string, ConnectionConfig>;
     server?: ServerConfig;
-    ccloudOAuth?: CCloudOAuthConfig;
   }) {
     this.connections = data.connections;
     // DEFAULT_SERVER_CONFIG is declared after the schemas below; it is always
     // initialized before any MCPServerConfiguration instance is created at runtime.
     this.server = data.server ?? DEFAULT_SERVER_CONFIG;
-    this.#ccloudOAuth = data.ccloudOAuth;
-  }
-
-  /**
-   * Returns the CCloud OAuth connection config when one was supplied at
-   * construction time; `undefined` otherwise. {@link ServerRuntime.fromConfig}
-   * uses this to decide whether to bootstrap an `OAuthHolder`.
-   */
-  getCCloudOAuth(): CCloudOAuthConfig | undefined {
-    return this.#ccloudOAuth;
   }
 
   /**
@@ -613,14 +579,6 @@ serverConfigSchema satisfies z.ZodType<ServerConfig>;
  * Derived from serverConfigSchema defaults — single source of truth.
  */
 export const DEFAULT_SERVER_CONFIG = serverConfigSchema.parse({});
-
-/** Zod schema for {@link CCloudOAuthConfig}. */
-export const ccloudOAuthConfigSchema = z
-  .object({
-    type: z.literal("ccloud_oauth"),
-    env: z.enum(["devel", "stag", "prod"]),
-  })
-  .strict();
 
 /**
  * Root configuration schema. This is the single validation and normalisation

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -22,7 +22,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-only.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.type).toBe("direct");
       expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
       expect(conn.kafka?.auth).toBeUndefined();
@@ -34,7 +34,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/sr-only.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.type).toBe("direct");
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       expect(conn.schema_registry?.auth).toBeUndefined();
@@ -46,7 +46,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-and-sr.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
       expect(conn.kafka?.auth).toBeUndefined();
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
@@ -58,7 +58,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka?.auth).toEqual({
         type: "api_key",
         key: "mykafkakey",
@@ -72,7 +72,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/sr-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.schema_registry?.auth).toEqual({
         type: "api_key",
         key: "mysrkey",
@@ -86,7 +86,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-and-sr-both-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka?.auth).toEqual({
         type: "api_key",
         key: "mykafkakey",
@@ -104,7 +104,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-interpolated-auth.yaml"),
         { KAFKA_API_KEY: "envkey", KAFKA_API_SECRET: "envsecret" },
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka?.auth).toEqual({
         type: "api_key",
         key: "envkey",
@@ -119,7 +119,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.confluent_cloud?.auth).toEqual({
         type: "api_key",
         key: "mycloudkey",
@@ -138,7 +138,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-with-endpoint-and-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.confluent_cloud?.endpoint).toBe(
         "https://custom.confluent.cloud",
       );
@@ -154,7 +154,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/tableflow-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.tableflow?.auth).toEqual({
         type: "api_key",
         key: "mytableflowkey",
@@ -170,7 +170,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-and-tableflow-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.confluent_cloud?.endpoint).toBe(
         "https://api.confluent.cloud",
       );
@@ -193,7 +193,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-extra-properties.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka?.bootstrap_servers).toBe("broker.confluent.cloud:9092");
       expect(conn.kafka?.extra_properties).toEqual({
         "socket.timeout.ms": "30000",
@@ -209,7 +209,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-rest-metadata.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.kafka?.bootstrap_servers).toBe("broker.confluent.cloud:9092");
       expect(conn.kafka?.rest_endpoint).toBe(
         "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
@@ -225,7 +225,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/flink-with-required-fields.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.flink?.auth).toEqual({
         type: "api_key",
         key: "myflinkkey",
@@ -250,7 +250,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/flink-with-all-fields.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.flink?.endpoint).toBe("https://flink.confluent.cloud");
       expect(conn.flink?.auth).toEqual({
         type: "api_key",
@@ -269,7 +269,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-and-flink-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.confluent_cloud?.auth).toEqual({
         type: "api_key",
         key: "mycloudkey",
@@ -290,7 +290,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/telemetry-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.telemetry).toEqual({
         endpoint: "https://api.telemetry.confluent.cloud",
         auth: {
@@ -308,7 +308,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/telemetry-with-endpoint-and-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getSoleDirectConnection();
       expect(conn.telemetry?.endpoint).toBe(
         "https://api.telemetry.confluent.cloud",
       );

--- a/src/confluent/oauth/auth0-config.ts
+++ b/src/confluent/oauth/auth0-config.ts
@@ -26,7 +26,7 @@ const AUTH0_CONFIGS: Record<Auth0Environment, Auth0Config> = {
     scopes: OAUTH_SCOPES,
   },
   prod: {
-    clientId: "", // TBD: not yet registered in identity-login-static
+    clientId: "cZ0wejEDJLNocYDJ54mAmGK21klrv21h",
     domain: "login.confluent.io",
     apiUrl: "https://confluent.cloud",
     cloudRestUrl: "https://api.confluent.cloud",

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -12,6 +12,7 @@ import {
   hasSchemaRegistry,
   hasTableflow,
   hasTelemetry,
+  isOAuth,
 } from "@src/confluent/tools/connection-predicates.js";
 import { describe, expect, it } from "vitest";
 
@@ -66,6 +67,11 @@ const CCLOUD_SR_CONN = conn({
     auth: { type: "api_key", key: "k", secret: "s" },
   },
 });
+
+const OAUTH_CONN: ConnectionConfig = {
+  type: "oauth",
+  development_env: "devel",
+};
 
 describe("connection-predicates.ts", () => {
   describe("hasKafka()", () => {
@@ -189,6 +195,33 @@ describe("connection-predicates.ts", () => {
 
     it("should return false when the tableflow block is absent", () => {
       expect(hasTableflow(KAFKA_CONN)).toBe(false);
+    });
+  });
+
+  describe("isOAuth()", () => {
+    it("should return true when the connection has type 'oauth'", () => {
+      expect(isOAuth(OAUTH_CONN)).toBe(true);
+    });
+
+    it("should return false for a direct connection", () => {
+      expect(isOAuth(KAFKA_CONN)).toBe(false);
+      expect(isOAuth(CONFLUENT_CLOUD_CONN)).toBe(false);
+    });
+
+    it("should leave block-presence predicates returning false on an oauth connection", () => {
+      // Block-presence predicates do NOT widen for OAuth — handler call sites
+      // compose `hasX || isOAuth` to opt in to OAuth, leaving the block-presence
+      // predicates focused on the direct-arm question they were designed for.
+      expect(hasConfluentCloud(OAUTH_CONN)).toBe(false);
+      expect(hasKafka(OAUTH_CONN)).toBe(false);
+      expect(hasKafkaBootstrap(OAUTH_CONN)).toBe(false);
+      expect(hasKafkaAuth(OAUTH_CONN)).toBe(false);
+      expect(hasKafkaRestWithAuth(OAUTH_CONN)).toBe(false);
+      expect(hasFlink(OAUTH_CONN)).toBe(false);
+      expect(hasSchemaRegistry(OAUTH_CONN)).toBe(false);
+      expect(hasTableflow(OAUTH_CONN)).toBe(false);
+      expect(hasTelemetry(OAUTH_CONN)).toBe(false);
+      expect(hasCCloudCatalogSupport(OAUTH_CONN)).toBe(false);
     });
   });
 

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -12,7 +12,6 @@ import {
   hasSchemaRegistry,
   hasTableflow,
   hasTelemetry,
-  isOAuth,
 } from "@src/confluent/tools/connection-predicates.js";
 import { describe, expect, it } from "vitest";
 
@@ -145,8 +144,13 @@ describe("connection-predicates.ts", () => {
       expect(hasConfluentCloud(CONFLUENT_CLOUD_CONN)).toBe(true);
     });
 
-    it("should return false when the confluent_cloud block is absent", () => {
+    it("should return false when the confluent_cloud block is absent on a direct connection", () => {
       expect(hasConfluentCloud(KAFKA_CONN)).toBe(false);
+    });
+
+    it("should return true unconditionally for an OAuth connection", () => {
+      // OAuth gets the CCloud REST URL from its Auth0 env, so it always reaches the CP surface.
+      expect(hasConfluentCloud(OAUTH_CONN)).toBe(true);
     });
   });
 
@@ -195,33 +199,6 @@ describe("connection-predicates.ts", () => {
 
     it("should return false when the tableflow block is absent", () => {
       expect(hasTableflow(KAFKA_CONN)).toBe(false);
-    });
-  });
-
-  describe("isOAuth()", () => {
-    it("should return true when the connection has type 'oauth'", () => {
-      expect(isOAuth(OAUTH_CONN)).toBe(true);
-    });
-
-    it("should return false for a direct connection", () => {
-      expect(isOAuth(KAFKA_CONN)).toBe(false);
-      expect(isOAuth(CONFLUENT_CLOUD_CONN)).toBe(false);
-    });
-
-    it("should leave block-presence predicates returning false on an oauth connection", () => {
-      // Block-presence predicates do NOT widen for OAuth — handler call sites
-      // compose `hasX || isOAuth` to opt in to OAuth, leaving the block-presence
-      // predicates focused on the direct-arm question they were designed for.
-      expect(hasConfluentCloud(OAUTH_CONN)).toBe(false);
-      expect(hasKafka(OAUTH_CONN)).toBe(false);
-      expect(hasKafkaBootstrap(OAUTH_CONN)).toBe(false);
-      expect(hasKafkaAuth(OAUTH_CONN)).toBe(false);
-      expect(hasKafkaRestWithAuth(OAUTH_CONN)).toBe(false);
-      expect(hasFlink(OAUTH_CONN)).toBe(false);
-      expect(hasSchemaRegistry(OAUTH_CONN)).toBe(false);
-      expect(hasTableflow(OAUTH_CONN)).toBe(false);
-      expect(hasTelemetry(OAUTH_CONN)).toBe(false);
-      expect(hasCCloudCatalogSupport(OAUTH_CONN)).toBe(false);
     });
   });
 

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -81,6 +81,10 @@ describe("connection-predicates.ts", () => {
     it("should return false when the kafka block is absent", () => {
       expect(hasKafka(SCHEMA_REGISTRY_CONN)).toBe(false);
     });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasKafka(OAUTH_CONN)).toBe(false);
+    });
   });
 
   describe("hasKafkaBootstrap()", () => {
@@ -95,6 +99,10 @@ describe("connection-predicates.ts", () => {
     it("should return false when kafka block is present but bootstrap_servers is absent", () => {
       expect(hasKafkaBootstrap(KAFKA_REST_CONN)).toBe(false);
     });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasKafkaBootstrap(OAUTH_CONN)).toBe(false);
+    });
   });
 
   describe("hasKafkaAuth()", () => {
@@ -108,6 +116,10 @@ describe("connection-predicates.ts", () => {
 
     it("should return false when the kafka block has no auth", () => {
       expect(hasKafkaAuth(KAFKA_CONN)).toBe(false);
+    });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasKafkaAuth(OAUTH_CONN)).toBe(false);
     });
   });
 
@@ -127,6 +139,10 @@ describe("connection-predicates.ts", () => {
     it("should return false when rest_endpoint is present but auth is absent", () => {
       expect(hasKafkaRestWithAuth(KAFKA_REST_CONN)).toBe(false);
     });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasKafkaRestWithAuth(OAUTH_CONN)).toBe(false);
+    });
   });
 
   describe("hasSchemaRegistry()", () => {
@@ -136,6 +152,10 @@ describe("connection-predicates.ts", () => {
 
     it("should return false when the schema_registry block is absent", () => {
       expect(hasSchemaRegistry(KAFKA_CONN)).toBe(false);
+    });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasSchemaRegistry(OAUTH_CONN)).toBe(false);
     });
   });
 
@@ -162,6 +182,10 @@ describe("connection-predicates.ts", () => {
     it("should return false when the flink block is absent", () => {
       expect(hasFlink(KAFKA_CONN)).toBe(false);
     });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasFlink(OAUTH_CONN)).toBe(false);
+    });
   });
 
   describe("hasTelemetry()", () => {
@@ -171,6 +195,10 @@ describe("connection-predicates.ts", () => {
 
     it("should return false when the telemetry block is absent", () => {
       expect(hasTelemetry(KAFKA_CONN)).toBe(false);
+    });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasTelemetry(OAUTH_CONN)).toBe(false);
     });
   });
 
@@ -190,6 +218,10 @@ describe("connection-predicates.ts", () => {
     it("should return false when neither block is present", () => {
       expect(hasCCloudCatalogSupport(KAFKA_CONN)).toBe(false);
     });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasCCloudCatalogSupport(OAUTH_CONN)).toBe(false);
+    });
   });
 
   describe("hasTableflow()", () => {
@@ -199,6 +231,10 @@ describe("connection-predicates.ts", () => {
 
     it("should return false when the tableflow block is absent", () => {
       expect(hasTableflow(KAFKA_CONN)).toBe(false);
+    });
+
+    it("should return false for an OAuth connection", () => {
+      expect(hasTableflow(OAUTH_CONN)).toBe(false);
     });
   });
 

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -69,7 +69,7 @@ const CCLOUD_SR_CONN = conn({
 
 const OAUTH_CONN: ConnectionConfig = {
   type: "oauth",
-  development_env: "devel",
+  ccloud_env: "devel",
 };
 
 describe("connection-predicates.ts", () => {

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -2,11 +2,10 @@ import type { ConnectionConfig } from "@src/config/models.js";
 
 export type ConnectionPredicate = (conn: ConnectionConfig) => boolean;
 
-// All block-presence predicates below check `conn.type === "direct"` first.
-// They answer "is this a direct connection with that block?" — OAuth connections
-// carry no service blocks, so every block-presence predicate is false for them.
-// Handler enablement under OAuth happens at the call site by composing with
-// `isOAuth` (e.g. `c => hasConfluentCloud(c) || isOAuth(c)`).
+// Block-presence predicates below check `conn.type === "direct"` first; OAuth
+// connections carry no service blocks, so they answer false for every block.
+// `hasConfluentCloud` is the single exception: it widens for OAuth because the
+// CCloud REST URL is reachable via the Auth0 environment without a block.
 
 export function hasKafka(conn: ConnectionConfig): boolean {
   return conn.type === "direct" && conn.kafka !== undefined;
@@ -32,8 +31,15 @@ export function hasSchemaRegistry(conn: ConnectionConfig): boolean {
   return conn.type === "direct" && conn.schema_registry !== undefined;
 }
 
+/**
+ * True when the connection can reach the Confluent Cloud control-plane REST
+ * surface. Direct connections satisfy this when they carry a `confluent_cloud`
+ * block; OAuth connections satisfy it unconditionally (the cloud REST URL is
+ * derived from the Auth0 environment).
+ */
 export function hasConfluentCloud(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.confluent_cloud !== undefined;
+  if (conn.type === "oauth") return true;
+  return conn.confluent_cloud !== undefined;
 }
 
 export function hasFlink(conn: ConnectionConfig): boolean {
@@ -58,16 +64,6 @@ export function hasCCloudCatalogSupport(conn: ConnectionConfig): boolean {
   return (
     conn.type === "direct" && conn.schema_registry?.auth?.type === "api_key"
   );
-}
-
-/**
- * True when the connection is the OAuth (PKCE) variant. Used at handler call
- * sites alongside a block-presence predicate to widen enablement, e.g.
- * `c => hasConfluentCloud(c) || isOAuth(c)`. Block-presence predicates stay
- * focused on the direct-arm question and do not widen for OAuth.
- */
-export function isOAuth(conn: ConnectionConfig): boolean {
-  return conn.type === "oauth";
 }
 
 export function connectionIdsWhere(

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -2,40 +2,50 @@ import type { ConnectionConfig } from "@src/config/models.js";
 
 export type ConnectionPredicate = (conn: ConnectionConfig) => boolean;
 
+// All block-presence predicates below check `conn.type === "direct"` first.
+// They answer "is this a direct connection with that block?" — OAuth connections
+// carry no service blocks, so every block-presence predicate is false for them.
+// Handler enablement under OAuth happens at the call site by composing with
+// `isOAuth` (e.g. `c => hasConfluentCloud(c) || isOAuth(c)`).
+
 export function hasKafka(conn: ConnectionConfig): boolean {
-  return conn.kafka !== undefined;
+  return conn.type === "direct" && conn.kafka !== undefined;
 }
 
 export function hasKafkaBootstrap(conn: ConnectionConfig): boolean {
-  return conn.kafka?.bootstrap_servers !== undefined;
+  return conn.type === "direct" && conn.kafka?.bootstrap_servers !== undefined;
 }
 
 export function hasKafkaAuth(conn: ConnectionConfig): boolean {
-  return conn.kafka?.auth !== undefined;
+  return conn.type === "direct" && conn.kafka?.auth !== undefined;
 }
 
 export function hasKafkaRestWithAuth(conn: ConnectionConfig): boolean {
-  return conn.kafka?.rest_endpoint !== undefined && hasKafkaAuth(conn);
+  return (
+    conn.type === "direct" &&
+    conn.kafka?.rest_endpoint !== undefined &&
+    hasKafkaAuth(conn)
+  );
 }
 
 export function hasSchemaRegistry(conn: ConnectionConfig): boolean {
-  return conn.schema_registry !== undefined;
+  return conn.type === "direct" && conn.schema_registry !== undefined;
 }
 
 export function hasConfluentCloud(conn: ConnectionConfig): boolean {
-  return conn.confluent_cloud !== undefined;
+  return conn.type === "direct" && conn.confluent_cloud !== undefined;
 }
 
 export function hasFlink(conn: ConnectionConfig): boolean {
-  return conn.flink !== undefined;
+  return conn.type === "direct" && conn.flink !== undefined;
 }
 
 export function hasTelemetry(conn: ConnectionConfig): boolean {
-  return conn.telemetry !== undefined;
+  return conn.type === "direct" && conn.telemetry !== undefined;
 }
 
 export function hasTableflow(conn: ConnectionConfig): boolean {
-  return conn.tableflow !== undefined;
+  return conn.type === "direct" && conn.tableflow !== undefined;
 }
 
 /**
@@ -45,7 +55,9 @@ export function hasTableflow(conn: ConnectionConfig): boolean {
  * false even when a schema_registry block is present.
  */
 export function hasCCloudCatalogSupport(conn: ConnectionConfig): boolean {
-  return conn.schema_registry?.auth?.type === "api_key";
+  return (
+    conn.type === "direct" && conn.schema_registry?.auth?.type === "api_key"
+  );
 }
 
 export function connectionIdsWhere(

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -60,6 +60,16 @@ export function hasCCloudCatalogSupport(conn: ConnectionConfig): boolean {
   );
 }
 
+/**
+ * True when the connection is the OAuth (PKCE) variant. Used at handler call
+ * sites alongside a block-presence predicate to widen enablement, e.g.
+ * `c => hasConfluentCloud(c) || isOAuth(c)`. Block-presence predicates stay
+ * focused on the direct-arm question and do not widen for OAuth.
+ */
+export function isOAuth(conn: ConnectionConfig): boolean {
+  return conn.type === "oauth";
+}
+
 export function connectionIdsWhere(
   connections: Readonly<Record<string, ConnectionConfig>>,
   predicate: ConnectionPredicate,

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -45,7 +45,7 @@ export class AlterTopicConfigHandler extends BaseToolHandler {
     const clientManager = runtime.clientManager;
     const { clusterId, topicName, topicConfigs, validateOnly } =
       alterTopicConfigArguments.parse(toolArguments);
-    const conn = runtime.config.getSoleConnection();
+    const conn = runtime.config.getSoleDirectConnection();
     const kafka_cluster_id = this.resolveParam(
       clusterId,
       conn.kafka?.cluster_id,

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -37,7 +37,7 @@ export class GetTopicConfigHandler extends BaseToolHandler {
     const clientManager = runtime.clientManager;
     const { clusterId, topicName } =
       getTopicConfigArguments.parse(toolArguments);
-    const conn = runtime.config.getSoleConnection();
+    const conn = runtime.config.getSoleDirectConnection();
     const kafka_cluster_id = this.resolveParam(
       clusterId,
       conn.kafka?.cluster_id,

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
@@ -48,8 +48,10 @@ describe("list-organizations-handler.ts", () => {
         expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
       });
 
-      it("should return an empty array when the OAuth side-car is set but the connection lacks a confluent_cloud block", () => {
-        expect(handler.enabledConnectionIds(ccloudOAuthRuntime())).toEqual([]);
+      it("should return the connection id when the connection is OAuth-typed", () => {
+        expect(handler.enabledConnectionIds(ccloudOAuthRuntime())).toEqual([
+          DEFAULT_CONNECTION_ID,
+        ]);
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ async function main() {
         allowedHosts: cliOptions.allowedHosts,
         kafkaConfig: cliOptions.kafkaConfig,
         oauth: cliOptions.oauth,
-        oauthEnv: cliOptions.oauthEnv,
+        developmentEnv: cliOptions.developmentEnv,
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,24 +131,8 @@ async function main() {
         allowedHosts: cliOptions.allowedHosts,
         kafkaConfig: cliOptions.kafkaConfig,
         oauth: cliOptions.oauth,
-        developmentEnv: cliOptions.developmentEnv,
+        ccloudEnv: cliOptions.ccloudEnv,
       });
-    }
-
-    // --oauth + --config is rejected in both shapes the combination can take.
-    // (a) YAML already declares an OAuth connection: ambiguous which env wins.
-    // (b) YAML is direct-only: --oauth would be silently ignored, since we don't
-    //     yet merge a synthesized OAuth connection into a multi-connection YAML.
-    // When multi-connection support lands (#151), case (b) can become a merge.
-    if (cliOptions.oauth && cliOptions.config) {
-      const yamlHasOauth = Object.values(mcpConfig.connections).some(
-        (c) => c.type === "oauth",
-      );
-      throw new Error(
-        yamlHasOauth
-          ? "--oauth conflicts with the OAuth connection already declared in the YAML config; remove one or the other"
-          : "--oauth and --config cannot be combined: declare OAuth as a connection inside the YAML (type: oauth) instead of passing --oauth",
-      );
     }
 
     setLogLevel(mcpConfig.server.log_level);

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,19 @@ async function main() {
       });
     }
 
+    // --oauth alongside a YAML that already declares an OAuth connection is a conflict —
+    // the user has expressed OAuth intent twice with potentially different envs. Reject.
+    if (cliOptions.oauth && cliOptions.config) {
+      const yamlHasOauth = Object.values(mcpConfig.connections).some(
+        (c) => c.type === "oauth",
+      );
+      if (yamlHasOauth) {
+        throw new Error(
+          "--oauth conflicts with the OAuth connection already declared in the YAML config; remove one or the other",
+        );
+      }
+    }
+
     setLogLevel(mcpConfig.server.log_level);
 
     // Transport selection: YAML config is authoritative when --config is used;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,17 +135,20 @@ async function main() {
       });
     }
 
-    // --oauth alongside a YAML that already declares an OAuth connection is a conflict —
-    // the user has expressed OAuth intent twice with potentially different envs. Reject.
+    // --oauth + --config is rejected in both shapes the combination can take.
+    // (a) YAML already declares an OAuth connection: ambiguous which env wins.
+    // (b) YAML is direct-only: --oauth would be silently ignored, since we don't
+    //     yet merge a synthesized OAuth connection into a multi-connection YAML.
+    // When multi-connection support lands (#151), case (b) can become a merge.
     if (cliOptions.oauth && cliOptions.config) {
       const yamlHasOauth = Object.values(mcpConfig.connections).some(
         (c) => c.type === "oauth",
       );
-      if (yamlHasOauth) {
-        throw new Error(
-          "--oauth conflicts with the OAuth connection already declared in the YAML config; remove one or the other",
-        );
-      }
+      throw new Error(
+        yamlHasOauth
+          ? "--oauth conflicts with the OAuth connection already declared in the YAML config; remove one or the other"
+          : "--oauth and --config cannot be combined: declare OAuth as a connection inside the YAML (type: oauth) instead of passing --oauth",
+      );
     }
 
     setLogLevel(mcpConfig.server.log_level);

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -208,8 +208,9 @@ describe("ServerRuntime", () => {
     it("should throw when the sole client manager is not a DirectClientManager (e.g., OAuth)", () => {
       vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
-        connections: { "env-connection": connWith({}) },
-        ccloudOAuth: { type: "ccloud_oauth", env: "stag" },
+        connections: {
+          "env-connection": { type: "oauth", development_env: "stag" },
+        },
       });
       const runtime = ServerRuntime.fromConfig(oauthConfig);
       expect(() => runtime.requireDirectClientManager()).toThrow(
@@ -261,7 +262,7 @@ describe("ServerRuntime", () => {
       expect(runtime.oauthHolder).toBeUndefined();
     });
 
-    it("should call OAuthHolder.start and expose oauthHolder when the config has ccloud-oauth", () => {
+    it("should call OAuthHolder.start and expose oauthHolder when a connection has type 'oauth'", () => {
       const fakeHolder = fakeOAuthHolder();
       const startSpy = vi
         .spyOn(OAuthHolder, "start")
@@ -269,11 +270,8 @@ describe("ServerRuntime", () => {
 
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": connWith({
-            kafka: { bootstrap_servers: "broker:9092" },
-          }),
+          "env-connection": { type: "oauth", development_env: "devel" },
         },
-        ccloudOAuth: { type: "ccloud_oauth", env: "devel" },
       });
 
       const runtime = ServerRuntime.fromConfig(oauthConfig);
@@ -282,15 +280,12 @@ describe("ServerRuntime", () => {
       expect(runtime.oauthHolder).toBe(fakeHolder);
     });
 
-    it("should construct OAuthClientManager instances for every connection when ccloud-oauth is set", () => {
+    it("should construct OAuthClientManager instances for every connection when an oauth connection is present", () => {
       vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": connWith({
-            kafka: { bootstrap_servers: "broker:9092" },
-          }),
+          "env-connection": { type: "oauth", development_env: "stag" },
         },
-        ccloudOAuth: { type: "ccloud_oauth", env: "stag" },
       });
 
       const runtime = ServerRuntime.fromConfig(oauthConfig);

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -209,7 +209,7 @@ describe("ServerRuntime", () => {
       vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": { type: "oauth", development_env: "stag" },
+          "env-connection": { type: "oauth", ccloud_env: "stag" },
         },
       });
       const runtime = ServerRuntime.fromConfig(oauthConfig);
@@ -270,7 +270,7 @@ describe("ServerRuntime", () => {
 
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": { type: "oauth", development_env: "devel" },
+          "env-connection": { type: "oauth", ccloud_env: "devel" },
         },
       });
 
@@ -284,7 +284,7 @@ describe("ServerRuntime", () => {
       vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": { type: "oauth", development_env: "stag" },
+          "env-connection": { type: "oauth", ccloud_env: "stag" },
         },
       });
 
@@ -292,6 +292,23 @@ describe("ServerRuntime", () => {
 
       expect(runtime.clientManagers["env-connection"]).toBeInstanceOf(
         OAuthClientManager,
+      );
+    });
+
+    it("should throw when more than one OAuth connection is defined", () => {
+      // enforceSingleConnectionOnly() prevents multi-connection records today,
+      // so this case is reached only by callers that bypass the schema (tests
+      // constructing MCPServerConfiguration directly). The defensive throw
+      // becomes load-bearing when multi-connection support lands (#151).
+      const multiOauthConfig = new MCPServerConfiguration({
+        connections: {
+          "oauth-1": { type: "oauth", ccloud_env: "devel" },
+          "oauth-2": { type: "oauth", ccloud_env: "stag" },
+        },
+      });
+
+      expect(() => ServerRuntime.fromConfig(multiOauthConfig)).toThrow(
+        /Multiple OAuth connections defined/,
       );
     });
   });

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,4 +1,7 @@
-import { MCPServerConfiguration } from "@src/config/index.js";
+import {
+  type OAuthConnectionConfig,
+  MCPServerConfiguration,
+} from "@src/config/index.js";
 import { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import {
   constructDirectClientManager,
@@ -16,12 +19,11 @@ export class ServerRuntime {
   readonly config: MCPServerConfiguration;
   readonly clientManagers: Record<string, BaseClientManager>;
   /**
-   * The active OAuth holder when the config carries a CCloud OAuth connection.
-   * Constructed by {@link ServerRuntime.fromConfig} when `config.getCCloudOAuth()`
-   * returns a value; `undefined` on api_key paths. The holder runs PKCE in the
-   * background — callers can await `holder.bootstrapPromise` to know the
-   * bootstrap attempt has finished, then inspect the token accessors to
-   * determine whether tokens are available.
+   * The active OAuth holder when any connection in the config has `type === "oauth"`.
+   * Constructed by {@link ServerRuntime.fromConfig}; `undefined` on api_key paths.
+   * The holder runs PKCE in the background — callers can await
+   * `holder.bootstrapPromise` to know the bootstrap attempt has finished, then
+   * inspect the token accessors to determine whether tokens are available.
    */
   readonly oauthHolder: OAuthHolder | undefined;
 
@@ -72,9 +74,11 @@ export class ServerRuntime {
   }
 
   static fromConfig(config: MCPServerConfiguration): ServerRuntime {
-    const ccloudOAuth = config.getCCloudOAuth();
-    const oauthHolder = ccloudOAuth
-      ? OAuthHolder.start(ccloudOAuth.env)
+    const oauthConn = Object.values(config.connections).find(
+      (c): c is OAuthConnectionConfig => c.type === "oauth",
+    );
+    const oauthHolder = oauthConn
+      ? OAuthHolder.start(oauthConn.development_env)
       : undefined;
 
     // Construct a client manager for each connection in the config.
@@ -83,15 +87,13 @@ export class ServerRuntime {
     // the shared holder; otherwise, fall back to the per-connection direct factory.
     const clientManagers = Object.fromEntries(
       Object.entries(config.connections).map(([id, conn]) => {
-        if (oauthHolder && ccloudOAuth) {
+        if (oauthHolder && oauthConn) {
           return [
             id,
-            new OAuthClientManager(oauthHolder, ccloudOAuth.env),
+            new OAuthClientManager(oauthHolder, oauthConn.development_env),
           ] as const;
         }
-        // Without an OAuth side-car, every connection in the record is direct.
-        // (Task 6 replaces the side-car with a connections-record OAuth entry
-        // and removes this guard altogether.)
+        // No OAuth connection found, so every connection is direct.
         if (conn.type !== "direct") {
           throw new Error(
             `Internal error: connection ${id} is not direct but no OAuth holder was constructed`,

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -74,11 +74,20 @@ export class ServerRuntime {
   }
 
   static fromConfig(config: MCPServerConfiguration): ServerRuntime {
-    const oauthConn = Object.values(config.connections).find(
+    const oauthConns = Object.values(config.connections).filter(
       (c): c is OAuthConnectionConfig => c.type === "oauth",
     );
+    if (oauthConns.length > 1) {
+      // `enforceSingleConnectionOnly()` already prevents this today; keep the
+      // defensive check so that when multi-connection support lands (#151),
+      // multi-OAuth is rejected explicitly rather than silently picking one.
+      throw new Error(
+        `Multiple OAuth connections defined in configuration; only one is supported`,
+      );
+    }
+    const oauthConn = oauthConns[0];
     const oauthHolder = oauthConn
-      ? OAuthHolder.start(oauthConn.development_env)
+      ? OAuthHolder.start(oauthConn.ccloud_env)
       : undefined;
 
     // Construct a client manager for each connection in the config.
@@ -90,7 +99,7 @@ export class ServerRuntime {
         if (oauthHolder && oauthConn) {
           return [
             id,
-            new OAuthClientManager(oauthHolder, oauthConn.development_env),
+            new OAuthClientManager(oauthHolder, oauthConn.ccloud_env),
           ] as const;
         }
         // No OAuth connection found, so every connection is direct.

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -82,12 +82,23 @@ export class ServerRuntime {
     // When OAuth is in play, every connection's manager is bearer-auth-backed by
     // the shared holder; otherwise, fall back to the per-connection direct factory.
     const clientManagers = Object.fromEntries(
-      Object.entries(config.connections).map(([id, conn]) => [
-        id,
-        oauthHolder && ccloudOAuth
-          ? new OAuthClientManager(oauthHolder, ccloudOAuth.env)
-          : constructDirectClientManager(conn),
-      ]),
+      Object.entries(config.connections).map(([id, conn]) => {
+        if (oauthHolder && ccloudOAuth) {
+          return [
+            id,
+            new OAuthClientManager(oauthHolder, ccloudOAuth.env),
+          ] as const;
+        }
+        // Without an OAuth side-car, every connection in the record is direct.
+        // (Task 6 replaces the side-car with a connections-record OAuth entry
+        // and removes this guard altogether.)
+        if (conn.type !== "direct") {
+          throw new Error(
+            `Internal error: connection ${id} is not direct but no OAuth holder was constructed`,
+          );
+        }
+        return [id, constructDirectClientManager(conn)] as const;
+      }),
     );
     return new ServerRuntime(config, clientManagers, oauthHolder);
   }

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -117,19 +117,19 @@ export function telemetryRuntime(): ServerRuntime {
 }
 
 /**
- * Runtime whose `MCPServerConfiguration` carries the `ccloudOAuth` side-car set
- * (as the env-var `--oauth --oauth-env=devel` path produces) but whose connection
- * has no `confluent_cloud` block. Used to assert that block-presence predicates
- * (e.g. `hasConfluentCloud`) are *not* satisfied by the OAuth side-car alone —
- * i.e. tools gated on `confluent_cloud` stay disabled until the connection itself
- * carries the block. Does not populate `runtime.oauthHolder`; tests that need a
- * holder should construct one explicitly.
+ * Runtime whose sole connection is an OAuth-typed `ConnectionConfig`. Used by
+ * handler tests to assert that handlers widened for OAuth (e.g. via the
+ * widened `hasConfluentCloud` predicate) see the connection as enabled, and
+ * that handlers staying direct-only (e.g. native Kafka) see it as disabled.
+ * Does not populate `runtime.oauthHolder`; tests that need a holder should
+ * construct one explicitly.
  */
 export function ccloudOAuthRuntime(): ServerRuntime {
   return new ServerRuntime(
     new MCPServerConfiguration({
-      connections: { [DEFAULT_CONNECTION_ID]: { type: "direct" } },
-      ccloudOAuth: { type: "ccloud_oauth", env: "devel" },
+      connections: {
+        [DEFAULT_CONNECTION_ID]: { type: "oauth", development_env: "devel" },
+      },
     }),
     { [DEFAULT_CONNECTION_ID]: createMockInstance(DirectClientManager) },
   );

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -132,7 +132,7 @@ export function ccloudOAuthRuntime(): ServerRuntime {
   return new ServerRuntime(
     new MCPServerConfiguration({
       connections: {
-        [DEFAULT_CONNECTION_ID]: { type: "oauth", development_env: "devel" },
+        [DEFAULT_CONNECTION_ID]: { type: "oauth", ccloud_env: "devel" },
       },
     }),
     { [DEFAULT_CONNECTION_ID]: createMockInstance(OAuthClientManager) },

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -1,6 +1,7 @@
 import type { DirectConnectionConfig } from "@src/config/index.js";
 import { MCPServerConfiguration } from "@src/config/models.js";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
+import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
 import type { Mocked } from "vitest";
@@ -117,12 +118,15 @@ export function telemetryRuntime(): ServerRuntime {
 }
 
 /**
- * Runtime whose sole connection is an OAuth-typed `ConnectionConfig`. Used by
- * handler tests to assert that handlers widened for OAuth (e.g. via the
- * widened `hasConfluentCloud` predicate) see the connection as enabled, and
- * that handlers staying direct-only (e.g. native Kafka) see it as disabled.
- * Does not populate `runtime.oauthHolder`; tests that need a holder should
- * construct one explicitly.
+ * Runtime whose sole connection is an OAuth-typed `ConnectionConfig`, paired
+ * with a mocked `OAuthClientManager` (matching what `ServerRuntime.fromConfig`
+ * actually constructs for OAuth connections). Used by handler tests to assert
+ * that handlers widened for OAuth (e.g. via the widened `hasConfluentCloud`
+ * predicate) see the connection as enabled, and that handlers staying
+ * direct-only (e.g. native Kafka) see it as disabled. Does not populate
+ * `runtime.oauthHolder`; tests that need a holder should construct one
+ * explicitly. `createMockInstance` doesn't invoke the real constructor, so the
+ * OAuthClientManager's eager cloud-REST client setup is sidestepped.
  */
 export function ccloudOAuthRuntime(): ServerRuntime {
   return new ServerRuntime(
@@ -131,6 +135,6 @@ export function ccloudOAuthRuntime(): ServerRuntime {
         [DEFAULT_CONNECTION_ID]: { type: "oauth", development_env: "devel" },
       },
     }),
-    { [DEFAULT_CONNECTION_ID]: createMockInstance(DirectClientManager) },
+    { [DEFAULT_CONNECTION_ID]: createMockInstance(OAuthClientManager) },
   );
 }

--- a/tests/harness/kafka-admin.ts
+++ b/tests/harness/kafka-admin.ts
@@ -34,8 +34,8 @@ export async function connectTestProducer(): Promise<KafkaJS.Producer> {
  * `undefined` and produce a confusing downstream error.
  */
 export function getTestClusterId(): string {
-  const conn = Object.values(integrationRuntime().config.connections)[0];
-  if (!conn?.kafka?.cluster_id) {
+  const conn = integrationRuntime().config.getSoleDirectConnection();
+  if (!conn.kafka?.cluster_id) {
     throw new Error(
       "test-side cluster id requires kafka.cluster_id in test-fixtures/yaml_configs/integration.yaml",
     );
@@ -106,8 +106,8 @@ function newKafkaClient(clientId: string): KafkaJS.Kafka {
 // resolve from the same YAML fixture the server reads, so the test-side admin and the MCP server
 // can never disagree on which cluster they're talking to
 function kafkaConfig(clientId: string): GlobalConfig {
-  const conn = Object.values(integrationRuntime().config.connections)[0];
-  if (!conn?.kafka?.bootstrap_servers || !conn.kafka.auth) {
+  const conn = integrationRuntime().config.getSoleDirectConnection();
+  if (!conn.kafka?.bootstrap_servers || !conn.kafka.auth) {
     throw new Error(
       "test-side kafka admin requires kafka.bootstrap_servers + kafka.auth in test-fixtures/yaml_configs/integration.yaml",
     );


### PR DESCRIPTION
## Summary of Changes

- **Promote OAuth from a `MCPServerConfiguration.#ccloudOAuth` side-car to a first-class arm of the `ConnectionConfig` discriminated union.**
  - New `OAuthConnectionConfig = { type: "oauth", ccloud_env }` interface and Zod arm. The existing `connections` record now holds either direct or oauth connections. `MCPServerConfiguration.#ccloudOAuth`, `getCCloudOAuth()`, the `ccloudOAuth?:` constructor arg, the `CCloudOAuthConfig` interface, and `ccloudOAuthConfigSchema` are all deleted. `ServerRuntime.fromConfig` detects OAuth via `Object.values(connections).find(c => c.type === "oauth")`, and throws on more than one OAuth connection.
- **Widen `hasConfluentCloud` to recognise OAuth connections.**
  - One predicate body change auto enables 8 cloud-REST handlers (orgs, environments list/read, clusters, billing, connectors list/read/delete) under `--oauth` with no per-handler edits. `create-connector` correctly stays direct-only because its compound predicate also requires `hasKafkaAuth`. DP REST + native Kafka tools remain disabled until their endpoint resolution lands separately.
- **CLI: rename `--oauth-env` → `--ccloud-env`, make optional, default to prod.**
  - `--oauth` alone is now a valid invocation (defaults to prod). `--oauth + --config` is rejected at parse time with a single clear message — declaring OAuth in YAML (`type: oauth`) is the supported way to combine the two. Per-tool fallback cleanup (e.g. `list-clusters` env-id) and the corresponding per-handler OAuth tests are tracked in #322.
- **Register prod Auth0 client id**
- **Add `MCPServerConfiguration.getSoleDirectConnection()`** narrowing helper. Replaces ad-hoc `conn.type === "direct" ? conn.X : undefined` shapes in handlers/harness with a single throw-on-mismatch call.
- **Naming rationale:** `ccloud_env` (YAML) / `ccloudEnv` (TS) / `--ccloud-env` (CLI) — names the *Confluent Cloud install* the OAuth flow targets, distinct from the `env_id` / `environment_id` resource concept used elsewhere in YAML. Most users never set it (prod is the default); only Confluent staff testing devel/stag override.

Fixes #315

### Manual testing instructions

> **Use `--ccloud-env stag` (or `devel`) for end-to-end verification.** Prod is wired in code but the prod CCloud auth backend isn't yet allowlisted to accept this Auth0 client (already following up with identity team). Stag exercises the full PKCE → CP/DP token chain → tool call path identically.

Two equivalent paths — exercise both to cover the env-var/CLI synthesis path AND the YAML discriminated-union path. Run the commands from the repo root after `npm run build`.

#### Path A — CLI flag (env-var pathway)

1. `npm run build` from this branch (run from repo root).
2. Register the built server with Claude Code as a local MCP, pointing at stag:
   ```
   claude mcp add mcp-confluent-oauth -- node dist/index.js --oauth --ccloud-env stag
   ```
   (Drop `--ccloud-env stag` once the prod backend is wired up; it'll then default to prod.)
3. Restart Claude Code (or run `/mcp` to refresh) and complete the PKCE login when the browser pops.
4. Verify the OAuth-enabled tool surface is listed for the new server: `list-organizations`, `list-environments`, `read-environment`, `list-clusters`, `list-billing-costs`, `list-connectors`, `read-connector`, `delete-connector`. Tools targeting Flink, Schema Registry, Catalog, Kafka REST, native Kafka, Tableflow, and Telemetry should NOT appear.
5. Invoke `list-organizations` (no args) and confirm it returns the user's CCloud orgs. Invoke `list-environments` and `list-clusters` to exercise paginated CP REST calls.
6. Try invoking a cluster-scoped tool like `list-clusters` without supplying an `environmentId`; the handler should surface a clear "missing required parameter" message because there's no config block to fall back to under OAuth (the LLM-discovery flow). Note: clean error messaging for this case is being polished as part of #322.
7. Cleanup: `claude mcp remove mcp-confluent-oauth`.

#### Path B — YAML config (discriminated-union path)

1. Create `oauth.yaml` in the repo root (or anywhere — adjust the `-c` path):
   ```yaml
   connections:
     stag-oauth:
       type: oauth
       ccloud_env: stag
   ```
   (Switch `stag` to `prod` once the prod backend is wired up; or omit the field entirely to default to prod.)
2. Register the server with Claude Code, using the YAML:
   ```
   claude mcp add mcp-confluent-oauth-yaml -- node dist/index.js -c oauth.yaml
   ```
3. Restart Claude Code, complete the PKCE login, and verify the same enabled tool surface as Path A.
4. Edge: `claude mcp add mcp-confluent-oauth-conflict -- node dist/index.js --oauth -c oauth.yaml` should fail at parse time with `"--oauth and --config cannot be combined: declare OAuth as a connection inside the YAML (type: oauth) instead of passing --oauth"`.
5. Cleanup: `claude mcp remove mcp-confluent-oauth-yaml`.

### Optional: Any additional details or context that should be provided?

- The `OAuthClientManager` only eagerly wires the cloud REST surface today (Flink, Schema Registry, and Kafka REST DP-token endpoints stay `undefined`). Tools targeting those surfaces remain direct-only; unblocking them is follow-up work tracked separately.
- **Note:** the prod CCloud auth backend currently rejects ID tokens issued by this client (`403 Invalid identity token` from `/api/sessions`); allowlisting in the prod auth backend is already being followed up with identity team. Stag works end-to-end.
- **Per-tool OAuth cleanup tracked in #322:** the `list-clusters` env-id fallback (which currently sends an empty string instead of throwing under OAuth) and the per-handler OAuth `enabledConnectionIds` test coverage for the 7 tools that didn't get an explicit OAuth regression in this PR.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
