### PR TITLE
Add --init-config flag to bootstrap a starter config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this MCP server will be documented in this file.
 - Configuration via YAML file.
   - Details go here eventually.
 - `config.example.yaml` template for YAML-based configuration. Users copy it to `config.yaml` to use; `.gitignore` rules for `/*.yaml` and `/*.yml` (with explicit allow-rules for currently-tracked root files) keep personal configs and any other accidental root-level yaml out of git.
+- `--init-config` CLI flag bootstraps a starter `./config.yaml` (a copy of the bundled `config.example.yaml`) in the current working directory and idempotently appends it to a sibling `.gitignore` (creating one if needed). Refuses to overwrite an existing `config.yaml`. Lets `npx` users get started without checking out the repo.
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -158,15 +158,17 @@ Flat environment variables can only express a single implicit connection. A YAML
 
 #### Configuration examples
 
-Start from [`config.example.yaml`](config.example.yaml) at the repo root — it is the YAML analogue of `.env.example`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) annotated and wired up with `${VAR}` placeholders so credentials stay in your environment.
-
-Copy it to `config.yaml` at the repo root and the `.gitignore` will keep your filled-in copy out of git — every `*.yaml`/`*.yml` file at the repo root is ignored by default unless explicitly allow-listed, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
+The fastest way to get a starter `config.yaml` is to let the CLI bootstrap one in your current directory — no checkout required:
 
 ```bash
-cp config.example.yaml config.yaml
-# edit config.yaml, then:
+npx @confluentinc/mcp-confluent --init-config
+# edit ./config.yaml, then:
 npx @confluentinc/mcp-confluent --config ./config.yaml
 ```
+
+`--init-config` drops a copy of [`config.example.yaml`](config.example.yaml) — the YAML analogue of `.env.example`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) annotated and wired up with `${VAR}` placeholders so credentials stay in your environment — into `./config.yaml` and adds it to a `.gitignore` next to it (creating one if needed) so your filled-in copy can't slip into git. It refuses to overwrite an existing `config.yaml`, so a stray rerun won't clobber edits.
+
+If you already have this repo cloned, `cp config.example.yaml config.yaml` works just as well — every `*.yaml`/`*.yml` file at the repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
 
 For more focused reference snippets, browse [test-fixtures/yaml_configs/valid/](test-fixtures/yaml_configs/valid/) — these files are executed as part of the test suite on every CI run, so they are always valid and current.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,11 +1,6 @@
 # Example MCP Confluent Server configuration.
 #
-# Copy this file to `config.yaml` at the repo root (that filename is gitignored
-# so your filled-in credentials stay out of git) and launch the server with:
-#
-#   cp config.example.yaml config.yaml
-#   # edit config.yaml, then:
-#   npx @confluentinc/mcp-confluent --config ./config.yaml
+# Generate this file with `npx @confluentinc/mcp-confluent --init-config`
 #
 # Every `${VAR}` and `${VAR:-default}` placeholder is resolved from the process
 # environment at startup, so secrets can stay in your shell or `.env` file

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,7 @@
 # Example MCP Confluent Server configuration.
 #
-# Generate this file with `npx @confluentinc/mcp-confluent --init-config`
+# Generate `config.yaml` from this template with:
+#   npx @confluentinc/mcp-confluent --init-config
 #
 # Every `${VAR}` and `${VAR:-default}` placeholder is resolved from the process
 # environment at startup, so secrets can stay in your shell or `.env` file

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "zod": "^4.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.example.yaml"
   ],
   "engines": {
     "node": ">=22"

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -335,6 +335,14 @@ describe("cli.ts", () => {
       expect(parseCliArgs(makeArgs(["--generate-key"])).generateKey).toBe(true);
     });
 
+    it("should set initConfig to true when --init-config is specified", () => {
+      expect(parseCliArgs(makeArgs(["--init-config"])).initConfig).toBe(true);
+    });
+
+    it("should leave initConfig false when --init-config is not specified", () => {
+      expect(parseCliArgs(makeArgs([])).initConfig).toBe(false);
+    });
+
     it("should parse --allowed-hosts into a lowercased array", () => {
       const result = parseCliArgs(
         makeArgs(["--allowed-hosts", "Localhost,127.0.0.1,MyHost.local"]),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ export interface CLIOptions {
   disableAuth?: boolean;
   allowedHosts?: string[];
   generateKey?: boolean;
+  initConfig?: boolean;
   oauth?: boolean;
   ccloudEnv?: "devel" | "stag" | "prod";
 }
@@ -211,6 +212,10 @@ export function parseCliArgs(argv: string[]): CLIOptions {
       "Generate a secure API key for MCP_API_KEY and print it to stdout, then exit. Use this to set MCP_API_KEY in your .env file.",
     )
     .option(
+      "--init-config",
+      "Bootstrap a starter config.yaml in the current working directory (also adds it to .gitignore), then exit. Refuses to overwrite an existing config.yaml.",
+    )
+    .option(
       "--oauth",
       "Enable OAuth (PKCE) auth against Confluent Cloud (defaults to prod)",
     )
@@ -275,6 +280,7 @@ export function parseCliArgs(argv: string[]): CLIOptions {
             .map((h: string) => h.trim().toLowerCase())
         : undefined,
       generateKey: !!opts.generateKey,
+      initConfig: !!opts.initConfig,
       oauth: opts.oauth,
       ccloudEnv: opts.ccloudEnv,
     };

--- a/src/confluent/node-deps.ts
+++ b/src/confluent/node-deps.ts
@@ -6,16 +6,28 @@ import { Analytics } from "@segment/analytics-node";
 import { TELEMETRY_WRITE_KEY } from "@src/build-config.js";
 import * as dotenv from "dotenv";
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer as httpCreateServer } from "node:http";
 import { arch, homedir, platform, release } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 export const buildConfig = { TELEMETRY_WRITE_KEY };
 export const dotenvLib = { config: dotenv.config };
-export const fs = { existsSync, readFileSync, writeFileSync, mkdirSync };
+export const fs = {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+  mkdirSync,
+};
 export const os = { homedir, platform, release, arch };
-export const path = { join, resolve };
+export const path = { join, resolve, dirname, basename };
 export const segment = { Analytics };
 export const nodeFetch = { fetch: globalThis.fetch };
 // Wrapped as a single-signature arrow so spies don't have to disambiguate

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -210,26 +210,49 @@ describe("index.ts", () => {
     });
 
     it("should refuse to overwrite an existing config.yaml", () => {
-      // existsSync(destPath) === true → bail out
-      fsMocks.existsSync.mockImplementation((p) => p === DEST_PATH);
+      // The exclusive-create write throws EEXIST when the destination
+      // already exists; outputInitConfig converts it to the friendly error.
+      fsMocks.readFileSync.mockReturnValue(EXAMPLE_CONTENTS);
+      const eexist: NodeJS.ErrnoException = Object.assign(
+        new Error("EEXIST: file already exists"),
+        { code: "EEXIST" },
+      );
+      fsMocks.writeFileSync.mockImplementation(() => {
+        throw eexist;
+      });
 
       expect(() => outputInitConfig()).toThrow(/config\.yaml already exists/);
-      expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+      // Failed write must not be followed by gitignore mutation.
+      expect(fsMocks.appendFileSync).not.toHaveBeenCalled();
     });
 
-    it("should write the bundled example to ./config.yaml when none exists", () => {
-      // No config.yaml, no .gitignore yet.
+    it("should propagate non-EEXIST write errors verbatim", () => {
+      fsMocks.readFileSync.mockReturnValue(EXAMPLE_CONTENTS);
+      const eacces: NodeJS.ErrnoException = Object.assign(
+        new Error("EACCES: permission denied"),
+        { code: "EACCES" },
+      );
+      fsMocks.writeFileSync.mockImplementation(() => {
+        throw eacces;
+      });
+
+      expect(() => outputInitConfig()).toThrow(eacces);
+    });
+
+    it("should write the bundled example to ./config.yaml with an exclusive-create flag", () => {
+      // No .gitignore yet.
       fsMocks.existsSync.mockReturnValue(false);
       fsMocks.readFileSync.mockReturnValue(EXAMPLE_CONTENTS);
 
       outputInitConfig();
 
-      // The first writeFileSync writes the config; the second creates the
-      // gitignore (since existsSync returned false for it too).
+      // The first writeFileSync writes the config with `wx` (exclusive create);
+      // the second creates the gitignore (since existsSync returned false for it too).
       expect(fsMocks.writeFileSync).toHaveBeenNthCalledWith(
         1,
         DEST_PATH,
         EXAMPLE_CONTENTS,
+        { flag: "wx" },
       );
     });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,4 @@
+import * as nodeDeps from "@src/confluent/node-deps.js";
 import { nodeCrypto } from "@src/confluent/node-deps.js";
 import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -5,10 +6,15 @@ import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import {
   getToolHandlersToRegister,
   outputApiKey,
+  outputInitConfig,
   outputToolList,
 } from "@src/index.js";
 import { runtimeWith } from "@tests/factories/runtime.js";
 import { StubHandler } from "@tests/stubs/index.js";
+import {
+  createFsWrappers,
+  type MockedFsWrappers,
+} from "@tests/stubs/node-deps.js";
 import {
   beforeEach,
   describe,
@@ -181,6 +187,120 @@ describe("index.ts", () => {
       outputApiKey();
       const allArgs: unknown[] = consoleLog.mock.calls.flat();
       expect(allArgs).toContain(EXPECTED_API_KEY);
+    });
+  });
+
+  describe("outputInitConfig()", () => {
+    const DEST_PATH = "/cwd/config.yaml";
+    const GITIGNORE_PATH = "/cwd/.gitignore";
+    const EXAMPLE_CONTENTS = "server: { transports: [stdio] }\n";
+
+    let fsMocks: MockedFsWrappers;
+
+    beforeEach(() => {
+      fsMocks = createFsWrappers();
+      // path.resolve("config.yaml") → /cwd/config.yaml
+      vi.spyOn(nodeDeps.path, "resolve").mockReturnValue(DEST_PATH);
+      // path.dirname(/cwd/config.yaml) → /cwd
+      vi.spyOn(nodeDeps.path, "dirname").mockReturnValue("/cwd");
+      // path.basename(/cwd/config.yaml) → config.yaml
+      vi.spyOn(nodeDeps.path, "basename").mockReturnValue("config.yaml");
+      // path.join("/cwd", ".gitignore") → /cwd/.gitignore
+      vi.spyOn(nodeDeps.path, "join").mockReturnValue(GITIGNORE_PATH);
+    });
+
+    it("should refuse to overwrite an existing config.yaml", () => {
+      // existsSync(destPath) === true → bail out
+      fsMocks.existsSync.mockImplementation((p) => p === DEST_PATH);
+
+      expect(() => outputInitConfig()).toThrow(/config\.yaml already exists/);
+      expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it("should write the bundled example to ./config.yaml when none exists", () => {
+      // No config.yaml, no .gitignore yet.
+      fsMocks.existsSync.mockReturnValue(false);
+      fsMocks.readFileSync.mockReturnValue(EXAMPLE_CONTENTS);
+
+      outputInitConfig();
+
+      // The first writeFileSync writes the config; the second creates the
+      // gitignore (since existsSync returned false for it too).
+      expect(fsMocks.writeFileSync).toHaveBeenNthCalledWith(
+        1,
+        DEST_PATH,
+        EXAMPLE_CONTENTS,
+      );
+    });
+
+    it("should create .gitignore with the file basename when it does not exist", () => {
+      fsMocks.existsSync.mockReturnValue(false);
+      fsMocks.readFileSync.mockReturnValue(EXAMPLE_CONTENTS);
+
+      outputInitConfig();
+
+      expect(fsMocks.writeFileSync).toHaveBeenCalledWith(
+        GITIGNORE_PATH,
+        "config.yaml\n",
+      );
+      expect(fsMocks.appendFileSync).not.toHaveBeenCalled();
+      const allArgs = consoleLog.mock.calls.flat().join(" ");
+      expect(allArgs).toContain("added to .gitignore");
+    });
+
+    it("should append the file basename when .gitignore exists without it", () => {
+      fsMocks.existsSync.mockImplementation((p) => p === GITIGNORE_PATH);
+      // First readFileSync = the bundled example; second = the gitignore.
+      fsMocks.readFileSync
+        .mockReturnValueOnce(EXAMPLE_CONTENTS)
+        .mockReturnValueOnce("node_modules\n.env\n");
+
+      outputInitConfig();
+
+      expect(fsMocks.appendFileSync).toHaveBeenCalledWith(
+        GITIGNORE_PATH,
+        "config.yaml\n",
+      );
+      const allArgs = consoleLog.mock.calls.flat().join(" ");
+      expect(allArgs).toContain("added to .gitignore");
+    });
+
+    it("should prepend a newline before appending if .gitignore lacks a trailing newline", () => {
+      fsMocks.existsSync.mockImplementation((p) => p === GITIGNORE_PATH);
+      fsMocks.readFileSync
+        .mockReturnValueOnce(EXAMPLE_CONTENTS)
+        .mockReturnValueOnce("node_modules"); // no trailing newline
+
+      outputInitConfig();
+
+      expect(fsMocks.appendFileSync).toHaveBeenCalledWith(
+        GITIGNORE_PATH,
+        "\nconfig.yaml\n",
+      );
+    });
+
+    it("should not append when .gitignore already lists the basename", () => {
+      fsMocks.existsSync.mockImplementation((p) => p === GITIGNORE_PATH);
+      fsMocks.readFileSync
+        .mockReturnValueOnce(EXAMPLE_CONTENTS)
+        .mockReturnValueOnce("node_modules\nconfig.yaml\n.env\n");
+
+      outputInitConfig();
+
+      expect(fsMocks.appendFileSync).not.toHaveBeenCalled();
+      const allArgs = consoleLog.mock.calls.flat().join(" ");
+      expect(allArgs).toContain(".gitignore already excludes it");
+    });
+
+    it("should ignore surrounding whitespace when matching existing .gitignore lines", () => {
+      fsMocks.existsSync.mockImplementation((p) => p === GITIGNORE_PATH);
+      fsMocks.readFileSync
+        .mockReturnValueOnce(EXAMPLE_CONTENTS)
+        .mockReturnValueOnce("  config.yaml  \n");
+
+      outputInitConfig();
+
+      expect(fsMocks.appendFileSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,21 +91,27 @@ export function outputApiKey(): void {
  * is the user's project but the example file lives next to the install.
  *
  * Refuses to overwrite an existing destination so an accidental rerun
- * cannot wipe credentials the user already filled in.
+ * cannot wipe credentials the user already filled in. The write uses
+ * `wx` (exclusive create) so the existence check and the create happen
+ * as a single syscall — there is no TOCTOU window where another process
+ * could create the file between a precheck and the write.
  */
 export function outputInitConfig(): void {
   const sourceUrl = new URL("../config.example.yaml", import.meta.url);
   const destPath = path.resolve("config.yaml");
 
-  if (fs.existsSync(destPath)) {
-    throw new Error(
-      `config.yaml already exists at ${destPath}. ` +
-        `Remove or rename it before running --init-config.`,
-    );
-  }
-
   const contents = fs.readFileSync(sourceUrl, "utf-8");
-  fs.writeFileSync(destPath, contents);
+  try {
+    fs.writeFileSync(destPath, contents, { flag: "wx" });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(
+        `config.yaml already exists at ${destPath}. ` +
+          `Remove or rename it before running --init-config.`,
+      );
+    }
+    throw err;
+  }
 
   const gitignoreNote = ensureGitignoreEntry(destPath);
 
@@ -171,7 +177,13 @@ async function main() {
     }
 
     if (cliOptions.initConfig) {
-      outputInitConfig();
+      try {
+        outputInitConfig();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        console.error(`--init-config failed: ${msg}`);
+        process.exit(1);
+      }
       process.exit(0);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   loadConfigFromYaml,
   MCPServerConfiguration,
 } from "@src/config/index.js";
+import { fs, path } from "@src/confluent/node-deps.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -79,6 +80,73 @@ export function outputApiKey(): void {
   console.log(`MCP_API_KEY=${apiKey}\n`);
 }
 
+/**
+ * Bootstrap a starter `config.yaml` in the current working directory by
+ * copying the bundled `config.example.yaml`, then ensure the new file is
+ * listed in `<cwd>/.gitignore` so credentials filled in later don't slip
+ * into git.
+ *
+ * Resolved relative to `import.meta.url` (the compiled `dist/index.js`)
+ * so this keeps working when invoked via `npx`, where `process.cwd()`
+ * is the user's project but the example file lives next to the install.
+ *
+ * Refuses to overwrite an existing destination so an accidental rerun
+ * cannot wipe credentials the user already filled in.
+ */
+export function outputInitConfig(): void {
+  const sourceUrl = new URL("../config.example.yaml", import.meta.url);
+  const destPath = path.resolve("config.yaml");
+
+  if (fs.existsSync(destPath)) {
+    throw new Error(
+      `config.yaml already exists at ${destPath}. ` +
+        `Remove or rename it before running --init-config.`,
+    );
+  }
+
+  const contents = fs.readFileSync(sourceUrl, "utf-8");
+  fs.writeFileSync(destPath, contents);
+
+  const gitignoreNote = ensureGitignoreEntry(destPath);
+
+  console.log(`wrote ./config.yaml (${gitignoreNote})`);
+  console.log(
+    `Next: edit credentials in config.yaml and run with --config ./config.yaml`,
+  );
+}
+
+/**
+ * Ensure the basename of `filePath` is listed in `<dirname(filePath)>/.gitignore`.
+ * Creates the gitignore if missing; appends idempotently if present (matching
+ * trimmed lines verbatim — `*.yaml` globs or `/config.yaml` anchors are not
+ * recognized, so a user who already wrote either form will see a duplicate
+ * `config.yaml` entry, which is harmless).
+ *
+ * @returns A short note describing what happened, suitable for the success message.
+ */
+function ensureGitignoreEntry(filePath: string): string {
+  const dir = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+  const gitignorePath = path.join(dir, ".gitignore");
+
+  if (!fs.existsSync(gitignorePath)) {
+    fs.writeFileSync(gitignorePath, `${fileName}\n`);
+    return "added to .gitignore";
+  }
+
+  const existing = fs.readFileSync(gitignorePath, "utf-8");
+  const alreadyListed = existing
+    .split("\n")
+    .some((line) => line.trim() === fileName);
+  if (alreadyListed) {
+    return ".gitignore already excludes it";
+  }
+
+  const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  fs.appendFileSync(gitignorePath, `${prefix}${fileName}\n`);
+  return "added to .gitignore";
+}
+
 export function outputToolList(filteredToolNames: ToolName[]): void {
   const MAX_DESC_LENGTH = 120;
   filteredToolNames.forEach((toolName) => {
@@ -99,6 +167,11 @@ async function main() {
     // Handle early-exit modes as requested by CLI args before initializing the server.
     if (cliOptions.generateKey) {
       outputApiKey();
+      process.exit(0);
+    }
+
+    if (cliOptions.initConfig) {
+      outputInitConfig();
       process.exit(0);
     }
 

--- a/tests/stubs/node-deps.ts
+++ b/tests/stubs/node-deps.ts
@@ -13,13 +13,15 @@ import { type MockInstance, vi } from "vitest";
  *
  * Read methods (`existsSync`, `readFileSync`) call through to the real fs
  * by default; tests should override with `.mockReturnValue(...)`. Write
- * methods (`writeFileSync`, `mkdirSync`) are no-op-by-default to prevent
- * an unmocked call from accidentally mutating the real filesystem.
+ * methods (`writeFileSync`, `appendFileSync`, `mkdirSync`) are
+ * no-op-by-default to prevent an unmocked call from accidentally mutating
+ * the real filesystem.
  */
 export type MockedFsWrappers = {
   existsSync: MockInstance<typeof nodeDeps.fs.existsSync>;
   readFileSync: MockInstance<typeof nodeDeps.fs.readFileSync>;
   writeFileSync: MockInstance<typeof nodeDeps.fs.writeFileSync>;
+  appendFileSync: MockInstance<typeof nodeDeps.fs.appendFileSync>;
   mkdirSync: MockInstance<typeof nodeDeps.fs.mkdirSync>;
 };
 
@@ -29,8 +31,8 @@ export type MockedFsWrappers = {
  * Read spies (`existsSync`, `readFileSync`) call through by default; real
  * `existsSync` on a non-existent path returns `false` and real `readFileSync`
  * throws ENOENT, both of which surface a missed mock loudly. Write spies
- * (`writeFileSync`, `mkdirSync`) are no-op-by-default so an unmocked call
- * doesn't accidentally mutate the real filesystem.
+ * (`writeFileSync`, `appendFileSync`, `mkdirSync`) are no-op-by-default
+ * so an unmocked call doesn't accidentally mutate the real filesystem.
  *
  * @example
  * ```ts
@@ -45,6 +47,9 @@ export function createFsWrappers(): MockedFsWrappers {
     readFileSync: vi.spyOn(nodeDeps.fs, "readFileSync"),
     writeFileSync: vi
       .spyOn(nodeDeps.fs, "writeFileSync")
+      .mockImplementation(() => undefined),
+    appendFileSync: vi
+      .spyOn(nodeDeps.fs, "appendFileSync")
       .mockImplementation(() => undefined),
     mkdirSync: vi
       .spyOn(nodeDeps.fs, "mkdirSync")


### PR DESCRIPTION
## Summary

- Adds `npx @confluentinc/mcp-confluent --init-config`: writes a starter `config.yaml` (a copy of the bundled `config.example.yaml`) into the user's CWD and adds it to a sibling `.gitignore` so credentials filled in later don't slip into git.
- Refuses to overwrite an existing `config.yaml` so a stray rerun won't clobber edits; gitignore append is idempotent.
- Ships `config.example.yaml` in the npm tarball (`package.json#files`) so users running via `npx` no longer need a checkout to bootstrap.

Fixes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)