### PR TITLE
Feat/232 wean metrics off of env vars

### DIFF
--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -20,7 +20,10 @@ const TELEMETRY_CONN = {
 
 const TELEMETRY_WITH_KAFKA_CONN = {
   ...TELEMETRY_CONN,
-  kafka: { cluster_id: "lkc-from-config" },
+  kafka: {
+    cluster_id: "lkc-from-config",
+    rest_endpoint: "https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443",
+  },
 };
 
 type FilterCase = HandleCaseWithConn & {
@@ -99,6 +102,21 @@ describe("query-metrics-handler.ts", () => {
             field: "resource.kafka.id",
             op: "EQ",
             value: "lkc-from-config",
+          },
+        },
+        {
+          label:
+            "send trimmed resource.kafka.id when caller passes a space-padded value",
+          connectionConfig: TELEMETRY_WITH_KAFKA_CONN,
+          args: {
+            metric: KAFKA_SERVER_METRIC,
+            filter: { "resource.kafka.id": " lkc-explicit " },
+          },
+          outcome: { resolves: "No data returned for metric" },
+          expectedFilter: {
+            field: "resource.kafka.id",
+            op: "EQ",
+            value: "lkc-explicit",
           },
         },
       ];

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -2,9 +2,22 @@ import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query
 import {
   bareRuntime,
   DEFAULT_CONNECTION_ID,
+  HandleCaseWithConn,
+  runtimeWith,
   telemetryRuntime,
 } from "@tests/factories/runtime.js";
+import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
+
+const KAFKA_SERVER_METRIC = "io.confluent.kafka.server/received_bytes";
+
+const WITH_KAFKA_CLUSTER_ID = {
+  kafka: { cluster_id: "lkc-from-config" },
+};
+
+type FilterCase = HandleCaseWithConn & {
+  expectedFilter?: { field: string; op: string; value: string };
+};
 
 describe("query-metrics-handler.ts", () => {
   describe("QueryMetricsHandler", () => {
@@ -20,6 +33,73 @@ describe("query-metrics-handler.ts", () => {
       it("should return an empty array for a connection without a telemetry block", () => {
         expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
       });
+    });
+
+    describe("handle()", () => {
+      const cases: FilterCase[] = [
+        {
+          label:
+            "auto-inject resource.kafka.id from config when no explicit filter is supplied",
+          connectionConfig: WITH_KAFKA_CLUSTER_ID,
+          args: { metric: KAFKA_SERVER_METRIC },
+          outcome: { resolves: "No data returned for metric" },
+          expectedFilter: {
+            field: "resource.kafka.id",
+            op: "EQ",
+            value: "lkc-from-config",
+          },
+        },
+        {
+          label:
+            "not inject a filter when both the arg filter and conn kafka.cluster_id are absent",
+          connectionConfig: {},
+          args: { metric: KAFKA_SERVER_METRIC },
+          outcome: { resolves: "No data returned for metric" },
+        },
+        {
+          label:
+            "prefer an explicit resource.kafka.id filter arg over the connection config value",
+          connectionConfig: WITH_KAFKA_CLUSTER_ID,
+          args: {
+            metric: KAFKA_SERVER_METRIC,
+            filter: { "resource.kafka.id": "lkc-explicit" },
+          },
+          outcome: { resolves: "No data returned for metric" },
+          expectedFilter: {
+            field: "resource.kafka.id",
+            op: "EQ",
+            value: "lkc-explicit",
+          },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({ connectionConfig = {}, args, outcome, expectedFilter }) => {
+          const { clientManager, clientGetters, capturedCalls } =
+            stubClientGetters({});
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              connectionConfig,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+          expect(capturedCalls).toHaveLength(1);
+          const body = (
+            capturedCalls[0]!.args as { body: Record<string, unknown> }
+          ).body;
+          if (expectedFilter) {
+            expect(body).toMatchObject({ filter: expectedFilter });
+          } else {
+            expect(body).not.toHaveProperty("filter");
+          }
+        },
+      );
     });
   });
 });

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -11,7 +11,15 @@ import { describe, expect, it } from "vitest";
 
 const KAFKA_SERVER_METRIC = "io.confluent.kafka.server/received_bytes";
 
-const WITH_KAFKA_CLUSTER_ID = {
+const TELEMETRY_CONN = {
+  telemetry: {
+    endpoint: "https://api.telemetry.confluent.cloud",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+  },
+};
+
+const TELEMETRY_WITH_KAFKA_CONN = {
+  ...TELEMETRY_CONN,
   kafka: { cluster_id: "lkc-from-config" },
 };
 
@@ -40,7 +48,7 @@ describe("query-metrics-handler.ts", () => {
         {
           label:
             "auto-inject resource.kafka.id from config when no explicit filter is supplied",
-          connectionConfig: WITH_KAFKA_CLUSTER_ID,
+          connectionConfig: TELEMETRY_WITH_KAFKA_CONN,
           args: { metric: KAFKA_SERVER_METRIC },
           outcome: { resolves: "No data returned for metric" },
           expectedFilter: {
@@ -52,14 +60,14 @@ describe("query-metrics-handler.ts", () => {
         {
           label:
             "not inject a filter when both the arg filter and conn kafka.cluster_id are absent",
-          connectionConfig: {},
+          connectionConfig: TELEMETRY_CONN,
           args: { metric: KAFKA_SERVER_METRIC },
           outcome: { resolves: "No data returned for metric" },
         },
         {
           label:
             "prefer an explicit resource.kafka.id filter arg over the connection config value",
-          connectionConfig: WITH_KAFKA_CLUSTER_ID,
+          connectionConfig: TELEMETRY_WITH_KAFKA_CONN,
           args: {
             metric: KAFKA_SERVER_METRIC,
             filter: { "resource.kafka.id": "lkc-explicit" },
@@ -74,9 +82,24 @@ describe("query-metrics-handler.ts", () => {
         {
           label:
             "not inject a filter for non-Kafka-server metrics even when cluster_id is in config",
-          connectionConfig: WITH_KAFKA_CLUSTER_ID,
+          connectionConfig: TELEMETRY_WITH_KAFKA_CONN,
           args: { metric: "io.confluent.flink/num_records_in" },
           outcome: { resolves: "No data returned for metric" },
+        },
+        {
+          label:
+            "fall back to config when resource.kafka.id filter arg is whitespace-only",
+          connectionConfig: TELEMETRY_WITH_KAFKA_CONN,
+          args: {
+            metric: KAFKA_SERVER_METRIC,
+            filter: { "resource.kafka.id": "   " },
+          },
+          outcome: { resolves: "No data returned for metric" },
+          expectedFilter: {
+            field: "resource.kafka.id",
+            op: "EQ",
+            value: "lkc-from-config",
+          },
         },
       ];
 

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -71,6 +71,13 @@ describe("query-metrics-handler.ts", () => {
             value: "lkc-explicit",
           },
         },
+        {
+          label:
+            "not inject a filter for non-Kafka-server metrics even when cluster_id is in config",
+          connectionConfig: WITH_KAFKA_CLUSTER_ID,
+          args: { metric: "io.confluent.flink/num_records_in" },
+          outcome: { resolves: "No data returned for metric" },
+        },
       ];
 
       it.each(cases)(

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -1,4 +1,9 @@
-import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
+import {
+  buildEffectiveFilter,
+  buildRequestBody,
+  QueryMetricsHandler,
+  resolveInterval,
+} from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
 import {
   bareRuntime,
   DEFAULT_CONNECTION_ID,
@@ -7,7 +12,7 @@ import {
   telemetryRuntime,
 } from "@tests/factories/runtime.js";
 import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const KAFKA_SERVER_METRIC = "io.confluent.kafka.server/received_bytes";
 
@@ -43,6 +48,126 @@ describe("query-metrics-handler.ts", () => {
 
       it("should return an empty array for a connection without a telemetry block", () => {
         expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+    });
+
+    describe("resolveInterval()", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it("should pass through an already-resolved start/end interval unchanged", () => {
+        const interval = "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z";
+        expect(resolveInterval(interval)).toBe(interval);
+      });
+
+      it("should default to the last 1 hour when interval is undefined", () => {
+        vi.setSystemTime(new Date("2024-06-01T12:00:00.000Z"));
+        expect(resolveInterval(undefined)).toBe(
+          "2024-06-01T11:00:00.000Z/2024-06-01T12:00:00.000Z",
+        );
+      });
+
+      it("should resolve an ISO 8601 duration to a start/end range ending now", () => {
+        vi.setSystemTime(new Date("2024-06-01T12:00:00.000Z"));
+        expect(resolveInterval("PT30M")).toBe(
+          "2024-06-01T11:30:00.000Z/2024-06-01T12:00:00.000Z",
+        );
+      });
+    });
+
+    describe("buildEffectiveFilter()", () => {
+      it("should inject cluster ID for Kafka server metrics when no filter is provided", () => {
+        expect(
+          buildEffectiveFilter(undefined, KAFKA_SERVER_METRIC, "lkc-abc"),
+        ).toEqual({ "resource.kafka.id": "lkc-abc" });
+      });
+
+      it("should trim a space-padded resource.kafka.id and keep it over the config value", () => {
+        const result = buildEffectiveFilter(
+          { "resource.kafka.id": " lkc-explicit " },
+          KAFKA_SERVER_METRIC,
+          "lkc-from-config",
+        );
+        expect(result["resource.kafka.id"]).toBe("lkc-explicit");
+      });
+
+      it("should remove a whitespace-only resource.kafka.id and fall back to config", () => {
+        const result = buildEffectiveFilter(
+          { "resource.kafka.id": "   " },
+          KAFKA_SERVER_METRIC,
+          "lkc-from-config",
+        );
+        expect(result["resource.kafka.id"]).toBe("lkc-from-config");
+      });
+
+      it("should not inject for non-Kafka-server metrics even when cluster ID is in config", () => {
+        const result = buildEffectiveFilter(
+          undefined,
+          "io.confluent.flink/num_records_in",
+          "lkc-abc",
+        );
+        expect(result).not.toHaveProperty("resource.kafka.id");
+      });
+    });
+
+    describe("buildRequestBody()", () => {
+      const BASE_ARGS = [
+        KAFKA_SERVER_METRIC,
+        "SUM",
+        "PT1M",
+        "2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
+        100,
+      ] as const;
+
+      it("should produce a flat EQ filter for a single filter entry", () => {
+        const body = buildRequestBody(
+          ...BASE_ARGS,
+          { "resource.kafka.id": "lkc-abc" },
+          undefined,
+        );
+        expect(body.filter).toEqual({
+          field: "resource.kafka.id",
+          op: "EQ",
+          value: "lkc-abc",
+        });
+      });
+
+      it("should wrap multiple filter entries in an AND object", () => {
+        const body = buildRequestBody(
+          ...BASE_ARGS,
+          { "resource.kafka.id": "lkc-abc", "metric.topic": "my-topic" },
+          undefined,
+        );
+        expect(body.filter).toMatchObject({
+          op: "AND",
+          filters: expect.arrayContaining([
+            { field: "resource.kafka.id", op: "EQ", value: "lkc-abc" },
+            { field: "metric.topic", op: "EQ", value: "my-topic" },
+          ]),
+        });
+      });
+
+      it("should omit filter when effectiveFilter is empty", () => {
+        const body = buildRequestBody(...BASE_ARGS, {}, undefined);
+        expect(body).not.toHaveProperty("filter");
+      });
+
+      it("should set GROUPED format when group_by is provided", () => {
+        const body = buildRequestBody(...BASE_ARGS, {}, ["metric.topic"]);
+        expect(body).toMatchObject({
+          group_by: ["metric.topic"],
+          format: "GROUPED",
+        });
+      });
+
+      it("should not set format when group_by is absent", () => {
+        const body = buildRequestBody(...BASE_ARGS, {}, undefined);
+        expect(body).not.toHaveProperty("format");
       });
     });
 

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -184,7 +184,10 @@ export class QueryMetricsHandler extends BaseToolHandler {
   }
 }
 
-function resolveInterval(interval: string | undefined): string {
+/** Normalises the caller-supplied interval to a "start/end" pair.
+ *  Accepts an already-resolved range ("2024-01-01T00:00:00Z/...") unchanged,
+ *  an ISO 8601 duration ("PT30M", "P1D"), or undefined (defaults to 1 hour). */
+export function resolveInterval(interval: string | undefined): string {
   if (interval?.includes("/")) return interval;
   const now = new Date();
   const durationMs = parseDuration(interval) ?? 60 * 60 * 1000;
@@ -192,7 +195,10 @@ function resolveInterval(interval: string | undefined): string {
   return `${start.toISOString()}/${now.toISOString()}`;
 }
 
-function buildEffectiveFilter(
+/** Returns a copy of `filter` with `resource.kafka.id` trimmed (removing
+ *  space-padded values) and, for `io.confluent.kafka.server/*` metrics,
+ *  auto-injected from `connKafkaClusterId` when absent. */
+export function buildEffectiveFilter(
   filter: Record<string, string> | undefined,
   metric: string,
   connKafkaClusterId: string | undefined,
@@ -217,7 +223,10 @@ function buildEffectiveFilter(
   return effectiveFilter;
 }
 
-function buildRequestBody(
+/** Builds the Telemetry API request body.  A single filter entry is sent as a
+ *  flat EQ object; multiple entries are wrapped in an AND.  Adds group_by and
+ *  GROUPED format when group_by is non-empty. */
+export function buildRequestBody(
   metric: string,
   aggregation: string,
   granularity: string,

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -104,7 +104,7 @@ export class QueryMetricsHandler extends BaseToolHandler {
       // Auto-inject resource.kafka.id for Kafka metrics if not provided
       const effectiveFilter = { ...filter };
       const connKafkaClusterId =
-        runtime.config.getSoleConnection().kafka?.cluster_id;
+        runtime.config.getSoleDirectConnection().kafka?.cluster_id;
       if (
         metric.startsWith("io.confluent.kafka.server/") &&
         !effectiveFilter["resource.kafka.id"] &&

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -87,68 +87,33 @@ export class QueryMetricsHandler extends BaseToolHandler {
       limit = 100,
     } = args;
 
-    // Resolve interval to a proper "start/end" range
-    let interval = args.interval;
-    if (!interval || !interval.includes("/")) {
-      // No interval provided, or a duration like "PT1H" was passed instead of a range
-      const now = new Date();
-      const durationMs = parseDuration(interval) ?? 60 * 60 * 1000; // default 1 hour
-      const start = new Date(now.getTime() - durationMs);
-      interval = `${start.toISOString()}/${now.toISOString()}`;
-    }
+    const interval = resolveInterval(args.interval);
 
     try {
       const telemetryClient =
         clientManager.getConfluentCloudTelemetryRestClient();
-
-      // Auto-inject resource.kafka.id for Kafka metrics if not provided
-      const effectiveFilter = { ...filter };
       const connKafkaClusterId =
         runtime.config.getSoleDirectConnection().kafka?.cluster_id;
-      if (
-        metric.startsWith("io.confluent.kafka.server/") &&
-        !effectiveFilter["resource.kafka.id"] &&
-        connKafkaClusterId
-      ) {
-        effectiveFilter["resource.kafka.id"] = connKafkaClusterId;
-      }
-
-      // Build filter object
-      const filters = Object.entries(effectiveFilter).map(([field, value]) => ({
-        field,
-        op: "EQ" as const,
-        value,
-      }));
-
-      const filterObj =
-        filters.length > 0
-          ? filters.length === 1
-            ? filters[0]
-            : { op: "AND" as const, filters }
-          : undefined;
+      const effectiveFilter = buildEffectiveFilter(
+        filter,
+        metric,
+        connKafkaClusterId,
+      );
 
       logger.debug(
         { metric, filter: effectiveFilter, granularity, interval },
         "Querying metrics",
       );
 
-      // Build request body
-      const useGrouped = group_by && group_by.length > 0;
-      const body: Record<string, unknown> = {
-        aggregations: [{ metric, agg: aggregation }],
+      const body = buildRequestBody(
+        metric,
+        aggregation,
         granularity,
-        intervals: [interval],
+        interval,
         limit,
-      };
-
-      if (filterObj) {
-        body.filter = filterObj;
-      }
-
-      if (useGrouped) {
-        body.group_by = group_by;
-        body.format = "GROUPED";
-      }
+        effectiveFilter,
+        group_by,
+      );
 
       const response = (await telemetryClient.POST(
         "/v2/metrics/{dataset}/query" as never,
@@ -177,7 +142,6 @@ export class QueryMetricsHandler extends BaseToolHandler {
         );
       }
 
-      // Format the response
       const output = formatMetricsResponse(
         data.data,
         metric,
@@ -218,6 +182,77 @@ export class QueryMetricsHandler extends BaseToolHandler {
   enabledConnectionIds(runtime: ServerRuntime): string[] {
     return connectionIdsWhere(runtime.config.connections, hasTelemetry);
   }
+}
+
+function resolveInterval(interval: string | undefined): string {
+  if (interval?.includes("/")) return interval;
+  const now = new Date();
+  const durationMs = parseDuration(interval) ?? 60 * 60 * 1000;
+  const start = new Date(now.getTime() - durationMs);
+  return `${start.toISOString()}/${now.toISOString()}`;
+}
+
+function buildEffectiveFilter(
+  filter: Record<string, string> | undefined,
+  metric: string,
+  connKafkaClusterId: string | undefined,
+): Record<string, string> {
+  const effectiveFilter = { ...filter };
+  if (!effectiveFilter["resource.kafka.id"]?.trim()) {
+    delete effectiveFilter["resource.kafka.id"];
+  }
+  if (
+    metric.startsWith("io.confluent.kafka.server/") &&
+    !effectiveFilter["resource.kafka.id"] &&
+    connKafkaClusterId
+  ) {
+    effectiveFilter["resource.kafka.id"] = connKafkaClusterId;
+  }
+  return effectiveFilter;
+}
+
+function buildRequestBody(
+  metric: string,
+  aggregation: string,
+  granularity: string,
+  interval: string,
+  limit: number,
+  effectiveFilter: Record<string, string>,
+  group_by: string[] | undefined,
+): Record<string, unknown> {
+  const filters = Object.entries(effectiveFilter).map(([field, value]) => ({
+    field,
+    op: "EQ" as const,
+    value,
+  }));
+
+  let filterObj:
+    | (typeof filters)[0]
+    | { op: "AND"; filters: typeof filters }
+    | undefined;
+  if (filters.length === 1) {
+    filterObj = filters[0];
+  } else if (filters.length > 1) {
+    filterObj = { op: "AND" as const, filters };
+  }
+
+  const body: Record<string, unknown> = {
+    aggregations: [{ metric, agg: aggregation }],
+    granularity,
+    intervals: [interval],
+    limit,
+  };
+
+  if (filterObj) {
+    body.filter = filterObj;
+  }
+
+  if (group_by && group_by.length > 0) {
+    body.group_by = group_by;
+    body.format = "GROUPED";
+  }
+
+  return body;
 }
 
 function formatMetricsResponse(

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -9,7 +9,6 @@ import {
   hasTelemetry,
 } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import env from "@src/env.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -104,12 +103,14 @@ export class QueryMetricsHandler extends BaseToolHandler {
 
       // Auto-inject resource.kafka.id for Kafka metrics if not provided
       const effectiveFilter = { ...filter };
+      const connKafkaClusterId =
+        runtime.config.getSoleConnection().kafka?.cluster_id;
       if (
         metric.startsWith("io.confluent.kafka.server/") &&
         !effectiveFilter["resource.kafka.id"] &&
-        env.KAFKA_CLUSTER_ID
+        connKafkaClusterId
       ) {
-        effectiveFilter["resource.kafka.id"] = env.KAFKA_CLUSTER_ID;
+        effectiveFilter["resource.kafka.id"] = connKafkaClusterId;
       }
 
       // Build filter object

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -198,8 +198,14 @@ function buildEffectiveFilter(
   connKafkaClusterId: string | undefined,
 ): Record<string, string> {
   const effectiveFilter = { ...filter };
-  if (!effectiveFilter["resource.kafka.id"]?.trim()) {
-    delete effectiveFilter["resource.kafka.id"];
+  const rawKafkaId = effectiveFilter["resource.kafka.id"];
+  if (rawKafkaId !== undefined) {
+    const trimmed = rawKafkaId.trim();
+    if (trimmed) {
+      effectiveFilter["resource.kafka.id"] = trimmed;
+    } else {
+      delete effectiveFilter["resource.kafka.id"];
+    }
   }
   if (
     metric.startsWith("io.confluent.kafka.server/") &&

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -184,9 +184,11 @@ export class QueryMetricsHandler extends BaseToolHandler {
   }
 }
 
-/** Normalises the caller-supplied interval to a "start/end" pair.
- *  Accepts an already-resolved range ("2024-01-01T00:00:00Z/...") unchanged,
- *  an ISO 8601 duration ("PT30M", "P1D"), or undefined (defaults to 1 hour). */
+/**
+ * Normalises the caller-supplied interval to a "start/end" pair.
+ * Accepts an already-resolved range ("2024-01-01T00:00:00Z/...") unchanged,
+ * an ISO 8601 duration ("PT30M", "P1D"), or undefined (defaults to 1 hour).
+ */
 export function resolveInterval(interval: string | undefined): string {
   if (interval?.includes("/")) return interval;
   const now = new Date();
@@ -195,9 +197,11 @@ export function resolveInterval(interval: string | undefined): string {
   return `${start.toISOString()}/${now.toISOString()}`;
 }
 
-/** Returns a copy of `filter` with `resource.kafka.id` trimmed (removing
- *  space-padded values) and, for `io.confluent.kafka.server/*` metrics,
- *  auto-injected from `connKafkaClusterId` when absent. */
+/**
+ * Returns a copy of `filter` with `resource.kafka.id` trimmed (removing
+ * space-padded values) and, for `io.confluent.kafka.server/*` metrics,
+ * auto-injected from `connKafkaClusterId` when absent.
+ */
 export function buildEffectiveFilter(
   filter: Record<string, string> | undefined,
   metric: string,
@@ -223,9 +227,11 @@ export function buildEffectiveFilter(
   return effectiveFilter;
 }
 
-/** Builds the Telemetry API request body.  A single filter entry is sent as a
- *  flat EQ object; multiple entries are wrapped in an AND.  Adds group_by and
- *  GROUPED format when group_by is non-empty. */
+/**
+ * Builds the Telemetry API request body. A single filter entry is sent as a
+ * flat EQ object; multiple entries are wrapped in an AND. Adds group_by and
+ * GROUPED format when group_by is non-empty.
+ */
 export function buildRequestBody(
   metric: string,
   aggregation: string,
@@ -270,6 +276,11 @@ export function buildRequestBody(
   return body;
 }
 
+/**
+ * Renders the Telemetry API response as a human-readable string. Detects flat
+ * vs. grouped format by inspecting whether the first element has a top-level
+ * `timestamp` field (flat) or a nested `points` array (grouped).
+ */
 function formatMetricsResponse(
   data: Array<Record<string, unknown>>,
   metric: string,
@@ -350,6 +361,9 @@ function formatMetricsResponse(
   return lines.join("\n").trimEnd();
 }
 
+/**
+ * Formats integers with locale separators; floats to 4 decimal places.
+ */
 function formatValue(value: number): string {
   if (Number.isInteger(value)) {
     return value.toLocaleString();
@@ -358,8 +372,8 @@ function formatValue(value: number): string {
 }
 
 /**
- * Parse an ISO 8601 duration string (e.g. "PT1H", "PT30M", "P1D") to milliseconds.
- * Returns undefined if the string is not a recognized duration.
+ * Parses an ISO 8601 duration string ("PT1H", "PT30M", "P1D") to milliseconds.
+ * Returns `undefined` for unrecognised strings so callers can apply a default.
  */
 function parseDuration(duration: string | undefined): number | undefined {
   if (!duration) return undefined;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Do for `query-metrics-handler.ts` what was done for all of the Flink handlers in #307. But this time short and sweet and using the infrastructure built out in that PR.
- No need for a new intermediate base class since was just a single affected handler in this subdomain.

- Closes #232

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
