### PR TITLE
Expand predicate results to describe reason why failed.

### DIFF
--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -1,9 +1,14 @@
 import type { DirectConnectionConfig } from "@src/config/index.js";
 import type { ConnectionConfig } from "@src/config/models.js";
 import {
+  ENABLED,
+  type PredicateResult,
+  ToolDisabledReason,
   connectionIdsWhere,
+  connectionReasonsWhere,
   hasCCloudCatalogSupport,
   hasConfluentCloud,
+  hasDirectConfluentCloud,
   hasFlink,
   hasKafka,
   hasKafkaAuth,
@@ -19,6 +24,10 @@ function conn(
   fields: Omit<DirectConnectionConfig, "type">,
 ): DirectConnectionConfig {
   return { type: "direct", ...fields };
+}
+
+function disabledFor(reason: ToolDisabledReason): PredicateResult {
+  return { enabled: false, reason };
 }
 
 const KAFKA_CONN = conn({ kafka: { bootstrap_servers: "broker:9092" } });
@@ -74,167 +83,235 @@ const OAUTH_CONN: ConnectionConfig = {
 
 describe("connection-predicates.ts", () => {
   describe("hasKafka()", () => {
-    it("should return true when the kafka block is present", () => {
-      expect(hasKafka(KAFKA_CONN)).toBe(true);
+    it("should return enabled when the kafka block is present", () => {
+      expect(hasKafka(KAFKA_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the kafka block is absent", () => {
-      expect(hasKafka(SCHEMA_REGISTRY_CONN)).toBe(false);
+    it("should report MissingKafkaBlock when the kafka block is absent", () => {
+      expect(hasKafka(SCHEMA_REGISTRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBlock),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasKafka(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasKafka(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasKafkaBootstrap()", () => {
-    it("should return true when kafka.bootstrap_servers is present", () => {
-      expect(hasKafkaBootstrap(KAFKA_CONN)).toBe(true);
+    it("should return enabled when kafka.bootstrap_servers is present", () => {
+      expect(hasKafkaBootstrap(KAFKA_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when kafka block is absent", () => {
-      expect(hasKafkaBootstrap(SCHEMA_REGISTRY_CONN)).toBe(false);
+    it("should report MissingKafkaBlock when kafka block is absent", () => {
+      expect(hasKafkaBootstrap(SCHEMA_REGISTRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBlock),
+      );
     });
 
-    it("should return false when kafka block is present but bootstrap_servers is absent", () => {
-      expect(hasKafkaBootstrap(KAFKA_REST_CONN)).toBe(false);
+    it("should report MissingKafkaBootstrap when kafka block is present but bootstrap_servers is absent", () => {
+      expect(hasKafkaBootstrap(KAFKA_REST_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBootstrap),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasKafkaBootstrap(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasKafkaBootstrap(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasKafkaAuth()", () => {
-    it("should return true when kafka.auth is present", () => {
-      expect(hasKafkaAuth(KAFKA_REST_WITH_AUTH_CONN)).toBe(true);
+    it("should return enabled when kafka.auth is present", () => {
+      expect(hasKafkaAuth(KAFKA_REST_WITH_AUTH_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the kafka block is absent", () => {
-      expect(hasKafkaAuth(SCHEMA_REGISTRY_CONN)).toBe(false);
+    it("should report MissingKafkaBlock when the kafka block is absent", () => {
+      expect(hasKafkaAuth(SCHEMA_REGISTRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBlock),
+      );
     });
 
-    it("should return false when the kafka block has no auth", () => {
-      expect(hasKafkaAuth(KAFKA_CONN)).toBe(false);
+    it("should report MissingKafkaAuth when the kafka block has no auth", () => {
+      expect(hasKafkaAuth(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaAuth),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasKafkaAuth(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasKafkaAuth(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasKafkaRestWithAuth()", () => {
-    it("should return true when kafka.rest_endpoint and auth are both present", () => {
-      expect(hasKafkaRestWithAuth(KAFKA_REST_WITH_AUTH_CONN)).toBe(true);
+    it("should return enabled when kafka.rest_endpoint and auth are both present", () => {
+      expect(hasKafkaRestWithAuth(KAFKA_REST_WITH_AUTH_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when kafka block is absent", () => {
-      expect(hasKafkaRestWithAuth(SCHEMA_REGISTRY_CONN)).toBe(false);
+    it("should report MissingKafkaBlock when kafka block is absent", () => {
+      expect(hasKafkaRestWithAuth(SCHEMA_REGISTRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBlock),
+      );
     });
 
-    it("should return false when kafka block has no rest_endpoint", () => {
-      expect(hasKafkaRestWithAuth(KAFKA_CONN)).toBe(false);
+    it("should report MissingKafkaRestEndpoint when kafka block has no rest_endpoint", () => {
+      expect(hasKafkaRestWithAuth(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaRestEndpoint),
+      );
     });
 
-    it("should return false when rest_endpoint is present but auth is absent", () => {
-      expect(hasKafkaRestWithAuth(KAFKA_REST_CONN)).toBe(false);
+    it("should report MissingKafkaAuth when rest_endpoint is present but auth is absent", () => {
+      expect(hasKafkaRestWithAuth(KAFKA_REST_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaAuth),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasKafkaRestWithAuth(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasKafkaRestWithAuth(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasSchemaRegistry()", () => {
-    it("should return true when the schema_registry block is present", () => {
-      expect(hasSchemaRegistry(SCHEMA_REGISTRY_CONN)).toBe(true);
+    it("should return enabled when the schema_registry block is present", () => {
+      expect(hasSchemaRegistry(SCHEMA_REGISTRY_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the schema_registry block is absent", () => {
-      expect(hasSchemaRegistry(KAFKA_CONN)).toBe(false);
+    it("should report MissingSchemaRegistryBlock when the schema_registry block is absent", () => {
+      expect(hasSchemaRegistry(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingSchemaRegistryBlock),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasSchemaRegistry(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasSchemaRegistry(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasConfluentCloud()", () => {
-    it("should return true when the confluent_cloud block is present", () => {
-      expect(hasConfluentCloud(CONFLUENT_CLOUD_CONN)).toBe(true);
+    it("should return enabled when the confluent_cloud block is present", () => {
+      expect(hasConfluentCloud(CONFLUENT_CLOUD_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the confluent_cloud block is absent on a direct connection", () => {
-      expect(hasConfluentCloud(KAFKA_CONN)).toBe(false);
+    it("should report MissingConfluentCloudBlock when the confluent_cloud block is absent on a direct connection", () => {
+      expect(hasConfluentCloud(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingConfluentCloudBlock),
+      );
     });
 
-    it("should return true unconditionally for an OAuth connection", () => {
+    it("should return enabled unconditionally for an OAuth connection", () => {
       // OAuth gets the CCloud REST URL from its Auth0 env, so it always reaches the CP surface.
-      expect(hasConfluentCloud(OAUTH_CONN)).toBe(true);
+      expect(hasConfluentCloud(OAUTH_CONN)).toEqual(ENABLED);
+    });
+  });
+
+  describe("hasDirectConfluentCloud()", () => {
+    it("should return enabled when the confluent_cloud block is present on a direct connection", () => {
+      expect(hasDirectConfluentCloud(CONFLUENT_CLOUD_CONN)).toEqual(ENABLED);
+    });
+
+    it("should report MissingConfluentCloudBlock when the confluent_cloud block is absent on a direct connection", () => {
+      expect(hasDirectConfluentCloud(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingConfluentCloudBlock),
+      );
+    });
+
+    it("should report OAuthNotDirectCapable for an OAuth connection", () => {
+      expect(hasDirectConfluentCloud(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNotDirectCapable),
+      );
     });
   });
 
   describe("hasFlink()", () => {
-    it("should return true when the flink block is present", () => {
-      expect(hasFlink(FLINK_CONN)).toBe(true);
+    it("should return enabled when the flink block is present", () => {
+      expect(hasFlink(FLINK_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the flink block is absent", () => {
-      expect(hasFlink(KAFKA_CONN)).toBe(false);
+    it("should report MissingFlinkBlock when the flink block is absent", () => {
+      expect(hasFlink(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingFlinkBlock),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasFlink(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasFlink(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasTelemetry()", () => {
-    it("should return true when the telemetry block is present", () => {
-      expect(hasTelemetry(TELEMETRY_CONN)).toBe(true);
+    it("should return enabled when the telemetry block is present", () => {
+      expect(hasTelemetry(TELEMETRY_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the telemetry block is absent", () => {
-      expect(hasTelemetry(KAFKA_CONN)).toBe(false);
+    it("should report MissingTelemetryBlock when the telemetry block is absent", () => {
+      expect(hasTelemetry(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingTelemetryBlock),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasTelemetry(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasTelemetry(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasCCloudCatalogSupport()", () => {
-    it("should return true when schema_registry has api_key auth", () => {
-      expect(hasCCloudCatalogSupport(CCLOUD_SR_CONN)).toBe(true);
+    it("should return enabled when schema_registry has api_key auth", () => {
+      expect(hasCCloudCatalogSupport(CCLOUD_SR_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when schema_registry has no auth", () => {
-      expect(hasCCloudCatalogSupport(SCHEMA_REGISTRY_CONN)).toBe(false);
+    it("should report MissingSchemaRegistryApiKeyAuth when schema_registry has no auth", () => {
+      expect(hasCCloudCatalogSupport(SCHEMA_REGISTRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingSchemaRegistryApiKeyAuth),
+      );
     });
 
-    it("should return false when the confluent_cloud block is present but schema_registry is absent", () => {
-      expect(hasCCloudCatalogSupport(CONFLUENT_CLOUD_CONN)).toBe(false);
+    it("should report MissingSchemaRegistryBlock when the confluent_cloud block is present but schema_registry is absent", () => {
+      expect(hasCCloudCatalogSupport(CONFLUENT_CLOUD_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingSchemaRegistryBlock),
+      );
     });
 
-    it("should return false when neither block is present", () => {
-      expect(hasCCloudCatalogSupport(KAFKA_CONN)).toBe(false);
+    it("should report MissingSchemaRegistryBlock when neither block is present", () => {
+      expect(hasCCloudCatalogSupport(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingSchemaRegistryBlock),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasCCloudCatalogSupport(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasCCloudCatalogSupport(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
   describe("hasTableflow()", () => {
-    it("should return true when the tableflow block is present", () => {
-      expect(hasTableflow(TABLEFLOW_CONN)).toBe(true);
+    it("should return enabled when the tableflow block is present", () => {
+      expect(hasTableflow(TABLEFLOW_CONN)).toEqual(ENABLED);
     });
 
-    it("should return false when the tableflow block is absent", () => {
-      expect(hasTableflow(KAFKA_CONN)).toBe(false);
+    it("should report MissingTableflowBlock when the tableflow block is absent", () => {
+      expect(hasTableflow(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingTableflowBlock),
+      );
     });
 
-    it("should return false for an OAuth connection", () => {
-      expect(hasTableflow(OAUTH_CONN)).toBe(false);
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(hasTableflow(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 
@@ -264,6 +341,55 @@ describe("connection-predicates.ts", () => {
         "kafka1",
         "kafka2",
       ]);
+    });
+  });
+
+  describe("connectionReasonsWhere()", () => {
+    it("should return an empty map when there are no connections", () => {
+      expect(connectionReasonsWhere({}, hasKafka)).toEqual(new Map());
+    });
+
+    it("should record one verdict per connection, preserving entry order", () => {
+      const connections: Record<string, ConnectionConfig> = {
+        kafka: KAFKA_CONN,
+        sr: SCHEMA_REGISTRY_CONN,
+        oauth: OAUTH_CONN,
+      };
+      const verdicts = connectionReasonsWhere(connections, hasKafka);
+      expect(verdicts).toEqual(
+        new Map([
+          ["kafka", ENABLED],
+          ["sr", disabledFor(ToolDisabledReason.MissingKafkaBlock)],
+          ["oauth", disabledFor(ToolDisabledReason.OAuthNoServiceBlocks)],
+        ]),
+      );
+      expect(Array.from(verdicts.keys())).toEqual(["kafka", "sr", "oauth"]);
+    });
+
+    it("should report enabled for every connection when all match the predicate", () => {
+      const connections: Record<string, ConnectionConfig> = {
+        a: KAFKA_CONN,
+        b: KAFKA_REST_CONN,
+      };
+      expect(connectionReasonsWhere(connections, hasKafka)).toEqual(
+        new Map([
+          ["a", ENABLED],
+          ["b", ENABLED],
+        ]),
+      );
+    });
+
+    it("should report disabled for every connection when none match the predicate", () => {
+      const connections: Record<string, ConnectionConfig> = {
+        sr: SCHEMA_REGISTRY_CONN,
+        oauth: OAUTH_CONN,
+      };
+      expect(connectionReasonsWhere(connections, hasFlink)).toEqual(
+        new Map([
+          ["sr", disabledFor(ToolDisabledReason.MissingFlinkBlock)],
+          ["oauth", disabledFor(ToolDisabledReason.OAuthNoServiceBlocks)],
+        ]),
+      );
     });
   });
 });

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -4,6 +4,7 @@ import {
   ENABLED,
   type PredicateResult,
   ToolDisabledReason,
+  allOf,
   connectionIdsWhere,
   connectionReasonsWhere,
   hasCCloudCatalogSupport,
@@ -18,7 +19,7 @@ import {
   hasTableflow,
   hasTelemetry,
 } from "@src/confluent/tools/connection-predicates.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 function conn(
   fields: Omit<DirectConnectionConfig, "type">,
@@ -390,6 +391,42 @@ describe("connection-predicates.ts", () => {
           ["oauth", disabledFor(ToolDisabledReason.OAuthNoServiceBlocks)],
         ]),
       );
+    });
+  });
+
+  describe("allOf()", () => {
+    it("should return ENABLED when every predicate passes", () => {
+      const combined = allOf(hasKafka, hasKafkaAuth);
+      expect(combined(KAFKA_REST_WITH_AUTH_CONN)).toEqual(ENABLED);
+    });
+
+    it("should return the first failing verdict when an early predicate fails", () => {
+      // hasFlink fails on KAFKA_CONN before hasKafkaAuth gets a chance.
+      const combined = allOf(hasFlink, hasKafkaAuth);
+      expect(combined(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingFlinkBlock),
+      );
+    });
+
+    it("should return the failing verdict from a later predicate when earlier predicates pass", () => {
+      // hasKafka passes on KAFKA_CONN; hasKafkaAuth then fails because
+      // KAFKA_CONN has no auth.
+      const combined = allOf(hasKafka, hasKafkaAuth);
+      expect(combined(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaAuth),
+      );
+    });
+
+    it("should short-circuit and not evaluate predicates after the first failure", () => {
+      const laterPredicate = vi.fn(() => ENABLED);
+      const combined = allOf(hasFlink, laterPredicate);
+      combined(KAFKA_CONN);
+      expect(laterPredicate).not.toHaveBeenCalled();
+    });
+
+    it("should return ENABLED when called with zero predicates", () => {
+      const combined = allOf();
+      expect(combined(KAFKA_CONN)).toEqual(ENABLED);
     });
   });
 });

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -1,78 +1,202 @@
+// Connection predicates: pure per-connection verdicts on whether a tool
+// should be enabled for a given `ConnectionConfig`. Each predicate returns
+// a `PredicateResult`; on failure the verdict carries a `ToolDisabledReason`
+// so callers can explain why a tool is absent rather than silently dropping
+// it from the catalogue.
+//
+// Tool handlers reach this module via `connectionIdsWhere` from their
+// `enabledConnectionIds()` method — the returned id list drives whether MCP
+// advertises the tool to its clients. `connectionReasonsWhere` returns the
+// full per-connection verdict map, the canonical shape for diagnostics that
+// need to render the verdict (group disabled tools by reason, surface
+// availability per connection) rather than just filter on it.
+//
+// OAuth note: while OAuth support is being built out, most predicates
+// currently short-circuit on `conn.type === "oauth"` and answer disabled
+// — OAuth connections do not yet carry the service blocks these predicates
+// inspect. Expect this treatment to evolve as OAuth-capable handlers land
+// and predicates widen to admit OAuth on a case-by-case basis.
+// `hasConfluentCloud` is the first to do so: it answers enabled for OAuth
+// because the CCloud REST URL is reachable via the Auth0 environment
+// without a block.
+
 import type { ConnectionConfig } from "@src/config/models.js";
 
-export type ConnectionPredicate = (conn: ConnectionConfig) => boolean;
+/**
+ * A connection predicate's verdict on whether a tool should be enabled for a
+ * given connection. Carries a {@linkcode ToolDisabledReason} when disabled so
+ * that downstream consumers (startup logging, diagnostic tooling) can group
+ * identical failures and render actionable messages to the user.
+ */
+export type PredicateResult =
+  | { readonly enabled: true }
+  | { readonly enabled: false; readonly reason: ToolDisabledReason };
 
-// Block-presence predicates below check `conn.type === "direct"` first; OAuth
-// connections carry no service blocks, so they answer false for every block.
-// `hasConfluentCloud` is the single exception: it widens for OAuth because the
-// CCloud REST URL is reachable via the Auth0 environment without a block.
+export type ConnectionPredicate = (conn: ConnectionConfig) => PredicateResult;
 
-export function hasKafka(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.kafka !== undefined;
-}
+export const ENABLED: PredicateResult = { enabled: true };
 
-export function hasKafkaBootstrap(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.kafka?.bootstrap_servers !== undefined;
-}
-
-export function hasKafkaAuth(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.kafka?.auth !== undefined;
-}
-
-export function hasKafkaRestWithAuth(conn: ConnectionConfig): boolean {
-  return (
-    conn.type === "direct" &&
-    conn.kafka?.rest_endpoint !== undefined &&
-    hasKafkaAuth(conn)
-  );
-}
-
-export function hasSchemaRegistry(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.schema_registry !== undefined;
+function disabled(reason: ToolDisabledReason): PredicateResult {
+  return { enabled: false, reason };
 }
 
 /**
- * True when the connection can reach the Confluent Cloud control-plane REST
- * surface. Direct connections satisfy this when they carry a `confluent_cloud`
- * block; OAuth connections satisfy it unconditionally (the cloud REST URL is
- * derived from the Auth0 environment).
+ * Block-level — required by any tool that needs Kafka access regardless of
+ * transport (native client or REST proxy).
  */
-export function hasConfluentCloud(conn: ConnectionConfig): boolean {
-  if (conn.type === "oauth") return true;
-  return conn.confluent_cloud !== undefined;
+export function hasKafka(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.kafka === undefined)
+    return disabled(ToolDisabledReason.MissingKafkaBlock);
+  return ENABLED;
 }
 
 /**
- * True only for direct connections that carry a `confluent_cloud` block.
- * Use this instead of `hasConfluentCloud` for handlers that are not yet
- * OAuth-capable and call `getSoleDirectConnection()` inside `handle()`.
+ * Field-level — required by tools that drive the native Kafka
+ * admin/producer/consumer client (the broker address lives on
+ * `bootstrap_servers`).
  */
-export function hasDirectConfluentCloud(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.confluent_cloud !== undefined;
-}
-
-export function hasFlink(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.flink !== undefined;
-}
-
-export function hasTelemetry(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.telemetry !== undefined;
-}
-
-export function hasTableflow(conn: ConnectionConfig): boolean {
-  return conn.type === "direct" && conn.tableflow !== undefined;
+export function hasKafkaBootstrap(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.kafka === undefined)
+    return disabled(ToolDisabledReason.MissingKafkaBlock);
+  if (conn.kafka.bootstrap_servers === undefined) {
+    return disabled(ToolDisabledReason.MissingKafkaBootstrap);
+  }
+  return ENABLED;
 }
 
 /**
- * True when the schema_registry block is present and carries api_key auth.
- * That combination is the reliable signal that the SR is CCloud-hosted and therefore
- * exposes the /catalog/v1/ endpoints. A vanilla CP SR has no auth block, so it returns
- * false even when a schema_registry block is present.
+ * Field-level — required by tools that perform authenticated Kafka calls.
  */
-export function hasCCloudCatalogSupport(conn: ConnectionConfig): boolean {
-  return (
-    conn.type === "direct" && conn.schema_registry?.auth?.type === "api_key"
-  );
+export function hasKafkaAuth(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.kafka === undefined)
+    return disabled(ToolDisabledReason.MissingKafkaBlock);
+  if (conn.kafka.auth === undefined)
+    return disabled(ToolDisabledReason.MissingKafkaAuth);
+  return ENABLED;
+}
+
+/**
+ * Field-level — required by tools that talk to the Kafka REST proxy
+ * (`/kafka/v3` endpoints); needs both `rest_endpoint` and `auth` on the
+ * `kafka` block.
+ */
+export function hasKafkaRestWithAuth(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.kafka === undefined)
+    return disabled(ToolDisabledReason.MissingKafkaBlock);
+  if (conn.kafka.rest_endpoint === undefined) {
+    return disabled(ToolDisabledReason.MissingKafkaRestEndpoint);
+  }
+  if (conn.kafka.auth === undefined)
+    return disabled(ToolDisabledReason.MissingKafkaAuth);
+  return ENABLED;
+}
+
+/**
+ * Block-level — required by tools that read or write through the Schema
+ * Registry.
+ */
+export function hasSchemaRegistry(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.schema_registry === undefined) {
+    return disabled(ToolDisabledReason.MissingSchemaRegistryBlock);
+  }
+  return ENABLED;
+}
+
+/**
+ * Block-level — verdict on whether the connection can reach the Confluent
+ * Cloud control-plane REST surface. Direct connections satisfy this when
+ * they carry a `confluent_cloud` block; OAuth connections satisfy it
+ * unconditionally (the cloud REST URL is derived from the Auth0
+ * environment).
+ */
+export function hasConfluentCloud(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth") return ENABLED;
+  if (conn.confluent_cloud === undefined) {
+    return disabled(ToolDisabledReason.MissingConfluentCloudBlock);
+  }
+  return ENABLED;
+}
+
+/**
+ * Block-level — verdict that holds only for direct connections carrying a
+ * `confluent_cloud` block. Use this instead of {@linkcode hasConfluentCloud}
+ * for handlers that are not yet OAuth-capable and call
+ * `getSoleDirectConnection()` inside `handle()`.
+ */
+export function hasDirectConfluentCloud(
+  conn: ConnectionConfig,
+): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNotDirectCapable);
+  if (conn.confluent_cloud === undefined) {
+    return disabled(ToolDisabledReason.MissingConfluentCloudBlock);
+  }
+  return ENABLED;
+}
+
+/**
+ * Block-level — required by tools that drive Flink SQL or its catalog.
+ */
+export function hasFlink(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.flink === undefined)
+    return disabled(ToolDisabledReason.MissingFlinkBlock);
+  return ENABLED;
+}
+
+/**
+ * Block-level — required by tools that read metrics from the Telemetry API.
+ */
+export function hasTelemetry(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.telemetry === undefined)
+    return disabled(ToolDisabledReason.MissingTelemetryBlock);
+  return ENABLED;
+}
+
+/**
+ * Block-level — required by tools that manage Tableflow topics or catalog
+ * entries.
+ */
+export function hasTableflow(conn: ConnectionConfig): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.tableflow === undefined)
+    return disabled(ToolDisabledReason.MissingTableflowBlock);
+  return ENABLED;
+}
+
+/**
+ * Field-level — verdict that holds when the `schema_registry` block is
+ * present and its `auth` field is `api_key`-typed. That combination is the
+ * reliable signal that the SR is CCloud-hosted and therefore exposes the
+ * `/catalog/v1/` endpoints. A vanilla CP SR has no auth, so it disables
+ * even when the `schema_registry` block itself is present.
+ */
+export function hasCCloudCatalogSupport(
+  conn: ConnectionConfig,
+): PredicateResult {
+  if (conn.type === "oauth")
+    return disabled(ToolDisabledReason.OAuthNoServiceBlocks);
+  if (conn.schema_registry === undefined) {
+    return disabled(ToolDisabledReason.MissingSchemaRegistryBlock);
+  }
+  if (conn.schema_registry.auth?.type !== "api_key") {
+    return disabled(ToolDisabledReason.MissingSchemaRegistryApiKeyAuth);
+  }
+  return ENABLED;
 }
 
 export function connectionIdsWhere(
@@ -80,6 +204,46 @@ export function connectionIdsWhere(
   predicate: ConnectionPredicate,
 ): string[] {
   return Object.entries(connections)
-    .filter(([, conn]) => predicate(conn))
+    .filter(([, conn]) => predicate(conn).enabled)
     .map(([id]) => id);
+}
+
+/**
+ * Returns the full predicate verdict for every connection, preserving
+ * insertion order — the canonical shape for diagnostics that need to group
+ * disabled connections by reason or render per-connection availability.
+ */
+export function connectionReasonsWhere(
+  connections: Readonly<Record<string, ConnectionConfig>>,
+  predicate: ConnectionPredicate,
+): Map<string, PredicateResult> {
+  return new Map(
+    Object.entries(connections).map(([id, conn]) => [id, predicate(conn)]),
+  );
+}
+
+/**
+ * Every reason a {@linkcode ConnectionPredicate} can return `enabled: false`.
+ * The symbol is the wire-stable identifier (referenced from predicate bodies
+ * and tests); the value is the human-readable phrasing surfaced to end users
+ * through startup logs and diagnostic tooling.
+ *
+ * Adding a reason: name the symbol after what's missing from the connection
+ * config (not which predicate emitted it — multiple predicates may share a
+ * reason), and write the value as a declarative phrase a misconfigured user
+ * could act on.
+ */
+export enum ToolDisabledReason {
+  MissingKafkaBlock = "no 'kafka' block in connection config",
+  MissingKafkaBootstrap = "'kafka' block does not have 'bootstrap_servers' field",
+  MissingKafkaAuth = "'kafka' block does not have 'auth' field",
+  MissingKafkaRestEndpoint = "'kafka' block does not have 'rest_endpoint' field",
+  MissingSchemaRegistryBlock = "no 'schema_registry' block in connection config",
+  MissingSchemaRegistryApiKeyAuth = "'schema_registry' block does not have 'auth' field of type 'api_key'",
+  MissingConfluentCloudBlock = "no 'confluent_cloud' block in connection config",
+  MissingFlinkBlock = "no 'flink' block in connection config",
+  MissingTelemetryBlock = "no 'telemetry' block in connection config",
+  MissingTableflowBlock = "no 'tableflow' block in connection config",
+  OAuthNoServiceBlocks = "OAuth connections carry no service blocks",
+  OAuthNotDirectCapable = "OAuth connection cannot satisfy a direct-only requirement",
 }

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -199,6 +199,29 @@ export function hasCCloudCatalogSupport(
   return ENABLED;
 }
 
+/**
+ * Combine predicates with logical AND, short-circuiting on the first
+ * failure. Returns {@linkcode ENABLED} only when every predicate passes for
+ * the given connection; otherwise returns the first failing verdict so the
+ * specific reason propagates to {@linkcode connectionReasonsWhere} and
+ * downstream diagnostics.
+ *
+ * Use this — never raw `predA(conn) && predB(conn)`. JavaScript boolean
+ * composition silently drops the first operand because every
+ * `PredicateResult` is a truthy object.
+ */
+export function allOf(
+  ...predicates: ConnectionPredicate[]
+): ConnectionPredicate {
+  return (conn) => {
+    for (const predicate of predicates) {
+      const verdict = predicate(conn);
+      if (!verdict.enabled) return verdict;
+    }
+    return ENABLED;
+  };
+}
+
 export function connectionIdsWhere(
   connections: Readonly<Record<string, ConnectionConfig>>,
   predicate: ConnectionPredicate,

--- a/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
@@ -7,6 +7,7 @@ import {
   CONNECT_CONN_WITH_AUTH,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
+  KAFKA_CONN,
   runtimeWith,
 } from "@tests/factories/runtime.js";
 import {
@@ -37,6 +38,16 @@ describe("create-connector-handler.ts", () => {
 
       it("should return an empty array for a connection with confluent_cloud but no kafka.auth", () => {
         expect(handler.enabledConnectionIds(confluentCloudRuntime())).toEqual(
+          [],
+        );
+      });
+
+      it("should return an empty array for a connection with kafka.auth but no confluent_cloud block", () => {
+        // Pins that hasDirectConfluentCloud and hasKafkaAuth are AND'd, not
+        // collapsed to the second predicate. A naive `&&` of two
+        // `PredicateResult` objects (both truthy) silently drops the first
+        // predicate; this case keeps that regression honest.
+        expect(handler.enabledConnectionIds(runtimeWith(KAFKA_CONN))).toEqual(
           [],
         );
       });

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
+  allOf,
   connectionIdsWhere,
   hasDirectConfluentCloud,
   hasKafkaAuth,
@@ -142,7 +143,7 @@ export class CreateConnectorHandler extends ConnectToolHandler {
   enabledConnectionIds(runtime: ServerRuntime): string[] {
     return connectionIdsWhere(
       runtime.config.connections,
-      (conn) => hasDirectConfluentCloud(conn) && hasKafkaAuth(conn),
+      allOf(hasDirectConfluentCloud, hasKafkaAuth),
     );
   }
 }

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
@@ -43,6 +43,20 @@ describe("query-profiler-handler.ts", () => {
         expect(handler.enabledConnectionIds(flinkRuntime())).toEqual([]);
       });
 
+      it("should return an empty array for a connection with telemetry but no flink block", () => {
+        // Pins that hasFlink and hasTelemetry are AND'd, not just OR'd or
+        // collapsed to the second predicate. A naive `&&` of two
+        // `PredicateResult` objects (both truthy) silently drops the first
+        // predicate; this case keeps that regression honest.
+        const runtime = runtimeWith({
+          telemetry: {
+            endpoint: "https://api.telemetry.confluent.cloud",
+            auth: { type: "api_key", key: "k", secret: "s" },
+          },
+        });
+        expect(handler.enabledConnectionIds(runtime)).toEqual([]);
+      });
+
       it("should return an empty array for a connection without a flink block", () => {
         expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
       });

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
+  allOf,
   connectionIdsWhere,
   hasFlink,
   hasTelemetry,
@@ -535,10 +536,9 @@ export class QueryProfilerHandler extends FlinkToolHandler {
 
   /** Overrides FlinkToolHandler: also requires a telemetry block because profiling fetches metrics from the Telemetry API in addition to the Flink REST API. */
   override enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, (conn) => {
-      const flinkVerdict = hasFlink(conn);
-      if (!flinkVerdict.enabled) return flinkVerdict;
-      return hasTelemetry(conn);
-    });
+    return connectionIdsWhere(
+      runtime.config.connections,
+      allOf(hasFlink, hasTelemetry),
+    );
   }
 }

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -535,9 +535,10 @@ export class QueryProfilerHandler extends FlinkToolHandler {
 
   /** Overrides FlinkToolHandler: also requires a telemetry block because profiling fetches metrics from the Telemetry API in addition to the Flink REST API. */
   override enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      (conn) => hasFlink(conn) && hasTelemetry(conn),
-    );
+    return connectionIdsWhere(runtime.config.connections, (conn) => {
+      const flinkVerdict = hasFlink(conn);
+      if (!flinkVerdict.enabled) return flinkVerdict;
+      return hasTelemetry(conn);
+    });
   }
 }


### PR DESCRIPTION
## Predicate verdicts

- Replaces the `boolean` return type of every connection predicate in `connection-predicates.ts` with a `PredicateResult` discriminated union: `{ enabled: true } | { enabled: false; reason: ToolDisabledReason }`. Predicates now report exactly which condition failed; the previous `false` was a black hole that left misconfigured users staring at silently-missing tools.
- Centralises every failure reason in a `ToolDisabledReason` enum whose value _is_ the human-readable phrasing. Source consumers reference the symbol (compile-time stable); #357's startup-log grouping and #358's `describe-tool-availability` diagnostic tool will surface the values directly. Embedding the message in the enum beats a parallel lookup record — one source of truth, no drift seam, and the docstring on the enum is the single roof under which every reason lives. The phrasings are deliberately first-pass; #357/#358 will revise as the rendering layer materialises.
- Compound predicates (`hasKafkaRestWithAuth`, `hasCCloudCatalogSupport`) return layered/specific reasons (`MissingKafkaRestEndpoint` then `MissingKafkaAuth`, etc.) rather than a single combined reason. The enum makes layered-and-specific as cheap to express as combined-and-vague, and #358's "tell the user what to add" story benefits from the granularity.
- Adds `connectionReasonsWhere(connections, predicate): Map<string, PredicateResult>` alongside the existing `connectionIdsWhere`. The map preserves insertion order and includes both enabled and disabled connections, so #357 can iterate it once to build startup-log groupings and #358 can return it as the canonical diagnostic shape. `connectionIdsWhere` keeps its `string[]` signature; the type change is absorbed internally (`predicate(conn).enabled`).
- Tests pin the exact `ToolDisabledReason` symbol on every disabled case — phrasing edits to enum values won't ripple through ~50 assertions. Verdict literals collapse to `toEqual(ENABLED)` and `toEqual(disabledFor(ToolDisabledReason.X))` via an exported `ENABLED` constant and a test-suite-local `disabledFor()` helper, so each assertion reads as a one-liner that names its intent. Added a brand-new `hasDirectConfluentCloud()` describe block (that predicate had zero direct test coverage before this pass) and four new `connectionReasonsWhere` cases (empty map, mixed verdicts with order pinned, all-enabled, all-disabled).

## Predicate AND-collapse and the `allOf` combinator

- The type change introduced a sharp edge: `predA(conn) && predB(conn)` AND'd two booleans before, but both operands are now truthy `PredicateResult` objects. The `&&` silently collapses to the second operand and `connectionIdsWhere` only inspects the second predicate's `.enabled` — dropping the first check entirely. TypeScript is content because the lambda still returns a `PredicateResult`. **Two call sites used this pattern.** Claude caught `QueryProfilerHandler.enabledConnectionIds` (`hasFlink && hasTelemetry`) during the original refactor pass; Copilot's review caught a second instance Claude missed and had explicitly asserted didn't exist: `CreateConnectorHandler.enabledConnectionIds` (`hasDirectConfluentCloud && hasKafkaAuth`), same shape, same blast radius.
- Introduced `allOf(...predicates)` as an exported combinator. Returns `ENABLED` only when every predicate passes; otherwise the first failing verdict, so the specific reason still propagates to `connectionReasonsWhere`. Both call sites now use `allOf`; the helper's docstring documents that raw `&&` between predicates is wrong, so future readers won't reintroduce the pattern.
- Pinned both bugs with regression tests on the respective handlers — each exercises the case that fails _only_ under the buggy collapse (a connection satisfying the second predicate but not the first). For each test, verified it goes red against a deliberately-buggy version of the lambda before re-applying the `allOf` fix, so the test is proven to catch the exact regression. `allOf` itself is covered by five unit tests in `connection-predicates.test.ts` (all-pass, first-fails, later-fails, short-circuit no-call-after-failure, zero-predicate vacuous-true).

## Relationships

- Closes #356
- First child of #355 — the handler-layer refactor (#357) and `describe-tool-availability` MCP tool (#358) build on the verdict shape this PR introduces.
