### PR TITLE
chore: add integration tests for `schema` tool handlers

### DIFF
--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -284,11 +284,10 @@ runs and retried CI jobs don't collide.
 
 **Naming convention**: `int-<slug>-<timestamp>-<random>` via the
 `uniqueName(slug)` helper in `@tests/harness/unique-name.js`. The `int-`
-prefix matches what the confluentinc/vscode repo uses (`e2e-`) for
-identifying test-created resources during cleanup of orphaned state. The
-helper is resource-agnostic: kafka topics, schema-registry subjects, and
-any future test-side resource share the same generator so naming stays
-consistent across tool groups.
+prefix marks resources as test-created so orphan cleanup of leaked state
+can identify them by name. The helper is resource-agnostic: kafka topics,
+schema-registry subjects, and any future test-side resource share the
+same generator so naming stays consistent across tool groups.
 
 ```ts
 import { withSharedAdminClient } from "@tests/harness/kafka-admin.js";
@@ -354,11 +353,11 @@ sets it per-block (see CI Matrix below).
 
 ## CI Matrix
 
-`.semaphore/integration.yml` is structured like vscode's `playwright-e2e.yml`:
-one block per MCP transport (stdio, http, and sse), each skippable via the
-`TRANSPORTS` pipeline parameter. Within a block, jobs parallelize across
-tool groups (the `TOOL_GROUP` matrix axis). The matrix axis picks up new
-tags automatically — no block or anchor changes needed.
+`.semaphore/integration.yml` has one block per MCP transport (stdio, http,
+and sse), each skippable via the `TRANSPORTS` pipeline parameter. Within a
+block, jobs parallelize across tool groups (the `TOOL_GROUP` matrix axis).
+The matrix axis picks up new tags automatically - no block or anchor
+changes needed.
 
 ## Adding a New Tool Group
 

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -283,21 +283,22 @@ Handlers that mutate state (`create-topics`, `delete-topics`,
 runs and retried CI jobs don't collide.
 
 **Naming convention**: `int-<slug>-<timestamp>-<random>` via the
-`uniqueTopicName(slug)` helper in `@tests/harness/kafka-admin.js`. The `int-`
+`uniqueName(slug)` helper in `@tests/harness/unique-name.js`. The `int-`
 prefix matches what the confluentinc/vscode repo uses (`e2e-`) for
-identifying test-created resources during cleanup of orphaned state.
+identifying test-created resources during cleanup of orphaned state. The
+helper is resource-agnostic: kafka topics, schema-registry subjects, and
+any future test-side resource share the same generator so naming stays
+consistent across tool groups.
 
 ```ts
-import {
-  uniqueTopicName,
-  withSharedAdminClient,
-} from "@tests/harness/kafka-admin.js";
+import { withSharedAdminClient } from "@tests/harness/kafka-admin.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 
 // in the describe body, after the predicate gate:
 const { admin, createdTopics } = withSharedAdminClient();
 
 // in an `it` block:
-const topic = uniqueTopicName("create"); // e.g. "int-create-1729123456789-a7f3b2"
+const topic = uniqueName("create"); // e.g. "int-create-1729123456789-a7f3b2"
 createdTopics.push(topic);
 await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
 ```

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,7 +63,7 @@ promotions:
       env_vars:
         - name: TOOL_GROUPS
           description: "Pipe-separated vitest tags to run (e.g. @kafka|@schema)"
-          default_value: "@smoke|@kafka"
+          default_value: "@smoke|@kafka|@schema"
           required: true
         - name: TRANSPORTS
           description: "Pipe-separated MCP transports (stdio|http|sse)"

--- a/service.yml
+++ b/service.yml
@@ -57,7 +57,7 @@ semaphore:
       parameters:
         - name: TOOL_GROUPS
           required: true
-          default_value: "@smoke|@kafka"
+          default_value: "@smoke|@kafka|@schema"
           description: 'Pipe-separated tool-group tags to test.'
         - name: TRANSPORTS
           required: true

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
@@ -2,7 +2,6 @@ import { AlterTopicConfigHandler } from "@src/confluent/tools/handlers/kafka/alt
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   getTestClusterId,
-  uniqueTopicName,
   withSharedAdminClient,
 } from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
@@ -12,6 +11,7 @@ import {
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -40,7 +40,7 @@ describe("alter-topic-config", { tags: [Tag.KAFKA] }, () => {
     });
 
     it("should alter retention.ms on the test topic via the REST proxy", async () => {
-      const topic = uniqueTopicName(`alter-${transport}`);
+      const topic = uniqueName(`alter-${transport}`);
       createdTopics.push(topic);
       await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
 

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -4,7 +4,6 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   connectTestAdmin,
   connectTestProducer,
-  uniqueTopicName,
 } from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
@@ -13,6 +12,7 @@ import {
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -28,7 +28,7 @@ describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
   // seed a shared test topic with messages (no need to split by transport)
   let admin: KafkaJS.Admin;
   let producer: KafkaJS.Producer;
-  const topic = uniqueTopicName("consume");
+  const topic = uniqueName("consume");
   const seededValues = ["msg-0", "msg-1", "msg-2"];
 
   beforeAll(async () => {

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
@@ -1,15 +1,13 @@
 import { CreateTopicsHandler } from "@src/confluent/tools/handlers/kafka/create-topics-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import {
-  uniqueTopicName,
-  withSharedAdminClient,
-} from "@tests/harness/kafka-admin.js";
+import { withSharedAdminClient } from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -37,7 +35,7 @@ describe("create-topics-handler", { tags: [Tag.KAFKA] }, () => {
     });
 
     it("should create the requested Kafka topic", async () => {
-      const topic = uniqueTopicName(`create-${transport}`);
+      const topic = uniqueName(`create-${transport}`);
       // track for cleanup before the call so a thrown callTool still enqueues
       // the topic for afterAll deletion if creation partially succeeded
       createdTopics.push(topic);

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
@@ -1,15 +1,13 @@
 import { DeleteTopicsHandler } from "@src/confluent/tools/handlers/kafka/delete-topics-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import {
-  uniqueTopicName,
-  withSharedAdminClient,
-} from "@tests/harness/kafka-admin.js";
+import { withSharedAdminClient } from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -37,7 +35,7 @@ describe("delete-topics-handler", { tags: [Tag.KAFKA] }, () => {
     });
 
     it("should delete the requested Kafka topic", async () => {
-      const topic = uniqueTopicName(`delete-${transport}`);
+      const topic = uniqueName(`delete-${transport}`);
       createdTopics.push(topic);
       await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
       // wait for the newly-created topic to be visible before deleting it

--- a/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
@@ -2,7 +2,6 @@ import { GetTopicConfigHandler } from "@src/confluent/tools/handlers/kafka/get-t
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   getTestClusterId,
-  uniqueTopicName,
   withSharedAdminClient,
 } from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
@@ -12,6 +11,7 @@ import {
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -40,7 +40,7 @@ describe("get-topic-config", { tags: [Tag.KAFKA] }, () => {
     });
 
     it("should return the topic configuration for an existing topic", async () => {
-      const topic = uniqueTopicName(`get-config-${transport}`);
+      const topic = uniqueName(`get-config-${transport}`);
       createdTopics.push(topic);
       await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
 

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -1,10 +1,7 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import {
-  connectTestAdmin,
-  uniqueTopicName,
-} from "@tests/harness/kafka-admin.js";
+import { connectTestAdmin } from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -12,6 +9,7 @@ import {
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -26,7 +24,7 @@ describe("produce-kafka-message-handler", { tags: [Tag.KAFKA] }, () => {
 
   // single shared topic for all transports (cheaper than creating one per transport)
   let admin: KafkaJS.Admin;
-  const topic = uniqueTopicName("produce");
+  const topic = uniqueName("produce");
 
   beforeAll(async () => {
     admin = await connectTestAdmin();

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
@@ -24,6 +24,7 @@ describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
     return;
   }
 
+  // installs beforeAll/afterAll at this describe scope (shared SR client, subject cleanup)
   const { client, createdSubjects } = withSharedSrClient();
 
   describe.each(activeTransports)("via %s transport", (transport) => {
@@ -38,6 +39,7 @@ describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
     });
 
     it("should soft-delete a registered subject", async () => {
+      // create a new schema+subject before we try to delete it
       const subject = uniqueName(`delete-${transport}`);
       createdSubjects.push(subject);
       await client().register(subject, { schema: TEST_AVRO_SCHEMA });

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
@@ -1,0 +1,70 @@
+import { DeleteSchemaHandler } from "@src/confluent/tools/handlers/schema/delete-schema-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  TEST_AVRO_SCHEMA,
+  withSharedSrClient,
+} from "@tests/harness/schema-registry.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new DeleteSchemaHandler();
+const runtime = integrationRuntime();
+
+describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth config", () => {});
+    return;
+  }
+
+  const { client, createdSubjects } = withSharedSrClient();
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should soft-delete a registered subject", async () => {
+      const subject = uniqueName(`delete-${transport}`);
+      createdSubjects.push(subject);
+      await client().register(subject, { schema: TEST_AVRO_SCHEMA });
+      // SR's listing is eventually consistent; poll until the new subject is visible before deleting
+      await expect
+        .poll(() => client().getAllSubjects(), {
+          timeout: 15_000,
+          interval: 500,
+        })
+        .toContain(subject);
+
+      const result = await server.client.callTool({
+        name: ToolName.DELETE_SCHEMA,
+        arguments: { subject },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toContain(
+        `Successfully deleted subject "${subject}"`,
+      );
+      // a soft delete removes the subject from the default `getAllSubjects()` listing
+      await expect
+        .poll(() => client().getAllSubjects(), {
+          timeout: 15_000,
+          interval: 500,
+        })
+        .not.toContain(subject);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
@@ -24,6 +24,7 @@ describe("list-schemas-handler", { tags: [Tag.SCHEMA] }, () => {
     return;
   }
 
+  // installs beforeAll/afterAll at this describe scope (shared SR client, subject cleanup)
   const { client, createdSubjects } = withSharedSrClient();
   const subject = uniqueName("list");
 

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
@@ -1,0 +1,67 @@
+import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  TEST_AVRO_SCHEMA,
+  withSharedSrClient,
+} from "@tests/harness/schema-registry.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListSchemasHandler();
+const runtime = integrationRuntime();
+
+describe("list-schemas-handler", { tags: [Tag.SCHEMA] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth config", () => {});
+    return;
+  }
+
+  const { client, createdSubjects } = withSharedSrClient();
+  const subject = uniqueName("list");
+
+  // seed one subject so the assertion still fires against a brand-new empty registry
+  beforeAll(async () => {
+    await client().register(subject, { schema: TEST_AVRO_SCHEMA });
+    createdSubjects.push(subject);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-schemas in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      const listSchemas = tools.find((t) => t.name === ToolName.LIST_SCHEMAS);
+      expect(listSchemas).toBeDefined();
+    });
+
+    it("should return a subject map that includes the seeded subject", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_SCHEMAS,
+        arguments: { subjectPrefix: subject },
+      });
+
+      expect(result.isError).not.toBe(true);
+      // handler stringifies a `Record<subject, metadata>` map; the prefix filter narrows the
+      // response to a single-key object
+      const parsed = JSON.parse(textContent(result));
+      expect(parsed).toHaveProperty(subject);
+    });
+  });
+});

--- a/test-fixtures/yaml_configs/integration.yaml
+++ b/test-fixtures/yaml_configs/integration.yaml
@@ -32,8 +32,8 @@ connections:
 
     # --- @schema (Schema Registry) ---
     schema_registry:
-      endpoint: "https://psrc-4xmdo33.us-east-2.aws.confluent.cloud"
       auth:
         type: api_key
         key: "${SCHEMA_REGISTRY_API_KEY}"
         secret: "${SCHEMA_REGISTRY_API_SECRET}"
+      endpoint: "https://psrc-4xmdo33.us-east-2.aws.confluent.cloud"

--- a/test-fixtures/yaml_configs/integration.yaml
+++ b/test-fixtures/yaml_configs/integration.yaml
@@ -1,10 +1,8 @@
 # Single source of truth for non-secret integration test config.
 #
-# Currently scoped to @kafka. Schema Registry, Flink, Tableflow, CCloud
-# control plane, and Telemetry blocks are added in follow-up PRs as those
-# tool-group integration tests land. Until then, `.env.integration` slots
-# for those groups have no matching block here, so handlers gating on them
-# skip via the empty-runtime path.
+# Service blocks land here as their tool-group integration tests do; each
+# sits under a `# --- @<tag> ---` marker. Handlers gating on a block that
+# isn't here yet skip via the empty-runtime path.
 #
 # Update these literals in place when resource identifiers change.
 #
@@ -31,3 +29,11 @@ connections:
       bootstrap_servers: "pkc-921jm.us-east-2.aws.confluent.cloud:9092"
       cluster_id: "lkc-dm5vyd"
       rest_endpoint: "https://pkc-921jm.us-east-2.aws.confluent.cloud:443"
+
+    # --- @schema (Schema Registry) ---
+    schema_registry:
+      endpoint: "https://psrc-4xmdo33.us-east-2.aws.confluent.cloud"
+      auth:
+        type: api_key
+        key: "${SCHEMA_REGISTRY_API_KEY}"
+        secret: "${SCHEMA_REGISTRY_API_SECRET}"

--- a/tests/harness/kafka-admin.ts
+++ b/tests/harness/kafka-admin.ts
@@ -44,17 +44,6 @@ export function getTestClusterId(): string {
 }
 
 /**
- * Generates a unique topic name with an `int-` prefix so stale resources from
- * failed test runs can be distinguished from production topics during
- * cleanup. Format: `int-<slug>-<timestamp>-<random>`, matching the `e2e-`
- * prefix convention used by confluentinc/vscode.
- */
-export function uniqueTopicName(slug: string): string {
-  const random = Math.random().toString(36).slice(2, 8);
-  return `int-${slug}-${Date.now()}-${random}`;
-}
-
-/**
  * Registers `beforeAll`/`afterAll` hooks at the calling describe scope to
  * manage a shared {@link KafkaJS.Admin} client across the tests in that
  * scope. Tests push topic names onto `createdTopics` as they create them;

--- a/tests/harness/schema-registry.ts
+++ b/tests/harness/schema-registry.ts
@@ -8,7 +8,7 @@ import { afterAll, beforeAll } from "vitest";
  * client and server can never disagree on which registry they're talking to.
  */
 export function newTestSrClient(): SchemaRegistryClient {
-  const conn = integrationRuntime().config.getSoleConnection();
+  const conn = integrationRuntime().config.getSoleDirectConnection();
   if (!conn.schema_registry?.endpoint || !conn.schema_registry.auth) {
     throw new Error(
       "test-side schema registry client requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml",

--- a/tests/harness/schema-registry.ts
+++ b/tests/harness/schema-registry.ts
@@ -1,0 +1,62 @@
+import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import { afterAll, beforeAll } from "vitest";
+
+/**
+ * Connects a Schema Registry SDK client directly (not via the MCP server) for test-side resource
+ * lifecycle. Built from the same `schema_registry` block the spawned server reads, so the test
+ * client and server can never disagree on which registry they're talking to.
+ */
+export function newTestSrClient(): SchemaRegistryClient {
+  const conn = integrationRuntime().config.getSoleConnection();
+  if (!conn.schema_registry?.endpoint || !conn.schema_registry.auth) {
+    throw new Error(
+      "test-side schema registry client requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml",
+    );
+  }
+  const { key, secret } = conn.schema_registry.auth;
+  return new SchemaRegistryClient({
+    baseURLs: [conn.schema_registry.endpoint],
+    basicAuthCredentials: {
+      credentialsSource: "USER_INFO",
+      userInfo: `${key}:${secret}`,
+    },
+  });
+}
+
+/**
+ * Shared {@link SchemaRegistryClient} across the tests in the calling describe scope.
+ * `afterAll` permanently deletes every subject pushed onto `createdSubjects` so reruns can reuse
+ * the unique-name space (a handler's soft-delete alone would leave the tombstone recoverable).
+ */
+export function withSharedSrClient(): {
+  client: () => SchemaRegistryClient;
+  createdSubjects: string[];
+} {
+  let client: SchemaRegistryClient;
+  const createdSubjects: string[] = [];
+
+  beforeAll(() => {
+    client = newTestSrClient();
+  });
+
+  afterAll(async () => {
+    // soft-then-permanent delete is required (SR rejects permanent on a not-yet-soft-deleted
+    // subject); 404s are swallowed since the handler may have already done one or both
+    await Promise.all(
+      createdSubjects.map(async (subject) => {
+        await client.deleteSubject(subject, false).catch(() => {});
+        await client.deleteSubject(subject, true).catch(() => {});
+      }),
+    );
+  });
+
+  return { client: () => client, createdSubjects };
+}
+
+/** Trivial Avro schema body for tests that need to register a subject. */
+export const TEST_AVRO_SCHEMA = JSON.stringify({
+  type: "record",
+  name: "IntegrationTestSchema",
+  fields: [{ name: "id", type: "string" }],
+});

--- a/tests/harness/unique-name.ts
+++ b/tests/harness/unique-name.ts
@@ -1,0 +1,10 @@
+/**
+ * Generates a unique `int-<slug>-<timestamp>-<random>` name for a test-side
+ * resource (Kafka topic, SR subject, etc.). The `int-` prefix lets cleanup
+ * sweeps tell test-created resources from production ones, mirroring the
+ * `e2e-` convention used by confluentinc/vscode.
+ */
+export function uniqueName(slug: string): string {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `int-${slug}-${Date.now()}-${random}`;
+}

--- a/tests/harness/unique-name.ts
+++ b/tests/harness/unique-name.ts
@@ -1,9 +1,4 @@
-/**
- * Generates a unique `int-<slug>-<timestamp>-<random>` name for a test-side
- * resource (Kafka topic, SR subject, etc.). The `int-` prefix lets cleanup
- * sweeps tell test-created resources from production ones, mirroring the
- * `e2e-` convention used by confluentinc/vscode.
- */
+/** Generates a unique `int-<slug>-<timestamp>-<random>` name for a test-side resources. */
 export function uniqueName(slug: string): string {
   const random = Math.random().toString(36).slice(2, 8);
   return `int-${slug}-${Date.now()}-${random}`;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to #300 (minus the majority of its test setup changes), this time just adding new schema-related integration tests, the `@schema` tag, and updated configs.

CI default parameters also included to run `@schema`-tagged tests:
<img width="701" height="495" alt="image" src="https://github.com/user-attachments/assets/7fb12338-732f-4844-b1ca-48384d8d73a1" />

Closes #334 

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- Includes minor adjustment to what was the `kafka`-specific `uniqueTopicName` utility function to be used by any integration tests as the now-named `uniqueName` 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
