### PR TITLE
chore: add integration tests for `metrics` tool handlers

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,7 +61,7 @@ promotions:
       env_vars:
         - name: TOOL_GROUPS
           description: "Pipe-separated vitest tags to run (e.g. @kafka|@schema)"
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect"
+          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics"
           required: true
         - name: TRANSPORTS
           description: "Pipe-separated MCP transports (stdio|http|sse)"

--- a/service.yml
+++ b/service.yml
@@ -57,7 +57,7 @@ semaphore:
       parameters:
         - name: TOOL_GROUPS
           required: true
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect"
+          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics"
           description: 'Pipe-separated tool-group tags to test.'
         - name: TRANSPORTS
           required: true

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
@@ -1,0 +1,53 @@
+import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListMetricsHandler();
+const runtime = integrationRuntime();
+
+describe("list-metrics-handler", { tags: [Tag.METRICS] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires telemetry.auth (or confluent_cloud.auth fallback) config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-metrics in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(tools.find((t) => t.name === ToolName.LIST_METRICS)).toBeDefined();
+    });
+
+    it("should list metrics filtered by resource_type=kafka", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_METRICS,
+        arguments: { resource_type: "kafka" },
+      });
+
+      expect(result.isError).not.toBe(true);
+      const text = textContent(result);
+      // received_bytes is a stable kafka.server metric, so finding it proves the end-to-end call
+      // returned kafka data
+      expect(text).toMatch(/Available Metrics \(kafka\): [1-9]\d*/);
+      expect(text).toContain("io.confluent.kafka.server/received_bytes");
+    });
+  });
+});

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
@@ -15,7 +15,7 @@ const runtime = integrationRuntime();
 
 describe("list-metrics-handler", { tags: [Tag.METRICS] }, () => {
   if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires telemetry.auth (or confluent_cloud.auth fallback) config", () => {});
+    it.skip("requires telemetry.auth config", () => {});
     return;
   }
 

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
@@ -1,0 +1,60 @@
+import { QueryMetricsHandler } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new QueryMetricsHandler();
+const runtime = integrationRuntime();
+
+describe("query-metrics-handler", { tags: [Tag.METRICS] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires telemetry.auth (or confluent_cloud.auth fallback) config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose query-metrics in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.QUERY_METRICS),
+      ).toBeDefined();
+    });
+
+    it("should query a kafka.server metric for the configured cluster", async () => {
+      // `filter` is omitted: for io.confluent.kafka.server/* metrics the handler auto-injects
+      // resource.kafka.id (from kafka.cluster_id in integration.yaml)
+      const result = await server.client.callTool({
+        name: ToolName.QUERY_METRICS,
+        arguments: {
+          metric: "io.confluent.kafka.server/received_bytes",
+          granularity: "PT5M",
+          interval: "PT15M",
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      // idle cluster may show "No data returned for metric"
+      expect(textContent(result)).toMatch(
+        /^(Metrics Query Results|No data returned for metric)/,
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
@@ -15,7 +15,7 @@ const runtime = integrationRuntime();
 
 describe("query-metrics-handler", { tags: [Tag.METRICS] }, () => {
   if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires telemetry.auth (or confluent_cloud.auth fallback) config", () => {});
+    it.skip("requires telemetry.auth config", () => {});
     return;
   }
 
@@ -46,7 +46,6 @@ describe("query-metrics-handler", { tags: [Tag.METRICS] }, () => {
         arguments: {
           metric: "io.confluent.kafka.server/received_bytes",
           granularity: "PT5M",
-          interval: "PT15M",
         },
       });
 

--- a/test-fixtures/yaml_configs/integration.yaml
+++ b/test-fixtures/yaml_configs/integration.yaml
@@ -45,3 +45,10 @@ connections:
         type: api_key
         key: "${CONFLUENT_CLOUD_API_KEY}"
         secret: "${CONFLUENT_CLOUD_API_SECRET}"
+
+    # --- @metrics (Telemetry API) ---
+    telemetry:
+      auth:
+        type: api_key
+        key: "${TELEMETRY_API_KEY}"
+        secret: "${TELEMETRY_API_SECRET}"


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Also includes updated `TOOL_GROUPS` default for CI:
<img width="351" height="715" alt="image" src="https://github.com/user-attachments/assets/55dcd4a8-d990-4f68-bcc9-20906ef0e580" />

Closes #332

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- I was tempted to export [`KAFKA_SERVER_METRICS`](https://github.com/confluentinc/mcp-confluent/blob/3845a150d505e42ba35d0c97bb0e2042c6e6ab2a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts#L57) but there wouldn't have been as much payoff in the test results compared to the additional logic required and dependency on actual cluster activity, so we're just starting with the basic `received_bytes` metric

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
