### PR TITLE
chore: add integration tests for `flink` tool handlers

### DIFF
--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -171,7 +171,6 @@ describe("my-handler", { tags: [Tag.KAFKA] }, () => {
         name: ToolName.MY_TOOL,
         arguments: {},
       });
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(/expected prefix/);
     });
   });
@@ -204,6 +203,33 @@ text content into structured data, run the tool once with
 the parser against that. Remove the diagnostic before commit. (E.g.
 `list-flink-databases` emits Flink SQL row payloads of shape
 `{ row: [...] }`, not column-named objects.)
+
+### When to assert `isError` explicitly
+
+**Skip the explicit `isError` check by default.** When the next assertion is
+`expect(textContent(result)).toMatch/toContain/toBe(...)`, the matcher's
+failure output already shows `received: "<actual error text>"`, because
+errors and successes share the same text content block
+(`BaseToolHandler.createResponse(msg, true)` puts the error message in
+`content[0].text`). A separate `expect(result.isError).not.toBe(true)` line
+adds noise without surfacing anything new.
+
+Reach for an explicit check only when the next assertion would shadow or
+destroy the error text:
+
+- The next assertion polls a separate resource (e.g.
+  `expect.poll(() => admin.listTopics()).toContain(topic)`). The handler's
+  error never reaches that matcher, so a failed call silently times out.
+- The next step parses the response (e.g.
+  `JSON.parse(textContent(result))`). A non-JSON error body throws a cryptic
+  `SyntaxError` with no original message.
+
+For those cases, use vitest's inline `expect(value, message)` form so the
+error text rides along with the failure (no helper needed):
+
+```ts
+expect(result.isError, textContent(result)).not.toBe(true);
+```
 
 ## Skip Pattern for Missing Credentials
 

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -196,6 +196,15 @@ expect(textContent(result)).toMatch(/^Kafka topics:/);
 practice the helper returns that block's text. For typed payloads, prefer
 `result.structuredContent` when the handler sets `_meta` via its third arg.
 
+**Verify response shape before writing a parser.** Handlers often
+re-stringify external API payloads verbatim, and the on-the-wire shape can
+differ from what the handler's source suggests. When a test needs to parse
+text content into structured data, run the tool once with
+`console.error(textContent(result))` to capture the actual shape, then write
+the parser against that. Remove the diagnostic before commit. (E.g.
+`list-flink-databases` emits Flink SQL row payloads of shape
+`{ row: [...] }`, not column-named objects.)
+
 ## Skip Pattern for Missing Credentials
 
 Do **NOT** use `describe.skipIf(!hasCreds)`. In vitest 4 it marks tests as
@@ -205,6 +214,28 @@ harness's server spawn then hits the hook timeout.
 
 Use the early-return pattern shown above: a plain `if (!hasCreds) { it.skip(reason); return; }` at the top of the describe body. The placeholder
 `it.skip()` keeps the file visible in vitest reports with a clear reason line.
+
+### Runtime preconditions vs file-load gates
+
+The skip above runs at file-load time against the parsed YAML. Some
+preconditions can only be evaluated _after_ the MCP server starts (e.g.,
+"the configured kafka cluster is catalogued in the Flink workspace" requires
+calling a tool to find out). Two options for those:
+
+- **Assertion (preferred when the precondition is supposed to hold).** Inline
+  `expect(value, "<actionable message>").toBeDefined()` (or
+  `.not.toBe(true)`, etc.) so a CI failure points at the env regression that
+  needs fixing. The custom message is the second arg to `expect`, not the
+  matcher.
+- **`ctx.skip(reason)` (only when the precondition genuinely may not hold).**
+  In vitest 4, `it("...", async (ctx) => { if (...) ctx.skip(...); ... })`
+  is the canonical mid-test skip. Use this only when "skipped" is a
+  legitimate outcome, not as a way to swallow a real failure. Silent green
+  on a broken env is exactly the failure mode this project warns against.
+
+When in doubt, prefer the assertion: an actionable failure message that
+names what to fix is more valuable than a green test run that hides the
+problem.
 
 ## Credential Gating by Tool Domain
 

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -446,9 +446,15 @@ Schema Registry, Flink, Tableflow):
   specific fields (URLs, status codes, IDs) rather than whole object bindings,
   and never pass `process.env` or a full config object to a logger or
   `console.*` call.
-- **Don't call `createClient<paths>(...)` directly in test code**: route
-  every test-side CCloud REST call through `newTestCloudClient()` in
-  `tests/harness/confluent-cloud.ts`. That factory wraps the client with
-  the 429-retry middleware. A new harness helper that builds its own client
-  silently bypasses retry coverage; full-suite runs already push CCloud's
-  per-account quota close to its limit.
+- **Don't build a `Client<paths>` without installing the 429-retry middleware**:
+  every test-side openapi-fetch `Client<paths>` (whether in a test file or
+  inside a harness helper) must call
+  `client.use(createRetryOn429Middleware())` (from
+  `@tests/harness/retry-on-429.js`) before being used. The existing factories
+  under `tests/harness/` already do this; reuse them, or use the higher-level
+  helpers built on top of them, instead of calling `createClient` directly.
+  A new harness helper on a different host or with different creds must
+  mirror the same `client.use(...)` line. A client built without the
+  middleware silently bypasses retry coverage; full-suite runs already push
+  CCloud's per-account quota close to its limit, and provision/teardown
+  traffic compounds across files × transports × the matrix.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,7 +61,7 @@ promotions:
       env_vars:
         - name: TOOL_GROUPS
           description: "Pipe-separated vitest tags to run (e.g. @kafka|@schema)"
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics"
+          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink"
           required: true
         - name: TRANSPORTS
           description: "Pipe-separated MCP transports (stdio|http|sse)"

--- a/service.yml
+++ b/service.yml
@@ -57,7 +57,7 @@ semaphore:
       parameters:
         - name: TOOL_GROUPS
           required: true
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics"
+          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink"
           description: 'Pipe-separated tool-group tags to test.'
         - name: TRANSPORTS
           required: true

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.integration.test.ts
@@ -50,7 +50,6 @@ describe("list-clusters-handler", { tags: [Tag.CLUSTERS] }, () => {
         arguments: { environmentId },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(
         /^Successfully retrieved [1-9]\d* clusters:/,
       );

--- a/src/confluent/tools/handlers/connect/create-connector-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.integration.test.ts
@@ -54,7 +54,6 @@ describe("create-connector-handler", { tags: [Tag.CONNECT] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toContain(`${connectorName} created:`);
     });
   });

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.integration.test.ts
@@ -48,7 +48,6 @@ describe("delete-connector-handler", { tags: [Tag.CONNECT] }, () => {
         arguments: { connectorName },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toBe(
         `Successfully deleted connector ${connectorName}`,
       );

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.integration.test.ts
@@ -43,7 +43,6 @@ describe("list-connectors-handler", { tags: [Tag.CONNECT] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(/^Active Connectors:/);
     });
   });

--- a/src/confluent/tools/handlers/connect/read-connectors-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/read-connectors-handler.integration.test.ts
@@ -59,7 +59,6 @@ describe("read-connector-handler", { tags: [Tag.CONNECT] }, () => {
         arguments: { connectorName },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toContain(
         `Connector Details for ${connectorName}:`,
       );

--- a/src/confluent/tools/handlers/environments/list-environments-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.integration.test.ts
@@ -43,7 +43,6 @@ describe("list-environments-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       // handler's success line starts with "Successfully retrieved N environments:"
       expect(textContent(result)).toMatch(
         /^Successfully retrieved \d+ environments:/,

--- a/src/confluent/tools/handlers/environments/read-environment-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.integration.test.ts
@@ -50,7 +50,6 @@ describe("read-environment-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
         arguments: { environmentId },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toContain(`ID: ${environmentId}`);
     });
   });

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
@@ -1,0 +1,53 @@
+import { DescribeTableHandler } from "@src/confluent/tools/handlers/flink/catalog/describe-table-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new DescribeTableHandler();
+const runtime = integrationRuntime();
+
+describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose describe-flink-table in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.DESCRIBE_FLINK_TABLE),
+      ).toBeDefined();
+    });
+
+    // INFORMATION_SCHEMA.CATALOGS is Flink-managed and present in every workspace, so we don't need
+    // to set up any tables/topics
+    it("should return the schema for the INFORMATION_SCHEMA.CATALOGS meta-table", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.DESCRIBE_FLINK_TABLE,
+        arguments: { tableName: "CATALOGS" },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toMatch(/^Table 'CATALOGS' schema:/);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
@@ -1,5 +1,10 @@
 import { DescribeTableHandler } from "@src/confluent/tools/handlers/flink/catalog/describe-table-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { findFriendlySchemaName } from "@tests/harness/flink.js";
+import {
+  getTestClusterId,
+  withSharedAdminClient,
+} from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -7,6 +12,7 @@ import {
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -18,6 +24,17 @@ describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
     it.skip("requires flink config", () => {});
     return;
   }
+
+  // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
+  const { admin, createdTopics } = withSharedAdminClient();
+  const tableName = uniqueName("flink-tbl");
+
+  beforeAll(async () => {
+    createdTopics.push(tableName);
+    await admin().createTopics({
+      topics: [{ topic: tableName, numPartitions: 1 }],
+    });
+  });
 
   describe.each(activeTransports)("via %s transport", (transport) => {
     let server: StartedServer;
@@ -38,16 +55,40 @@ describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
       ).toBeDefined();
     });
 
-    // INFORMATION_SCHEMA.CATALOGS is Flink-managed and present in every workspace, so we don't need
-    // to set up any tables/topics
-    it("should return the schema for the INFORMATION_SCHEMA.CATALOGS meta-table", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.DESCRIBE_FLINK_TABLE,
-        arguments: { tableName: "CATALOGS" },
+    it("should return the schema for the seeded kafka-backed table", async () => {
+      // catalog SQL filter uses TABLE_SCHEMA (friendly name), not the lkc-* id, so we need to
+      // resolve the friendly name via list-databases
+      const dbResult = await server.client.callTool({
+        name: ToolName.LIST_FLINK_DATABASES,
+        arguments: {},
       });
+      expect(
+        dbResult.isError,
+        `list-databases failed: ${textContent(dbResult)}`,
+      ).not.toBe(true);
+      const databaseName = findFriendlySchemaName(
+        textContent(dbResult),
+        getTestClusterId(),
+      );
+      expect(
+        databaseName,
+        `kafka cluster ${getTestClusterId()} not catalogued in Flink workspace. Verify flink.compute_pool_id is in the same region/provider as the kafka cluster (see test-fixtures/yaml_configs/integration.yaml).`,
+      ).toBeDefined();
 
-      expect(result.isError).not.toBe(true);
-      expect(textContent(result)).toMatch(/^Table 'CATALOGS' schema:/);
-    });
+      // CCloud may take a while to auto-discover kafka topics as Flink tables
+      await expect
+        .poll(
+          async () => {
+            const result = await server.client.callTool({
+              name: ToolName.DESCRIBE_FLINK_TABLE,
+              arguments: { tableName, databaseName },
+            });
+            if (result.isError === true) throw new Error(textContent(result));
+            return textContent(result);
+          },
+          { timeout: 90_000, interval: 5_000 },
+        )
+        .toContain(`Table '${tableName}' schema:`);
+    }, 120_000);
   });
 });

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
@@ -25,6 +25,18 @@ describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
     return;
   }
 
+  // also provisions a kafka topic and addresses it by cluster id, so gate
+  // explicitly on the kafka fields the flink predicate doesn't cover
+  const conn = runtime.config.getSoleDirectConnection();
+  if (
+    !conn.kafka?.bootstrap_servers ||
+    !conn.kafka.auth ||
+    !conn.kafka.cluster_id
+  ) {
+    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id config", () => {});
+    return;
+  }
+
   // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
   const { admin, createdTopics } = withSharedAdminClient();
   const tableName = uniqueName("flink-tbl");

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
@@ -25,6 +25,18 @@ describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
     return;
   }
 
+  // also provisions a kafka topic and addresses it by cluster id, so gate
+  // explicitly on the kafka fields the flink predicate doesn't cover
+  const conn = runtime.config.getSoleDirectConnection();
+  if (
+    !conn.kafka?.bootstrap_servers ||
+    !conn.kafka.auth ||
+    !conn.kafka.cluster_id
+  ) {
+    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id config", () => {});
+    return;
+  }
+
   // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
   const { admin, createdTopics } = withSharedAdminClient();
   const tableName = uniqueName("flink-tbl");

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
@@ -1,5 +1,10 @@
 import { GetTableInfoHandler } from "@src/confluent/tools/handlers/flink/catalog/get-table-info-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { findFriendlySchemaName } from "@tests/harness/flink.js";
+import {
+  getTestClusterId,
+  withSharedAdminClient,
+} from "@tests/harness/kafka-admin.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -7,6 +12,7 @@ import {
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -18,6 +24,17 @@ describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
     it.skip("requires flink config", () => {});
     return;
   }
+
+  // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
+  const { admin, createdTopics } = withSharedAdminClient();
+  const tableName = uniqueName("flink-tbl");
+
+  beforeAll(async () => {
+    createdTopics.push(tableName);
+    await admin().createTopics({
+      topics: [{ topic: tableName, numPartitions: 1 }],
+    });
+  });
 
   describe.each(activeTransports)("via %s transport", (transport) => {
     let server: StartedServer;
@@ -38,16 +55,40 @@ describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
       ).toBeDefined();
     });
 
-    // INFORMATION_SCHEMA.CATALOGS is Flink-managed and present in every workspace, so we don't need
-    // to set up any tables/topics
-    it("should return metadata for the INFORMATION_SCHEMA.CATALOGS meta-table", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.GET_FLINK_TABLE_INFO,
-        arguments: { tableName: "CATALOGS" },
+    it("should return metadata for the seeded kafka-backed table", async () => {
+      // catalog SQL filter uses TABLE_SCHEMA (friendly name), not the lkc-* id, so we need to
+      // resolve the friendly name via list-databases
+      const dbResult = await server.client.callTool({
+        name: ToolName.LIST_FLINK_DATABASES,
+        arguments: {},
       });
+      expect(
+        dbResult.isError,
+        `list-databases failed: ${textContent(dbResult)}`,
+      ).not.toBe(true);
+      const databaseName = findFriendlySchemaName(
+        textContent(dbResult),
+        getTestClusterId(),
+      );
+      expect(
+        databaseName,
+        `kafka cluster ${getTestClusterId()} not catalogued in Flink workspace. Verify flink.compute_pool_id is in the same region/provider as the kafka cluster (see test-fixtures/yaml_configs/integration.yaml).`,
+      ).toBeDefined();
 
-      expect(result.isError).not.toBe(true);
-      expect(textContent(result)).toMatch(/^Table info for 'CATALOGS':/);
-    });
+      // CCloud may take a while to auto-discover kafka topics as Flink tables
+      await expect
+        .poll(
+          async () => {
+            const result = await server.client.callTool({
+              name: ToolName.GET_FLINK_TABLE_INFO,
+              arguments: { tableName, databaseName },
+            });
+            if (result.isError === true) throw new Error(textContent(result));
+            return textContent(result);
+          },
+          { timeout: 90_000, interval: 5_000 },
+        )
+        .toContain(`Table info for '${tableName}':`);
+    }, 120_000);
   });
 });

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
@@ -1,0 +1,53 @@
+import { GetTableInfoHandler } from "@src/confluent/tools/handlers/flink/catalog/get-table-info-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new GetTableInfoHandler();
+const runtime = integrationRuntime();
+
+describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose get-flink-table-info in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.GET_FLINK_TABLE_INFO),
+      ).toBeDefined();
+    });
+
+    // INFORMATION_SCHEMA.CATALOGS is Flink-managed and present in every workspace, so we don't need
+    // to set up any tables/topics
+    it("should return metadata for the INFORMATION_SCHEMA.CATALOGS meta-table", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.GET_FLINK_TABLE_INFO,
+        arguments: { tableName: "CATALOGS" },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toMatch(/^Table info for 'CATALOGS':/);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
@@ -44,7 +44,6 @@ describe("list-catalogs-handler", { tags: [Tag.FLINK] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(/^Catalogs:/);
     });
   });

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
@@ -1,0 +1,51 @@
+import { ListCatalogsHandler } from "@src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListCatalogsHandler();
+const runtime = integrationRuntime();
+
+describe("list-catalogs-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-flink-catalogs in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.LIST_FLINK_CATALOGS),
+      ).toBeDefined();
+    });
+
+    it("should return at least the configured environment as a catalog", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_FLINK_CATALOGS,
+        arguments: {},
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toMatch(/^Catalogs:/);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
@@ -44,7 +44,6 @@ describe("list-databases-handler", { tags: [Tag.FLINK] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       // fresh test account may have no databases; either response shape is valid
       expect(textContent(result)).toMatch(/^(Databases:|No databases found)/);
     });

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
@@ -1,0 +1,52 @@
+import { ListDatabasesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-databases-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListDatabasesHandler();
+const runtime = integrationRuntime();
+
+describe("list-databases-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-flink-databases in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.LIST_FLINK_DATABASES),
+      ).toBeDefined();
+    });
+
+    it("should return databases for the configured catalog", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_FLINK_DATABASES,
+        arguments: {},
+      });
+
+      expect(result.isError).not.toBe(true);
+      // fresh test account may have no databases; either response shape is valid
+      expect(textContent(result)).toMatch(/^(Databases:|No databases found)/);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
@@ -1,0 +1,54 @@
+import { ListTablesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-tables-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListTablesHandler();
+const runtime = integrationRuntime();
+
+describe("list-tables-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-flink-tables in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.LIST_FLINK_TABLES),
+      ).toBeDefined();
+    });
+
+    it("should return tables (or the empty-set string) for the configured catalog", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_FLINK_TABLES,
+        arguments: {},
+      });
+
+      expect(result.isError).not.toBe(true);
+      // handler filters out INFORMATION_SCHEMA; a fresh env may have no user tables
+      expect(textContent(result)).toMatch(
+        /^(Tables in catalog|No tables found)/,
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
@@ -44,7 +44,6 @@ describe("list-tables-handler", { tags: [Tag.FLINK] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       // handler filters out INFORMATION_SCHEMA; a fresh env may have no user tables
       expect(textContent(result)).toMatch(
         /^(Tables in catalog|No tables found)/,

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.integration.test.ts
@@ -1,0 +1,63 @@
+import { CreateFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/create-flink-statement-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { withSharedFlinkStatementCleanup } from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new CreateFlinkStatementHandler();
+const runtime = integrationRuntime();
+
+describe("create-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (sweeps tool-created statements)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose create-flink-statement in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.CREATE_FLINK_STATEMENT),
+      ).toBeDefined();
+    });
+
+    it("should create a SELECT 1 statement", async () => {
+      const statementName = uniqueName("create-stmt");
+      createdStatements.push(statementName);
+
+      const result = await server.client.callTool({
+        name: ToolName.CREATE_FLINK_STATEMENT,
+        arguments: {
+          statementName,
+          statement: "SELECT 1;",
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      // just check for the name since the handler returns the stringified JSON response
+      expect(textContent(result)).toContain(`"name":"${statementName}"`);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.integration.test.ts
@@ -55,7 +55,6 @@ describe("create-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
       // just check for the name since the handler returns the stringified JSON response
       expect(textContent(result)).toContain(`"name":"${statementName}"`);
     });

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.integration.test.ts
@@ -1,0 +1,66 @@
+import { DeleteFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/delete-flink-statement-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new DeleteFlinkStatementHandler();
+const runtime = integrationRuntime();
+
+describe("delete-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (sweeps any leftover tracked statements)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose delete-flink-statements in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.DELETE_FLINK_STATEMENTS),
+      ).toBeDefined();
+    });
+
+    it("should delete a test-side provisioned statement", async () => {
+      const statementName = uniqueName("delete-stmt");
+      // track first so a failure mid-create still gets swept by afterAll
+      createdStatements.push(statementName);
+      await provisionTestFlinkStatement(statementName);
+
+      const result = await server.client.callTool({
+        name: ToolName.DELETE_FLINK_STATEMENTS,
+        arguments: { statementName },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toMatch(
+        /^Flink SQL Statement Deletion Status Code:/,
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.integration.test.ts
@@ -57,7 +57,6 @@ describe("delete-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
         arguments: { statementName },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(
         /^Flink SQL Statement Deletion Status Code:/,
       );

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.integration.test.ts
@@ -1,0 +1,67 @@
+import { CheckHealthHandler } from "@src/confluent/tools/handlers/flink/diagnostics/check-health-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new CheckHealthHandler();
+const runtime = integrationRuntime();
+
+describe("check-health-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (cleans up the seeded statement)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+  const statementName = uniqueName("health-stmt");
+
+  beforeAll(async () => {
+    await provisionTestFlinkStatement(statementName);
+    createdStatements.push(statementName);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose check-flink-statement-health in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.CHECK_FLINK_STATEMENT_HEALTH),
+      ).toBeDefined();
+    });
+
+    it("should return a health report for the seeded statement", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.CHECK_FLINK_STATEMENT_HEALTH,
+        arguments: { statementName },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toMatch(
+        new RegExp(`^Health check for '${statementName}':`),
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.integration.test.ts
@@ -58,7 +58,6 @@ describe("check-health-handler", { tags: [Tag.FLINK] }, () => {
         arguments: { statementName },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(
         new RegExp(`^Health check for '${statementName}':`),
       );

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.integration.test.ts
@@ -1,0 +1,71 @@
+import { DetectIssuesHandler } from "@src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new DetectIssuesHandler();
+const runtime = integrationRuntime();
+
+describe("detect-issues-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (cleans up the seeded statement)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+  const statementName = uniqueName("issues-stmt");
+
+  beforeAll(async () => {
+    await provisionTestFlinkStatement(statementName);
+    createdStatements.push(statementName);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose detect-flink-statement-issues in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.DETECT_FLINK_STATEMENT_ISSUES),
+      ).toBeDefined();
+    });
+
+    it("should return an issue report for the seeded statement", async () => {
+      // includeMetrics: false skips the Telemetry roundtrip
+      const result = await server.client.callTool({
+        name: ToolName.DETECT_FLINK_STATEMENT_ISSUES,
+        arguments: { statementName, includeMetrics: false },
+      });
+
+      expect(result.isError).not.toBe(true);
+      // SELECT 1 typically reports no issues; accept either response prefix.
+      expect(textContent(result)).toMatch(
+        new RegExp(
+          `(No issues detected|Detected \\d+ issue).*'${statementName}'`,
+        ),
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.integration.test.ts
@@ -59,7 +59,6 @@ describe("detect-issues-handler", { tags: [Tag.FLINK] }, () => {
         arguments: { statementName, includeMetrics: false },
       });
 
-      expect(result.isError).not.toBe(true);
       // SELECT 1 typically reports no issues; accept either response prefix.
       expect(textContent(result)).toMatch(
         new RegExp(

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
@@ -59,7 +59,6 @@ describe("query-profiler-handler", { tags: [Tag.FLINK] }, () => {
         arguments: { statementName, includeAnalysis: false },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(
         new RegExp(`^Query Profiler for '${statementName}':`),
       );

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
@@ -1,0 +1,68 @@
+import { QueryProfilerHandler } from "@src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new QueryProfilerHandler();
+const runtime = integrationRuntime();
+
+describe("query-profiler-handler", { tags: [Tag.FLINK] }, () => {
+  // composes hasFlink + hasTelemetry, stricter than the rest of the flink suite
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink + telemetry config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (cleans up the seeded statement)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+  const statementName = uniqueName("profile-stmt");
+
+  beforeAll(async () => {
+    await provisionTestFlinkStatement(statementName);
+    createdStatements.push(statementName);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose get-flink-statement-profile in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.GET_FLINK_STATEMENT_PROFILE),
+      ).toBeDefined();
+    });
+
+    it("should return a profiler report for the seeded statement", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.GET_FLINK_STATEMENT_PROFILE,
+        arguments: { statementName, includeAnalysis: false },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(textContent(result)).toMatch(
+        new RegExp(`^Query Profiler for '${statementName}':`),
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.integration.test.ts
@@ -58,7 +58,6 @@ describe("get-flink-exceptions-handler", { tags: [Tag.FLINK] }, () => {
         arguments: { statementName },
       });
 
-      expect(result.isError).not.toBe(true);
       // SELECT 1 typically completes cleanly, so accept either response shape
       expect(textContent(result)).toMatch(
         /^(No exceptions found|Flink Statement Exceptions)/,

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.integration.test.ts
@@ -1,0 +1,68 @@
+import { GetFlinkExceptionsHandler } from "@src/confluent/tools/handlers/flink/get-flink-exceptions-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new GetFlinkExceptionsHandler();
+const runtime = integrationRuntime();
+
+describe("get-flink-exceptions-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (cleans up the seeded statement)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+  const statementName = uniqueName("exc-stmt");
+
+  beforeAll(async () => {
+    await provisionTestFlinkStatement(statementName);
+    createdStatements.push(statementName);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose get-flink-statement-exceptions in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.GET_FLINK_STATEMENT_EXCEPTIONS),
+      ).toBeDefined();
+    });
+
+    it("should return either an empty or populated exceptions response", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.GET_FLINK_STATEMENT_EXCEPTIONS,
+        arguments: { statementName },
+      });
+
+      expect(result.isError).not.toBe(true);
+      // SELECT 1 typically completes cleanly, so accept either response shape
+      expect(textContent(result)).toMatch(
+        /^(No exceptions found|Flink Statement Exceptions)/,
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
@@ -1,0 +1,66 @@
+import { ListFlinkStatementsHandler } from "@src/confluent/tools/handlers/flink/list-flink-statements-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListFlinkStatementsHandler();
+const runtime = integrationRuntime();
+
+describe("list-flink-statements-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (tracks the seed statement for delete)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+  const seedName = uniqueName("list-stmts");
+
+  beforeAll(async () => {
+    await provisionTestFlinkStatement(seedName);
+    createdStatements.push(seedName);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-flink-statements in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.LIST_FLINK_STATEMENTS),
+      ).toBeDefined();
+    });
+
+    it("should return a JSON payload that includes the seeded statement", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_FLINK_STATEMENTS,
+        arguments: {},
+      });
+
+      expect(result.isError).not.toBe(true);
+      // handler stringifies the raw response, so just check that the statement name appears
+      expect(textContent(result)).toContain(seedName);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
@@ -58,7 +58,6 @@ describe("list-flink-statements-handler", { tags: [Tag.FLINK] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       // handler stringifies the raw response, so just check that the statement name appears
       expect(textContent(result)).toContain(seedName);
     });

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
@@ -53,13 +53,20 @@ describe("read-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
     });
 
     it("should read the seeded statement and return a results header", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.READ_FLINK_STATEMENT,
-        arguments: { statementName, timeoutInMilliseconds: 5000 },
-      });
-
-      // results header is emitted regardless of phase; SELECT 1 may still be PENDING.
-      expect(textContent(result)).toMatch(/^Flink SQL Statement Results:/);
+      // CCloud briefly returns 409 "Results not ready" between statement creation time and the time
+      // results are available
+      await expect
+        .poll(
+          async () => {
+            const result = await server.client.callTool({
+              name: ToolName.READ_FLINK_STATEMENT,
+              arguments: { statementName, timeoutInMilliseconds: 5000 },
+            });
+            return textContent(result);
+          },
+          { timeout: 30_000, interval: 2_000 },
+        )
+        .toMatch(/^Flink SQL Statement Results:/);
     });
   });
 });

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
@@ -1,0 +1,66 @@
+import { ReadFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/read-flink-statement-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  provisionTestFlinkStatement,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ReadFlinkStatementHandler();
+const runtime = integrationRuntime();
+
+describe("read-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires flink config", () => {});
+    return;
+  }
+
+  // installs afterAll at this describe scope (cleans up the seeded statement)
+  const { createdStatements } = withSharedFlinkStatementCleanup();
+  const statementName = uniqueName("read-stmt");
+
+  beforeAll(async () => {
+    await provisionTestFlinkStatement(statementName);
+    createdStatements.push(statementName);
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose read-flink-statement in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.READ_FLINK_STATEMENT),
+      ).toBeDefined();
+    });
+
+    it("should read the seeded statement and return a results header", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.READ_FLINK_STATEMENT,
+        arguments: { statementName, timeoutInMilliseconds: 5000 },
+      });
+
+      expect(result.isError).not.toBe(true);
+      // results header is emitted regardless of phase; SELECT 1 may still be PENDING.
+      expect(textContent(result)).toMatch(/^Flink SQL Statement Results:/);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
@@ -58,7 +58,6 @@ describe("read-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
         arguments: { statementName, timeoutInMilliseconds: 5000 },
       });
 
-      expect(result.isError).not.toBe(true);
       // results header is emitted regardless of phase; SELECT 1 may still be PENDING.
       expect(textContent(result)).toMatch(/^Flink SQL Statement Results:/);
     });

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
@@ -60,7 +60,6 @@ describe("alter-topic-config", { tags: [Tag.KAFKA] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toMatch(/Successfully altered topic config/);
     });
   });

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -75,8 +75,6 @@ describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
-
       const text = textContent(result);
       expect(text).toMatch(/^Consumed \d+ messages/);
       for (const value of seededValues) {

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
@@ -6,6 +6,7 @@ import {
   startServer,
   type StartedServer,
 } from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
@@ -45,7 +46,7 @@ describe("create-topics-handler", { tags: [Tag.KAFKA] }, () => {
         arguments: { topics: [{ topic, numPartitions: 1 }] },
       });
 
-      expect(result.isError).not.toBe(true);
+      expect(result.isError, textContent(result)).not.toBe(true);
 
       await expect
         .poll(() => admin().listTopics(), {

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
@@ -6,6 +6,7 @@ import {
   startServer,
   type StartedServer,
 } from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
 import { activeTransports } from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
@@ -51,7 +52,7 @@ describe("delete-topics-handler", { tags: [Tag.KAFKA] }, () => {
         arguments: { topicNames: [topic] },
       });
 
-      expect(result.isError).not.toBe(true);
+      expect(result.isError, textContent(result)).not.toBe(true);
 
       await expect
         .poll(() => admin().listTopics(), {

--- a/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
@@ -52,7 +52,6 @@ describe("get-topic-config", { tags: [Tag.KAFKA] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
       // handler embeds a JSON blob with both topicDetails and topicConfig
       const text = textContent(result);
       expect(text).toContain(`Topic configuration for '${topic}'`);

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.integration.test.ts
@@ -43,7 +43,6 @@ describe("list-topics-handler", { tags: [Tag.KAFKA] }, () => {
         arguments: {},
       });
 
-      expect(result.isError).not.toBe(true);
       // handler response is always prefixed with "Kafka topics:" whether the
       // cluster is empty or not, so this proves the tool ran end-to-end
       expect(textContent(result)).toMatch(/^Kafka topics:/);

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -58,7 +58,6 @@ describe("produce-kafka-message-handler", { tags: [Tag.KAFKA] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
       // handler formats each delivery report as:
       //   "Message produced successfully to [Topic: ..., Partition: ..., Offset: ...]"
       const text = textContent(result);

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
@@ -42,7 +42,6 @@ describe("list-metrics-handler", { tags: [Tag.METRICS] }, () => {
         arguments: { resource_type: "kafka" },
       });
 
-      expect(result.isError).not.toBe(true);
       const text = textContent(result);
       // received_bytes is a stable kafka.server metric, so finding it proves the end-to-end call
       // returned kafka data

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
@@ -49,7 +49,6 @@ describe("query-metrics-handler", { tags: [Tag.METRICS] }, () => {
         },
       });
 
-      expect(result.isError).not.toBe(true);
       // idle cluster may show "No data returned for metric"
       expect(textContent(result)).toMatch(
         /^(Metrics Query Results|No data returned for metric)/,

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
@@ -56,7 +56,6 @@ describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
         arguments: { subject },
       });
 
-      expect(result.isError).not.toBe(true);
       expect(textContent(result)).toContain(
         `Successfully deleted subject "${subject}"`,
       );

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
@@ -58,7 +58,7 @@ describe("list-schemas-handler", { tags: [Tag.SCHEMA] }, () => {
         arguments: { subjectPrefix: subject },
       });
 
-      expect(result.isError).not.toBe(true);
+      expect(result.isError, textContent(result)).not.toBe(true);
       // handler stringifies a `Record<subject, metadata>` map; the prefix filter narrows the
       // response to a single-key object
       const parsed = JSON.parse(textContent(result));

--- a/test-fixtures/yaml_configs/integration.yaml
+++ b/test-fixtures/yaml_configs/integration.yaml
@@ -59,6 +59,8 @@ connections:
         type: api_key
         key: "${FLINK_API_KEY}"
         secret: "${FLINK_API_SECRET}"
+      # any future updates to the configured Flink compute pool must ensure the associated cloud
+      # provider/region pair matches the cluster in the `kafka` block
       compute_pool_id: "lfcp-1gv99z"
       endpoint: "https://flink.us-east-2.aws.confluent.cloud"
       environment_id: "env-rw7g8k"

--- a/test-fixtures/yaml_configs/integration.yaml
+++ b/test-fixtures/yaml_configs/integration.yaml
@@ -52,3 +52,14 @@ connections:
         type: api_key
         key: "${TELEMETRY_API_KEY}"
         secret: "${TELEMETRY_API_SECRET}"
+
+    # --- @flink (Flink SQL + catalog/diagnostics) ---
+    flink:
+      auth:
+        type: api_key
+        key: "${FLINK_API_KEY}"
+        secret: "${FLINK_API_SECRET}"
+      compute_pool_id: "lfcp-jqd12q"
+      endpoint: "https://flink.us-east-1.aws.confluent.cloud"
+      environment_id: "env-rw7g8k"
+      organization_id: "683187f4-4132-484a-adf7-0553cea0a5e4"

--- a/test-fixtures/yaml_configs/integration.yaml
+++ b/test-fixtures/yaml_configs/integration.yaml
@@ -59,7 +59,7 @@ connections:
         type: api_key
         key: "${FLINK_API_KEY}"
         secret: "${FLINK_API_SECRET}"
-      compute_pool_id: "lfcp-jqd12q"
-      endpoint: "https://flink.us-east-1.aws.confluent.cloud"
+      compute_pool_id: "lfcp-1gv99z"
+      endpoint: "https://flink.us-east-2.aws.confluent.cloud"
       environment_id: "env-rw7g8k"
       organization_id: "683187f4-4132-484a-adf7-0553cea0a5e4"

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -123,3 +123,22 @@ export function withSharedFlinkStatementCleanup(): {
   });
   return { createdStatements };
 }
+
+/**
+ * Parses a list-databases response and returns the friendly SCHEMA_NAME for
+ * the given cluster id, or `undefined` if the cluster isn't catalogued in the
+ * Flink workspace. The friendly name is what TABLE_SCHEMA filters expect.
+ */
+export function findFriendlySchemaName(
+  listDatabasesText: string,
+  clusterId: string,
+): string | undefined {
+  const jsonStart = listDatabasesText.indexOf("[");
+  const jsonEnd = listDatabasesText.lastIndexOf("]");
+  if (jsonStart < 0 || jsonEnd < jsonStart) return undefined;
+  // handler emits raw Flink-SQL row payloads of shape `{ row: [SCHEMA_ID, SCHEMA_NAME] }`
+  const databases = JSON.parse(
+    listDatabasesText.slice(jsonStart, jsonEnd + 1),
+  ) as Array<{ row: [string, string] }>;
+  return databases.find((d) => d.row[0] === clusterId)?.row[1];
+}

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -1,4 +1,5 @@
 import type { paths } from "@src/confluent/openapi-schema.js";
+import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import createClient, { type Client } from "openapi-fetch";
 import { afterAll } from "vitest";
@@ -33,10 +34,14 @@ function newTestFlinkClient(scope: FlinkScope): Client<paths> {
   const basic = Buffer.from(`${scope.authKey}:${scope.authSecret}`).toString(
     "base64",
   );
-  return createClient<paths>({
+  const client = createClient<paths>({
     baseUrl: scope.endpoint,
     headers: { Authorization: `Basic ${basic}` },
   });
+  // smooths transient CCloud rate limiting during full-suite runs (provision/teardown across
+  // many flink test files compounds against the per-account quota)
+  client.use(createRetryOn429Middleware());
+  return client;
 }
 
 /**

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -1,0 +1,125 @@
+import type { paths } from "@src/confluent/openapi-schema.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import createClient, { type Client } from "openapi-fetch";
+import { afterAll } from "vitest";
+
+interface FlinkScope {
+  organizationId: string;
+  environmentId: string;
+  computePoolId: string;
+  endpoint: string;
+  authKey: string;
+  authSecret: string;
+}
+
+function getFlinkScope(): FlinkScope {
+  const conn = integrationRuntime().config.getSoleDirectConnection();
+  if (!conn.flink) {
+    throw new Error(
+      "test-side flink helpers require flink config in test-fixtures/yaml_configs/integration.yaml",
+    );
+  }
+  return {
+    organizationId: conn.flink.organization_id,
+    environmentId: conn.flink.environment_id,
+    computePoolId: conn.flink.compute_pool_id,
+    endpoint: conn.flink.endpoint,
+    authKey: conn.flink.auth.key,
+    authSecret: conn.flink.auth.secret,
+  };
+}
+
+function newTestFlinkClient(scope: FlinkScope): Client<paths> {
+  const basic = Buffer.from(`${scope.authKey}:${scope.authSecret}`).toString(
+    "base64",
+  );
+  return createClient<paths>({
+    baseUrl: scope.endpoint,
+    headers: { Authorization: `Basic ${basic}` },
+  });
+}
+
+/**
+ * Submits a Flink SQL statement (defaults to `SELECT 1`) and resolves once
+ * the POST returns. CCloud's submit returns immediately with phase PENDING;
+ * tests that just need the statement to exist (read, list, exceptions, health)
+ * can proceed without waiting for RUNNING.
+ */
+export async function provisionTestFlinkStatement(
+  name: string,
+  sql = "SELECT 1",
+): Promise<void> {
+  const scope = getFlinkScope();
+  const client = newTestFlinkClient(scope);
+  const { error } = await client.POST(
+    "/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements",
+    {
+      params: {
+        path: {
+          organization_id: scope.organizationId,
+          environment_id: scope.environmentId,
+        },
+      },
+      body: {
+        name,
+        organization_id: scope.organizationId,
+        environment_id: scope.environmentId,
+        spec: {
+          compute_pool_id: scope.computePoolId,
+          statement: sql,
+        },
+      },
+    },
+  );
+  if (error) {
+    throw new Error(
+      `failed to provision test flink statement ${name}: ${JSON.stringify(error)}`,
+    );
+  }
+}
+
+/**
+ * DELETE the named statement. Tolerates 404 silently because the
+ * delete-statement test deletes via the tool, so teardown's 404 isn't a real
+ * failure. Logs other failures to stderr; {@linkcode withSharedFlinkStatementCleanup}
+ * uses `Promise.allSettled`, so logging is the only path that surfaces them.
+ */
+export async function deleteTestFlinkStatement(name: string): Promise<void> {
+  const scope = getFlinkScope();
+  const client = newTestFlinkClient(scope);
+  const { error, response } = await client.DELETE(
+    "/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}",
+    {
+      params: {
+        path: {
+          organization_id: scope.organizationId,
+          environment_id: scope.environmentId,
+          statement_name: name,
+        },
+      },
+    },
+  );
+  if (error && response.status !== 404) {
+    console.error(
+      `failed to delete test flink statement ${name} (status ${response.status}): ${JSON.stringify(error)}`,
+    );
+  }
+}
+
+/**
+ * Registers an `afterAll` at the calling describe scope to delete any tracked
+ * statements. Tests push names onto `createdStatements` as they create them;
+ * the sweep is best-effort so a teardown failure can't fail an already-asserted
+ * test.
+ */
+export function withSharedFlinkStatementCleanup(): {
+  createdStatements: string[];
+} {
+  const createdStatements: string[] = [];
+  afterAll(async () => {
+    await Promise.allSettled(
+      createdStatements.map((n) => deleteTestFlinkStatement(n)),
+    );
+  });
+  return { createdStatements };
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Larger than the recent integration test PRs since this one breaks down into three sub-groups for the `@flink`-tagged handlers:
- statements
- diagnostics
- catalog

And of course we're updating the default `TOOL_GROUPS` param for CI:
<img width="645" height="712" alt="image" src="https://github.com/user-attachments/assets/04cf45e3-a46d-4cdb-af56-7f89a31ebacb" />

Closes #331

> [!NOTE]
> Lots of extra files changed here to remove `expect(result.isError).not.toBe(true);` since it was hurting more than helping. The happy-path result content for errors and regular responses still show up the same way via the base handler `createResponse`, so if we fall back to just asserting on the content of the response, we'll see error content for free.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
