### PR TITLE
Refactor/357 predicate data member in all tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "permissions": {
-    "allow": ["Bash(echo \"typecheck exit: $?\")", "Bash(echo \"exit: $?\")"],
     "deny": [
       "Read(.env)",
       "Read(.env.integration)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
   "permissions": {
+    "allow": [
+      "Bash(echo \"tc_exit=$?\")",
+      "Bash(echo \"test_exit=$?\")",
+      "Bash(echo \"lint_exit=$?\")"
+    ],
     "deny": [
       "Read(.env)",
       "Read(.env.integration)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(echo \"tc_exit=$?\")",
-      "Bash(echo \"test_exit=$?\")",
-      "Bash(echo \"lint_exit=$?\")"
-    ],
     "deny": [
       "Read(.env)",
       "Read(.env.integration)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "permissions": {
+    "allow": ["Bash(echo \"typecheck exit: $?\")", "Bash(echo \"exit: $?\")"],
     "deny": [
       "Read(.env)",
       "Read(.env.integration)",

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -1,9 +1,51 @@
+import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
+import { bareRuntime, kafkaRuntime } from "@tests/factories/runtime.js";
 import { StubHandler } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 describe("base-tools.ts", () => {
   describe("BaseToolHandler", () => {
     const handler = new StubHandler();
+
+    describe("predicate-derived enabledConnectionIds()", () => {
+      it("should return the connection ID for an enabled stub on any runtime", () => {
+        expect(new StubHandler().enabledConnectionIds(kafkaRuntime())).toEqual([
+          "default",
+        ]);
+      });
+
+      it("should return an empty array for a disabled stub", () => {
+        expect(
+          new StubHandler({ enabled: false }).enabledConnectionIds(
+            kafkaRuntime(),
+          ),
+        ).toEqual([]);
+      });
+    });
+
+    describe("predicate-derived connectionVerdicts()", () => {
+      it("should report enabled verdicts for a stub configured as enabled", () => {
+        expect(new StubHandler().connectionVerdicts(kafkaRuntime())).toEqual(
+          new Map([["default", { enabled: true }]]),
+        );
+      });
+
+      it("should report disabled verdicts (with a reason) for a stub configured as disabled", () => {
+        expect(
+          new StubHandler({ enabled: false }).connectionVerdicts(bareRuntime()),
+        ).toEqual(
+          new Map([
+            [
+              "default",
+              {
+                enabled: false,
+                reason: ToolDisabledReason.MissingFlinkBlock,
+              },
+            ],
+          ]),
+        );
+      });
+    });
 
     describe("resolveParam()", () => {
       // BaseToolHandler.resolveParam() is protected, so we have to work a little bit to get at

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -1,5 +1,9 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  ConnectionPredicate,
+  PredicateResult,
+} from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { ZodRawShape } from "zod";
@@ -32,15 +36,19 @@ export interface ToolHandler {
   getToolConfig(): ToolConfig;
 
   /**
-   * Returns the IDs of connections that satisfy this tool's service requirements.
-   * A non-empty result enables the tool; an empty result disables it. Implementations
-   * should return a subset of the keys in runtime.config.connections.
-   *
-   * Each handler implements this by applying the appropriate predicate from
-   * connection-predicates.ts via connectionIdsWhere(), e.g.:
-   *   return connectionIdsWhere(runtime.config.connections, hasKafka);
+   * IDs of connections that satisfy this tool's service requirements. A
+   * non-empty result enables the tool; an empty result disables it. Always a
+   * subset of `runtime.config.connections` keys.
    */
   enabledConnectionIds(runtime: ServerRuntime): string[];
+
+  /**
+   * Per-connection verdict map for this tool: `{ enabled: true }` for
+   * connections that satisfy its requirements, `{ enabled: false; reason }`
+   * for those that don't. Powers startup-log grouping and the
+   * `describe-tool-availability` diagnostic tool.
+   */
+  connectionVerdicts(runtime: ServerRuntime): Map<string, PredicateResult>;
 }
 
 export interface ToolConfig {
@@ -60,13 +68,48 @@ export abstract class BaseToolHandler implements ToolHandler {
   abstract getToolConfig(): ToolConfig;
 
   /**
-   * Determines which configured connections can serve this tool by inspecting
-   * their service blocks. If returns an empty array, the tool is disabled.
-   *
-   * The canonical implementation is a one-liner:
-   *   return connectionIdsWhere(runtime.config.connections, some-predicate-function);
+   * The connection predicate that gates this tool. Subclasses declare it as
+   * a readonly property; {@linkcode enabledConnectionIds} and
+   * {@linkcode connectionVerdicts} are derived from it. Use a
+   * predicate from `connection-predicates.ts` (e.g. `hasKafka`), or compose
+   * with `allOf(...)` for compound requirements; use `alwaysEnabled` for
+   * tools with no service-block requirement.
    */
-  abstract enabledConnectionIds(runtime: ServerRuntime): string[];
+  abstract readonly predicate: ConnectionPredicate;
+
+  /**
+   * IDs of connections that satisfy this tool's {@linkcode predicate}. A
+   * non-empty result enables the tool; an empty result disables it.
+   *
+   * Customize tool gating by declaring {@linkcode predicate}, never by
+   * replacing this derivation.
+   *
+   * @final — concrete on `BaseToolHandler`; subclasses must not override.
+   */
+  enabledConnectionIds(runtime: ServerRuntime): string[] {
+    return Object.entries(runtime.config.connections)
+      .filter(([, conn]) => this.predicate(conn).enabled)
+      .map(([id]) => id);
+  }
+
+  /**
+   * Per-connection verdict map for this tool, derived from
+   * {@linkcode predicate}. Powers grouped startup logging and
+   * the diagnostic-tool surface.
+   *
+   * Customize tool gating by declaring {@linkcode predicate}, never by
+   * replacing this derivation.
+   *
+   * @final — concrete on `BaseToolHandler`; subclasses must not override.
+   */
+  connectionVerdicts(runtime: ServerRuntime): Map<string, PredicateResult> {
+    return new Map(
+      Object.entries(runtime.config.connections).map(([id, conn]) => [
+        id,
+        this.predicate(conn),
+      ]),
+    );
+  }
 
   /**
    * Resolves a required string from an explicit tool argument, falling back to

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -5,8 +5,6 @@ import {
   type PredicateResult,
   ToolDisabledReason,
   allOf,
-  connectionIdsWhere,
-  connectionReasonsWhere,
   hasCCloudCatalogSupport,
   hasConfluentCloud,
   hasDirectConfluentCloud,
@@ -312,84 +310,6 @@ describe("connection-predicates.ts", () => {
     it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
       expect(hasTableflow(OAUTH_CONN)).toEqual(
         disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
-      );
-    });
-  });
-
-  describe("connectionIdsWhere()", () => {
-    it("should return an empty array when no connections match the predicate", () => {
-      const connections: Record<string, ConnectionConfig> = {
-        sr: SCHEMA_REGISTRY_CONN,
-      };
-      expect(connectionIdsWhere(connections, hasKafka)).toEqual([]);
-    });
-
-    it("should return the matching connection ID when one connection matches", () => {
-      const connections: Record<string, ConnectionConfig> = {
-        kafka: KAFKA_CONN,
-        sr: SCHEMA_REGISTRY_CONN,
-      };
-      expect(connectionIdsWhere(connections, hasKafka)).toEqual(["kafka"]);
-    });
-
-    it("should return all matching IDs when multiple connections satisfy the predicate", () => {
-      const connections: Record<string, ConnectionConfig> = {
-        kafka1: KAFKA_CONN,
-        kafka2: KAFKA_REST_CONN,
-        sr: SCHEMA_REGISTRY_CONN,
-      };
-      expect(connectionIdsWhere(connections, hasKafka)).toEqual([
-        "kafka1",
-        "kafka2",
-      ]);
-    });
-  });
-
-  describe("connectionReasonsWhere()", () => {
-    it("should return an empty map when there are no connections", () => {
-      expect(connectionReasonsWhere({}, hasKafka)).toEqual(new Map());
-    });
-
-    it("should record one verdict per connection, preserving entry order", () => {
-      const connections: Record<string, ConnectionConfig> = {
-        kafka: KAFKA_CONN,
-        sr: SCHEMA_REGISTRY_CONN,
-        oauth: OAUTH_CONN,
-      };
-      const verdicts = connectionReasonsWhere(connections, hasKafka);
-      expect(verdicts).toEqual(
-        new Map([
-          ["kafka", ENABLED],
-          ["sr", disabledFor(ToolDisabledReason.MissingKafkaBlock)],
-          ["oauth", disabledFor(ToolDisabledReason.OAuthNoServiceBlocks)],
-        ]),
-      );
-      expect(Array.from(verdicts.keys())).toEqual(["kafka", "sr", "oauth"]);
-    });
-
-    it("should report enabled for every connection when all match the predicate", () => {
-      const connections: Record<string, ConnectionConfig> = {
-        a: KAFKA_CONN,
-        b: KAFKA_REST_CONN,
-      };
-      expect(connectionReasonsWhere(connections, hasKafka)).toEqual(
-        new Map([
-          ["a", ENABLED],
-          ["b", ENABLED],
-        ]),
-      );
-    });
-
-    it("should report disabled for every connection when none match the predicate", () => {
-      const connections: Record<string, ConnectionConfig> = {
-        sr: SCHEMA_REGISTRY_CONN,
-        oauth: OAUTH_CONN,
-      };
-      expect(connectionReasonsWhere(connections, hasFlink)).toEqual(
-        new Map([
-          ["sr", disabledFor(ToolDisabledReason.MissingFlinkBlock)],
-          ["oauth", disabledFor(ToolDisabledReason.OAuthNoServiceBlocks)],
-        ]),
       );
     });
   });

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -4,12 +4,11 @@
 // so callers can explain why a tool is absent rather than silently dropping
 // it from the catalogue.
 //
-// Tool handlers reach this module via `connectionIdsWhere` from their
-// `enabledConnectionIds()` method — the returned id list drives whether MCP
-// advertises the tool to its clients. `connectionReasonsWhere` returns the
-// full per-connection verdict map, the canonical shape for diagnostics that
-// need to render the verdict (group disabled tools by reason, surface
-// availability per connection) rather than just filter on it.
+// Tool handlers consume predicates indirectly: each handler declares a
+// `predicate` property, and `BaseToolHandler` derives both
+// `enabledConnectionIds()` and `connectionVerdicts()` from it. Compose
+// compound requirements with `allOf(...)` and use `alwaysEnabled` for
+// tools with no service-block requirement.
 //
 // OAuth note: while OAuth support is being built out, most predicates
 // currently short-circuit on `conn.type === "oauth"` and answer disabled
@@ -200,11 +199,18 @@ export function hasCCloudCatalogSupport(
 }
 
 /**
+ * Predicate that returns {@linkcode ENABLED} for every connection. Use as
+ * the {@linkcode BaseToolHandler.predicate} for tools with no service-block
+ * requirement (e.g., generic docs search).
+ */
+export const alwaysEnabled: ConnectionPredicate = () => ENABLED;
+
+/**
  * Combine predicates with logical AND, short-circuiting on the first
  * failure. Returns {@linkcode ENABLED} only when every predicate passes for
  * the given connection; otherwise returns the first failing verdict so the
- * specific reason propagates to {@linkcode connectionReasonsWhere} and
- * downstream diagnostics.
+ * specific reason propagates downstream to startup logging and the
+ * diagnostic-tool surface.
  *
  * Use this — never raw `predA(conn) && predB(conn)`. JavaScript boolean
  * composition silently drops the first operand because every
@@ -220,29 +226,6 @@ export function allOf(
     }
     return ENABLED;
   };
-}
-
-export function connectionIdsWhere(
-  connections: Readonly<Record<string, ConnectionConfig>>,
-  predicate: ConnectionPredicate,
-): string[] {
-  return Object.entries(connections)
-    .filter(([, conn]) => predicate(conn).enabled)
-    .map(([id]) => id);
-}
-
-/**
- * Returns the full predicate verdict for every connection, preserving
- * insertion order — the canonical shape for diagnostics that need to group
- * disabled connections by reason or render per-connection availability.
- */
-export function connectionReasonsWhere(
-  connections: Readonly<Record<string, ConnectionConfig>>,
-  predicate: ConnectionPredicate,
-): Map<string, PredicateResult> {
-  return new Map(
-    Object.entries(connections).map(([id, conn]) => [id, predicate(conn)]),
-  );
 }
 
 /**

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasConfluentCloud,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasConfluentCloud } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -213,8 +210,5 @@ Pagination:${metadata.total_size ? `\n  Total Items: ${metadata.total_size}` : "
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasConfluentCloud);
-  }
+  readonly predicate = hasConfluentCloud;
 }

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
@@ -4,10 +4,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -67,11 +64,5 @@ export class AddTagToTopicHandler extends BaseToolHandler {
       annotations: CREATE_UPDATE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.ts
@@ -4,10 +4,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -71,11 +68,5 @@ export class CreateTopicTagsHandler extends BaseToolHandler {
       annotations: CREATE_UPDATE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/catalog/delete-tag.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.ts
@@ -4,10 +4,7 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -58,11 +55,5 @@ export class DeleteTagHandler extends BaseToolHandler {
       annotations: DESTRUCTIVE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/catalog/list-tags.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -41,11 +38,5 @@ export class ListTagsHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
@@ -4,10 +4,7 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -75,11 +72,5 @@ export class RemoveTagFromEntityHandler extends BaseToolHandler {
       annotations: DESTRUCTIVE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasDirectConfluentCloud,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasDirectConfluentCloud } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -192,11 +189,5 @@ Cluster: ${cluster.name}
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasDirectConfluentCloud,
-    );
-  }
+  readonly predicate = hasDirectConfluentCloud;
 }

--- a/src/confluent/tools/handlers/connect/connect-tool-handler.ts
+++ b/src/confluent/tools/handlers/connect/connect-tool-handler.ts
@@ -1,10 +1,6 @@
 import { DirectConnectionConfig } from "@src/config/models.js";
 import { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasDirectConfluentCloud,
-} from "@src/confluent/tools/connection-predicates.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import { hasDirectConfluentCloud } from "@src/confluent/tools/connection-predicates.js";
 
 /**
  * Intermediate base class for all Connect tool handlers.
@@ -12,12 +8,7 @@ import { ServerRuntime } from "@src/server-runtime.js";
  * `resolveConnectEnvAndClusterId` for consistent env/cluster resolution.
  */
 export abstract class ConnectToolHandler extends BaseToolHandler {
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasDirectConfluentCloud,
-    );
-  }
+  readonly predicate = hasDirectConfluentCloud;
 
   /**
    * Resolves environment and Kafka cluster IDs from explicit tool args,

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -2,7 +2,6 @@ import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   allOf,
-  connectionIdsWhere,
   hasDirectConfluentCloud,
   hasKafkaAuth,
 } from "@src/confluent/tools/connection-predicates.js";
@@ -140,10 +139,5 @@ export class CreateConnectorHandler extends ConnectToolHandler {
     };
   }
 
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      allOf(hasDirectConfluentCloud, hasKafkaAuth),
-    );
-  }
+  override readonly predicate = allOf(hasDirectConfluentCloud, hasKafkaAuth);
 }

--- a/src/confluent/tools/handlers/docs/get-product-doc-page-handler.ts
+++ b/src/confluent/tools/handlers/docs/get-product-doc-page-handler.ts
@@ -5,6 +5,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
+import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -280,9 +281,7 @@ export class GetProductDocPageHandler extends BaseToolHandler {
     };
   }
 
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return Object.keys(runtime.config.connections);
-  }
+  readonly predicate = alwaysEnabled;
 }
 
 function toMarkdownTwin(parsed: URL): string {

--- a/src/confluent/tools/handlers/docs/search-product-docs-handler.ts
+++ b/src/confluent/tools/handlers/docs/search-product-docs-handler.ts
@@ -5,6 +5,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
+import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -233,10 +234,8 @@ export class SearchProductDocsHandler extends BaseToolHandler {
     };
   }
 
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    // No service-block requirement; enabled if any connection exists.
-    return Object.keys(runtime.config.connections);
-  }
+  // No service-block requirement; enabled on any connection.
+  readonly predicate = alwaysEnabled;
 }
 
 interface SwiftypeHit {

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasConfluentCloud,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasConfluentCloud } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -173,8 +170,5 @@ Pagination:${metadata.total_size ? `\n  Total Environments: ${metadata.total_siz
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasConfluentCloud);
-  }
+  readonly predicate = hasConfluentCloud;
 }

--- a/src/confluent/tools/handlers/environments/read-environment-handler.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasConfluentCloud,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasConfluentCloud } from "@src/confluent/tools/connection-predicates.js";
 import {
   Environment,
   environmentSchema,
@@ -122,8 +119,5 @@ Environment: ${environmentDetails.name}
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasConfluentCloud);
-  }
+  readonly predicate = hasConfluentCloud;
 }

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -2,7 +2,6 @@ import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   allOf,
-  connectionIdsWhere,
   hasFlink,
   hasTelemetry,
 } from "@src/confluent/tools/connection-predicates.js";
@@ -535,10 +534,5 @@ export class QueryProfilerHandler extends FlinkToolHandler {
   }
 
   /** Overrides FlinkToolHandler: also requires a telemetry block because profiling fetches metrics from the Telemetry API in addition to the Flink REST API. */
-  override enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      allOf(hasFlink, hasTelemetry),
-    );
-  }
+  override readonly predicate = allOf(hasFlink, hasTelemetry);
 }

--- a/src/confluent/tools/handlers/flink/flink-tool-handler.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.ts
@@ -3,18 +3,11 @@ import {
   MCPServerConfiguration,
 } from "@src/config/models.js";
 import { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasFlink,
-} from "@src/confluent/tools/connection-predicates.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import { hasFlink } from "@src/confluent/tools/connection-predicates.js";
 
 /** Intermediate base class for Flink tool handlers */
 export abstract class FlinkToolHandler extends BaseToolHandler {
-  /** Implementation of enabledConnectionIds gating on having a connection with a valid Flink block.  */
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasFlink);
-  }
+  readonly predicate = hasFlink;
 
   /**
    * Extracts the Flink config block from the sole connection, asserting it exists.

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -4,10 +4,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaRestWithAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaRestWithAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -85,8 +82,5 @@ export class AlterTopicConfigHandler extends BaseToolHandler {
       annotations: CREATE_UPDATE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaRestWithAuth);
-  }
+  readonly predicate = hasKafkaRestWithAuth;
 }

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -11,10 +11,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaBootstrap,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaBootstrap } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -266,8 +263,5 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaBootstrap);
-  }
+  readonly predicate = hasKafkaBootstrap;
 }

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -4,10 +4,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaBootstrap,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaBootstrap } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -63,8 +60,5 @@ export class CreateTopicsHandler extends BaseToolHandler {
       annotations: CREATE_UPDATE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaBootstrap);
-  }
+  readonly predicate = hasKafkaBootstrap;
 }

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -4,10 +4,7 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaBootstrap,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaBootstrap } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -38,8 +35,5 @@ export class DeleteTopicsHandler extends BaseToolHandler {
       annotations: DESTRUCTIVE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaBootstrap);
-  }
+  readonly predicate = hasKafkaBootstrap;
 }

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaRestWithAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaRestWithAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -93,8 +90,5 @@ export class GetTopicConfigHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaRestWithAuth);
-  }
+  readonly predicate = hasKafkaRestWithAuth;
 }

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaBootstrap,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaBootstrap } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -34,8 +31,5 @@ export class ListTopicsHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaBootstrap);
-  }
+  readonly predicate = hasKafkaBootstrap;
 }

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -12,10 +12,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasKafkaBootstrap,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasKafkaBootstrap } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -215,8 +212,5 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
       annotations: CREATE_UPDATE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasKafkaBootstrap);
-  }
+  readonly predicate = hasKafkaBootstrap;
 }

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasTelemetry,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasTelemetry } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -264,8 +261,5 @@ export class ListMetricsHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasTelemetry);
-  }
+  readonly predicate = hasTelemetry;
 }

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasTelemetry,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasTelemetry } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -178,10 +175,7 @@ export class QueryMetricsHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasTelemetry);
-  }
+  readonly predicate = hasTelemetry;
 }
 
 /**

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasConfluentCloud,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasConfluentCloud } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -167,8 +164,5 @@ Organization: ${org.name}
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasConfluentCloud);
-  }
+  readonly predicate = hasConfluentCloud;
 }

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.ts
@@ -4,10 +4,7 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasSchemaRegistry,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasSchemaRegistry } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -114,8 +111,5 @@ export class DeleteSchemaHandler extends BaseToolHandler {
       annotations: DESTRUCTIVE,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
-  }
+  readonly predicate = hasSchemaRegistry;
 }

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -5,10 +5,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasSchemaRegistry,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasSchemaRegistry } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -169,8 +166,5 @@ export class ListSchemasHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasSchemaRegistry);
-  }
+  readonly predicate = hasSchemaRegistry;
 }

--- a/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -66,11 +63,5 @@ export class SearchTopicsByTagHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasCCloudCatalogSupport,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasCCloudCatalogSupport } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
@@ -58,11 +55,5 @@ export class SearchTopicsByNameHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(
-      runtime.config.connections,
-      hasCCloudCatalogSupport,
-    );
-  }
+  readonly predicate = hasCCloudCatalogSupport;
 }

--- a/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.ts
@@ -1,8 +1,5 @@
 import { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
-import {
-  connectionIdsWhere,
-  hasTableflow,
-} from "@src/confluent/tools/connection-predicates.js";
+import { hasTableflow } from "@src/confluent/tools/connection-predicates.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
 /**
@@ -16,9 +13,7 @@ import { ServerRuntime } from "@src/server-runtime.js";
  * from both the call arguments and the connection config.
  */
 export abstract class TableflowToolHandler extends BaseToolHandler {
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return connectionIdsWhere(runtime.config.connections, hasTableflow);
-  }
+  readonly predicate = hasTableflow;
 
   /**
    * Resolves the environment ID and Kafka cluster ID for a Tableflow operation,

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -1,0 +1,174 @@
+import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import {
+  ConnectionPredicate,
+  ToolDisabledReason,
+  alwaysEnabled,
+} from "@src/confluent/tools/connection-predicates.js";
+import { groupDisabledToolsByReason } from "@src/confluent/tools/tool-availability.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  KAFKA_CONN,
+  bareRuntime,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import { StubHandler } from "@tests/stubs/index.js";
+import { describe, expect, it } from "vitest";
+
+function stubWithPredicate(predicate: ConnectionPredicate): ToolHandler {
+  const handler = new StubHandler();
+  // Override the readonly predicate via type assertion for test composition.
+  (handler as unknown as { predicate: ConnectionPredicate }).predicate =
+    predicate;
+  return handler;
+}
+
+const disabledForKafka: ConnectionPredicate = () => ({
+  enabled: false,
+  reason: ToolDisabledReason.MissingKafkaBlock,
+});
+
+const disabledForFlink: ConnectionPredicate = () => ({
+  enabled: false,
+  reason: ToolDisabledReason.MissingFlinkBlock,
+});
+
+describe("tool-availability.ts", () => {
+  describe("groupDisabledToolsByReason()", () => {
+    it("should return an empty array when no tools are passed", () => {
+      expect(groupDisabledToolsByReason([], bareRuntime())).toEqual([]);
+    });
+
+    it("should return an empty array when every tool is enabled on every connection", () => {
+      const handler = stubWithPredicate(alwaysEnabled);
+      expect(
+        groupDisabledToolsByReason(
+          [[ToolName.LIST_TOPICS, handler]],
+          runtimeWith(KAFKA_CONN),
+        ),
+      ).toEqual([]);
+    });
+
+    it("should produce one group per (connectionId, reason) when one tool is disabled", () => {
+      const handler = stubWithPredicate(disabledForKafka);
+      const groups = groupDisabledToolsByReason(
+        [[ToolName.LIST_TOPICS, handler]],
+        runtimeWith({ schema_registry: { endpoint: "http://sr" } }),
+      );
+      expect(groups).toEqual([
+        {
+          connectionId: "default",
+          reason: ToolDisabledReason.MissingKafkaBlock,
+          toolNames: [ToolName.LIST_TOPICS],
+        },
+      ]);
+    });
+
+    it("should collapse multiple tools failing for the same (connectionId, reason) into one group", () => {
+      const handlerA = stubWithPredicate(disabledForKafka);
+      const handlerB = stubWithPredicate(disabledForKafka);
+      const groups = groupDisabledToolsByReason(
+        [
+          [ToolName.LIST_TOPICS, handlerA],
+          [ToolName.CREATE_TOPICS, handlerB],
+        ],
+        runtimeWith({ schema_registry: { endpoint: "http://sr" } }),
+      );
+      expect(groups).toEqual([
+        {
+          connectionId: "default",
+          reason: ToolDisabledReason.MissingKafkaBlock,
+          toolNames: [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+        },
+      ]);
+    });
+
+    it("should split into separate groups when tools fail with different reasons", () => {
+      const kafkaTool = stubWithPredicate(disabledForKafka);
+      const flinkTool = stubWithPredicate(disabledForFlink);
+      const groups = groupDisabledToolsByReason(
+        [
+          [ToolName.LIST_TOPICS, kafkaTool],
+          [ToolName.LIST_FLINK_STATEMENTS, flinkTool],
+        ],
+        runtimeWith({ schema_registry: { endpoint: "http://sr" } }),
+      );
+      expect(groups).toEqual([
+        {
+          connectionId: "default",
+          reason: ToolDisabledReason.MissingKafkaBlock,
+          toolNames: [ToolName.LIST_TOPICS],
+        },
+        {
+          connectionId: "default",
+          reason: ToolDisabledReason.MissingFlinkBlock,
+          toolNames: [ToolName.LIST_FLINK_STATEMENTS],
+        },
+      ]);
+    });
+
+    it("should omit tools that are enabled on at least one connection (only fully-disabled tools group)", () => {
+      // Predicate enables only on connections carrying a kafka block.
+      const partiallyEnabled: ConnectionPredicate = (conn) =>
+        conn.type === "direct" && conn.kafka !== undefined
+          ? { enabled: true }
+          : {
+              enabled: false,
+              reason: ToolDisabledReason.MissingKafkaBlock,
+            };
+      const handler = stubWithPredicate(partiallyEnabled);
+      const runtime = runtimeWith(KAFKA_CONN);
+      // Cast because `connections` is typed as `Readonly<Record<…>>`. We
+      // splice in a second connection here rather than building a fresh
+      // multi-connection ServerRuntime — the test only exercises the
+      // grouping helper's read path.
+      (
+        runtime.config.connections as Record<
+          string,
+          (typeof runtime.config.connections)[string]
+        >
+      )["other"] = {
+        type: "direct",
+        schema_registry: { endpoint: "http://sr" },
+      };
+      expect(
+        groupDisabledToolsByReason([[ToolName.LIST_TOPICS, handler]], runtime),
+      ).toEqual([]);
+    });
+
+    it("should order groups lexicographically by connectionId, regardless of insertion order", () => {
+      // `zeta` is inserted first; `alpha` is appended after. Lexicographic
+      // ordering puts `alpha` first. Pins the helper's ordering against JS
+      // plain-object key-iteration quirks — integer-like keys get
+      // reordered numerically, and `Record<string, …>` is not a portable
+      // insertion-order container — so deterministic log output cannot
+      // rely on declaration order.
+      const kafkaTool = stubWithPredicate(disabledForKafka);
+      const flinkTool = stubWithPredicate(disabledForFlink);
+      const runtime = runtimeWith({}, "zeta");
+      (
+        runtime.config.connections as Record<
+          string,
+          (typeof runtime.config.connections)[string]
+        >
+      )["alpha"] = {
+        type: "direct",
+        schema_registry: { endpoint: "http://sr-alpha" },
+      };
+
+      const groups = groupDisabledToolsByReason(
+        [
+          [ToolName.LIST_TOPICS, kafkaTool],
+          [ToolName.LIST_FLINK_STATEMENTS, flinkTool],
+        ],
+        runtime,
+      );
+
+      expect(groups.map((g) => [g.connectionId, g.reason] as const)).toEqual([
+        ["alpha", ToolDisabledReason.MissingKafkaBlock],
+        ["alpha", ToolDisabledReason.MissingFlinkBlock],
+        ["zeta", ToolDisabledReason.MissingKafkaBlock],
+        ["zeta", ToolDisabledReason.MissingFlinkBlock],
+      ]);
+    });
+  });
+});

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -32,20 +32,25 @@ export function groupDisabledToolsByReason(
   const groups = new Map<string, DisabledToolGroup>();
   for (const [toolName, handler] of handlers) {
     const verdicts = handler.connectionVerdicts(runtime);
-    const fullyDisabled = Array.from(verdicts.values()).every(
-      (v) => !v.enabled,
-    );
-    if (!fullyDisabled) continue;
+    // Single pass over the verdicts: collect disabled entries, abort on
+    // the first enabled one (the tool is partially-enabled and doesn't
+    // belong in a disabled-tool group).
+    const disabledEntries: Array<readonly [string, ToolDisabledReason]> = [];
+    let partiallyEnabled = false;
     for (const [connectionId, verdict] of verdicts) {
-      if (verdict.enabled) continue;
-      const key = `${connectionId}::${verdict.reason}`;
+      if (verdict.enabled) {
+        partiallyEnabled = true;
+        break;
+      }
+      disabledEntries.push([connectionId, verdict.reason]);
+    }
+    if (partiallyEnabled) continue;
+
+    for (const [connectionId, reason] of disabledEntries) {
+      const key = `${connectionId}::${reason}`;
       let group = groups.get(key);
       if (!group) {
-        group = {
-          connectionId,
-          reason: verdict.reason,
-          toolNames: [],
-        };
+        group = { connectionId, reason, toolNames: [] };
         groups.set(key, group);
       }
       group.toolNames.push(toolName);

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -1,0 +1,57 @@
+import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
+
+/**
+ * One bucket of tools that all share the same `(connectionId, reason)` pair —
+ * the unit of one log line at startup and one row in the `describe-tool-
+ * availability` diagnostic surface. `toolNames` preserves the order tools
+ * appeared in the input iterable.
+ */
+export interface DisabledToolGroup {
+  readonly connectionId: string;
+  readonly reason: ToolDisabledReason;
+  readonly toolNames: ToolName[];
+}
+
+/**
+ * Group fully-disabled tools by `(connectionId, reason)`. A tool is "fully
+ * disabled" when every configured connection reports a non-enabled verdict;
+ * tools enabled on at least one connection are omitted entirely (they are
+ * already going to be advertised by the server, so they don't belong in a
+ * disabled-tool log line).
+ *
+ * Returned groups are sorted lexicographically by `connectionId`. Stable
+ * sort preserves the relative order of groups within the same connection.
+ */
+export function groupDisabledToolsByReason(
+  handlers: Iterable<readonly [ToolName, ToolHandler]>,
+  runtime: ServerRuntime,
+): DisabledToolGroup[] {
+  const groups = new Map<string, DisabledToolGroup>();
+  for (const [toolName, handler] of handlers) {
+    const verdicts = handler.connectionVerdicts(runtime);
+    const fullyDisabled = Array.from(verdicts.values()).every(
+      (v) => !v.enabled,
+    );
+    if (!fullyDisabled) continue;
+    for (const [connectionId, verdict] of verdicts) {
+      if (verdict.enabled) continue;
+      const key = `${connectionId}::${verdict.reason}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = {
+          connectionId,
+          reason: verdict.reason,
+          toolNames: [],
+        };
+        groups.set(key, group);
+      }
+      group.toolNames.push(toolName);
+    }
+  }
+  return Array.from(groups.values()).sort((a, b) =>
+    a.connectionId.localeCompare(b.connectionId),
+  );
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   outputApiKey,
   outputToolList,
 } from "@src/index.js";
+import { logger } from "@src/logger.js";
 import { runtimeWith } from "@tests/factories/runtime.js";
 import { StubHandler } from "@tests/stubs/index.js";
 import {
@@ -17,6 +18,14 @@ import {
   type MockInstance,
   vi,
 } from "vitest";
+
+/**
+ * Capture-and-mute logger.warn so test assertions can pin grouped warning
+ * format without polluting test output.
+ */
+function spyOnLoggerWarn(): MockInstance<typeof logger.warn> {
+  return vi.spyOn(logger, "warn").mockImplementation((() => {}) as never);
+}
 
 describe("index.ts", () => {
   let consoleLog: MockInstance<typeof console.log>;
@@ -156,6 +165,36 @@ describe("index.ts", () => {
 
       expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
       expect(result.has(ToolName.CREATE_TOPICS)).toBe(false);
+    });
+
+    it("should emit one grouped warn per (connectionId, reason) for fully-disabled tools", () => {
+      const warnSpy = spyOnLoggerWarn();
+      vi.spyOn(ToolHandlerRegistry, "getToolHandler").mockImplementation(
+        (name) => {
+          if (name === ToolName.LIST_TOPICS) return new StubHandler();
+          // Both disabled-stub tools share the same arbitrary reason
+          // (`MissingFlinkBlock`), so they should collapse into a single
+          // grouped warn line listing both names.
+          return new StubHandler({ enabled: false });
+        },
+      );
+
+      getToolHandlersToRegister(
+        [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS, ToolName.DELETE_TOPICS],
+        runtimeWith(),
+      );
+
+      const warningMessages = warnSpy.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (msg): msg is string =>
+            typeof msg === "string" && msg.startsWith("Tools disabled"),
+        );
+
+      expect(warningMessages).toHaveLength(1);
+      expect(warningMessages[0]).toBe(
+        `Tools disabled on connection 'default' — no 'flink' block in connection config: ${ToolName.CREATE_TOPICS}, ${ToolName.DELETE_TOPICS}`,
+      );
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from "@src/config/index.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { groupDisabledToolsByReason } from "@src/confluent/tools/tool-availability.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
@@ -33,15 +34,20 @@ export function getToolHandlersToRegister(
   const toolHandlers = new Map<ToolName, ToolHandler>();
   const knownIds = new Set(Object.keys(runtime.config.connections));
 
-  Object.values(ToolName).forEach((toolName) => {
-    // Skip names that are not in the filtered list of tool names provided.
+  // Pass 1: drop tools excluded by the allow/block list (logged per-tool —
+  // the reason is config-driven, not predicate-driven, so it doesn't fold
+  // into the grouped warning emitted later).
+  const candidates: Array<readonly [ToolName, ToolHandler]> = [];
+  for (const toolName of Object.values(ToolName)) {
     if (!filteredToolNames.includes(toolName)) {
       logger.warn(`Tool ${toolName} disabled due to allow/block list rules`);
-      return;
+      continue;
     }
+    candidates.push([toolName, ToolHandlerRegistry.getToolHandler(toolName)]);
+  }
 
-    const handler = ToolHandlerRegistry.getToolHandler(toolName);
-
+  // Pass 2: register tools that are enabled on at least one connection.
+  for (const [toolName, handler] of candidates) {
     const enabledIds = handler.enabledConnectionIds(runtime);
     const unknownIds = enabledIds.filter((id) => !knownIds.has(id));
     if (unknownIds.length > 0) {
@@ -52,12 +58,18 @@ export function getToolHandlersToRegister(
     if (enabledIds.length > 0) {
       toolHandlers.set(toolName, handler);
       logger.info(`Tool ${toolName} enabled`);
-    } else {
-      logger.warn(
-        `Tool ${toolName} disabled; no connections satisfy its requirements`,
-      );
     }
-  });
+  }
+
+  // Pass 3: emit one grouped warning per (connectionId, reason) for tools
+  // that are fully disabled — readers see the missing config piece and the
+  // list of all tools blocked by it in a single line, rather than one
+  // line per tool.
+  for (const group of groupDisabledToolsByReason(candidates, runtime)) {
+    logger.warn(
+      `Tools disabled on connection '${group.connectionId}' — ${group.reason}: ${group.toolNames.join(", ")}`,
+    );
+  }
 
   // Raise an error if no tools are enabled, as the server would be non-functional without any tools.
   if (toolHandlers.size === 0) {

--- a/tests/stubs/stub-handler.ts
+++ b/tests/stubs/stub-handler.ts
@@ -4,20 +4,33 @@ import {
   READ_ONLY,
   type ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
+import {
+  ConnectionPredicate,
+  ToolDisabledReason,
+  alwaysEnabled,
+} from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import type { ServerRuntime } from "@src/server-runtime.js";
 
 /**
  * Minimal concrete BaseToolHandler for use in tests.
- * Pass `enabled = false` to simulate a handler that disables itself for all connections.
- * Uses ToolName.LIST_TOPICS as a placeholder — any declared ToolName would do.
+ * Pass `enabled = false` to simulate a handler that disables itself for all
+ * connections. The disabled-state reason is an arbitrary placeholder
+ * (`MissingFlinkBlock`); tests check whether the tool is filtered out, not
+ * which reason was reported. Uses ToolName.LIST_TOPICS as a placeholder —
+ * any declared ToolName would do.
  */
 export class StubHandler extends BaseToolHandler {
-  private readonly enabled: boolean;
+  readonly predicate: ConnectionPredicate;
 
   constructor({ enabled = true }: { enabled?: boolean } = {}) {
     super();
-    this.enabled = enabled;
+    this.predicate = enabled
+      ? alwaysEnabled
+      : () => ({
+          enabled: false,
+          reason: ToolDisabledReason.MissingFlinkBlock,
+        });
   }
 
   getToolConfig(): ToolConfig {
@@ -35,9 +48,5 @@ export class StubHandler extends BaseToolHandler {
     _sessionId?: string,
   ): CallToolResult {
     return this.createResponse("stub");
-  }
-
-  enabledConnectionIds(runtime: ServerRuntime): string[] {
-    return this.enabled ? Object.keys(runtime.config.connections) : [];
   }
 }


### PR DESCRIPTION
## Handler `predicate` property

- Adds `abstract readonly predicate: ConnectionPredicate` to `BaseToolHandler` and makes `enabledConnectionIds()` and `connectionVerdicts()` concrete on the base — both methods do a single pass over `runtime.config.connections` against `this.predicate`, no extra indirection. Every handler now declares only its predicate; the coordination between predicate and the rest of the enabled-connection machinery lives in one place. 29 handler files transitioned: 26 leaf handlers each lost a 3-line override (most now read as a bare `readonly predicate = hasXxx;` line; the five native-Kafka leaves wrap with `widenForOAuth(hasKafkaBootstrap)` and the two compound leaves use `override readonly predicate = allOf(...)` — see next bullet), and the three domain bases (`FlinkToolHandler`, `TableflowToolHandler`, `ConnectToolHandler`) lost their predicate-bound override too.
- The two compound-predicate handlers from #356 (`CreateConnectorHandler`, `QueryProfilerHandler`) declare their predicates as `allOf(...)` rather than overriding methods. The unsafe raw-`&&` shape is now structurally unreachable: there's no method to override with bad boolean composition because the API surface is "name your predicate," not "compute your enabled-set."
- Adds `alwaysEnabled: ConnectionPredicate` to `connection-predicates.ts` for the no-domain-requirement case (`SearchProductDocsHandler`). Reads as exactly what it does at the use site: `readonly predicate = alwaysEnabled;`. Replaces the previous bespoke `Object.keys(runtime.config.connections)` branch.
- Adds `connectionVerdicts` to the `ToolHandler` interface so external consumers (the diagnostic-tool work in #358) can call it without a `BaseToolHandler` cast.

## Helper inlining + `@final` JSDoc

- Deleted `connectionIdsWhere` and `connectionReasonsWhere` from `connection-predicates.ts`. Both were single-consumer thin wrappers around language primitives — `Object.entries(…).filter(…).map(…)` in one, `new Map(Object.entries(…).map(…))` in the other — and their only callers were the matching `BaseToolHandler` methods. Inlined into those methods directly; the seven helper-isolation tests went with the helpers (3 for `connectionIdsWhere`, 4 for `connectionReasonsWhere`). Predicate-derived behavior stays covered by 4 cases in `base-tools.test.ts` plus the 43 handler unit-test files that already exercise `enabledConnectionIds(runtime)` end-to-end. The `connection-predicates.ts` API surface is now strictly the predicate library: predicates, `allOf`, `alwaysEnabled`. No iteration helpers.
- Marked `enabledConnectionIds` and `connectionVerdicts` `@final` in JSDoc with a one-line "subclasses must not override" rationale. TypeScript has no native `final` keyword; the tag is documentation-grade enforcement layered on top of the structural mitigation — subclasses have no reason to override because the `predicate` property is the customization seam, and overriding the methods would let `enabledConnectionIds` and `connectionVerdicts` disagree about which connections a tool is enabled on.

## Grouped startup logging

- Replaces the per-tool "Tool X disabled; no connections satisfy its requirements" warn with a grouped warn keyed on `(connectionId, reason)`. New shape: `Tools disabled on connection 'default' — no 'flink' block in connection config: list-flink-statements, create-flink-statement, …`. One log line per missing config piece, listing every tool blocked by it, instead of N copies of "X disabled" with no diagnostic content. Per-tool _enabled_ info logs and the allow/block-list per-tool warns stay as-is — those reasons aren't predicate-driven.
- Introduces `groupDisabledToolsByReason(handlers, runtime): DisabledToolGroup[]` in a new `tool-availability.ts` module. Pure function — takes an iterable of `(ToolName, ToolHandler)` pairs and a runtime, returns groups ordered lexicographically by `connectionId` (deterministic, engine-independent — JS plain-object iteration order is not a portable invariant for `Record<string, …>` because integer-like keys get reordered numerically). A tool is included only when it's "fully disabled" (every connection's verdict is non-enabled); tools enabled on at least one connection are omitted entirely so users don't see noise about tools that are actually working. Unit-tested with seven cases covering empty input, all-enabled, single-disabled, same-reason collapse, different-reasons split, the partially-enabled omission rule, and lexicographic-order pinning across connections inserted in non-alphabetical order.
- Issue #357 named `ServerRuntime.fromConfig()` as the host for the new logging, but `ServerRuntime` doesn't currently know about tools or the registry. Logging stayed in `index.ts`'s `getToolHandlersToRegister()` where both runtime and registry are already at hand, keeping `ServerRuntime` tool-agnostic. Confirmed with James before doing it this way.

## Composition with `widenForOAuth` (post-merge with #359)

- After merging #359, the five native-Kafka handlers (`consume`, `create-topics`, `delete-topics`, `list-topics`, `produce`) declare `readonly predicate = widenForOAuth(hasKafkaBootstrap);`. The combinator from #359 plugs into the property-API with no special-casing — `widenForOAuth` is just another `(predicate) => predicate` factory, and the base class derives `enabledConnectionIds()` and `connectionVerdicts()` from whatever predicate the handler names. The five OAuth-typed `enabledConnectionIds()` test cases #359 added (one per kafka handler) stay green against the property-API implementation, confirming the seam composes correctly.
- The file-header OAuth note in `connection-predicates.ts` was tightened to reference `widenForOAuth` as the canonical mechanism for OAuth-capable handlers (alongside `hasConfluentCloud`'s built-in OAuth pass), replacing the "predicates widen on a case-by-case basis" hand-wave.

### Try it locally

After `npm run build`, point the server at any fixture in `test-fixtures/yaml_configs/valid/` to see the new grouped-by-reason warns:

```bash
node dist/index.js -c <fixture-path> </dev/null 2>&1 \
  | grep -E '"Tools disabled|tool\(s\) enabled"'
```

The `</dev/null` closes stdio so the server shuts down once startup is done; the `grep` keeps just the grouped warns plus the final "N tool(s) enabled" summary.

Sample fixtures to try, each producing a different mix of enabled vs grouped-disabled output:

- `valid/kafka-only.yaml` — six tools enabled (native-Kafka group + `search-product-docs`); one grouped warn per missing-block reason for flink/ccloud/sr/tableflow/telemetry, plus `'kafka' block does not have 'rest_endpoint' field` covering the two kafka REST tools.
- `valid/flink-with-required-fields.yaml` — only flink + `search-product-docs` enabled; every other domain grouped under its own missing-block reason.
- `valid/ccloud-and-flink-with-auth.yaml` — flink + the ccloud REST tools enabled; kafka/sr/tableflow/telemetry grouped.
- A two-connection custom fixture (drop one in `/tmp/`) to see two parallel grouped warns, each keyed on its own `connectionId` — confirms the `(connectionId, reason)` grouping isn't collapsing across connections.

or human-readable output rather than JSON envelopes, prefilter to JSON lines and pipe through `jq`:

```bash
node dist/index.js -c <fixture-path> </dev/null 2>&1 \
  | grep '^{' \
  | jq -r 'select(.msg | startswith("Tools disabled")) | .msg'
```

For example:
```bash
$ node dist/index.js -c test-fixtures/yaml_configs/valid/ccloud-with-auth.yaml </dev/null 2>&1   | grep '^{' | jq -r 'select(.msg | startswith
("Tools disabled")) | .msg'
Tools disabled on connection 'production' — no 'kafka' block in connection config: list-topics, create-topics, delete-topics, produce-message, consume-messages, create-connector, alter-topic-config, get-topic-config
Tools disabled on connection 'production' — no 'flink' block in connection config: list-flink-statements, create-flink-statement, read-flink-statement, delete-flink-statements, get-flink-statement-exceptions, list-flink-catalogs, list-flink-databases, list-flink-tables, describe-flink-table, get-flink-table-info, check-flink-statement-health, detect-flink-statement-issues, get-flink-statement-profile
Tools disabled on connection 'production' — no 'schema_registry' block in connection config: search-topics-by-tag, search-topics-by-name, create-topic-tags, delete-tag, remove-tag-from-entity, add-tags-to-topic, list-tags, list-schemas, delete-schema
Tools disabled on connection 'production' — no 'tableflow' block in connection config: create-tableflow-topic, list-tableflow-regions, list-tableflow-topics, read-tableflow-topic, update-tableflow-topic, delete-tableflow-topic, create-tableflow-catalog-integration, list-tableflow-catalog-integrations, read-tableflow-catalog-integration, update-tableflow-catalog-integration, delete-tableflow-catalog-integration
```

## Test coverage

- Existing handler tests assert on `enabledConnectionIds(runtime)` outcomes — those keep passing untouched, confirming the refactor preserved behavior across all 26 leaves and 3 domain bases.
- New `BaseToolHandler` tests pin the predicate-derived behavior directly: `enabledConnectionIds()` and `connectionVerdicts()` against an enabled stub and a disabled stub.
- New `groupDisabledToolsByReason()` tests cover the seven cases above; new `getToolHandlersToRegister` test asserts the exact grouped-warn message format (collapses two same-reason tools into one log line).

### Followup: per-handler test slim-down (three-PR sequence, out of scope here)

With `predicate` as the sole customization seam and `enabledConnectionIds`/`connectionVerdicts` derived on the base class, the per-handler `enabledConnectionIds(runtime)` cases now duplicate coverage that already lives at two stronger levels: `base-tools.test.ts` pins the derivation exactly once, and `connection-predicates.test.ts` pins each predicate's verdict exhaustively. What remains for a per-handler test to prove is just "the right predicate is wired."

Leaving the existing handler tests in place rather than churn the ~43 unit test files alongside the refactor itself. The followup sequence (three PRs total, issues filed):

1. **Predicate library completion (#389, one PR).** Promote each unique composed predicate to a named export in `connection-predicates.ts` with a one-line intent docstring and focused predicate-level tests. Concrete examples: `widenForOAuth(hasKafkaBootstrap)` (shared by the five native-Kafka handlers from #359) becomes a named const; `allOf(...)` compositions used by `CreateConnectorHandler` and `QueryProfilerHandler` (from #356) get named too. After this PR every handler's `predicate` property is a bare named-export reference.
2. **Handler test slim-down (#390, one mechanical PR sweeping all 13 domains).** Replace each handler's `describe("enabledConnectionIds()")` block with a single `expect(handler.predicate).toBe(theNamedPredicate)` identity assertion across `billing, catalog, clusters, connect, docs, environments, flink, kafka, metrics, organizations, schema, search, tableflow`. `getToolConfig()` and `handle()` tests stay untouched. The work is uniformly mechanical — the same edit pattern repeated across every handler test file, the redundancy itself the asset — so a single PR lets a reviewer verify the pattern once and `grep` the diff to confirm ~26 identical repetitions. Splitting into 13 per-domain PRs would add review-cycle overhead with no per-PR insight value.
3. **Cleanup pass (#391, one PR).** Audit `tests/factories/runtime.ts` for fixture factories whose only remaining consumers were the deleted handler tests; fold or delete. Re-ask whether `enabledConnectionIds` and `connectionVerdicts` still need to be on the public `ToolHandler` interface — startup-logging and the `describe-tool-availability` consumer (#358) probably keep them load-bearing, but worth checking once the per-handler call sites are gone.

The deliberate choice here is **identity-based wiring tests across the board** rather than a mix of identity (for bare predicates) and behavioral (for composed ones). Promoting compositions to named exports makes the predicate library a complete catalog of "valid tool gates," reads better at the use site than re-decoding `widenForOAuth(hasKafkaBootstrap)` inline, and keeps the per-handler test shape uniform.

## Relationships

- Closes #357
- Builds on #356 (predicate-verdict types + `allOf` combinator)
- Unblocks #358 (the `describe-tool-availability` MCP tool) — that PR can now call `handler.connectionVerdicts(runtime)` from any consumer that holds a `ToolHandler` reference.
- Spawns #389 → #390 → #391 — the three-PR followup chain detailed under `## Test coverage` above.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
