### PR TITLE
Wean  `list-clusters-handler` off `env.KAFKA_ENV_ID`

### DIFF
--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -42,6 +42,15 @@ export function hasConfluentCloud(conn: ConnectionConfig): boolean {
   return conn.confluent_cloud !== undefined;
 }
 
+/**
+ * True only for direct connections that carry a `confluent_cloud` block.
+ * Use this instead of `hasConfluentCloud` for handlers that are not yet
+ * OAuth-capable and call `getSoleDirectConnection()` inside `handle()`.
+ */
+export function hasDirectConfluentCloud(conn: ConnectionConfig): boolean {
+  return conn.type === "direct" && conn.confluent_cloud !== undefined;
+}
+
 export function hasFlink(conn: ConnectionConfig): boolean {
   return conn.type === "direct" && conn.flink !== undefined;
 }

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
@@ -1,10 +1,18 @@
 import { ListClustersHandler } from "@src/confluent/tools/handlers/clusters/list-clusters-handler.js";
 import {
   bareRuntime,
+  CCLOUD_CONN,
   confluentCloudRuntime,
   DEFAULT_CONNECTION_ID,
+  HandleCaseWithConn,
+  runtimeWith,
 } from "@tests/factories/runtime.js";
+import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
+
+type EnvIdCase = HandleCaseWithConn & {
+  expectedEnvId: string;
+};
 
 describe("list-clusters-handler.ts", () => {
   describe("ListClustersHandler", () => {
@@ -20,6 +28,76 @@ describe("list-clusters-handler.ts", () => {
       it("should return an empty array for a connection without a confluent_cloud block", () => {
         expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
       });
+    });
+
+    describe("handle()", () => {
+      const CCLOUD_WITH_KAFKA_CONN = {
+        ...CCLOUD_CONN,
+        kafka: {
+          env_id: "env-from-config",
+          rest_endpoint: "https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443",
+        },
+      };
+
+      const cases: EnvIdCase[] = [
+        {
+          label:
+            "fall back to conn kafka.env_id when environmentId arg is absent",
+          connectionConfig: CCLOUD_WITH_KAFKA_CONN,
+          args: {},
+          responseData: { data: [] },
+          outcome: { resolves: "Successfully retrieved 0 clusters" },
+          expectedEnvId: "env-from-config",
+        },
+        {
+          label: "prefer explicit environmentId arg over conn kafka.env_id",
+          connectionConfig: CCLOUD_WITH_KAFKA_CONN,
+          args: { environmentId: "env-explicit" },
+          responseData: { data: [] },
+          outcome: { resolves: "Successfully retrieved 0 clusters" },
+          expectedEnvId: "env-explicit",
+        },
+        {
+          label:
+            "use empty string when both environmentId arg and conn kafka.env_id are absent",
+          connectionConfig: CCLOUD_CONN,
+          args: {},
+          responseData: { data: [] },
+          outcome: { resolves: "Successfully retrieved 0 clusters" },
+          expectedEnvId: "",
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({
+          connectionConfig = {},
+          args,
+          responseData,
+          outcome,
+          expectedEnvId,
+        }) => {
+          const { clientManager, clientGetters, capturedCalls } =
+            stubClientGetters(responseData);
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              connectionConfig,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientGetters,
+          });
+          expect(capturedCalls).toHaveLength(1);
+          expect(capturedCalls[0]!.args).toMatchObject({
+            params: expect.objectContaining({
+              query: expect.objectContaining({ environment: expectedEnvId }),
+            }),
+          });
+        },
+      );
     });
   });
 });

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
@@ -2,6 +2,7 @@ import { ListClustersHandler } from "@src/confluent/tools/handlers/clusters/list
 import {
   bareRuntime,
   CCLOUD_CONN,
+  ccloudOAuthRuntime,
   confluentCloudRuntime,
   DEFAULT_CONNECTION_ID,
   HandleCaseWithConn,
@@ -27,6 +28,10 @@ describe("list-clusters-handler.ts", () => {
 
       it("should return an empty array for a connection without a confluent_cloud block", () => {
         expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
+      });
+
+      it("should return an empty array for an OAuth-typed connection", () => {
+        expect(handler.enabledConnectionIds(ccloudOAuthRuntime())).toEqual([]);
       });
     });
 

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -9,7 +9,6 @@ import {
   hasConfluentCloud,
 } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import env from "@src/env.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -81,7 +80,10 @@ export class ListClustersHandler extends BaseToolHandler {
       ].GET({
         params: {
           query: {
-            environment: environmentId ?? env.KAFKA_ENV_ID ?? "",
+            environment:
+              environmentId ??
+              runtime.config.getSoleDirectConnection().kafka?.env_id ??
+              "",
             page_size: 100,
           },
         },

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -6,7 +6,7 @@ import {
 } from "@src/confluent/tools/base-tools.js";
 import {
   connectionIdsWhere,
-  hasConfluentCloud,
+  hasDirectConfluentCloud,
 } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
@@ -194,6 +194,9 @@ Cluster: ${cluster.name}
   }
 
   enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasConfluentCloud);
+    return connectionIdsWhere(
+      runtime.config.connections,
+      hasDirectConfluentCloud,
+    );
   }
 }

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
@@ -1,6 +1,7 @@
 import { ListOrganizationsHandler } from "@src/confluent/tools/handlers/organizations/list-organizations-handler.js";
 import {
   bareRuntime,
+  CCLOUD_CONN,
   ccloudOAuthRuntime,
   confluentCloudRuntime,
   DEFAULT_CONNECTION_ID,
@@ -12,13 +13,6 @@ import {
   type HandleCase,
 } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
-
-const CCLOUD_CONN = {
-  confluent_cloud: {
-    endpoint: "https://api.confluent.cloud",
-    auth: { type: "api_key" as const, key: "k", secret: "s" },
-  },
-};
 
 const ORG_FIXTURE = {
   api_version: "org/v2",

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -117,6 +117,14 @@ export function telemetryRuntime(): ServerRuntime {
   });
 }
 
+/** Shared Confluent Cloud control-plane connection config fixture for handle() tests. */
+export const CCLOUD_CONN = {
+  confluent_cloud: {
+    endpoint: "https://api.confluent.cloud",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+  },
+};
+
 /** Shared Flink connection config fixture for handle() tests. */
 export const FLINK_CONN = {
   flink: {


### PR DESCRIPTION
## Summary

- Weans `list-clusters-handler` off `env.KAFKA_ENV_ID`, replacing the global env fallback with `runtime.config.getSoleDirectConnection().kafka?.env_id` — the same migration done for Flink handlers in #307 and the metrics handler in #344.
- Adds a `handle()` test suite covering the three env_id resolution cases: config fallback, explicit arg precedence, and absent-on-both-sides empty-string default.

## While here

- Promoted `CCLOUD_CONN` to a shared export in `tests/factories/runtime.ts` — it was defined identically in both the clusters and organizations test files.
- New predicate `hasDirectConfluentCloud` guarding ccloud-configuration-block loving handlers from being enabled when configured for oauth before the handler has been proven working (such as this one!). New issue #347 written to investigate any others.

## Relationships

- Closes #233
- Part of the broader env-to-config migration tracked in #230
- Follows the pattern established in #307 (Flink) and #344 (metrics)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
