### PR TITLE
refactor `stubClientGetters` into nested mock instances

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -144,7 +144,7 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   whose connection has the relevant service block (expect the connection id) and a bare runtime
   without that block (expect `[]`). Helper factories live in `tests/factories/runtime.ts`
   (`flinkRuntime()`, `tableflowRuntime()`, `bareRuntime()`, etc.).
-- Test `handle()` for typical and edge-case inputs using `stubClientGetters` +
+- Test `handle()` for typical and edge-case inputs using `getMockedClientManager` +
   `assertHandleCase` from `@tests/stubs/index.js`. The standard three cases per
   config-backed parameter: (1) throws when arg absent and not in config, (2) resolves
   using config fallback, (3) resolves using explicit arg. Use `HandleCaseWithConn` to
@@ -153,46 +153,29 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   handler and get a copy-paste suggestion for the correct expectation; replace before
   committing.
 
-  `stubClientGetters(responseData)` returns three co-equal values:
-  - `clientManager` — inject into `runtimeWith()` to wire the mock into the handler's
-    runtime.
-  - `clientGetters` — pass to `assertHandleCase` to assert the handler reached the
-    client layer on a successful resolve.
-  - `capturedCalls: CapturedCall[]` — primarily for asserting what a handler sent to
-    an OpenAPI REST endpoint (POST body, query params, path params) when
-    `outcome.resolves` alone doesn't prove the payload. Each entry has `.pathTemplate`
-    and `.args` (the `{ params, body, ... }` object). The capture rule is
-    first-string-arg: for OpenAPI REST clients (both `wrapAsPathBasedClient` and
-    direct `client.GET("/path", options)` callers) the first argument is always a
-    path string. Note that SDK-based clients like Schema Registry may also produce
-    entries when their methods take a string as their first argument (e.g. subject
-    names in `getLatestSchemaMetadata(subject)`) — filter by
-    `capturedCalls.filter(c => c.pathTemplate.startsWith("/"))` to isolate REST
-    entries in mixed handlers. Non-string first-arg invocations (Kafka admin,
-    producer, consumer) are silently skipped.
-
-  `responseData` accepts a single element or an array for sequential per-call responses;
-  see the `stubClientGetters` JSDoc for the full element-shape contract (`data`,
-  `response`, `error` keys).
-
-  **When the endpoint returns a bare array** (e.g. list-connectors returns `string[]`),
-  the stub's single-vs-sequence detection fires on the outer array and each element would
-  be treated as a separate response. Wrap the array in a one-element outer array so the
-  inner array is delivered as `data` for the single call:
+  `getMockedClientManager()` returns a `MockedClientManager` (a
+  `Mocked<DirectClientManager>` whose client-getters are narrowed to return
+  `Mocked<...>` of the corresponding production client). Tests retrieve a typed
+  mock from the manager and configure return values per-method on the
+  specific client(s) the handler exercises. Sync getters (the six REST clients
+  and Schema Registry) return the mock directly; async Kafka getters need an
+  `await`:
 
   ```typescript
-  // handler does: const { data: response } = await client.GET(...); response.join(",")
-  stubClientGetters([["connector-a", "connector-b"]]);
-  //                 ↑ outer = "sequence of calls"
-  //                  ↑↑ inner = the array that becomes `data`
-  ```
+  const clientManager = getMockedClientManager();
 
-  Basic usage:
+  // openapi-fetch (sync getter):
+  clientManager
+    .getConfluentCloudFlinkRestClient()
+    .GET.mockResolvedValue({ data: { items: [] } });
 
-  ```typescript
-  const { clientManager, clientGetters, capturedCalls } = stubClientGetters({
-    status: { phase: "COMPLETED" },
-  });
+  // KafkaJS (async getter):
+  const admin = await clientManager.getAdminClient();
+  admin.listTopics.mockResolvedValue(["topic-a"]);
+
+  // SchemaRegistryClient (sync getter):
+  clientManager.getSchemaRegistryClient().getAllSubjects.mockResolvedValue([]);
+
   await assertHandleCase({
     handler,
     runtime: runtimeWith(
@@ -202,32 +185,56 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
     ),
     args,
     outcome,
-    clientGetters,
+    clientManager,
   });
+  ```
+
+  For poll-then-fetch flows or any case where a method returns different data
+  on successive calls, chain `mockResolvedValueOnce`:
+
+  ```typescript
+  const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+  flinkRest.GET.mockResolvedValueOnce({
+    data: { status: { phase: "RUNNING" } },
+  }).mockResolvedValue({ data: { data: [] } });
   ```
 
   Asserting a POST body (when `outcome.resolves` doesn't prove the payload):
 
   ```typescript
-  expect(capturedCalls).toHaveLength(1);
-  expect(capturedCalls[0]!.args).toMatchObject({
-    body: expect.objectContaining({
-      spec: expect.objectContaining({
-        properties: expect.objectContaining({
-          "sql.current-catalog": "env-name-from-config",
+  const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+  expect(flinkRest.POST).toHaveBeenCalledOnce();
+  expect(flinkRest.POST).toHaveBeenCalledWith(
+    expect.stringContaining("/statements"),
+    expect.objectContaining({
+      body: expect.objectContaining({
+        spec: expect.objectContaining({
+          properties: expect.objectContaining({
+            "sql.current-catalog": "env-name-from-config",
+          }),
         }),
       }),
     }),
-  });
+  );
   ```
 
-  Proving a zero-arg REST call was made (`wrapAsPathBasedClient` always injects the
-  path, so the call is still captured even when the handler passes no init object):
+  Asserting that a different client was not touched (negative assertions are
+  first-class because each seam has its own mock):
 
   ```typescript
-  expect(capturedCalls).toHaveLength(1);
-  expect(capturedCalls[0]!.args).toBeUndefined();
+  expect(
+    clientManager.getConfluentCloudKafkaRestClient().POST,
+  ).not.toHaveBeenCalled();
+  expect(
+    clientManager.getConfluentCloudFlinkRestClient().GET,
+  ).not.toHaveBeenCalled();
   ```
+
+  For tests that need a single typed mock without the full
+  `getMockedClientManager` wiring (e.g., focused unit tests against one seam),
+  the per-client helpers are exported directly: `getMockedRestClient()`,
+  `getMockedAdmin()`, `getMockedProducer()`, `getMockedConsumer()`,
+  `getMockedSchemaRegistry()`.
 
 - Use `as any` only on partial mock return values (e.g., a mock admin client with only
   `listTopics`), not on the `ClientManager` mock itself; add an eslint-disable comment when needed.

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -189,6 +189,37 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   });
   ```
 
+  Two invariants are load-bearing:
+  - **Same getter, same mock.** Each `cm.getXxx()` getter is wired with
+    `mockReturnValue`, so every call returns the same mock instance. A
+    `const flinkRest = cm.getConfluentCloudFlinkRestClient()` captured in
+    setup stays valid for assertions after the handler runs, and the
+    handler's own getter call lands on the same mock the test configured.
+  - **Build per test, not per suite.** Invoke `getMockedClientManager()`
+    once per test — either inline in each `it` body or by reassigning a
+    suite-scope `let` from a `beforeEach`. The anti-pattern is a
+    suite-scope `const cm = getMockedClientManager()` that runs once: with
+    that shape, vitest's
+    [`restoreMocks: true`](https://vitest.dev/config/restoremocks) (which
+    only restores `vi.spyOn` originals) won't touch the manager's
+    `vi.fn()`s, so call histories and configured return values leak across
+    tests in the suite. To share setup across tests, rebuild in
+    `beforeEach`:
+
+    ```typescript
+    let clientManager: MockedClientManager;
+
+    beforeEach(() => {
+      clientManager = getMockedClientManager();
+    });
+
+    it("...", async () => {
+      const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+      flinkRest.GET.mockResolvedValue({ data: { items: [] } });
+      // ...
+    });
+    ```
+
   For poll-then-fetch flows or any case where a method returns different data
   on successive calls, chain `mockResolvedValueOnce`:
 

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
@@ -8,7 +8,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 type EnvIdCase = HandleCaseWithConn & {
@@ -50,7 +53,6 @@ describe("list-clusters-handler.ts", () => {
             "fall back to conn kafka.env_id when environmentId arg is absent",
           connectionConfig: CCLOUD_WITH_KAFKA_CONN,
           args: {},
-          responseData: { data: [] },
           outcome: { resolves: "Successfully retrieved 0 clusters" },
           expectedEnvId: "env-from-config",
         },
@@ -58,7 +60,6 @@ describe("list-clusters-handler.ts", () => {
           label: "prefer explicit environmentId arg over conn kafka.env_id",
           connectionConfig: CCLOUD_WITH_KAFKA_CONN,
           args: { environmentId: "env-explicit" },
-          responseData: { data: [] },
           outcome: { resolves: "Successfully retrieved 0 clusters" },
           expectedEnvId: "env-explicit",
         },
@@ -67,7 +68,6 @@ describe("list-clusters-handler.ts", () => {
             "use empty string when both environmentId arg and conn kafka.env_id are absent",
           connectionConfig: CCLOUD_CONN,
           args: {},
-          responseData: { data: [] },
           outcome: { resolves: "Successfully retrieved 0 clusters" },
           expectedEnvId: "",
         },
@@ -75,15 +75,11 @@ describe("list-clusters-handler.ts", () => {
 
       it.each(cases)(
         "should $label",
-        async ({
-          connectionConfig = {},
-          args,
-          responseData,
-          outcome,
-          expectedEnvId,
-        }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(responseData);
+        async ({ connectionConfig = {}, args, outcome, expectedEnvId }) => {
+          const clientManager = getMockedClientManager();
+          const cloudRest = clientManager.getConfluentCloudRestClient();
+          cloudRest.GET.mockResolvedValue({ data: { data: [] } });
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -93,14 +89,18 @@ describe("list-clusters-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
-          expect(capturedCalls).toHaveLength(1);
-          expect(capturedCalls[0]!.args).toMatchObject({
-            params: expect.objectContaining({
-              query: expect.objectContaining({ environment: expectedEnvId }),
+
+          expect(cloudRest.GET).toHaveBeenCalledOnce();
+          expect(cloudRest.GET).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              params: expect.objectContaining({
+                query: expect.objectContaining({ environment: expectedEnvId }),
+              }),
             }),
-          });
+          );
         },
       );
     });

--- a/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
@@ -9,12 +9,19 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 type ConnectHandleCase = HandleCaseWithConn & {
   expectedEnvId?: string;
   expectedClusterId?: string;
+  /** Response object the cloud REST POST resolves with. Use { data } for the
+   *  success path or { error } for the API-error path. Omit for cases that
+   *  throw before reaching the client. */
+  mockResponse?: { data?: unknown; error?: unknown };
 };
 
 const MINIMAL_CONNECTOR_ARGS = {
@@ -55,7 +62,7 @@ describe("create-connector-handler.ts", () => {
             "fall back to conn kafka env_id and cluster_id when args are absent",
           connectionConfig: CONNECT_CONN_WITH_AUTH,
           args: MINIMAL_CONNECTOR_ARGS,
-          responseData: { name: "my-connector" },
+          mockResponse: { data: { name: "my-connector" } },
           outcome: { resolves: "my-connector created" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -69,7 +76,7 @@ describe("create-connector-handler.ts", () => {
             environmentId: "env-from-arg",
             clusterId: "lkc-from-arg",
           },
-          responseData: { name: "my-connector" },
+          mockResponse: { data: { name: "my-connector" } },
           outcome: { resolves: "my-connector created" },
           expectedEnvId: "env-from-arg",
           expectedClusterId: "lkc-from-arg",
@@ -85,7 +92,6 @@ describe("create-connector-handler.ts", () => {
             },
           },
           args: MINIMAL_CONNECTOR_ARGS,
-          responseData: {},
           outcome: { throws: "Environment ID is required" },
         },
         {
@@ -100,14 +106,13 @@ describe("create-connector-handler.ts", () => {
             },
           },
           args: MINIMAL_CONNECTOR_ARGS,
-          responseData: {},
           outcome: { throws: "Kafka Cluster ID is required" },
         },
         {
           label: "resolve with an error message when the API returns an error",
           connectionConfig: CONNECT_CONN_WITH_AUTH,
           args: MINIMAL_CONNECTOR_ARGS,
-          responseData: { error: { message: "connector already exists" } },
+          mockResponse: { error: { message: "connector already exists" } },
           outcome: { resolves: "Failed to create connector my-connector" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -119,13 +124,17 @@ describe("create-connector-handler.ts", () => {
         async ({
           connectionConfig = {},
           args,
-          responseData,
+          mockResponse,
           outcome,
           expectedEnvId,
           expectedClusterId,
         }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          const cloudRest = clientManager.getConfluentCloudRestClient();
+          if (mockResponse !== undefined) {
+            cloudRest.POST.mockResolvedValue(mockResponse);
+          }
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -135,26 +144,31 @@ describe("create-connector-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
+
           if (typeof outcome === "object" && "resolves" in outcome) {
-            expect(capturedCalls).toHaveLength(1);
-            expect(capturedCalls[0]!.args).toMatchObject({
-              params: expect.objectContaining({
-                path: expect.objectContaining({
-                  environment_id: expectedEnvId,
-                  kafka_cluster_id: expectedClusterId,
+            expect(cloudRest.POST).toHaveBeenCalledOnce();
+            expect(cloudRest.POST).toHaveBeenCalledWith(
+              expect.any(String),
+              expect.objectContaining({
+                params: expect.objectContaining({
+                  path: expect.objectContaining({
+                    environment_id: expectedEnvId,
+                    kafka_cluster_id: expectedClusterId,
+                  }),
                 }),
               }),
-            });
+            );
           }
         },
       );
 
       it("should embed kafka auth credentials from conn config in the POST body", async () => {
-        const { clientManager, capturedCalls } = stubClientGetters({
-          name: "my-connector",
-        });
+        const clientManager = getMockedClientManager();
+        const cloudRest = clientManager.getConfluentCloudRestClient();
+        cloudRest.POST.mockResolvedValue({ data: { name: "my-connector" } });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -164,15 +178,20 @@ describe("create-connector-handler.ts", () => {
           ),
           args: MINIMAL_CONNECTOR_ARGS,
           outcome: { resolves: "my-connector created" },
+          clientManager,
         });
-        expect(capturedCalls[0]!.args).toMatchObject({
-          body: expect.objectContaining({
-            config: expect.objectContaining({
-              "kafka.api.key": "kafka-key",
-              "kafka.api.secret": "kafka-secret",
+
+        expect(cloudRest.POST).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              config: expect.objectContaining({
+                "kafka.api.key": "kafka-key",
+                "kafka.api.secret": "kafka-secret",
+              }),
             }),
           }),
-        });
+        );
       });
     });
   });

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.test.ts
@@ -9,12 +9,19 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 type ConnectHandleCase = HandleCaseWithConn & {
   expectedEnvId?: string;
   expectedClusterId?: string;
+  /** Response object the cloud REST DELETE resolves with. Use {} for success
+   *  (handler only reads `error`) or { error } for the API-error path. Omit
+   *  for cases that throw before reaching the client. */
+  mockResponse?: { data?: unknown; error?: unknown };
 };
 
 describe("delete-connector-handler.ts", () => {
@@ -44,7 +51,7 @@ describe("delete-connector-handler.ts", () => {
             "fall back to conn kafka env_id and cluster_id when args are absent",
           connectionConfig: CONNECT_CONN,
           args: { connectorName: "my-connector" },
-          responseData: {},
+          mockResponse: {},
           outcome: { resolves: "Successfully deleted connector my-connector" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -58,7 +65,7 @@ describe("delete-connector-handler.ts", () => {
             environmentId: "env-from-arg",
             clusterId: "lkc-from-arg",
           },
-          responseData: {},
+          mockResponse: {},
           outcome: { resolves: "Successfully deleted connector my-connector" },
           expectedEnvId: "env-from-arg",
           expectedClusterId: "lkc-from-arg",
@@ -67,7 +74,6 @@ describe("delete-connector-handler.ts", () => {
           label: "throw when environment_id is absent from both arg and config",
           connectionConfig: CCLOUD_CONN,
           args: { connectorName: "my-connector" },
-          responseData: {},
           outcome: { throws: "Environment ID is required" },
         },
         {
@@ -81,14 +87,13 @@ describe("delete-connector-handler.ts", () => {
             },
           },
           args: { connectorName: "my-connector" },
-          responseData: {},
           outcome: { throws: "Kafka Cluster ID is required" },
         },
         {
           label: "resolve with an error message when the API returns an error",
           connectionConfig: CONNECT_CONN,
           args: { connectorName: "my-connector" },
-          responseData: { error: { message: "connector not found" } },
+          mockResponse: { error: { message: "connector not found" } },
           outcome: { resolves: "Failed to delete connector my-connector" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -100,13 +105,17 @@ describe("delete-connector-handler.ts", () => {
         async ({
           connectionConfig = {},
           args,
-          responseData,
+          mockResponse,
           outcome,
           expectedEnvId,
           expectedClusterId,
         }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          const cloudRest = clientManager.getConfluentCloudRestClient();
+          if (mockResponse !== undefined) {
+            cloudRest.DELETE.mockResolvedValue(mockResponse);
+          }
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -116,19 +125,23 @@ describe("delete-connector-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
+
           if (typeof outcome === "object" && "resolves" in outcome) {
-            expect(capturedCalls).toHaveLength(1);
-            expect(capturedCalls[0]!.args).toMatchObject({
-              params: expect.objectContaining({
-                path: expect.objectContaining({
-                  connector_name: "my-connector",
-                  environment_id: expectedEnvId,
-                  kafka_cluster_id: expectedClusterId,
+            expect(cloudRest.DELETE).toHaveBeenCalledOnce();
+            expect(cloudRest.DELETE).toHaveBeenCalledWith(
+              expect.any(String),
+              expect.objectContaining({
+                params: expect.objectContaining({
+                  path: expect.objectContaining({
+                    connector_name: "my-connector",
+                    environment_id: expectedEnvId,
+                    kafka_cluster_id: expectedClusterId,
+                  }),
                 }),
               }),
-            });
+            );
           }
         },
       );

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
@@ -9,12 +9,19 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 type ConnectHandleCase = HandleCaseWithConn & {
   expectedEnvId?: string;
   expectedClusterId?: string;
+  /** Response object the cloud REST GET resolves with. Use { data } for the
+   *  success path or { error } for the API-error path. Omit for cases that
+   *  throw before reaching the client. */
+  mockResponse?: { data?: unknown; error?: unknown };
 };
 
 describe("list-connectors-handler.ts", () => {
@@ -44,7 +51,7 @@ describe("list-connectors-handler.ts", () => {
             "fall back to conn kafka env_id and cluster_id when args are absent",
           connectionConfig: CONNECT_CONN,
           args: {},
-          responseData: [["connector-a", "connector-b"]],
+          mockResponse: { data: ["connector-a", "connector-b"] },
           outcome: { resolves: "Active Connectors" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -54,7 +61,7 @@ describe("list-connectors-handler.ts", () => {
             "prefer explicit environmentId and clusterId args over conn config",
           connectionConfig: CONNECT_CONN,
           args: { environmentId: "env-from-arg", clusterId: "lkc-from-arg" },
-          responseData: [["connector-a"]],
+          mockResponse: { data: ["connector-a"] },
           outcome: { resolves: "Active Connectors" },
           expectedEnvId: "env-from-arg",
           expectedClusterId: "lkc-from-arg",
@@ -63,7 +70,6 @@ describe("list-connectors-handler.ts", () => {
           label: "throw when environment_id is absent from both arg and config",
           connectionConfig: CCLOUD_CONN,
           args: {},
-          responseData: {},
           outcome: { throws: "Environment ID is required" },
         },
         {
@@ -77,14 +83,13 @@ describe("list-connectors-handler.ts", () => {
             },
           },
           args: {},
-          responseData: {},
           outcome: { throws: "Kafka Cluster ID is required" },
         },
         {
           label: "resolve with an error message when the API returns an error",
           connectionConfig: CONNECT_CONN,
           args: {},
-          responseData: { error: { message: "unauthorized" } },
+          mockResponse: { error: { message: "unauthorized" } },
           outcome: { resolves: "Failed to list Confluent Cloud connectors" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -96,13 +101,17 @@ describe("list-connectors-handler.ts", () => {
         async ({
           connectionConfig = {},
           args,
-          responseData,
+          mockResponse,
           outcome,
           expectedEnvId,
           expectedClusterId,
         }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          const cloudRest = clientManager.getConfluentCloudRestClient();
+          if (mockResponse !== undefined) {
+            cloudRest.GET.mockResolvedValue(mockResponse);
+          }
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -112,18 +121,22 @@ describe("list-connectors-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
+
           if (typeof outcome === "object" && "resolves" in outcome) {
-            expect(capturedCalls).toHaveLength(1);
-            expect(capturedCalls[0]!.args).toMatchObject({
-              params: expect.objectContaining({
-                path: expect.objectContaining({
-                  environment_id: expectedEnvId,
-                  kafka_cluster_id: expectedClusterId,
+            expect(cloudRest.GET).toHaveBeenCalledOnce();
+            expect(cloudRest.GET).toHaveBeenCalledWith(
+              expect.any(String),
+              expect.objectContaining({
+                params: expect.objectContaining({
+                  path: expect.objectContaining({
+                    environment_id: expectedEnvId,
+                    kafka_cluster_id: expectedClusterId,
+                  }),
                 }),
               }),
-            });
+            );
           }
         },
       );

--- a/src/confluent/tools/handlers/connect/read-connectors-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/read-connectors-handler.test.ts
@@ -9,12 +9,19 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 type ConnectHandleCase = HandleCaseWithConn & {
   expectedEnvId?: string;
   expectedClusterId?: string;
+  /** Response object the cloud REST GET resolves with. Use { data } for the
+   *  success path or { error } for the API-error path. Omit for cases that
+   *  throw before reaching the client. */
+  mockResponse?: { data?: unknown; error?: unknown };
 };
 
 describe("read-connectors-handler.ts", () => {
@@ -44,7 +51,7 @@ describe("read-connectors-handler.ts", () => {
             "fall back to conn kafka env_id and cluster_id when args are absent",
           connectionConfig: CONNECT_CONN,
           args: { connectorName: "my-connector" },
-          responseData: { name: "my-connector", type: "SOURCE" },
+          mockResponse: { data: { name: "my-connector", type: "SOURCE" } },
           outcome: { resolves: "Connector Details for my-connector" },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
@@ -58,7 +65,7 @@ describe("read-connectors-handler.ts", () => {
             environmentId: "env-from-arg",
             clusterId: "lkc-from-arg",
           },
-          responseData: { name: "my-connector" },
+          mockResponse: { data: { name: "my-connector" } },
           outcome: { resolves: "Connector Details for my-connector" },
           expectedEnvId: "env-from-arg",
           expectedClusterId: "lkc-from-arg",
@@ -67,7 +74,6 @@ describe("read-connectors-handler.ts", () => {
           label: "throw when environment_id is absent from both arg and config",
           connectionConfig: CCLOUD_CONN,
           args: { connectorName: "my-connector" },
-          responseData: {},
           outcome: { throws: "Environment ID is required" },
         },
         {
@@ -81,14 +87,13 @@ describe("read-connectors-handler.ts", () => {
             },
           },
           args: { connectorName: "my-connector" },
-          responseData: {},
           outcome: { throws: "Kafka Cluster ID is required" },
         },
         {
           label: "resolve with an error message when the API returns an error",
           connectionConfig: CONNECT_CONN,
           args: { connectorName: "my-connector" },
-          responseData: { error: { message: "not found" } },
+          mockResponse: { error: { message: "not found" } },
           outcome: {
             resolves: "Failed to get information about connector my-connector",
           },
@@ -102,13 +107,17 @@ describe("read-connectors-handler.ts", () => {
         async ({
           connectionConfig = {},
           args,
-          responseData,
+          mockResponse,
           outcome,
           expectedEnvId,
           expectedClusterId,
         }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          const cloudRest = clientManager.getConfluentCloudRestClient();
+          if (mockResponse !== undefined) {
+            cloudRest.GET.mockResolvedValue(mockResponse);
+          }
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -118,19 +127,23 @@ describe("read-connectors-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
+
           if (typeof outcome === "object" && "resolves" in outcome) {
-            expect(capturedCalls).toHaveLength(1);
-            expect(capturedCalls[0]!.args).toMatchObject({
-              params: expect.objectContaining({
-                path: expect.objectContaining({
-                  connector_name: "my-connector",
-                  environment_id: expectedEnvId,
-                  kafka_cluster_id: expectedClusterId,
+            expect(cloudRest.GET).toHaveBeenCalledOnce();
+            expect(cloudRest.GET).toHaveBeenCalledWith(
+              expect.any(String),
+              expect.objectContaining({
+                params: expect.objectContaining({
+                  path: expect.objectContaining({
+                    connector_name: "my-connector",
+                    environment_id: expectedEnvId,
+                    kafka_cluster_id: expectedClusterId,
+                  }),
                 }),
               }),
-            });
+            );
           }
         },
       );

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const TABLE_NAME = "my-table";
@@ -31,7 +34,6 @@ describe("describe-table-handler.ts", () => {
           label: "use org/env/compute IDs from config when args absent",
           args: { tableName: TABLE_NAME },
           outcome: { resolves: `Table '${TABLE_NAME}' schema` },
-          responseData: SQL_RESPONSE,
         },
         {
           label: "use explicit org/env/compute args over config",
@@ -42,20 +44,16 @@ describe("describe-table-handler.ts", () => {
             computePoolId: "lfcp-from-args",
           },
           outcome: { resolves: `Table '${TABLE_NAME}' schema` },
-          responseData: SQL_RESPONSE,
         },
       ];
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = FLINK_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -65,7 +63,7 @@ describe("describe-table-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
@@ -84,8 +82,11 @@ describe("describe-table-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(SQL_RESPONSE);
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -95,16 +96,20 @@ describe("describe-table-handler.ts", () => {
             ),
             args,
             outcome: { resolves: `Table '${TABLE_NAME}' schema` },
-            clientGetters,
+            clientManager,
           });
-          expect(capturedCalls).toHaveLength(3);
-          expect(capturedCalls[0]!.args).toMatchObject({
-            body: expect.objectContaining({
-              spec: expect.objectContaining({
-                statement: expect.stringContaining(expectedCatalog),
+
+          expect(flinkRest.POST).toHaveBeenCalledOnce();
+          expect(flinkRest.POST).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              body: expect.objectContaining({
+                spec: expect.objectContaining({
+                  statement: expect.stringContaining(expectedCatalog),
+                }),
               }),
             }),
-          });
+          );
         },
       );
     });

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
@@ -8,8 +8,10 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
+  type MockedRestClient,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const TABLE_NAME = "my-table";
 
@@ -23,6 +25,16 @@ describe("describe-table-handler.ts", () => {
     const handler = new DescribeTableHandler();
 
     describe("handle()", () => {
+      let clientManager: MockedClientManager;
+      let flinkRest: MockedRestClient;
+
+      beforeEach(() => {
+        clientManager = getMockedClientManager();
+        flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+      });
+
       const cases: HandleCaseWithConn[] = [
         {
           label: "throw ZodError when tableName is absent",
@@ -50,10 +62,6 @@ describe("describe-table-handler.ts", () => {
       it.each(cases)(
         "should $label",
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -82,11 +90,6 @@ describe("describe-table-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
-
           await assertHandleCase({
             handler,
             runtime: runtimeWith(

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const TABLE_NAME = "my-table";
@@ -31,7 +34,6 @@ describe("get-table-info-handler.ts", () => {
           label: "use org/env/compute IDs from config when args absent",
           args: { tableName: TABLE_NAME },
           outcome: { resolves: `Table info for '${TABLE_NAME}'` },
-          responseData: SQL_RESPONSE,
         },
         {
           label: "use explicit org/env/compute args over config",
@@ -42,20 +44,16 @@ describe("get-table-info-handler.ts", () => {
             computePoolId: "lfcp-from-args",
           },
           outcome: { resolves: `Table info for '${TABLE_NAME}'` },
-          responseData: SQL_RESPONSE,
         },
       ];
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = FLINK_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -65,7 +63,7 @@ describe("get-table-info-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
@@ -84,8 +82,11 @@ describe("get-table-info-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(SQL_RESPONSE);
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -95,16 +96,20 @@ describe("get-table-info-handler.ts", () => {
             ),
             args,
             outcome: { resolves: `Table info for '${TABLE_NAME}'` },
-            clientGetters,
+            clientManager,
           });
-          expect(capturedCalls).toHaveLength(3);
-          expect(capturedCalls[0]!.args).toMatchObject({
-            body: expect.objectContaining({
-              spec: expect.objectContaining({
-                statement: expect.stringContaining(expectedCatalog),
+
+          expect(flinkRest.POST).toHaveBeenCalledOnce();
+          expect(flinkRest.POST).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              body: expect.objectContaining({
+                spec: expect.objectContaining({
+                  statement: expect.stringContaining(expectedCatalog),
+                }),
               }),
             }),
-          });
+          );
         },
       );
     });

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
@@ -8,8 +8,10 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
+  type MockedRestClient,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const TABLE_NAME = "my-table";
 
@@ -23,6 +25,16 @@ describe("get-table-info-handler.ts", () => {
     const handler = new GetTableInfoHandler();
 
     describe("handle()", () => {
+      let clientManager: MockedClientManager;
+      let flinkRest: MockedRestClient;
+
+      beforeEach(() => {
+        clientManager = getMockedClientManager();
+        flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+      });
+
       const cases: HandleCaseWithConn[] = [
         {
           label: "throw ZodError when tableName is absent",
@@ -50,10 +62,6 @@ describe("get-table-info-handler.ts", () => {
       it.each(cases)(
         "should $label",
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -82,11 +90,6 @@ describe("get-table-info-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
-
           await assertHandleCase({
             handler,
             runtime: runtimeWith(

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const SQL_RESPONSE = {
@@ -23,7 +26,6 @@ describe("list-catalogs-handler.ts", () => {
           label: "use org/env/compute IDs from config when args absent",
           args: {},
           outcome: { resolves: "Catalogs" },
-          responseData: SQL_RESPONSE,
         },
         {
           label: "use explicit org/env/compute args over config",
@@ -33,20 +35,17 @@ describe("list-catalogs-handler.ts", () => {
             computePoolId: "lfcp-from-args",
           },
           outcome: { resolves: "Catalogs" },
-          responseData: SQL_RESPONSE,
         },
       ];
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = FLINK_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
+          const clientManager = getMockedClientManager();
+          // executeFlinkSql does POST (submit) → GET (poll status) → GET (results)
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -56,14 +55,17 @@ describe("list-catalogs-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
 
       it("should embed config environment_id as catalog name in the POST SQL statement", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters(SQL_RESPONSE);
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -73,18 +75,22 @@ describe("list-catalogs-handler.ts", () => {
           ),
           args: {},
           outcome: { resolves: "Catalogs" },
-          clientGetters,
+          clientManager,
         });
-        expect(capturedCalls).toHaveLength(3);
-        expect(capturedCalls[0]!.args).toMatchObject({
-          body: expect.objectContaining({
-            spec: expect.objectContaining({
-              statement: expect.stringContaining(
-                FLINK_CONN.flink.environment_id,
-              ),
+
+        expect(flinkRest.POST).toHaveBeenCalledOnce();
+        expect(flinkRest.POST).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              spec: expect.objectContaining({
+                statement: expect.stringContaining(
+                  FLINK_CONN.flink.environment_id,
+                ),
+              }),
             }),
           }),
-        });
+        );
       });
     });
   });

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
@@ -8,8 +8,10 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
+  type MockedRestClient,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const SQL_RESPONSE = {
   status: { phase: "COMPLETED" },
@@ -21,6 +23,17 @@ describe("list-catalogs-handler.ts", () => {
     const handler = new ListCatalogsHandler();
 
     describe("handle()", () => {
+      let clientManager: MockedClientManager;
+      let flinkRest: MockedRestClient;
+
+      beforeEach(() => {
+        // executeFlinkSql does POST (submit) → GET (poll status) → GET (results)
+        clientManager = getMockedClientManager();
+        flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+      });
+
       const cases: HandleCaseWithConn[] = [
         {
           label: "use org/env/compute IDs from config when args absent",
@@ -41,11 +54,6 @@ describe("list-catalogs-handler.ts", () => {
       it.each(cases)(
         "should $label",
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
-          const clientManager = getMockedClientManager();
-          // executeFlinkSql does POST (submit) → GET (poll status) → GET (results)
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -61,11 +69,6 @@ describe("list-catalogs-handler.ts", () => {
       );
 
       it("should embed config environment_id as catalog name in the POST SQL statement", async () => {
-        const clientManager = getMockedClientManager();
-        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
-
         await assertHandleCase({
           handler,
           runtime: runtimeWith(

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const SQL_RESPONSE = {
@@ -23,7 +26,6 @@ describe("list-databases-handler.ts", () => {
           label: "use org/env/compute IDs from config when args absent",
           args: {},
           outcome: { resolves: "Databases" },
-          responseData: SQL_RESPONSE,
         },
         {
           label: "use explicit org/env/compute args over config",
@@ -33,20 +35,16 @@ describe("list-databases-handler.ts", () => {
             computePoolId: "lfcp-from-args",
           },
           outcome: { resolves: "Databases" },
-          responseData: SQL_RESPONSE,
         },
       ];
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = FLINK_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -56,7 +54,7 @@ describe("list-databases-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
@@ -75,8 +73,11 @@ describe("list-databases-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(SQL_RESPONSE);
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -86,16 +87,20 @@ describe("list-databases-handler.ts", () => {
             ),
             args,
             outcome: { resolves: "Databases" },
-            clientGetters,
+            clientManager,
           });
-          expect(capturedCalls).toHaveLength(3);
-          expect(capturedCalls[0]!.args).toMatchObject({
-            body: expect.objectContaining({
-              spec: expect.objectContaining({
-                statement: expect.stringContaining(expectedCatalog),
+
+          expect(flinkRest.POST).toHaveBeenCalledOnce();
+          expect(flinkRest.POST).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              body: expect.objectContaining({
+                spec: expect.objectContaining({
+                  statement: expect.stringContaining(expectedCatalog),
+                }),
               }),
             }),
-          });
+          );
         },
       );
     });

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
@@ -8,8 +8,10 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
+  type MockedRestClient,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const SQL_RESPONSE = {
   status: { phase: "COMPLETED" },
@@ -21,6 +23,16 @@ describe("list-databases-handler.ts", () => {
     const handler = new ListDatabasesHandler();
 
     describe("handle()", () => {
+      let clientManager: MockedClientManager;
+      let flinkRest: MockedRestClient;
+
+      beforeEach(() => {
+        clientManager = getMockedClientManager();
+        flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+      });
+
       const cases: HandleCaseWithConn[] = [
         {
           label: "use org/env/compute IDs from config when args absent",
@@ -41,10 +53,6 @@ describe("list-databases-handler.ts", () => {
       it.each(cases)(
         "should $label",
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -73,11 +81,6 @@ describe("list-databases-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
-
           await assertHandleCase({
             handler,
             runtime: runtimeWith(

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const SQL_RESPONSE = {
@@ -25,7 +28,6 @@ describe("list-tables-handler.ts", () => {
           label: "use org/env/compute IDs from config when args absent",
           args: {},
           outcome: { resolves: "Tables in catalog" },
-          responseData: SQL_RESPONSE,
         },
         {
           label: "use explicit org/env/compute args over config",
@@ -35,20 +37,16 @@ describe("list-tables-handler.ts", () => {
             computePoolId: "lfcp-from-args",
           },
           outcome: { resolves: "Tables in catalog" },
-          responseData: SQL_RESPONSE,
         },
       ];
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = FLINK_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -58,7 +56,7 @@ describe("list-tables-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
@@ -77,8 +75,11 @@ describe("list-tables-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters(SQL_RESPONSE);
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -88,16 +89,20 @@ describe("list-tables-handler.ts", () => {
             ),
             args,
             outcome: { resolves: "Tables in catalog" },
-            clientGetters,
+            clientManager,
           });
-          expect(capturedCalls).toHaveLength(3);
-          expect(capturedCalls[0]!.args).toMatchObject({
-            body: expect.objectContaining({
-              spec: expect.objectContaining({
-                statement: expect.stringContaining(expectedCatalog),
+
+          expect(flinkRest.POST).toHaveBeenCalledOnce();
+          expect(flinkRest.POST).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+              body: expect.objectContaining({
+                spec: expect.objectContaining({
+                  statement: expect.stringContaining(expectedCatalog),
+                }),
               }),
             }),
-          });
+          );
         },
       );
     });

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
@@ -8,8 +8,10 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
+  type MockedRestClient,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const SQL_RESPONSE = {
   status: { phase: "COMPLETED" },
@@ -23,6 +25,16 @@ describe("list-tables-handler.ts", () => {
     const handler = new ListTablesHandler();
 
     describe("handle()", () => {
+      let clientManager: MockedClientManager;
+      let flinkRest: MockedRestClient;
+
+      beforeEach(() => {
+        clientManager = getMockedClientManager();
+        flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
+        flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
+      });
+
       const cases: HandleCaseWithConn[] = [
         {
           label: "use org/env/compute IDs from config when args absent",
@@ -43,10 +55,6 @@ describe("list-tables-handler.ts", () => {
       it.each(cases)(
         "should $label",
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -75,11 +83,6 @@ describe("list-tables-handler.ts", () => {
       ])(
         "should $label in POST SQL statement",
         async ({ args, expectedCatalog }) => {
-          const clientManager = getMockedClientManager();
-          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-          flinkRest.POST.mockResolvedValue({ data: SQL_RESPONSE });
-          flinkRest.GET.mockResolvedValue({ data: SQL_RESPONSE });
-
           await assertHandleCase({
             handler,
             runtime: runtimeWith(

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const FLINK_CONN = {
@@ -97,14 +100,11 @@ describe("create-flink-statement-handler.ts", () => {
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = FLINK_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
+          const clientManager = getMockedClientManager();
+          clientManager
+            .getConfluentCloudFlinkRestClient()
+            .POST.mockResolvedValue({ data: {} });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -114,14 +114,16 @@ describe("create-flink-statement-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
 
       it("should include catalog/database names from config in POST spec.properties when absent from args", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters({});
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: {} });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -131,24 +133,30 @@ describe("create-flink-statement-handler.ts", () => {
           ),
           args: REQUIRED_ARGS,
           outcome: { resolves: "{}" },
-          clientGetters,
+          clientManager,
         });
-        expect(capturedCalls).toHaveLength(1);
-        expect(capturedCalls[0]!.args).toMatchObject({
-          body: expect.objectContaining({
-            spec: expect.objectContaining({
-              properties: {
-                "sql.current-catalog": FLINK_CONN.flink.environment_name,
-                "sql.current-database": FLINK_CONN.flink.database_name,
-              },
+
+        expect(flinkRest.POST).toHaveBeenCalledOnce();
+        expect(flinkRest.POST).toHaveBeenCalledWith(
+          expect.stringContaining("/statements"),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              spec: expect.objectContaining({
+                properties: {
+                  "sql.current-catalog": FLINK_CONN.flink.environment_name,
+                  "sql.current-database": FLINK_CONN.flink.database_name,
+                },
+              }),
             }),
           }),
-        });
+        );
       });
 
       it("should omit catalog/database keys from POST spec.properties when absent from both args and config", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters({});
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: {} });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -158,21 +166,27 @@ describe("create-flink-statement-handler.ts", () => {
           ),
           args: { ...REQUIRED_ARGS, ...EXPLICIT_IDS },
           outcome: { resolves: "{}" },
-          clientGetters,
+          clientManager,
         });
-        expect(capturedCalls).toHaveLength(1);
-        expect(capturedCalls[0]!.args).toMatchObject({
-          body: expect.objectContaining({
-            spec: expect.objectContaining({
-              properties: {},
+
+        expect(flinkRest.POST).toHaveBeenCalledOnce();
+        expect(flinkRest.POST).toHaveBeenCalledWith(
+          expect.stringContaining("/statements"),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              spec: expect.objectContaining({
+                properties: {},
+              }),
             }),
           }),
-        });
+        );
       });
 
       it("should use explicit catalogName/databaseName args over config values in POST spec.properties", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters({});
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: {} });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -187,24 +201,30 @@ describe("create-flink-statement-handler.ts", () => {
             databaseName: "db-from-args",
           },
           outcome: { resolves: "{}" },
-          clientGetters,
+          clientManager,
         });
-        expect(capturedCalls).toHaveLength(1);
-        expect(capturedCalls[0]!.args).toMatchObject({
-          body: expect.objectContaining({
-            spec: expect.objectContaining({
-              properties: {
-                "sql.current-catalog": "catalog-from-args",
-                "sql.current-database": "db-from-args",
-              },
+
+        expect(flinkRest.POST).toHaveBeenCalledOnce();
+        expect(flinkRest.POST).toHaveBeenCalledWith(
+          expect.stringContaining("/statements"),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              spec: expect.objectContaining({
+                properties: {
+                  "sql.current-catalog": "catalog-from-args",
+                  "sql.current-database": "db-from-args",
+                },
+              }),
             }),
           }),
-        });
+        );
       });
 
       it("should fall back to config catalog/database in POST spec.properties when args are blank", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters({});
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.POST.mockResolvedValue({ data: {} });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -219,19 +239,23 @@ describe("create-flink-statement-handler.ts", () => {
             databaseName: "   ",
           },
           outcome: { resolves: "{}" },
-          clientGetters,
+          clientManager,
         });
-        expect(capturedCalls).toHaveLength(1);
-        expect(capturedCalls[0]!.args).toMatchObject({
-          body: expect.objectContaining({
-            spec: expect.objectContaining({
-              properties: {
-                "sql.current-catalog": FLINK_CONN.flink.environment_name,
-                "sql.current-database": FLINK_CONN.flink.database_name,
-              },
+
+        expect(flinkRest.POST).toHaveBeenCalledOnce();
+        expect(flinkRest.POST).toHaveBeenCalledWith(
+          expect.stringContaining("/statements"),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              spec: expect.objectContaining({
+                properties: {
+                  "sql.current-catalog": FLINK_CONN.flink.environment_name,
+                  "sql.current-database": FLINK_CONN.flink.database_name,
+                },
+              }),
             }),
           }),
-        });
+        );
       });
     });
   });

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, it } from "vitest";
 
 const EXPLICIT_IDS = {
@@ -15,12 +18,18 @@ const EXPLICIT_IDS = {
 
 const STATEMENT_NAME = "my-statement";
 
+type DeleteStatementCase = HandleCaseWithConn & {
+  /** HTTP status returned by the Flink REST DELETE. Omit for cases that
+   *  throw before reaching the client. */
+  deleteStatus?: number;
+};
+
 describe("delete-flink-statement-handler.ts", () => {
   describe("DeleteFlinkStatementHandler", () => {
     const handler = new DeleteFlinkStatementHandler();
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: DeleteStatementCase[] = [
         {
           label: "throw ZodError when statementName is absent",
           args: {},
@@ -30,13 +39,13 @@ describe("delete-flink-statement-handler.ts", () => {
         {
           label: "use org/env IDs from config when args absent",
           args: { statementName: STATEMENT_NAME },
-          responseData: { response: { status: 204 } },
+          deleteStatus: 204,
           outcome: { resolves: "Flink SQL Statement Deletion Status Code" },
         },
         {
           label: "use explicit org/env args over config",
           args: { statementName: STATEMENT_NAME, ...EXPLICIT_IDS },
-          responseData: { response: { status: 204 } },
+          deleteStatus: 204,
           outcome: { resolves: "Flink SQL Statement Deletion Status Code" },
         },
       ];
@@ -46,11 +55,17 @@ describe("delete-flink-statement-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          deleteStatus,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          if (deleteStatus !== undefined) {
+            clientManager
+              .getConfluentCloudFlinkRestClient()
+              .DELETE.mockResolvedValue({
+                response: { status: deleteStatus },
+              });
+          }
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -60,7 +75,7 @@ describe("delete-flink-statement-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, it } from "vitest";
 
 const EXPLICIT_IDS = {
@@ -15,12 +18,18 @@ const EXPLICIT_IDS = {
 
 const STATEMENT_NAME = "my-statement";
 
+type CheckHealthCase = HandleCaseWithConn & {
+  /** Body returned by the Flink REST GET. Omit for cases that throw before
+   *  reaching the client. */
+  flinkGetData?: unknown;
+};
+
 describe("check-health-handler.ts", () => {
   describe("CheckHealthHandler", () => {
     const handler = new CheckHealthHandler();
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: CheckHealthCase[] = [
         {
           label: "throws ZodError when statementName is absent",
           args: {},
@@ -31,13 +40,13 @@ describe("check-health-handler.ts", () => {
           label:
             "uses org/env IDs from config and reports healthy for running statement",
           args: { statementName: STATEMENT_NAME },
-          responseData: { status: { phase: "RUNNING" }, data: [] },
+          flinkGetData: { status: { phase: "RUNNING" }, data: [] },
           outcome: { resolves: `Health check for '${STATEMENT_NAME}'` },
         },
         {
           label: "uses explicit org/env args over config",
           args: { statementName: STATEMENT_NAME, ...EXPLICIT_IDS },
-          responseData: { status: { phase: "RUNNING" }, data: [] },
+          flinkGetData: { status: { phase: "RUNNING" }, data: [] },
           outcome: { resolves: `Health check for '${STATEMENT_NAME}'` },
         },
       ];
@@ -47,11 +56,15 @@ describe("check-health-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          flinkGetData,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          if (flinkGetData !== undefined) {
+            clientManager
+              .getConfluentCloudFlinkRestClient()
+              .GET.mockResolvedValue({ data: flinkGetData });
+          }
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -61,7 +74,7 @@ describe("check-health-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
@@ -5,27 +5,37 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const STATEMENT_NAME = "my-statement";
+
+type IssuesCase = HandleCaseWithConn & {
+  /** Body returned by the Flink REST GET. Omit for cases that throw before
+   *  reaching the client. */
+  flinkGetData?: unknown;
+};
 
 describe("detect-issues-handler.ts", () => {
   describe("DetectIssuesHandler", () => {
     const handler = new DetectIssuesHandler();
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: IssuesCase[] = [
         {
           label: "throws ZodError when statementName is absent",
           args: {},
           outcome: { throws: "ZodError" },
+          connectionConfig: {},
         },
         {
           label:
             "uses org/env IDs from config when args absent and reports no issues for running statement",
           args: { statementName: STATEMENT_NAME, includeMetrics: false },
-          responseData: { status: { phase: "RUNNING" }, data: [] },
+          flinkGetData: { status: { phase: "RUNNING" }, data: [] },
           outcome: {
             resolves: `No issues detected for statement '${STATEMENT_NAME}'. Statement is running normally.`,
           },
@@ -38,22 +48,13 @@ describe("detect-issues-handler.ts", () => {
             environmentId: "env-from-args",
             includeMetrics: false,
           },
-          responseData: {
+          flinkGetData: {
             status: { phase: "FAILED", detail: "OOM" },
             data: [],
           },
           outcome: {
             resolves: `Detected 1 issue(s) for statement '${STATEMENT_NAME}'`,
           },
-        },
-        {
-          label:
-            "runs metrics branch when includeMetrics is true and reports summary",
-          args: { statementName: STATEMENT_NAME, includeMetrics: true },
-          // Call 1: GET statement status; call 2: GET exceptions (reused for
-          // all 13 subsequent telemetry POSTs since it is the last element).
-          responseData: [{ status: { phase: "RUNNING" } }, { data: [] }],
-          outcome: { resolves: "Metrics: No metrics data available" },
         },
       ];
 
@@ -62,11 +63,15 @@ describe("detect-issues-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          flinkGetData,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          if (flinkGetData !== undefined) {
+            clientManager
+              .getConfluentCloudFlinkRestClient()
+              .GET.mockResolvedValue({ data: flinkGetData });
+          }
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -76,14 +81,23 @@ describe("detect-issues-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
 
-      it("should use explicit computePoolId in metrics POST body when arg is provided", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters([{ status: { phase: "RUNNING" } }, { data: [] }]);
+      it("should pass explicit computePoolId to metrics POST body when arg is provided", async () => {
+        // first GET returns the RUNNING statement; the exceptions GET and any further
+        // fallthroughs return an empty list so the metrics summary is the only output
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.GET.mockResolvedValueOnce({
+          data: { status: { phase: "RUNNING" } },
+        }).mockResolvedValue({ data: { data: [] } });
+        const telemetryRest =
+          clientManager.getConfluentCloudTelemetryRestClient();
+        telemetryRest.POST.mockResolvedValue({ data: { data: [] } });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -97,25 +111,24 @@ describe("detect-issues-handler.ts", () => {
             includeMetrics: true,
           },
           outcome: { resolves: "Metrics: No metrics data available" },
-          clientGetters,
+          clientManager,
         });
-        // calls 0+1 are the GET statement + GET exceptions; the telemetry POSTs follow
-        const metricsCall = capturedCalls.find((c) =>
-          c.pathTemplate.includes("/metrics/"),
-        );
-        expect(metricsCall).toBeDefined();
-        expect(metricsCall!.args).toMatchObject({
-          body: expect.objectContaining({
-            filter: expect.objectContaining({
-              filters: expect.arrayContaining([
-                expect.objectContaining({
-                  field: "resource.compute_pool.id",
-                  value: "lfcp-from-args",
-                }),
-              ]),
+
+        expect(telemetryRest.POST).toHaveBeenCalledWith(
+          expect.stringContaining("/metrics/"),
+          expect.objectContaining({
+            body: expect.objectContaining({
+              filter: expect.objectContaining({
+                filters: expect.arrayContaining([
+                  expect.objectContaining({
+                    field: "resource.compute_pool.id",
+                    value: "lfcp-from-args",
+                  }),
+                ]),
+              }),
             }),
           }),
-        });
+        );
       });
     });
   });

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
@@ -86,50 +86,66 @@ describe("detect-issues-handler.ts", () => {
         },
       );
 
-      it("should pass explicit computePoolId to metrics POST body when arg is provided", async () => {
-        // first GET returns the RUNNING statement; the exceptions GET and any further
-        // fallthroughs return an empty list so the metrics summary is the only output
-        const clientManager = getMockedClientManager();
-        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
-        flinkRest.GET.mockResolvedValueOnce({
-          data: { status: { phase: "RUNNING" } },
-        }).mockResolvedValue({ data: { data: [] } });
-        const telemetryRest =
-          clientManager.getConfluentCloudTelemetryRestClient();
-        telemetryRest.POST.mockResolvedValue({ data: { data: [] } });
-
-        await assertHandleCase({
-          handler,
-          runtime: runtimeWith(
-            FLINK_CONN,
-            DEFAULT_CONNECTION_ID,
-            clientManager,
-          ),
+      // Metrics branch: includeMetrics: true triggers a poll-then-fetch on the
+      // Flink REST client (RUNNING status → empty exceptions list) followed by
+      // telemetry POSTs. The cases below cover both the config-fallback and
+      // explicit-arg paths for resource.compute_pool.id in the POST body.
+      it.each([
+        {
+          label: "use config computePoolId when arg is absent",
+          args: { statementName: STATEMENT_NAME, includeMetrics: true },
+          expectedComputePoolId: FLINK_CONN.flink.compute_pool_id,
+        },
+        {
+          label: "use explicit computePoolId arg over config",
           args: {
             statementName: STATEMENT_NAME,
             computePoolId: "lfcp-from-args",
             includeMetrics: true,
           },
-          outcome: { resolves: "Metrics: No metrics data available" },
-          clientManager,
-        });
+          expectedComputePoolId: "lfcp-from-args",
+        },
+      ])(
+        "should $label in metrics POST body",
+        async ({ args, expectedComputePoolId }) => {
+          const clientManager = getMockedClientManager();
+          const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+          flinkRest.GET.mockResolvedValueOnce({
+            data: { status: { phase: "RUNNING" } },
+          }).mockResolvedValue({ data: { data: [] } });
+          const telemetryRest =
+            clientManager.getConfluentCloudTelemetryRestClient();
+          telemetryRest.POST.mockResolvedValue({ data: { data: [] } });
 
-        expect(telemetryRest.POST).toHaveBeenCalledWith(
-          expect.stringContaining("/metrics/"),
-          expect.objectContaining({
-            body: expect.objectContaining({
-              filter: expect.objectContaining({
-                filters: expect.arrayContaining([
-                  expect.objectContaining({
-                    field: "resource.compute_pool.id",
-                    value: "lfcp-from-args",
-                  }),
-                ]),
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWith(
+              FLINK_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome: { resolves: "Metrics: No metrics data available" },
+            clientManager,
+          });
+
+          expect(telemetryRest.POST).toHaveBeenCalledWith(
+            expect.stringContaining("/metrics/"),
+            expect.objectContaining({
+              body: expect.objectContaining({
+                filter: expect.objectContaining({
+                  filters: expect.arrayContaining([
+                    expect.objectContaining({
+                      field: "resource.compute_pool.id",
+                      value: expectedComputePoolId,
+                    }),
+                  ]),
+                }),
               }),
             }),
-          }),
-        );
-      });
+          );
+        },
+      );
     });
   });
 });

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
@@ -7,10 +7,19 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const STATEMENT_NAME = "my-statement";
+
+type QueryProfilerCase = HandleCaseWithConn & {
+  /** Body returned by the Flink REST GET (the statement's exec graph). Omit for
+   *  cases that throw before reaching the client. */
+  flinkGetData?: unknown;
+};
 
 describe("query-profiler-handler.ts", () => {
   describe("QueryProfilerHandler", () => {
@@ -46,7 +55,7 @@ describe("query-profiler-handler.ts", () => {
     });
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: QueryProfilerCase[] = [
         {
           label: "throws ZodError when statementName is absent",
           args: {},
@@ -56,7 +65,7 @@ describe("query-profiler-handler.ts", () => {
         {
           label: "uses org/env/compute IDs from config when args absent",
           args: { statementName: STATEMENT_NAME },
-          responseData: { Graph: '{"tasks":[]}' },
+          flinkGetData: { Graph: '{"tasks":[]}' },
           outcome: { resolves: `Query Profiler for '${STATEMENT_NAME}'` },
         },
         {
@@ -67,7 +76,7 @@ describe("query-profiler-handler.ts", () => {
             environmentId: "env-from-args",
             computePoolId: "lfcp-from-args",
           },
-          responseData: { Graph: '{"tasks":[]}' },
+          flinkGetData: { Graph: '{"tasks":[]}' },
           outcome: { resolves: `Query Profiler for '${STATEMENT_NAME}'` },
         },
       ];
@@ -77,11 +86,20 @@ describe("query-profiler-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          flinkGetData,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          if (flinkGetData !== undefined) {
+            // handler GETs the statement graph from Flink REST and POSTs telemetry
+            // queries afterwards; both clients need a usable response
+            clientManager
+              .getConfluentCloudFlinkRestClient()
+              .GET.mockResolvedValue({ data: flinkGetData });
+            clientManager
+              .getConfluentCloudTelemetryRestClient()
+              .POST.mockResolvedValue({ data: { data: [] } });
+          }
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -91,7 +109,7 @@ describe("query-profiler-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
@@ -37,21 +37,6 @@ describe("get-flink-exceptions-handler.ts", () => {
           connectionConfig: {},
         },
         {
-          label: "throws when organizationId is absent and not in config",
-          args: { statementName: STATEMENT_NAME },
-          outcome: { throws: "Organization ID is required" },
-          connectionConfig: {},
-        },
-        {
-          label: "throws when environmentId is absent and not in config",
-          args: {
-            statementName: STATEMENT_NAME,
-            organizationId: "org-from-args",
-          },
-          outcome: { throws: "Environment ID is required" },
-          connectionConfig: {},
-        },
-        {
           label: "uses org/env IDs from config when args absent",
           args: { statementName: STATEMENT_NAME },
           flinkGetData: { data: [] },

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
@@ -5,22 +5,31 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, it } from "vitest";
+
+const STATEMENT_NAME = "my-statement";
 
 const EXPLICIT_IDS = {
   organizationId: "org-from-args",
   environmentId: "env-from-args",
 };
 
-const STATEMENT_NAME = "my-statement";
+type ExceptionsCase = HandleCaseWithConn & {
+  /** Body returned by the Flink REST GET. Omit for cases that throw before
+   *  reaching the client. */
+  flinkGetData?: unknown;
+};
 
 describe("get-flink-exceptions-handler.ts", () => {
   describe("GetFlinkExceptionsHandler", () => {
     const handler = new GetFlinkExceptionsHandler();
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: ExceptionsCase[] = [
         {
           label: "throws ZodError when statementName is absent",
           args: {},
@@ -28,9 +37,24 @@ describe("get-flink-exceptions-handler.ts", () => {
           connectionConfig: {},
         },
         {
+          label: "throws when organizationId is absent and not in config",
+          args: { statementName: STATEMENT_NAME },
+          outcome: { throws: "Organization ID is required" },
+          connectionConfig: {},
+        },
+        {
+          label: "throws when environmentId is absent and not in config",
+          args: {
+            statementName: STATEMENT_NAME,
+            organizationId: "org-from-args",
+          },
+          outcome: { throws: "Environment ID is required" },
+          connectionConfig: {},
+        },
+        {
           label: "uses org/env IDs from config when args absent",
           args: { statementName: STATEMENT_NAME },
-          responseData: { data: [] },
+          flinkGetData: { data: [] },
           outcome: {
             resolves: `No exceptions found for statement '${STATEMENT_NAME}'.`,
           },
@@ -39,7 +63,7 @@ describe("get-flink-exceptions-handler.ts", () => {
           label:
             "uses explicit org/env args over config and returns exception list",
           args: { statementName: STATEMENT_NAME, ...EXPLICIT_IDS },
-          responseData: {
+          flinkGetData: {
             data: [{ message: "OOM error" }, { message: "Timeout" }],
           },
           outcome: {
@@ -53,11 +77,15 @@ describe("get-flink-exceptions-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          flinkGetData,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          if (flinkGetData !== undefined) {
+            clientManager
+              .getConfluentCloudFlinkRestClient()
+              .GET.mockResolvedValue({ data: flinkGetData });
+          }
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -67,7 +95,7 @@ describe("get-flink-exceptions-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const EXPLICIT_IDS = {
@@ -13,30 +16,34 @@ const EXPLICIT_IDS = {
   environmentId: "env-from-args",
 };
 
+type ListStatementsCase = HandleCaseWithConn & {
+  /** Body returned by the Flink REST GET. */
+  flinkGetData: unknown;
+};
+
 describe("list-flink-statements-handler.ts", () => {
   describe("ListFlinkStatementsHandler", () => {
     const handler = new ListFlinkStatementsHandler();
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: ListStatementsCase[] = [
         {
           label:
             "use org/env IDs and computePoolId from config when args absent",
           args: {},
+          flinkGetData: {},
           outcome: { resolves: "{}" },
         },
         {
           label: "resolve when required IDs are supplied as explicit args",
           args: EXPLICIT_IDS,
+          flinkGetData: {},
           outcome: { resolves: "{}" },
         },
         {
           label: "filter statements client-side by statusPhase",
-          args: {
-            ...EXPLICIT_IDS,
-            statusPhase: "RUNNING",
-          },
-          responseData: {
+          args: { ...EXPLICIT_IDS, statusPhase: "RUNNING" },
+          flinkGetData: {
             data: [
               { status: { phase: "RUNNING" } },
               { status: { phase: "FAILED" } },
@@ -47,13 +54,8 @@ describe("list-flink-statements-handler.ts", () => {
         {
           label:
             "report zero results when no statements match the statusPhase filter",
-          args: {
-            ...EXPLICIT_IDS,
-            statusPhase: "RUNNING",
-          },
-          responseData: {
-            data: [{ status: { phase: "FAILED" } }],
-          },
+          args: { ...EXPLICIT_IDS, statusPhase: "RUNNING" },
+          flinkGetData: { data: [{ status: { phase: "FAILED" } }] },
           outcome: { resolves: "Found 0 statement(s) with status 'RUNNING'" },
         },
       ];
@@ -63,11 +65,13 @@ describe("list-flink-statements-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          flinkGetData,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          clientManager
+            .getConfluentCloudFlinkRestClient()
+            .GET.mockResolvedValue({ data: flinkGetData });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -77,14 +81,16 @@ describe("list-flink-statements-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );
 
       it("should fall back to config computePoolId when arg is whitespace-only", async () => {
-        const { clientManager, clientGetters, capturedCalls } =
-          stubClientGetters({});
+        const clientManager = getMockedClientManager();
+        const flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+        flinkRest.GET.mockResolvedValue({ data: {} });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith(
@@ -94,16 +100,20 @@ describe("list-flink-statements-handler.ts", () => {
           ),
           args: { ...EXPLICIT_IDS, computePoolId: "   " },
           outcome: { resolves: "{}" },
-          clientGetters,
+          clientManager,
         });
-        expect(capturedCalls).toHaveLength(1);
-        expect(capturedCalls[0]!.args).toMatchObject({
-          params: expect.objectContaining({
-            query: expect.objectContaining({
-              "spec.compute_pool_id": FLINK_CONN.flink.compute_pool_id,
+
+        expect(flinkRest.GET).toHaveBeenCalledOnce();
+        expect(flinkRest.GET).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            params: expect.objectContaining({
+              query: expect.objectContaining({
+                "spec.compute_pool_id": FLINK_CONN.flink.compute_pool_id,
+              }),
             }),
           }),
-        });
+        );
       });
     });
   });

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.test.ts
@@ -5,7 +5,10 @@ import {
   HandleCaseWithConn,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, it } from "vitest";
 
 const EXPLICIT_IDS = {
@@ -15,12 +18,18 @@ const EXPLICIT_IDS = {
 
 const STATEMENT_NAME = "my-statement";
 
+type ReadStatementCase = HandleCaseWithConn & {
+  /** Body returned by the Flink REST GET. Omit for cases that throw before
+   *  reaching the client. */
+  flinkGetData?: unknown;
+};
+
 describe("read-flink-statement-handler.ts", () => {
   describe("ReadFlinkStatementHandler", () => {
     const handler = new ReadFlinkStatementHandler();
 
     describe("handle()", () => {
-      const cases: HandleCaseWithConn[] = [
+      const cases: ReadStatementCase[] = [
         {
           label: "throws ZodError when statementName is absent",
           args: {},
@@ -30,7 +39,7 @@ describe("read-flink-statement-handler.ts", () => {
         {
           label: "uses org/env IDs from config when args absent",
           args: { statementName: STATEMENT_NAME, timeoutInMilliseconds: 0 },
-          responseData: { results: { data: [] }, metadata: {} },
+          flinkGetData: { results: { data: [] }, metadata: {} },
           outcome: { resolves: "Flink SQL Statement Results" },
         },
         {
@@ -40,7 +49,7 @@ describe("read-flink-statement-handler.ts", () => {
             timeoutInMilliseconds: 0,
             ...EXPLICIT_IDS,
           },
-          responseData: { results: { data: [] }, metadata: {} },
+          flinkGetData: { results: { data: [] }, metadata: {} },
           outcome: { resolves: "Flink SQL Statement Results" },
         },
       ];
@@ -50,11 +59,15 @@ describe("read-flink-statement-handler.ts", () => {
         async ({
           args,
           outcome,
-          responseData,
+          flinkGetData,
           connectionConfig = FLINK_CONN,
         }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+          const clientManager = getMockedClientManager();
+          if (flinkGetData !== undefined) {
+            clientManager
+              .getConfluentCloudFlinkRestClient()
+              .GET.mockResolvedValue({ data: flinkGetData });
+          }
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -64,7 +77,7 @@ describe("read-flink-statement-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
@@ -8,7 +8,10 @@ import {
   kafkaRestRuntime,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 const VALID_CONFIGS = [
@@ -70,14 +73,12 @@ describe("alter-topic-config.ts", () => {
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = KAFKA_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = KAFKA_CONN }) => {
+          const clientManager = getMockedClientManager();
+          // handler POSTs to alter-configs and returns success on no error
+          clientManager
+            .getConfluentCloudKafkaRestClient()
+            .POST.mockResolvedValue({ data: undefined });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -87,7 +88,7 @@ describe("alter-topic-config.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
@@ -8,7 +8,10 @@ import {
   kafkaRestRuntime,
   runtimeWith,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 describe("get-topic-config.ts", () => {
@@ -62,14 +65,13 @@ describe("get-topic-config.ts", () => {
 
       it.each(cases)(
         "should $label",
-        async ({
-          args,
-          outcome,
-          responseData,
-          connectionConfig = KAFKA_CONN,
-        }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, connectionConfig = KAFKA_CONN }) => {
+          const clientManager = getMockedClientManager();
+          // handler does two GETs (topic details, then topic config) and stringifies the combined
+          // result, so an empty object is fine here
+          clientManager
+            .getConfluentCloudKafkaRestClient()
+            .GET.mockResolvedValue({ data: {} });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -79,7 +81,7 @@ describe("get-topic-config.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -11,7 +11,10 @@ import {
   runtimeWith,
   telemetryRuntime,
 } from "@tests/factories/runtime.js";
-import { assertHandleCase, stubClientGetters } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const KAFKA_SERVER_METRIC = "io.confluent.kafka.server/received_bytes";
@@ -249,8 +252,11 @@ describe("query-metrics-handler.ts", () => {
       it.each(cases)(
         "should $label",
         async ({ connectionConfig = {}, args, outcome, expectedFilter }) => {
-          const { clientManager, clientGetters, capturedCalls } =
-            stubClientGetters({});
+          const clientManager = getMockedClientManager();
+          const telemetryRest =
+            clientManager.getConfluentCloudTelemetryRestClient();
+          telemetryRest.POST.mockResolvedValue({ data: {} });
+
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -260,17 +266,20 @@ describe("query-metrics-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
-          expect(capturedCalls).toHaveLength(1);
-          const body = (
-            capturedCalls[0]!.args as { body: Record<string, unknown> }
-          ).body;
-          if (expectedFilter) {
-            expect(body).toMatchObject({ filter: expectedFilter });
-          } else {
-            expect(body).not.toHaveProperty("filter");
-          }
+
+          expect(telemetryRest.POST).toHaveBeenCalledOnce();
+          // expect.not.objectContaining lets us assert filter-absent without
+          // reaching into mock.calls, which openapi-fetch's overloaded POST
+          // collapses to `never` for TypeScript
+          const expectedBody = expectedFilter
+            ? expect.objectContaining({ filter: expectedFilter })
+            : expect.not.objectContaining({ filter: expect.anything() });
+          expect(telemetryRest.POST).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ body: expectedBody }),
+          );
         },
       );
     });

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
-  stubClientGetters,
+  getMockedClientManager,
   type HandleCase,
 } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
@@ -50,12 +50,13 @@ describe("list-organizations-handler.ts", () => {
     });
 
     describe("handle()", () => {
-      const cases: HandleCase[] = [
+      type OrgsCase = HandleCase & { cloudGetData: unknown };
+      const cases: OrgsCase[] = [
         {
           label:
             "resolve with 'Retrieved 0 organizations' when the API returns an empty list",
           args: {},
-          responseData: {
+          cloudGetData: {
             api_version: "org/v2",
             kind: "OrganizationList",
             data: [],
@@ -66,7 +67,7 @@ describe("list-organizations-handler.ts", () => {
           label:
             "resolve with the organization's display name when the API returns one entry",
           args: {},
-          responseData: {
+          cloudGetData: {
             api_version: "org/v2",
             kind: "OrganizationList",
             data: [ORG_FIXTURE],
@@ -77,7 +78,7 @@ describe("list-organizations-handler.ts", () => {
           label:
             "include a 'more pages available' hint when metadata.next is present",
           args: { pageSize: 1 },
-          responseData: {
+          cloudGetData: {
             api_version: "org/v2",
             kind: "OrganizationList",
             metadata: {
@@ -91,16 +92,18 @@ describe("list-organizations-handler.ts", () => {
           label:
             "resolve with a validation-error response when the API returns an unexpected payload",
           args: {},
-          responseData: { not: "an OrganizationList" },
+          cloudGetData: { not: "an OrganizationList" },
           outcome: { resolves: "Invalid organization list data" },
         },
       ];
 
       it.each(cases)(
         "should $label",
-        async ({ args, outcome, responseData }) => {
-          const { clientManager, clientGetters } =
-            stubClientGetters(responseData);
+        async ({ args, outcome, cloudGetData }) => {
+          const clientManager = getMockedClientManager();
+          clientManager
+            .getConfluentCloudRestClient()
+            .GET.mockResolvedValue({ data: cloudGetData });
           await assertHandleCase({
             handler,
             runtime: runtimeWith(
@@ -110,7 +113,7 @@ describe("list-organizations-handler.ts", () => {
             ),
             args,
             outcome,
-            clientGetters,
+            clientManager,
           });
         },
       );

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -1,4 +1,3 @@
-import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import {
   CREATE_UPDATE,
   DESTRUCTIVE,
@@ -13,10 +12,11 @@ import {
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
-  stubClientGetters,
+  getMockedClientManager,
   type HandleOutcome,
+  type MockedClientManager,
 } from "@tests/stubs/index.js";
-import { beforeAll, describe, expect, it, type Mocked } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
 
@@ -140,7 +140,7 @@ describe("tool-registry.ts", () => {
      * Builds a `ServerRuntime` with every service block populated, injecting
      * `clientManager` so callers can verify which client getters were invoked.
      */
-    function allServicesRuntime(clientManager: Mocked<DirectClientManager>) {
+    function allServicesRuntime(clientManager: MockedClientManager) {
       return runtimeWith(
         {
           kafka: {
@@ -181,110 +181,204 @@ describe("tool-registry.ts", () => {
     ) as Record<ToolName, string>;
 
     /**
-     * What each handler produces when called with no arguments against a
-     * fully-wired universal client. Use `{ resolves }` when the handler
-     * completes and `{ throws }` when it raises before returning.
-     * Use `"DISCOVER"` as a placeholder — the smoke test will run the handler
-     * and report the correct entry to paste in.
+     * Per-tool fixture: what each handler produces when called with no
+     * arguments, plus an optional `setup` that mocks the specific client
+     * method(s) the handler exercises. Tools that throw before reaching the
+     * client layer (ZodError, missing-ID errors) need no `setup`. Tools that
+     * resolve must `setup` whichever client they call so the bare `vi.fn()`
+     * mocks returned by {@linkcode getMockedClientManager} produce a usable
+     * response.
+     *
+     * Use `"DISCOVER"` as the outcome placeholder; the smoke test will run
+     * the handler and report the correct entry to paste in.
      */
-    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, HandleOutcome>> = {
+    type SmokeFixture = {
+      outcome: HandleOutcome;
+      setup?: (cm: MockedClientManager) => Promise<void> | void;
+    };
+
+    /** Stubs the Flink REST client to return a completed empty SQL query result.
+     *  Shared by the catalog/database/table listing tools that all run a SQL
+     *  query and stringify the empty result set. */
+    function mockFlinkSqlEmpty(cm: MockedClientManager) {
+      const flinkRest = cm.getConfluentCloudFlinkRestClient();
+      const sqlResponse = {
+        data: { status: { phase: "COMPLETED" }, results: { data: [] } },
+      };
+      flinkRest.POST.mockResolvedValue(sqlResponse);
+      flinkRest.GET.mockResolvedValue(sqlResponse);
+    }
+
+    const ZERO_ARG_OUTCOMES: Partial<Record<ToolName, SmokeFixture>> = {
       // Kafka
-      [ToolName.LIST_TOPICS]: { resolves: "Kafka topics:" },
-      [ToolName.CREATE_TOPICS]: { throws: "ZodError" },
-      [ToolName.DELETE_TOPICS]: { throws: "ZodError" },
-      [ToolName.PRODUCE_MESSAGE]: { throws: "ZodError" },
-      [ToolName.CONSUME_MESSAGES]: { throws: "ZodError" },
-      [ToolName.ALTER_TOPIC_CONFIG]: { throws: "ZodError" },
-      [ToolName.GET_TOPIC_CONFIG]: { throws: "ZodError" },
+      [ToolName.LIST_TOPICS]: {
+        outcome: { resolves: "Kafka topics:" },
+        setup: async (cm) => {
+          (await cm.getAdminClient()).listTopics.mockResolvedValue([]);
+        },
+      },
+      [ToolName.CREATE_TOPICS]: { outcome: { throws: "ZodError" } },
+      [ToolName.DELETE_TOPICS]: { outcome: { throws: "ZodError" } },
+      [ToolName.PRODUCE_MESSAGE]: { outcome: { throws: "ZodError" } },
+      [ToolName.CONSUME_MESSAGES]: { outcome: { throws: "ZodError" } },
+      [ToolName.ALTER_TOPIC_CONFIG]: { outcome: { throws: "ZodError" } },
+      [ToolName.GET_TOPIC_CONFIG]: { outcome: { throws: "ZodError" } },
       // Schema Registry
-      [ToolName.LIST_SCHEMAS]: { resolves: "{}" },
-      [ToolName.DELETE_SCHEMA]: { throws: "ZodError" },
+      [ToolName.LIST_SCHEMAS]: {
+        outcome: { resolves: "{}" },
+        setup: (cm) => {
+          cm.getSchemaRegistryClient().getAllSubjects.mockResolvedValue([]);
+        },
+      },
+      [ToolName.DELETE_SCHEMA]: { outcome: { throws: "ZodError" } },
       // Flink
-      [ToolName.LIST_FLINK_STATEMENTS]: { resolves: "{}" },
-      [ToolName.CREATE_FLINK_STATEMENT]: { throws: "ZodError" },
-      [ToolName.READ_FLINK_STATEMENT]: { throws: "ZodError" },
-      [ToolName.DELETE_FLINK_STATEMENTS]: { throws: "ZodError" },
-      [ToolName.GET_FLINK_STATEMENT_EXCEPTIONS]: { throws: "ZodError" },
-      [ToolName.CHECK_FLINK_STATEMENT_HEALTH]: { throws: "ZodError" },
-      [ToolName.DETECT_FLINK_STATEMENT_ISSUES]: { throws: "ZodError" },
-      [ToolName.GET_FLINK_STATEMENT_PROFILE]: { throws: "ZodError" },
+      [ToolName.LIST_FLINK_STATEMENTS]: {
+        outcome: { resolves: "{}" },
+        setup: (cm) => {
+          cm.getConfluentCloudFlinkRestClient().GET.mockResolvedValue({
+            data: {},
+          });
+        },
+      },
+      [ToolName.CREATE_FLINK_STATEMENT]: { outcome: { throws: "ZodError" } },
+      [ToolName.READ_FLINK_STATEMENT]: { outcome: { throws: "ZodError" } },
+      [ToolName.DELETE_FLINK_STATEMENTS]: { outcome: { throws: "ZodError" } },
+      [ToolName.GET_FLINK_STATEMENT_EXCEPTIONS]: {
+        outcome: { throws: "ZodError" },
+      },
+      [ToolName.CHECK_FLINK_STATEMENT_HEALTH]: {
+        outcome: { throws: "ZodError" },
+      },
+      [ToolName.DETECT_FLINK_STATEMENT_ISSUES]: {
+        outcome: { throws: "ZodError" },
+      },
+      [ToolName.GET_FLINK_STATEMENT_PROFILE]: {
+        outcome: { throws: "ZodError" },
+      },
       [ToolName.LIST_FLINK_CATALOGS]: {
-        responseData: { status: { phase: "COMPLETED" }, results: { data: [] } },
-        resolves: "No catalogs found.",
+        outcome: { resolves: "No catalogs found." },
+        setup: mockFlinkSqlEmpty,
       },
       [ToolName.LIST_FLINK_DATABASES]: {
-        responseData: { status: { phase: "COMPLETED" }, results: { data: [] } },
-        resolves: "No databases found.",
+        outcome: { resolves: "No databases found." },
+        setup: mockFlinkSqlEmpty,
       },
       [ToolName.LIST_FLINK_TABLES]: {
-        responseData: { status: { phase: "COMPLETED" }, results: { data: [] } },
-        resolves: "No tables found in catalog",
+        outcome: { resolves: "No tables found in catalog" },
+        setup: mockFlinkSqlEmpty,
       },
-      [ToolName.DESCRIBE_FLINK_TABLE]: { throws: "ZodError" },
-      [ToolName.GET_FLINK_TABLE_INFO]: { throws: "ZodError" },
+      [ToolName.DESCRIBE_FLINK_TABLE]: { outcome: { throws: "ZodError" } },
+      [ToolName.GET_FLINK_TABLE_INFO]: { outcome: { throws: "ZodError" } },
       // Connect
-      [ToolName.LIST_CONNECTORS]: { throws: "Environment ID is required" },
-      [ToolName.READ_CONNECTOR]: { throws: "ZodError" },
-      [ToolName.CREATE_CONNECTOR]: { throws: "ZodError" },
-      [ToolName.DELETE_CONNECTOR]: { throws: "ZodError" },
+      [ToolName.LIST_CONNECTORS]: {
+        outcome: { throws: "Environment ID is required" },
+      },
+      [ToolName.READ_CONNECTOR]: { outcome: { throws: "ZodError" } },
+      [ToolName.CREATE_CONNECTOR]: { outcome: { throws: "ZodError" } },
+      [ToolName.DELETE_CONNECTOR]: { outcome: { throws: "ZodError" } },
       // Catalog
-      [ToolName.CREATE_TOPIC_TAGS]: { throws: "ZodError" },
-      [ToolName.DELETE_TAG]: { throws: "ZodError" },
-      [ToolName.REMOVE_TAG_FROM_ENTITY]: { throws: "ZodError" },
-      [ToolName.ADD_TAGS_TO_TOPIC]: { throws: "ZodError" },
-      [ToolName.LIST_TAGS]: { resolves: "Successfully retrieved tags" },
+      [ToolName.CREATE_TOPIC_TAGS]: { outcome: { throws: "ZodError" } },
+      [ToolName.DELETE_TAG]: { outcome: { throws: "ZodError" } },
+      [ToolName.REMOVE_TAG_FROM_ENTITY]: { outcome: { throws: "ZodError" } },
+      [ToolName.ADD_TAGS_TO_TOPIC]: { outcome: { throws: "ZodError" } },
+      [ToolName.LIST_TAGS]: {
+        outcome: { resolves: "Successfully retrieved tags" },
+        setup: (cm) => {
+          cm.getConfluentCloudSchemaRegistryRestClient().GET.mockResolvedValue({
+            data: [],
+          });
+        },
+      },
       // Search
-      [ToolName.SEARCH_TOPICS_BY_TAG]: { resolves: "{}" },
-      [ToolName.SEARCH_TOPICS_BY_NAME]: { throws: "ZodError" },
+      [ToolName.SEARCH_TOPICS_BY_TAG]: {
+        outcome: { resolves: "{}" },
+        setup: (cm) => {
+          cm.getConfluentCloudSchemaRegistryRestClient().GET.mockResolvedValue({
+            data: {},
+          });
+        },
+      },
+      [ToolName.SEARCH_TOPICS_BY_NAME]: { outcome: { throws: "ZodError" } },
       // Environments
       [ToolName.LIST_ENVIRONMENTS]: {
-        responseData: {
-          api_version: "org/v2",
-          kind: "EnvironmentList",
-          data: [],
+        outcome: { resolves: "Successfully retrieved 0 environments" },
+        setup: (cm) => {
+          cm.getConfluentCloudRestClient().GET.mockResolvedValue({
+            data: {
+              api_version: "org/v2",
+              kind: "EnvironmentList",
+              data: [],
+            },
+          });
         },
-        resolves: "Successfully retrieved 0 environments",
       },
-      [ToolName.READ_ENVIRONMENT]: { throws: "ZodError" },
+      [ToolName.READ_ENVIRONMENT]: { outcome: { throws: "ZodError" } },
       // Clusters
       [ToolName.LIST_CLUSTERS]: {
-        responseData: { data: [] },
-        resolves: "Successfully retrieved 0 clusters",
+        outcome: { resolves: "Successfully retrieved 0 clusters" },
+        setup: (cm) => {
+          cm.getConfluentCloudRestClient().GET.mockResolvedValue({
+            data: { data: [] },
+          });
+        },
       },
       // Tableflow
-      [ToolName.CREATE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
-      [ToolName.LIST_TABLEFLOW_REGIONS]: { resolves: "Tableflow Regions" },
+      [ToolName.CREATE_TABLEFLOW_TOPIC]: { outcome: { throws: "ZodError" } },
+      [ToolName.LIST_TABLEFLOW_REGIONS]: {
+        outcome: { resolves: "Tableflow Regions" },
+        setup: (cm) => {
+          cm.getConfluentCloudTableflowRestClient().GET.mockResolvedValue({
+            data: { data: [] },
+          });
+        },
+      },
       [ToolName.LIST_TABLEFLOW_TOPICS]: {
-        throws: "Environment ID is required",
+        outcome: { throws: "Environment ID is required" },
       },
-      [ToolName.READ_TABLEFLOW_TOPIC]: { throws: "ZodError" },
-      [ToolName.UPDATE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
-      [ToolName.DELETE_TABLEFLOW_TOPIC]: { throws: "ZodError" },
-      [ToolName.CREATE_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
+      [ToolName.READ_TABLEFLOW_TOPIC]: { outcome: { throws: "ZodError" } },
+      [ToolName.UPDATE_TABLEFLOW_TOPIC]: { outcome: { throws: "ZodError" } },
+      [ToolName.DELETE_TABLEFLOW_TOPIC]: { outcome: { throws: "ZodError" } },
+      [ToolName.CREATE_TABLEFLOW_CATALOG_INTEGRATION]: {
+        outcome: { throws: "ZodError" },
+      },
       [ToolName.LIST_TABLEFLOW_CATALOG_INTEGRATIONS]: {
-        throws: "Environment ID is required",
+        outcome: { throws: "Environment ID is required" },
       },
-      [ToolName.READ_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
-      [ToolName.UPDATE_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
-      [ToolName.DELETE_TABLEFLOW_CATALOG_INTEGRATION]: { throws: "ZodError" },
+      [ToolName.READ_TABLEFLOW_CATALOG_INTEGRATION]: {
+        outcome: { throws: "ZodError" },
+      },
+      [ToolName.UPDATE_TABLEFLOW_CATALOG_INTEGRATION]: {
+        outcome: { throws: "ZodError" },
+      },
+      [ToolName.DELETE_TABLEFLOW_CATALOG_INTEGRATION]: {
+        outcome: { throws: "ZodError" },
+      },
       // Billing
-      [ToolName.LIST_BILLING_COSTS]: { throws: "ZodError" },
+      [ToolName.LIST_BILLING_COSTS]: { outcome: { throws: "ZodError" } },
       // Metrics
-      [ToolName.QUERY_METRICS]: { throws: "ZodError" },
+      [ToolName.QUERY_METRICS]: { outcome: { throws: "ZodError" } },
       [ToolName.LIST_METRICS]: {
-        responseData: { data: [] },
-        resolves: "No metrics descriptors available",
+        outcome: { resolves: "No metrics descriptors available" },
+        setup: (cm) => {
+          cm.getConfluentCloudTelemetryRestClient().GET.mockResolvedValue({
+            data: { data: [] },
+          });
+        },
       },
       // Documentation
-      [ToolName.SEARCH_PRODUCT_DOCS]: { throws: "ZodError" },
+      [ToolName.SEARCH_PRODUCT_DOCS]: { outcome: { throws: "ZodError" } },
       // Organizations
       [ToolName.LIST_ORGANIZATIONS]: {
-        responseData: {
-          api_version: "org/v2",
-          kind: "OrganizationList",
-          data: [],
+        outcome: { resolves: "Retrieved 0 organizations" },
+        setup: (cm) => {
+          cm.getConfluentCloudRestClient().GET.mockResolvedValue({
+            data: {
+              api_version: "org/v2",
+              kind: "OrganizationList",
+              data: [],
+            },
+          });
         },
-        resolves: "Retrieved 0 organizations",
       },
     };
 
@@ -304,21 +398,17 @@ describe("tool-registry.ts", () => {
       },
     );
 
-    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, HandleOutcome][])(
+    it.each(Object.entries(ZERO_ARG_OUTCOMES) as [ToolName, SmokeFixture][])(
       "%s: handle() should not crash before reaching the ClientManager",
-      async (name, outcome) => {
-        const responseData =
-          typeof outcome === "object" && "responseData" in outcome
-            ? outcome.responseData
-            : undefined;
-        const { clientManager, clientGetters } =
-          stubClientGetters(responseData);
+      async (name, fixture) => {
+        const clientManager = getMockedClientManager();
+        await fixture.setup?.(clientManager);
         await assertHandleCase({
           handler: ToolHandlerRegistry.getToolHandler(name),
           runtime: allServicesRuntime(clientManager),
           args: {},
-          outcome,
-          clientGetters,
+          outcome: fixture.outcome,
+          clientManager,
           name,
         });
       },

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -1,0 +1,155 @@
+import { KafkaJS } from "@confluentinc/kafka-javascript";
+import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
+import { paths } from "@src/confluent/openapi-schema.js";
+import type { Client } from "openapi-fetch";
+import { type Mock, type Mocked, vi } from "vitest";
+import { createMockInstance } from "./mock-instance.js";
+
+// shared shape for the six openapi-fetch REST seams (they differ only in `paths`).
+type MockedRestClient = Mocked<Client<paths, `${string}/${string}`>>;
+
+/** Returns a bare-mocked openapi-fetch {@link Client} with every HTTP-verb
+ *  method as a `vi.fn()`. */
+export function getMockedRestClient(): MockedRestClient {
+  return {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+    PATCH: vi.fn(),
+    HEAD: vi.fn(),
+    OPTIONS: vi.fn(),
+    TRACE: vi.fn(),
+  } as unknown as MockedRestClient;
+}
+
+/** Returns a bare-mocked {@link KafkaJS.Admin}. `KafkaJS.Admin` is a type alias
+ *  (not a runtime class export) in `kafkajs.d.ts`, so methods are listed
+ *  explicitly rather than walked via {@linkcode createMockInstance}. */
+export function getMockedAdmin(): Mocked<KafkaJS.Admin> {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    createTopics: vi.fn(),
+    deleteTopics: vi.fn(),
+    listTopics: vi.fn(),
+    listGroups: vi.fn(),
+    describeGroups: vi.fn(),
+    deleteGroups: vi.fn(),
+    fetchOffsets: vi.fn(),
+    deleteTopicRecords: vi.fn(),
+    fetchTopicMetadata: vi.fn(),
+    fetchTopicOffsets: vi.fn(),
+    fetchTopicOffsetsByTimestamp: vi.fn(),
+  } as unknown as Mocked<KafkaJS.Admin>;
+}
+
+/** Returns a bare-mocked {@link KafkaJS.Producer}. See {@linkcode getMockedAdmin}
+ *  for why methods are listed explicitly. */
+export function getMockedProducer(): Mocked<KafkaJS.Producer> {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    send: vi.fn(),
+    sendBatch: vi.fn(),
+    flush: vi.fn(),
+    transaction: vi.fn(),
+    commit: vi.fn(),
+    abort: vi.fn(),
+    sendOffsets: vi.fn(),
+    isActive: vi.fn(),
+  } as unknown as Mocked<KafkaJS.Producer>;
+}
+
+/** Returns a bare-mocked {@link KafkaJS.Consumer}. See {@linkcode getMockedAdmin}
+ *  for why methods are listed explicitly. */
+export function getMockedConsumer(): Mocked<KafkaJS.Consumer> {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(),
+    stop: vi.fn(),
+    run: vi.fn(),
+    storeOffsets: vi.fn(),
+    commitOffsets: vi.fn(),
+    committed: vi.fn(),
+    seek: vi.fn(),
+    pause: vi.fn(),
+    paused: vi.fn(),
+    resume: vi.fn(),
+    assignment: vi.fn(),
+  } as unknown as Mocked<KafkaJS.Consumer>;
+}
+
+/** Returns a bare-mocked {@link SchemaRegistryClient} via {@linkcode createMockInstance}
+ *  (a real runtime class, so its methods come from prototype-walking). */
+export function getMockedSchemaRegistry(): Mocked<SchemaRegistryClient> {
+  return createMockInstance(SchemaRegistryClient);
+}
+
+/**
+ * {@link DirectClientManager} where each client-getter's return type is
+ * narrowed to the corresponding `Mocked<...>` of the production client. Tests
+ * call `cm.getXxxClient()` to retrieve a typed mock and use Vitest mock
+ * helpers (`mockResolvedValue`, `mockResolvedValueOnce`, etc.) on the result
+ * directly.
+ *
+ * Each override here pairs with one line of wiring in
+ * {@linkcode getMockedClientManager}; adding a new client to
+ * `DirectClientManager` requires updating both places.
+ *
+ * Explicit interface overrides (rather than a derived intersection) are
+ * load-bearing: TypeScript treats an intersection of two function-typed keys
+ * as an overload set and resolves access to the base signature, stripping
+ * the `Mock` helpers from `cm.getXxx()`. Interface extension forces the
+ * narrowed types to win.
+ */
+export interface MockedClientManager extends Mocked<DirectClientManager> {
+  getAdminClient: Mock<() => Promise<Mocked<KafkaJS.Admin>>>;
+  getProducer: Mock<() => Promise<Mocked<KafkaJS.Producer>>>;
+  getConsumer: Mock<(sessionId?: string) => Promise<Mocked<KafkaJS.Consumer>>>;
+  getConfluentCloudFlinkRestClient: Mock<() => MockedRestClient>;
+  getConfluentCloudRestClient: Mock<() => MockedRestClient>;
+  getConfluentCloudTableflowRestClient: Mock<() => MockedRestClient>;
+  getConfluentCloudSchemaRegistryRestClient: Mock<() => MockedRestClient>;
+  getConfluentCloudKafkaRestClient: Mock<() => MockedRestClient>;
+  getConfluentCloudTelemetryRestClient: Mock<() => MockedRestClient>;
+  getSchemaRegistryClient: Mock<() => Mocked<SchemaRegistryClient>>;
+}
+
+/**
+ * Builds a {@link MockedClientManager} with every client getter wired to a
+ * fresh bare mock. Tests configure return values per-method on the specific
+ * client they exercise:
+ *
+ * ```ts
+ * const cm = getMockedClientManager();
+ * cm.getConfluentCloudFlinkRestClient().GET.mockResolvedValue({ data: ... });
+ * (await cm.getAdminClient()).listTopics.mockResolvedValue(["topic-a"]);
+ * ```
+ */
+export function getMockedClientManager(): MockedClientManager {
+  const cm = createMockInstance(DirectClientManager) as MockedClientManager;
+
+  cm.getConfluentCloudFlinkRestClient.mockReturnValue(getMockedRestClient());
+  cm.getConfluentCloudRestClient.mockReturnValue(getMockedRestClient());
+  cm.getConfluentCloudTableflowRestClient.mockReturnValue(
+    getMockedRestClient(),
+  );
+  cm.getConfluentCloudSchemaRegistryRestClient.mockReturnValue(
+    getMockedRestClient(),
+  );
+  cm.getConfluentCloudKafkaRestClient.mockReturnValue(getMockedRestClient());
+  cm.getConfluentCloudTelemetryRestClient.mockReturnValue(
+    getMockedRestClient(),
+  );
+
+  cm.getAdminClient.mockResolvedValue(getMockedAdmin());
+  cm.getProducer.mockResolvedValue(getMockedProducer());
+  cm.getConsumer.mockResolvedValue(getMockedConsumer());
+
+  cm.getSchemaRegistryClient.mockReturnValue(getMockedSchemaRegistry());
+
+  return cm;
+}

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -7,7 +7,7 @@ import { type Mock, type Mocked, vi } from "vitest";
 import { createMockInstance } from "./mock-instance.js";
 
 // shared shape for the six openapi-fetch REST seams (they differ only in `paths`).
-type MockedRestClient = Mocked<Client<paths, `${string}/${string}`>>;
+export type MockedRestClient = Mocked<Client<paths, `${string}/${string}`>>;
 
 /** Returns a bare-mocked openapi-fetch {@link Client} with every HTTP-verb
  *  method as a `vi.fn()`. */
@@ -128,6 +128,22 @@ export interface MockedClientManager extends Mocked<DirectClientManager> {
  * cm.getConfluentCloudFlinkRestClient().GET.mockResolvedValue({ data: ... });
  * (await cm.getAdminClient()).listTopics.mockResolvedValue(["topic-a"]);
  * ```
+ *
+ * Two invariants are load-bearing:
+ *
+ * - **Same getter, same mock.** Getters use `mockReturnValue` (not
+ *   `mockReturnValueOnce`), so every call to `cm.getXxx()` returns the same
+ *   underlying mock. A reference captured in setup stays valid for
+ *   assertions after the handler runs, and the handler's own getter call
+ *   lands on the same mock the test wired.
+ * - **Build per test, not per suite.** Invoke this once per test — either
+ *   inline in each `it` body or by reassigning a suite-scope `let` from a
+ *   `beforeEach`. The anti-pattern is a suite-scope `const cm =
+ *   getMockedClientManager()` that runs once, since Vitest's
+ *   `restoreMocks: true` only restores `vi.spyOn` originals and `vi.fn()`
+ *   call histories and configured return values would then leak across
+ *   tests.
+ *   {@see https://vitest.dev/config/restoremocks}
  */
 export function getMockedClientManager(): MockedClientManager {
   const cm = createMockInstance(DirectClientManager) as MockedClientManager;

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -1,87 +1,32 @@
-import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import type { CallToolResult } from "@src/confluent/schema.js";
 import type { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
 import type { ServerRuntime } from "@src/server-runtime.js";
-import { expect } from "vitest";
+import { type Mock, expect } from "vitest";
 import { ZodError } from "zod";
-import { createMockInstance } from "./mock-instance.js";
+import type { MockedClientManager } from "./clients.js";
 
 export type Resolves = {
-  /**
-   * Controls what each stubbed API call resolves to. Forwarded directly to
-   * `stubClientGetters()` — see its JSDoc for the full element-shape contract.
-   *
-   * Quick reference:
-   * - Omit (or `{}`) when the handler short-circuits before reading the result.
-   * - Plain object → becomes `(await call()).data`. Match the shape the handler
-   *   reads: e.g. `{ status: { phase: "COMPLETED" }, results: { data: [...] } }`.
-   * - `{ response: { status: N } }` → for handlers that destructure `response`
-   *   (e.g. DELETE endpoints: `const { response } = await client.DELETE(...)`).
-   * - `{ error: { ... } }` → makes `(await call()).error` truthy, triggering
-   *   error-branch code.
-   * - Array of the above → consumed in call order; last element reused when
-   *   the array is exhausted (needed for poll-then-fetch handlers).
-   */
-  responseData?: unknown;
   /** Substring that must appear in the resolved response text. */
   resolves: string;
 };
 
 export type Throws = {
-  /**
-   * Same contract as `Resolves.responseData`. Supply when the handler must
-   * complete one or more successful API calls before reaching the code that
-   * throws (e.g. a handler that fetches data and then validates it).
-   * Omit when the throw happens before any client call.
-   */
-  responseData?: unknown;
   /** Substring that must appear in the thrown error message, or "ZodError"
    *  to match any ZodError regardless of message. */
   throws: string;
 };
 
-/** Complete specification for one `handle()` invocation: what to feed in
- *  (`responseData`) and what to expect out (`resolves` / `throws`).
- *  Pass `"DISCOVER"` as a sentinel to run the handler, report the actual
- *  outcome, and get a copy-paste suggestion for the recorded expectation. */
+/** Complete specification for one `handle()` invocation: what to expect out
+ *  (`resolves` / `throws`). Pass `"DISCOVER"` as a sentinel to run the handler,
+ *  report the actual outcome, and get a copy-paste suggestion for the recorded
+ *  expectation. */
 export type HandleOutcome = Resolves | Throws | "DISCOVER";
-
-/** The array of client-getter mock functions returned by `stubClientGetters()`.
- *  Each element is a Vitest mock whose `.mock.calls` records invocations. */
-export type ClientGetters = Array<{ mock: { calls: unknown[] } }>;
-
-/**
- * One intercepted REST call captured by the proxy in `stubClientGetters()`.
- *
- * An entry is recorded for any invocation where the first argument is a string
- * path — this covers both `wrapAsPathBasedClient` callers (where
- * `PathCallForwarder` injects the path automatically) and handlers that call
- * the REST client directly as `client.GET("/path", options)`.
- *
- *   - `pathTemplate` — the raw OpenAPI path string, e.g.
- *     `"/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements"`
- *   - `args` — the `{ params, body, ... }` object passed as the second argument
- *     to the HTTP method (undefined when the handler passes no init object)
- *
- * Use `capturedCalls[N].args` to assert POST body contents or query params
- * that are not observable through the handler's return value alone.
- */
-export interface CapturedCall {
-  pathTemplate: string;
-  args: unknown;
-}
 
 /** One entry in an `it.each` handler test suite. */
 export type HandleCase = {
   label: string;
   args: Record<string, unknown>;
   outcome: HandleOutcome;
-  /**
-   * Forwarded to `stubClientGetters()`. Omit for cases that throw or
-   * short-circuit before touching the client. See `Resolves.responseData`
-   * for the element-shape contract and array usage.
-   */
-  responseData?: unknown;
 };
 
 /** Classifies a thrown value into the string used for matching in HandleOutcome. */
@@ -94,186 +39,26 @@ export function classifyThrown(label: string, thrown: unknown): string {
 }
 
 /**
- * Wires every client getter on a fresh `Mocked<DirectClientManager>` to a
- * two-proxy pair so handler bodies can traverse arbitrary method chains
- * (`.GET(...)`, `.POST(...)`, `.path(...).method(...)`, etc.) without throwing
- * a TypeError. Every async call resolves to a proxy that models the
- * `{ data, error, response }` shape returned by `openapi-fetch`.
- *
- * ## `responseData` — single value
- *
- * Pass a plain object; it becomes `(await call()).data`. Shape it to match
- * what the handler reads:
- * ```typescript
- * // handler does: const { data } = await client.GET(...); data.status.phase
- * stubClientGetters({ status: { phase: "COMPLETED" }, results: { data: [] } })
- * ```
- *
- * Two special top-level keys override the defaults:
- * - `response` — surfaced as `(await call()).response`. Use for handlers that
- *   destructure `response` directly, e.g. DELETE endpoints that check
- *   `response?.status`:
- *   ```typescript
- *   stubClientGetters({ response: { status: 204 } })
- *   ```
- * - `error` — surfaced as `(await call()).error`. Use to exercise a handler's
- *   error branch (`if (error) return this.createResponse(..., true)`):
- *   ```typescript
- *   stubClientGetters({ error: { message: "not found" } })
- *   ```
- *
- * ## `responseData` — array of elements
- *
- * Pass an array to feed different data to successive calls. Each element
- * follows the same shape contract above. The last element is reused once the
- * array is exhausted, so you only need to enumerate the calls that differ:
- * ```typescript
- * // handler: POST to create → GET to poll status → GET to fetch results
- * stubClientGetters([
- *   {},                                                    // POST (ignored)
- *   { status: { phase: "COMPLETED" } },                   // GET poll
- *   { results: { data: [{ COLUMN_NAME: "id" }] } },       // GET results
- * ])
- * ```
- *
- * Returns `{ clientManager, clientGetters, capturedCalls }`.
- * - Pass `clientGetters` to `assertHandleCase` to assert the handler reached
- *   the client layer on a successful resolve.
- * - `capturedCalls` is a `CapturedCall[]`; each entry has `.pathTemplate` (the
- *   raw OpenAPI path string) and `.args` (the `{ params, body, ... }` object).
- *   Use it to assert what the handler actually sent to the REST layer, e.g.
- *   POST body contents or query params. Any call whose first argument is a
- *   string path is captured — this includes both `wrapAsPathBasedClient`
- *   callers and direct `client.METHOD(path, options)` calls. Invocations whose
- *   first argument is not a string (Kafka admin, producer, consumer, etc.) are
- *   silently skipped.
- */
-export function stubClientGetters(responseData: unknown = {}) {
-  // Two-proxy setup: callableProxy (function target) handles method chains
-  // and calls; per-call responseProxies model the { data, error, response }
-  // shape from openapi-fetch. When responseData is an array, each element is
-  // consumed in order; the last element is reused once the array is exhausted.
-  const responses = Array.isArray(responseData) ? responseData : [responseData];
-  if (responses.length === 0)
-    throw new Error("stubClientGetters: responseData array must not be empty");
-  let callIndex = 0;
-
-  const capturedCalls: CapturedCall[] = [];
-
-  const callableProxy: object = new Proxy((() => {}) as () => Promise<object>, {
-    get: (_t, prop) => {
-      if (prop === "then" || prop === "error") return undefined;
-      return callableProxy;
-    },
-    apply: (_target, _thisArg, args) => {
-      // Only REST clients (wrapAsPathBasedClient) produce captured calls —
-      // PathCallForwarder always passes the path template string as the first
-      // argument. Non-REST calls (Kafka admin, producer, consumer) fire apply
-      // with zero args (proxy-chain continuations) or non-string first args
-      // (e.g. createTopics({ topics: [...] })); both are silently skipped.
-      // A test that tries to assert capturedCalls on a non-REST handler will
-      // see an empty array and fail the toHaveLength guard with a clear message.
-      //
-      // Future: if we ever need to inspect Kafka-client or other non-REST calls,
-      // replace CapturedCall with a discriminated union:
-      //   | { kind: "rest"; pathTemplate: string; args: unknown }
-      //   | { kind: "raw"; args: unknown[] }
-      // and push accordingly here.
-      if (typeof args[0] === "string") {
-        capturedCalls.push({ pathTemplate: args[0], args: args[1] });
-      }
-      const element = responses[Math.min(callIndex++, responses.length - 1)];
-      return Promise.resolve(makeResponseProxy(element));
-    },
-  });
-
-  function makeResponseProxy(element: unknown): object {
-    const elem =
-      element !== null && typeof element === "object"
-        ? (element as Record<string | symbol, unknown>)
-        : null;
-    return new Proxy({} as object, {
-      // Special-cased properties:
-      //   `then`          → undefined  (prevents JS treating this as a thenable)
-      //   `error`         → element.error if present, else undefined
-      //   `data`          → element  (backward compat: element IS the data)
-      //   `response`      → element.response if present, else callableProxy
-      //   Symbol.iterator → empty-array iterator
-      get: (_t, prop) => {
-        if (prop === "then") return undefined;
-        if (prop === Symbol.iterator)
-          return Array.prototype[Symbol.iterator].bind([]);
-        if (prop === "error")
-          return elem && "error" in elem ? elem["error"] : undefined;
-        if (prop === "data") return element;
-        if (prop === "response")
-          return elem && "response" in elem ? elem["response"] : callableProxy;
-        return callableProxy;
-      },
-    });
-  }
-
-  const clientManager = createMockInstance(DirectClientManager);
-  clientManager.getAdminClient.mockResolvedValue(callableProxy as never);
-  clientManager.getProducer.mockResolvedValue(callableProxy as never);
-  clientManager.getConsumer.mockResolvedValue(callableProxy as never);
-  clientManager.getConfluentCloudFlinkRestClient.mockReturnValue(
-    callableProxy as never,
-  );
-  clientManager.getConfluentCloudRestClient.mockReturnValue(
-    callableProxy as never,
-  );
-  clientManager.getConfluentCloudTableflowRestClient.mockReturnValue(
-    callableProxy as never,
-  );
-  clientManager.getConfluentCloudSchemaRegistryRestClient.mockReturnValue(
-    callableProxy as never,
-  );
-  clientManager.getConfluentCloudKafkaRestClient.mockReturnValue(
-    callableProxy as never,
-  );
-  clientManager.getConfluentCloudTelemetryRestClient.mockReturnValue(
-    callableProxy as never,
-  );
-  clientManager.getSchemaRegistryClient.mockReturnValue(callableProxy as never);
-
-  const clientGetters = [
-    clientManager.getAdminClient,
-    clientManager.getProducer,
-    clientManager.getConsumer,
-    clientManager.getConfluentCloudFlinkRestClient,
-    clientManager.getConfluentCloudRestClient,
-    clientManager.getConfluentCloudTableflowRestClient,
-    clientManager.getConfluentCloudSchemaRegistryRestClient,
-    clientManager.getConfluentCloudKafkaRestClient,
-    clientManager.getConfluentCloudTelemetryRestClient,
-    clientManager.getSchemaRegistryClient,
-  ];
-
-  return { clientManager, clientGetters, capturedCalls };
-}
-
-/**
  * Runs `handler.handle(runtime, args)` and asserts the outcome matches the
  * `HandleOutcome` specification. Designed for both per-handler unit tests
  * and the global smoke suite.
  *
  * @param handler - The handler under test. Only `handle()` is required; pass
  *   the full handler instance or any `Pick<BaseToolHandler, "handle">`.
- * @param runtime - The `ServerRuntime` injected into `handle()`. Build it with
- *   `runtimeWith(connectionConfig, connectionId, clientManager)` so the
- *   connection shape and mock client are both under test control.
+ * @param runtime - The {@link ServerRuntime} injected into `handle()`. Build it
+ *   with `runtimeWith(connectionConfig, connectionId, clientManager)` so the
+ *   connection shape and mocked client are both under test control.
  * @param args - Tool arguments forwarded to `handle()`. Defaults to `{}`.
  *   Supply only the fields relevant to the case under test.
  * @param outcome - What to expect: `{ resolves: substring }` asserts the
  *   response text contains the substring; `{ throws: substring }` asserts the
- *   thrown error message contains it (or `"ZodError"` for any `ZodError`);
+ *   thrown error message contains it (or `"ZodError"` for any {@link ZodError});
  *   the discovery sentinel runs the handler and fails with a copy-paste
- *   suggestion for the correct entry (see `HandleOutcome`).
- * @param clientGetters - When supplied, asserts that at least one getter was
- *   called on a successful resolve, proving the handler reached the client
- *   layer. Omit in cases that short-circuit before touching the client.
- *   (Obtain from the `clientGetters` field returned by `stubClientGetters()`.)
+ *   suggestion for the correct entry (see {@link HandleOutcome}).
+ * @param clientManager - When supplied, asserts that at least one client
+ *   getter on the manager was called on a successful resolve, proving the
+ *   handler reached the client layer. Omit in cases that short-circuit
+ *   before touching the client.
  * @param name - Label prepended to assertion failure messages and used in
  *   discovery-sentinel output. Defaults to `"(handler)"`.
  */
@@ -282,7 +67,7 @@ export async function assertHandleCase(options: {
   runtime: ServerRuntime;
   args?: Record<string, unknown>;
   outcome: HandleOutcome;
-  clientGetters?: ClientGetters;
+  clientManager?: MockedClientManager;
   name?: string;
 }): Promise<void> {
   const {
@@ -290,7 +75,7 @@ export async function assertHandleCase(options: {
     runtime,
     args = {},
     outcome,
-    clientGetters,
+    clientManager,
     name = "(handler)",
   } = options;
 
@@ -344,9 +129,18 @@ export async function assertHandleCase(options: {
       `${name}: response text does not contain expected substring`,
     ).toContain(resolves);
 
-    if (clientGetters) {
+    if (clientManager) {
+      // dynamic walk: every method on a `Mocked<DirectClientManager>` is a `vi.fn()` assigned as an
+      // enumerable property by `createMockInstance`, so any of them having `mock.calls.length > 0`
+      // proves the handler touched the client layer
+      const anyMockCalled = Object.values(clientManager).some(
+        (v) =>
+          typeof v === "function" &&
+          "mock" in v &&
+          (v as Mock).mock.calls.length > 0,
+      );
       expect(
-        clientGetters.some((m) => m.mock.calls.length > 0),
+        anyMockCalled,
         `${name}: resolved without error but no client getter was called`,
       ).toBe(true);
     }

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -86,6 +86,18 @@ export async function assertHandleCase(options: {
     ).not.toBe("");
   }
 
+  // Snapshot getter call counts before the handler runs so the dynamic walk
+  // below only counts deltas from the handler itself, not from test setup
+  // calls like `const flinkRest = cm.getConfluentCloudFlinkRestClient()`.
+  const callCountsBefore = new Map<string, number>();
+  if (clientManager) {
+    for (const [key, value] of Object.entries(clientManager)) {
+      if (typeof value === "function" && "mock" in value) {
+        callCountsBefore.set(key, (value as Mock).mock.calls.length);
+      }
+    }
+  }
+
   let result: CallToolResult | undefined;
   let thrown: unknown;
   try {
@@ -130,14 +142,15 @@ export async function assertHandleCase(options: {
     ).toContain(resolves);
 
     if (clientManager) {
-      // dynamic walk: every method on a `Mocked<DirectClientManager>` is a `vi.fn()` assigned as an
-      // enumerable property by `createMockInstance`, so any of them having `mock.calls.length > 0`
-      // proves the handler touched the client layer
-      const anyMockCalled = Object.values(clientManager).some(
-        (v) =>
-          typeof v === "function" &&
-          "mock" in v &&
-          (v as Mock).mock.calls.length > 0,
+      // every getter on a `Mocked<DirectClientManager>` is a `vi.fn()` assigned
+      // as an enumerable property by `createMockInstance`; comparing
+      // post-handler counts against the pre-handler snapshot proves the
+      // handler (not test setup) touched the client layer
+      const anyMockCalled = Object.entries(clientManager).some(
+        ([key, value]) =>
+          typeof value === "function" &&
+          "mock" in value &&
+          (value as Mock).mock.calls.length > (callCountsBefore.get(key) ?? 0),
       );
       expect(
         anyMockCalled,

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -1,10 +1,16 @@
 export { createMockAdmin, type MockedAdmin } from "./admin.js";
 export {
+  getMockedAdmin,
+  getMockedClientManager,
+  getMockedConsumer,
+  getMockedProducer,
+  getMockedRestClient,
+  getMockedSchemaRegistry,
+  type MockedClientManager,
+} from "./clients.js";
+export {
   assertHandleCase,
   classifyThrown,
-  stubClientGetters,
-  type CapturedCall,
-  type ClientGetters,
   type HandleCase,
   type HandleOutcome,
   type Resolves,

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -7,6 +7,7 @@ export {
   getMockedRestClient,
   getMockedSchemaRegistry,
   type MockedClientManager,
+  type MockedRestClient,
 } from "./clients.js";
 export {
   assertHandleCase,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The core idea of this PR is to lean on `Mocked<T>` client instances in tests and make assertions on their behavior directly. `stubClientGetters` was starting to implement additional logic to inspect call args, which wasn't vitest-idiomatic.

- `getMockedClientManager` replaces `stubClientGetters` and returns a single `Mocked<ClientManager>` where all of the previous client-getters are, themselves, `Mocked<T>` instances
https://github.com/confluentinc/mcp-confluent/blob/9bc0518881522e455755c6a7a4e365c903b54443/tests/stubs/clients.ts#L132-L155

This allows for more explicit changes to client method behavior, as well as more ergonomic assertion syntax:
<img width="1317" height="561" alt="image" src="https://github.com/user-attachments/assets/c09d81a9-e9d5-44a6-91da-5a2531b5dae6" />


Closes #323 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [x] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
