### PR TITLE
Fix flake OAuth refresh test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ connector-config.json
 
 # GSD planning directory
 .planning
+
+# Worktree directories
+.worktrees/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,12 @@ export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { languageOptions: { globals: globals.browser } },
   {
-    ignores: ["dist/**", "src/confluent/openapi-schema.d.ts", "coverage/**"],
+    ignores: [
+      "dist/**",
+      "src/confluent/openapi-schema.d.ts",
+      "coverage/**",
+      ".worktrees/**",
+    ],
   },
   { files: ["scripts/**"], languageOptions: { globals: globals.node } },
   pluginJs.configs.recommended,

--- a/src/confluent/oauth/auth-context.test.ts
+++ b/src/confluent/oauth/auth-context.test.ts
@@ -1,6 +1,7 @@
 import { AuthContext } from "@src/confluent/oauth/auth-context.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 import {
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
   MAX_CONSECUTIVE_TRANSIENT_FAILURES,
   REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
   REFRESH_TOKEN_IDLE_LIFETIME_MS,
@@ -553,6 +554,13 @@ describe("oauth/auth-context.ts", () => {
       // real setTimeout. Install fake timers only after the login resolves.
       ctx = await newLoggedInContext(fetchSpy);
       vi.useFakeTimers();
+      // Re-stamp controlPlaneExpiresAt from the fake clock so the absolute
+      // timestamp and the loop's Date.now() share a baseline. Without this,
+      // drift between login (real clock) and useFakeTimers() install
+      // shortens the first scheduled fire by a few ms, making
+      // `advanceTimersByTimeAsync(FIRST_FIRE_MS - 1)` flakily trip the timer.
+      internals(ctx).controlPlaneExpiresAt =
+        Date.now() + CONTROL_PLANE_TOKEN_LIFETIME_MS;
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Re-stamp controlPlaneExpiresAt from the fake clock so the absolute timestamp and the loop's Date.now() share a baseline to prevent test flake
- Added `./worktrees` dir to `.gitignore` and `eslint.config.mjs`

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
