### PR TITLE
Retire env default export; thread ServerConfig through HTTP startup (#234)

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -61,15 +61,14 @@ limitation (Sinon had the same constraint).
 
 ### ESM Live Bindings and `node-deps.ts`
 
-`@src/confluent/node-deps.js` re-exports Node builtins, third-party constructors, and env access
-as plain objects whose properties Vitest can spy on:
+`@src/confluent/node-deps.js` re-exports Node builtins and third-party constructors as plain
+objects whose properties Vitest can spy on:
 
 ```typescript
 // source file
-import { fs, os, segment, config } from "@src/confluent/node-deps.js";
+import { fs, os, segment } from "@src/confluent/node-deps.js";
 fs.readFileSync(path); // node builtins
 new segment.Analytics({ key }); // third-party constructors
-config.env.DO_NOT_TRACK; // env proxy
 
 // test file
 import * as nodeDeps from "@src/confluent/node-deps.js";
@@ -77,10 +76,12 @@ vi.spyOn(nodeDeps.fs, "readFileSync").mockReturnValue("content");
 vi.spyOn(nodeDeps.segment, "Analytics").mockImplementation(function () {
   return { track: trackStub };
 } as any);
-vi.spyOn(nodeDeps.config, "env", "get").mockReturnValue({
-  DO_NOT_TRACK: false,
-} as any);
 ```
+
+The env proxy is intentionally **not** wrapped in `node-deps.ts`. Production code receives an
+already-validated `Environment` as an explicit parameter from the bootstrap; it doesn't reach
+into a global. Tests therefore don't need to stub the env — if a code path under test reads
+process state, that state should be a parameter you pass in.
 
 **Constructor note**: `vi.spyOn` on a `new`-called function requires `mockImplementation` with a
 **regular function** (not arrow — arrows can't be constructors). Return the instance from inside
@@ -125,8 +126,9 @@ The project settled on the `vi.spyOn` + namespace-object combination because it 
 - **Type safety on the real boundary.** Spies land on the actual imported value, so if the
   real module's API changes, TypeScript flags the test immediately. `vi.mock` factories drift
   silently when the real module's shape changes.
-- **Accessor-mode spies for getters.** `vi.spyOn(obj, "prop", "get")` powers the `config.env`
-  and `buildConfig` patterns; there's no clean `vi.mock` equivalent for per-test value changes.
+- **Accessor-mode spies for getters.** `vi.spyOn(obj, "prop", "get")` powers the `buildConfig`
+  pattern (and any future getter-on-namespace seam); there's no clean `vi.mock` equivalent for
+  per-test value changes.
 - **No hoisting surprises.** Execution order in tests matches source order. `vi.mock` is
   hoisted by the Vitest transformer, which can confuse readers trying to trace setup.
 - **Integration tests stay simple.** `*.integration.test.ts` files default to real I/O. A

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,28 @@ export default [
           argsIgnorePattern: "^_",
         },
       ],
+      // Production code reads service config from `ConnectionConfig`, not the
+      // process env. The env singleton in `@src/env.js` only legitimately
+      // serves the bootstrap (`initEnv` named export from `src/index.ts`),
+      // the legacy YAML-vs-env-config bridge (`Environment` type from
+      // `src/config/env-config.ts`), and the test-stubbing wrapper in
+      // `src/confluent/node-deps.ts` (which imports the proxy as a named
+      // export). The default export was retired in #234; this rule slams the
+      // door so any future regression surfaces with a useful message rather
+      // than a generic TypeScript "no default export" error.
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@src/env.js",
+              importNames: ["default"],
+              message:
+                "Use ConnectionConfig instead. The env singleton is only consumed by the bootstrap and by node-deps.ts (named import); production code should not read it directly.",
+            },
+          ],
+        },
+      ],
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,13 +39,12 @@ export default [
       ],
       // Production code reads service config from `ConnectionConfig`, not the
       // process env. The env singleton in `@src/env.js` only legitimately
-      // serves the bootstrap (`initEnv` named export from `src/index.ts`),
+      // serves the bootstrap (`initEnv` named export from `src/index.ts`) and
       // the legacy YAML-vs-env-config bridge (`Environment` type from
-      // `src/config/env-config.ts`), and the test-stubbing wrapper in
-      // `src/confluent/node-deps.ts` (which imports the proxy as a named
-      // export). The default export was retired in #234; this rule slams the
-      // door so any future regression surfaces with a useful message rather
-      // than a generic TypeScript "no default export" error.
+      // `src/config/env-config.ts`). The default export was retired in #234;
+      // this rule slams the door so any future regression surfaces with a
+      // useful message rather than a generic TypeScript "no default export"
+      // error.
       "no-restricted-imports": [
         "error",
         {
@@ -54,7 +53,7 @@ export default [
               name: "@src/env.js",
               importNames: ["default"],
               message:
-                "Use ConnectionConfig instead. The env singleton is only consumed by the bootstrap and by node-deps.ts (named import); production code should not read it directly.",
+                "Use ConnectionConfig instead. The env singleton is consumed only by the bootstrap (initEnv) and the legacy env-config bridge; production code should not read it directly.",
             },
           ],
         },

--- a/src/confluent/node-deps.ts
+++ b/src/confluent/node-deps.ts
@@ -3,7 +3,6 @@
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Analytics } from "@segment/analytics-node";
 import { TELEMETRY_WRITE_KEY } from "@src/build-config.js";
-import envProxy from "@src/env.js";
 import * as dotenv from "dotenv";
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -17,7 +16,6 @@ export const fs = { existsSync, readFileSync, writeFileSync, mkdirSync };
 export const os = { homedir, platform, release, arch };
 export const path = { join, resolve };
 export const segment = { Analytics };
-export const config = { env: envProxy };
 export const nodeFetch = { fetch: globalThis.fetch };
 // Wrapped as a single-signature arrow so spies don't have to disambiguate
 // between the sync and callback overloads of the underlying `node:crypto`

--- a/src/confluent/telemetry.test.ts
+++ b/src/confluent/telemetry.test.ts
@@ -4,7 +4,6 @@ import {
   TelemetryEvent,
   TelemetryService,
 } from "@src/confluent/telemetry.js";
-import { mockEnv } from "@tests/stubs/index.js";
 import {
   afterEach,
   beforeEach,
@@ -66,9 +65,6 @@ describe("TelemetryService", () => {
         () => undefined as ReturnType<typeof nodeDeps.fs.mkdirSync>,
       );
     vi.spyOn(nodeDeps.os, "homedir").mockReturnValue("/tmp/test-home");
-
-    // env stub (replaces Proxy that would throw before initEnv)
-    mockEnv({ DO_NOT_TRACK: false });
 
     // default: no built-in write key (simulates unpacked/dev build)
     vi.spyOn(

--- a/src/env.ts
+++ b/src/env.ts
@@ -33,8 +33,19 @@ export function initEnv(): Environment {
   return envValues;
 }
 
-// Create a module to provide access to environment variables
-const env = new Proxy({} as Environment, {
+/**
+ * Lazy proxy over the validated environment values. Reading any property
+ * before {@linkcode initEnv} has run throws — this is what catches code that
+ * tries to consult the env outside the bootstrap.
+ *
+ * The default-export shape was retired in #234 to make accidental consumers
+ * visibly fail at the import site, and an ESLint rule slams the door behind
+ * it. The intended pattern is: `main()` calls `initEnv()` once, captures the
+ * returned `Environment` into a local, and passes it explicitly to the few
+ * call sites that need it. No global env consultation lives in handler code,
+ * test infrastructure, or anywhere else.
+ */
+export const env = new Proxy({} as Environment, {
   get: (_, property: string) => {
     if (!isInitialized) {
       throw new Error(
@@ -44,5 +55,3 @@ const env = new Proxy({} as Environment, {
     return envValues[property as keyof Environment];
   },
 });
-
-export default env;

--- a/src/mcp/transports/manager.ts
+++ b/src/mcp/transports/manager.ts
@@ -96,7 +96,7 @@ export class TransportManager {
         };
 
         this.httpServer = new HttpServer({ auth: authConfig });
-        await this.httpServer.prepare();
+        await this.httpServer.prepare(http);
 
         if (authEnabled) {
           logger.info("MCP Server authentication enabled");
@@ -114,7 +114,7 @@ export class TransportManager {
 
       // Start HTTP server if needed (after routes are registered)
       if (needsHttpServer && this.httpServer && http) {
-        await this.httpServer.start({ port: http.port, host: http.host });
+        await this.httpServer.start(http);
       }
 
       logger.info("All transports started successfully");

--- a/src/mcp/transports/server.test.ts
+++ b/src/mcp/transports/server.test.ts
@@ -1,0 +1,27 @@
+import { HttpServer } from "@src/mcp/transports/server.js";
+import { describe, expect, it } from "vitest";
+
+describe("server.ts", () => {
+  describe("HttpServer", () => {
+    describe("prepare()", () => {
+      it("should build the swagger servers[0].url from the passed ServerConfig", async () => {
+        const httpServer = new HttpServer();
+        await httpServer.prepare({ host: "test-host", port: 9999 });
+
+        // @fastify/swagger augments the FastifyInstance with .swagger() but
+        // requires .ready() first so the spec is materialized.
+        const fastify = httpServer.getInstance();
+        await fastify.ready();
+        const spec = (
+          fastify as unknown as {
+            swagger: () => { servers?: { url: string }[] };
+          }
+        ).swagger();
+
+        expect(spec.servers?.[0]?.url).toBe("http://test-host:9999");
+
+        await fastify.close();
+      });
+    });
+  });
+});

--- a/src/mcp/transports/server.ts
+++ b/src/mcp/transports/server.ts
@@ -1,6 +1,5 @@
 import fastifySwagger from "@fastify/swagger";
 import fastifySwaggerUi from "@fastify/swagger-ui";
-import env from "@src/env.js";
 import { logger } from "@src/logger.js";
 import {
   AuthConfig,
@@ -39,7 +38,7 @@ export class HttpServer {
     }
   }
 
-  async prepare(): Promise<void> {
+  async prepare(config: ServerConfig): Promise<void> {
     if (this.isSwaggerConfigured) {
       return;
     }
@@ -63,7 +62,7 @@ export class HttpServer {
         },
         servers: [
           {
-            url: `http://${env.HTTP_HOST}:${env.HTTP_PORT}`,
+            url: `http://${config.host}:${config.port}`,
             description: "Local development server",
           },
         ],

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -21,7 +21,6 @@ export { createMockInstance } from "./mock-instance.js";
 export {
   createFsWrappers,
   mockDotenv,
-  mockEnv,
   mockFetch,
   mockHttpServer,
   mockOpen,

--- a/tests/stubs/node-deps.ts
+++ b/tests/stubs/node-deps.ts
@@ -55,22 +55,6 @@ export function createFsWrappers(): MockedFsWrappers {
 }
 
 /**
- * Spy on the env-proxy getter ({@linkcode nodeDeps.config.env}) and return
- * the supplied partial as the full env object. Lets tests express only the
- * env vars they actually care about without listing every other field.
- *
- * @example
- * ```ts
- * mockEnv({ DO_NOT_TRACK: true });
- * ```
- */
-export function mockEnv(overrides: Partial<typeof nodeDeps.config.env>): void {
-  vi.spyOn(nodeDeps.config, "env", "get").mockReturnValue(
-    overrides as unknown as typeof nodeDeps.config.env,
-  );
-}
-
-/**
  * Spy returned by {@linkcode mockFetch}. Auto-restored between tests by the
  * `restoreMocks: true` setting in `vitest.config.ts`.
  */


### PR DESCRIPTION
## HTTP startup

- Removes the last non-bootstrap `env` read from `src/mcp/transports/server.ts` by threading the validated `ServerConfig` (already held by `TransportManager.start()`) through `HttpServer.prepare()`. The Swagger `servers[0].url` now interpolates `config.host` / `config.port` instead of `env.HTTP_HOST` / `env.HTTP_PORT`. After this change, `initEnv()` has exactly one production caller — `main()` in `src/index.ts` — and the YAML-vs-env-config bridge in `src/config/env-config.ts` only references the `Environment` _type_, not the singleton.
- While the `manager.ts` call site was open, simplified `httpServer.start({ port: http.port, host: http.host })` to `httpServer.start(http)` — `HttpStartOptions` is structurally a `ServerConfig` superset, so the explicit field-pick was always redundant.
- Adds `src/mcp/transports/server.test.ts` covering `HttpServer.prepare()`. The test constructs a real `HttpServer`, calls `prepare({ host: "test-host", port: 9999 })`, and asserts the materialised swagger spec's `servers[0].url` matches. Confirmed red against the original code (threw "Environment not initialized" because the test process never calls `initEnv()`) before the fix; green after.

## env module locked away

- Retires `env.ts`'s default export entirely. The proxy is now exported as `export const env`. The issue (#234) proposed only an ESLint rule and asserted that no per-file override would be needed because `node-deps.ts` "wraps" the import — that misreads `no-restricted-imports`, which checks the `import` statement and would have fired on the wrapper. Switching to a named-only export adds a TypeScript-level guard at the import site (any future `import env from "@src/env.js"` fails to compile because no default export exists) on top of the lint rule, which is strictly better than the per-file-override alternative the issue text would have required.
- Adds the `no-restricted-imports` ESLint rule banning default imports of `@src/env.js` with a friendly message. Belt-and-suspenders behind the type-system guard — the rule's message is cleaner than TypeScript's generic "module has no default export" error and leaves a clear paper trail for future readers about why this path is walled off. Verified the rule fires on a probe file with the forbidden import shape before finalising.
- Deletes the `config` wrapper from `node-deps.ts` and the `mockEnv` test helper that targeted it. The wrapper existed only to expose the env proxy as a `vi.spyOn`-able property — but no production code consumed it, and the lone test caller in `telemetry.test.ts` was defensively stubbing the proxy against an access pattern that doesn't actually occur (the code under test takes `doNotTrack` as a constructor arg). With the wrapper gone, `node-deps.ts` no longer touches env at all. The named `env` proxy now has zero importers — it survives only as the throw-on-access tripwire that the named-only export plus the lint rule wall off. The `unit-tests.md` rule was updated to drop the `config.env` example and replace it with a note that env is intentionally not wrapped — production code passes `Environment` as a parameter; tests receive it the same way. The `env.ts` docstring on the proxy itself was rewritten to describe this philosophy directly so future readers find the rule of the road at the source.

## Relationships

- Closes #234
- Closes #230


#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
