### PR TITLE
Lockdown tool predicates to known (tested) set.

### DIFF
--- a/.claude/rules/tool-handlers.md
+++ b/.claude/rules/tool-handlers.md
@@ -31,12 +31,11 @@ Every tool handler follows this pattern:
    - `handle(runtime, toolArguments, sessionId?)` → returns `Promise<CallToolResult>`.
    - `readonly predicate` (skip if you inherited it from a domain subclass) → a `ConnectionPredicate` from `connection-predicates.ts` that gates tool enablement. Declared as a one-liner property, never as a method:
      ```typescript
-     readonly predicate = hasKafka;
-     readonly predicate = widenForOAuth(hasKafkaBootstrap);
-     readonly predicate = allOf(hasKafka, hasFlink);
-     readonly predicate = alwaysEnabled;
+     readonly predicate = hasKafka;                  // base predicate
+     readonly predicate = kafkaBootstrapOrOAuth;     // named composite
+     readonly predicate = alwaysEnabled;             // no requirement
      ```
-     `BaseToolHandler` derives `enabledConnectionIds()` and `connectionVerdicts()` from this property. **Do not override either method** — they are `@final`. The retired iteration helpers `connectionIdsWhere`/`connectionReasonsWhere` are no longer exported.
+     **The `predicate` property must reference a named export from `connection-predicates.ts`. No inline composition at the use site.** `widenForOAuth(...)` and `allOf(...)` are predicate-library construction tools, not handler-side glue. If no existing named export expresses the gate you need, the path is: add a named `const` export to `connection-predicates.ts` → add a per-predicate test in `connection-predicates.test.ts` matching the depth of the existing `hasKafka` / `flinkWithTelemetry` blocks (direct-enabled, each conjunct's failure mode, OAuth verdict) → add the new export to `NAMED_PREDICATES` in the `predicate property` block of `tool-registry.test.ts` → reference the new export from your handler. Promotion is a precondition of adding the handler, not a followup. Enforced mechanically: that `NAMED_PREDICATES` set is typed `ReadonlySet<ConnectionPredicate>` so combinators cannot compile in, and the per-tool assertion fails with the offending tool name in the row label whenever a handler's `predicate` is not in the set — whether because of inline composition or because the allow-list was not updated alongside a new predicate. `BaseToolHandler` derives `enabledConnectionIds()` and `connectionVerdicts()` from this property. **Do not override either method** — they are `@final`. The retired iteration helpers `connectionIdsWhere`/`connectionReasonsWhere` are no longer exported.
 
 ## Input Schema
 
@@ -59,7 +58,7 @@ When adding a new tool, touch these files:
 2. `src/confluent/tools/handlers/<domain>/my-tool-handler.ts` — create handler class
 3. `src/confluent/tools/tool-registry.ts` — import handler and add `[ToolName.MY_TOOL, new MyToolHandler()]` to the `ToolHandlerRegistry.handlers` map
 4. `src/index.test.ts` — classify the new `ToolName` in the capstone partition test by adding it to either `EXPECTED_OAUTH_ENABLED` or `EXPECTED_OAUTH_DISABLED`. The partition test fails if a tool belongs to neither — the guard against birthing a tool without thinking about its OAuth posture.
-5. (Only if needed) `src/confluent/tools/connection-predicates.ts` — add a new predicate if no existing one expresses the tool's requirement
+5. (Only if needed) `src/confluent/tools/connection-predicates.ts` — add a new predicate if no existing one expresses the tool's requirement. A new gate must land as a named `const` here (with a per-predicate test in `connection-predicates.test.ts`) before the handler that consumes it; the new predicate also needs adding to the `NAMED_PREDICATES` allow-list in `tool-registry.test.ts`'s `predicate property` block, otherwise the per-tool membership assertion will fail.
 
 ## Connection Predicates
 
@@ -69,9 +68,16 @@ Tool enablement is decided by inspecting which **service blocks** are present in
 
 - A tool whose predicate matches zero connections is automatically disabled.
 - A tool with no service-specific requirement uses `alwaysEnabled` from `connection-predicates.ts`.
-- For compound requirements, compose with `allOf(p1, p2, ...)` — never raw `&&`, which silently drops the first operand because every `PredicateResult` is a truthy object.
-- For OAuth-capable handlers, wrap a block-based predicate with `widenForOAuth(p)` so OAuth connections answer enabled even though they carry no service blocks.
 - New predicates should be additive and pure; they read the `ConnectionConfig` shape only and return a `PredicateResult` with a `ToolDisabledReason` on failure.
+
+When you need a gate the library doesn't yet publish, add a new named `const` export to `connection-predicates.ts` (then reference it from the handler — see the rule above). Two combinators inside the library make composition safe:
+
+- `allOf(p1, p2, ...)` for compound requirements — never raw `&&`, which silently drops the first operand because every `PredicateResult` is a truthy object.
+- `widenForOAuth(p)` to admit OAuth through a block-based predicate, for handlers genuinely adapted to operate against an OAuth connection at call time.
+
+These combinators are construction tools used to define new named exports; they are not for inline use at the handler site. After adding the named export, give it a per-predicate test in `connection-predicates.test.ts` (modelled on the existing blocks: direct-enabled, each conjunct's failure mode, OAuth verdict) before the handler that consumes it lands.
+
+The named-export-only rule is enforced by the `predicate property` block in `tool-registry.test.ts`, which maintains an explicit `NAMED_PREDICATES` allow-list typed as `ReadonlySet<ConnectionPredicate>` (so combinators can't compile in) and asserts every handler's `predicate` is a member. Use it as the "did I get the wiring right" oracle — if the test fails for your tool, the row label names which handler is the problem and the assertion message distinguishes the two failure modes (inline composition vs. forgot to update the allow-list).
 
 ### `hasConfluentCloud` vs `hasDirectConfluentCloud` — pick carefully
 

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -76,17 +76,24 @@ export abstract class BaseToolHandler implements ToolHandler {
    * The connection predicate that gates this tool. The single customization
    * seam for tool enablement — declared as a one-line readonly property:
    *
-   *     readonly predicate = hasKafka;
-   *     readonly predicate = widenForOAuth(hasKafkaBootstrap);
-   *     readonly predicate = allOf(hasKafka, hasFlink);
-   *     readonly predicate = alwaysEnabled;
+   *     readonly predicate = hasKafka;                  // base predicate
+   *     readonly predicate = kafkaBootstrapOrOAuth;     // named composite
+   *     readonly predicate = alwaysEnabled;             // no requirement
    *
-   * Pick from `connection-predicates.ts`: a base predicate (`hasKafka`,
-   * `hasFlink`, `hasSchemaRegistry`, `hasConfluentCloud`,
-   * `hasDirectConfluentCloud`, `hasTelemetry`, `hasTableflow`, etc.),
-   * `widenForOAuth(p)` to admit OAuth connections through a block-based
-   * predicate, `allOf(p1, p2, ...)` for compound requirements, or
-   * `alwaysEnabled` for tools with no service-block requirement.
+   * **Must reference a named export from `connection-predicates.ts`.** Do
+   * not compose with `allOf(...)` or `widenForOAuth(...)` at the use site.
+   * If no existing named export expresses the gate you need, add one —
+   * with a per-predicate test in `connection-predicates.test.ts` matching
+   * the depth of the existing `hasKafka` / `flinkWithTelemetry` blocks —
+   * and reference that. Enforced mechanically: the `predicate property`
+   * block in `tool-registry.test.ts` maintains an explicit allow-list
+   * typed as `ReadonlySet<ConnectionPredicate>` (so combinators cannot
+   * compile in) and asserts each handler's `predicate` is a member. New
+   * predicates added to `connection-predicates.ts` need a one-line
+   * addition to that allow-list; inline `allOf(...)` or `widenForOAuth(...)`
+   * at a handler use site returns a closure that is not in the set and
+   * fails the membership check with the offending tool name in the row
+   * label.
    *
    * Both {@linkcode enabledConnectionIds} and {@linkcode connectionVerdicts}
    * are derived from this property and are marked `@final`; never override

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -5,6 +5,8 @@ import {
   type PredicateResult,
   ToolDisabledReason,
   allOf,
+  canCreateDirectConnector,
+  flinkWithTelemetry,
   hasCCloudCatalogSupport,
   hasConfluentCloud,
   hasDirectConfluentCloud,
@@ -16,6 +18,7 @@ import {
   hasSchemaRegistry,
   hasTableflow,
   hasTelemetry,
+  kafkaBootstrapOrOAuth,
   widenForOAuth,
 } from "@src/confluent/tools/connection-predicates.js";
 import { describe, expect, it, vi } from "vitest";
@@ -72,6 +75,31 @@ const TABLEFLOW_CONN = conn({
 const CCLOUD_SR_CONN = conn({
   schema_registry: {
     endpoint: "https://psrc-abc.us-east-1.aws.confluent.cloud",
+    auth: { type: "api_key", key: "k", secret: "s" },
+  },
+});
+
+const DIRECT_CCLOUD_KAFKA_AUTH_CONN = conn({
+  confluent_cloud: {
+    endpoint: "https://api.confluent.cloud",
+    auth: { type: "api_key", key: "k", secret: "s" },
+  },
+  kafka: {
+    bootstrap_servers: "broker:9092",
+    auth: { type: "api_key", key: "k", secret: "s" },
+  },
+});
+
+const FLINK_AND_TELEMETRY_CONN = conn({
+  flink: {
+    endpoint: "https://flink.confluent.cloud",
+    auth: { type: "api_key", key: "k", secret: "s" },
+    environment_id: "env-abc",
+    organization_id: "org-123",
+    compute_pool_id: "lfcp-xyz",
+  },
+  telemetry: {
+    endpoint: "https://api.telemetry.confluent.cloud",
     auth: { type: "api_key", key: "k", secret: "s" },
   },
 });
@@ -378,6 +406,82 @@ describe("connection-predicates.ts", () => {
       const widened = widenForOAuth(wrapped);
       widened(OAUTH_CONN);
       expect(wrapped).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("kafkaBootstrapOrOAuth", () => {
+    it("should return ENABLED for a direct connection with kafka.bootstrap_servers", () => {
+      expect(kafkaBootstrapOrOAuth(KAFKA_CONN)).toEqual(ENABLED);
+    });
+
+    it("should report MissingKafkaBootstrap for a direct connection whose kafka block has no bootstrap_servers", () => {
+      expect(kafkaBootstrapOrOAuth(KAFKA_REST_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBootstrap),
+      );
+    });
+
+    it("should report MissingKafkaBlock for a direct connection without a kafka block", () => {
+      expect(kafkaBootstrapOrOAuth(SCHEMA_REGISTRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBlock),
+      );
+    });
+
+    it("should return ENABLED for an OAuth connection (the predicate is widened)", () => {
+      expect(kafkaBootstrapOrOAuth(OAUTH_CONN)).toEqual(ENABLED);
+    });
+  });
+
+  describe("canCreateDirectConnector", () => {
+    it("should return ENABLED when both confluent_cloud and kafka.auth are present on a direct connection", () => {
+      expect(canCreateDirectConnector(DIRECT_CCLOUD_KAFKA_AUTH_CONN)).toEqual(
+        ENABLED,
+      );
+    });
+
+    it("should report MissingConfluentCloudBlock when the first conjunct fails (no confluent_cloud block)", () => {
+      // KAFKA_REST_WITH_AUTH_CONN has kafka.auth but no confluent_cloud,
+      // so hasDirectConfluentCloud short-circuits before hasKafkaAuth runs.
+      expect(canCreateDirectConnector(KAFKA_REST_WITH_AUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingConfluentCloudBlock),
+      );
+    });
+
+    it("should report MissingKafkaBlock when the second conjunct fails (confluent_cloud present but no kafka block)", () => {
+      // CONFLUENT_CLOUD_CONN has confluent_cloud but no kafka block;
+      // hasKafkaAuth's first check (kafka block presence) trips first.
+      expect(canCreateDirectConnector(CONFLUENT_CLOUD_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingKafkaBlock),
+      );
+    });
+
+    it("should report OAuthNotDirectCapable for an OAuth connection", () => {
+      expect(canCreateDirectConnector(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNotDirectCapable),
+      );
+    });
+  });
+
+  describe("flinkWithTelemetry", () => {
+    it("should return ENABLED when both flink and telemetry blocks are present on a direct connection", () => {
+      expect(flinkWithTelemetry(FLINK_AND_TELEMETRY_CONN)).toEqual(ENABLED);
+    });
+
+    it("should report MissingFlinkBlock when only the telemetry block is present (first conjunct fails)", () => {
+      expect(flinkWithTelemetry(TELEMETRY_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingFlinkBlock),
+      );
+    });
+
+    it("should report MissingTelemetryBlock when only the flink block is present (second conjunct fails)", () => {
+      expect(flinkWithTelemetry(FLINK_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingTelemetryBlock),
+      );
+    });
+
+    it("should report OAuthNoServiceBlocks for an OAuth connection", () => {
+      expect(flinkWithTelemetry(OAUTH_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.OAuthNoServiceBlocks),
+      );
     });
   });
 });

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -5,10 +5,16 @@
 // it from the catalogue.
 //
 // Tool handlers consume predicates indirectly: each handler declares a
-// `predicate` property, and `BaseToolHandler` derives both
-// `enabledConnectionIds()` and `connectionVerdicts()` from it. Compose
-// compound requirements with `allOf(...)` and use `alwaysEnabled` for
-// tools with no service-block requirement.
+// `predicate` property referencing one of this file's named exports, and
+// `BaseToolHandler` derives both `enabledConnectionIds()` and
+// `connectionVerdicts()` from it. Handlers must not call `allOf(...)` or
+// `widenForOAuth(...)` at the use site — those combinators are construction
+// tools used here to define new named exports. When adding a new named
+// predicate here: also add it to the `NAMED_PREDICATES` allow-list in
+// `tool-registry.test.ts`'s `predicate property` block (typed as
+// `ReadonlySet<ConnectionPredicate>`, so combinators can't slip in) and to
+// `connection-predicates.test.ts` for per-predicate coverage. Handlers
+// referencing it then sail through the membership assertion.
 //
 // OAuth note: most predicates short-circuit on `conn.type === "oauth"`
 // and answer disabled — OAuth connections carry no service blocks for these
@@ -17,8 +23,8 @@
 // is reachable via the Auth0 environment without a block), and the
 // `widenForOAuth(predicate)` combinator wraps any block-checking predicate
 // so OAuth connections bypass the block check and answer enabled. Use
-// `widenForOAuth` on tool handlers that have been adapted to operate
-// against an OAuth-typed connection at call time.
+// `widenForOAuth` here, when defining a new named composite export, for
+// gates that should admit OAuth.
 
 import type { ConnectionConfig } from "@src/config/models.js";
 
@@ -241,6 +247,37 @@ export function widenForOAuth(
 ): ConnectionPredicate {
   return (conn) => (conn.type === "oauth" ? ENABLED : predicate(conn));
 }
+
+/**
+ * The native-Kafka client gate, widened to admit OAuth. Direct connections
+ * still need `kafka.bootstrap_servers`; OAuth connections satisfy it
+ * unconditionally (the broker URL is synthesized from the Auth0 environment).
+ * Use on handlers that have been brought into the OAuth fold.
+ */
+export const kafkaBootstrapOrOAuth: ConnectionPredicate =
+  widenForOAuth(hasKafkaBootstrap);
+
+/**
+ * Gate for tools that create connectors against the direct Confluent Cloud
+ * REST surface: requires both a `confluent_cloud` block (the `/connect/v1`
+ * endpoint) and `kafka.auth` (the connector spec carries kafka API
+ * credentials). Strict-direct — OAuth connections answer `OAuthNotDirectCapable`
+ * because the handler calls `getSoleDirectConnection()`.
+ */
+export const canCreateDirectConnector: ConnectionPredicate = allOf(
+  hasDirectConfluentCloud,
+  hasKafkaAuth,
+);
+
+/**
+ * Gate for tools that read telemetry metrics about Flink statements:
+ * requires both the `flink` block (to address a statement) and the
+ * `telemetry` block (to query the metrics API).
+ */
+export const flinkWithTelemetry: ConnectionPredicate = allOf(
+  hasFlink,
+  hasTelemetry,
+);
 
 /**
  * Every reason a {@linkcode ConnectionPredicate} can return `enabled: false`.

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -1,10 +1,6 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
-import {
-  allOf,
-  hasDirectConfluentCloud,
-  hasKafkaAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { canCreateDirectConnector } from "@src/confluent/tools/connection-predicates.js";
 import { ConnectToolHandler } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -84,7 +80,7 @@ export class CreateConnectorHandler extends ConnectToolHandler {
     const conn = runtime.config.getSoleDirectConnection();
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
-    // hasKafkaAuth in enabledConnectionIds() guarantees auth is present here.
+    // The canCreateDirectConnector predicate guarantees kafka.auth is present.
     const kafkaApiKey = this.resolveParam(
       undefined,
       conn.kafka?.auth?.key,
@@ -139,5 +135,5 @@ export class CreateConnectorHandler extends ConnectToolHandler {
     };
   }
 
-  override readonly predicate = allOf(hasDirectConfluentCloud, hasKafkaAuth);
+  override readonly predicate = canCreateDirectConnector;
 }

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -1,10 +1,6 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
-import {
-  allOf,
-  hasFlink,
-  hasTelemetry,
-} from "@src/confluent/tools/connection-predicates.js";
+import { flinkWithTelemetry } from "@src/confluent/tools/connection-predicates.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -534,5 +530,5 @@ export class QueryProfilerHandler extends FlinkToolHandler {
   }
 
   /** Overrides FlinkToolHandler: also requires a telemetry block because profiling fetches metrics from the Telemetry API in addition to the Flink REST API. */
-  override readonly predicate = allOf(hasFlink, hasTelemetry);
+  override readonly predicate = flinkWithTelemetry;
 }

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -11,10 +11,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  hasKafkaBootstrap,
-  widenForOAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
   formatKafkaError,
   resolveKafkaClusterArgs,
@@ -299,5 +296,5 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     };
   }
 
-  readonly predicate = widenForOAuth(hasKafkaBootstrap);
+  readonly predicate = kafkaBootstrapOrOAuth;
 }

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -4,10 +4,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  hasKafkaBootstrap,
-  widenForOAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
   disposeIfOAuth,
   formatKafkaError,
@@ -100,5 +97,5 @@ export class CreateTopicsHandler extends BaseToolHandler {
     };
   }
 
-  readonly predicate = widenForOAuth(hasKafkaBootstrap);
+  readonly predicate = kafkaBootstrapOrOAuth;
 }

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -4,10 +4,7 @@ import {
   DESTRUCTIVE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  hasKafkaBootstrap,
-  widenForOAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
   disposeIfOAuth,
   resolveKafkaClusterArgs,
@@ -67,5 +64,5 @@ export class DeleteTopicsHandler extends BaseToolHandler {
     };
   }
 
-  readonly predicate = widenForOAuth(hasKafkaBootstrap);
+  readonly predicate = kafkaBootstrapOrOAuth;
 }

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -4,10 +4,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  hasKafkaBootstrap,
-  widenForOAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
   disposeIfOAuth,
   resolveKafkaClusterArgs,
@@ -61,5 +58,5 @@ export class ListTopicsHandler extends BaseToolHandler {
     };
   }
 
-  readonly predicate = widenForOAuth(hasKafkaBootstrap);
+  readonly predicate = kafkaBootstrapOrOAuth;
 }

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -12,10 +12,7 @@ import {
   CREATE_UPDATE,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import {
-  hasKafkaBootstrap,
-  widenForOAuth,
-} from "@src/confluent/tools/connection-predicates.js";
+import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
   disposeIfOAuth,
   formatKafkaError,
@@ -261,5 +258,5 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
     };
   }
 
-  readonly predicate = widenForOAuth(hasKafkaBootstrap);
+  readonly predicate = kafkaBootstrapOrOAuth;
 }

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -1,8 +1,27 @@
 import {
+  BaseToolHandler,
   CREATE_UPDATE,
   DESTRUCTIVE,
   READ_ONLY,
 } from "@src/confluent/tools/base-tools.js";
+import {
+  alwaysEnabled,
+  canCreateDirectConnector,
+  type ConnectionPredicate,
+  flinkWithTelemetry,
+  hasCCloudCatalogSupport,
+  hasConfluentCloud,
+  hasDirectConfluentCloud,
+  hasFlink,
+  hasKafka,
+  hasKafkaAuth,
+  hasKafkaBootstrap,
+  hasKafkaRestWithAuth,
+  hasSchemaRegistry,
+  hasTableflow,
+  hasTelemetry,
+  kafkaBootstrapOrOAuth,
+} from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
@@ -132,6 +151,57 @@ describe("tool-registry.ts", () => {
           }
         }
       });
+    });
+
+    describe("predicate property", () => {
+      // The exhaustive allow-list of legal handler `predicate` values.
+      const NAMED_PREDICATES: ReadonlySet<ConnectionPredicate> = new Set([
+        alwaysEnabled,
+        hasKafka,
+        hasKafkaBootstrap,
+        hasKafkaAuth,
+        hasKafkaRestWithAuth,
+        hasSchemaRegistry,
+        hasConfluentCloud,
+        hasDirectConfluentCloud,
+        hasFlink,
+        hasTelemetry,
+        hasTableflow,
+        hasCCloudCatalogSupport,
+        kafkaBootstrapOrOAuth,
+        canCreateDirectConnector,
+        flinkWithTelemetry,
+      ]);
+
+      it.each(ALL_TOOL_NAMES)(
+        "%s: predicate must be one of the expected predicates from connection-predicates.ts (no inline allOf/widenForOAuth at handler use sites)",
+        (toolName) => {
+          const handler = ToolHandlerRegistry.getToolHandler(toolName);
+          // Every registered handler is expected to extend BaseToolHandler —
+          // that's where the `predicate` property lives. The instanceof check
+          // both narrows the type for the next assertion and enforces the
+          // class-extension invariant in its own right.
+          expect(
+            handler,
+            `Tool ${toolName}'s handler does not extend BaseToolHandler; the ` +
+              `predicate property lives on BaseToolHandler, so a handler that ` +
+              `implements ToolHandler directly cannot be checked for predicate ` +
+              `compliance.`,
+          ).toBeInstanceOf(BaseToolHandler);
+          const predicate = (handler as BaseToolHandler).predicate;
+          expect(
+            NAMED_PREDICATES.has(predicate),
+            `Tool ${toolName}'s predicate is not one of the named exports from ` +
+              `connection-predicates.ts. Two possible causes: (1) the handler ` +
+              `composes inline with allOf(...) or widenForOAuth(...) at the use ` +
+              `site — promote the composition to a named const export (with a ` +
+              `per-predicate test in connection-predicates.test.ts) and reference ` +
+              `the named export here; or (2) you added a new predicate to ` +
+              `connection-predicates.ts but forgot to add it to NAMED_PREDICATES ` +
+              `in this test.`,
+          ).toBe(true);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
## Predicate library completion

## TL;DR ##

Make every actual handler predicate a known named and tested function so that we can then stop testing `getConnectionIds()` at the per-tool-level, since it is now singularly implemted in `BaseToolHandler` atop the concrete tool's `predicate`.

## TL ##

Three composed predicates were inlined at handler use sites after #357 landed. This PR promotes each to a named `const` export in `connection-predicates.ts`, swaps the seven handler use sites to reference the named exports, and publishes the assembled vocabularies callers actually want — not just the kit-of-parts.

| Inline composition                             | Named export               | What it gates                                                                                                                                                                                                                                                                    |
| ---------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `widenForOAuth(hasKafkaBootstrap)`             | `kafkaBootstrapOrOAuth`    | Native-Kafka client gate, widened to admit OAuth. Direct connections still need `kafka.bootstrap_servers`; OAuth satisfies it unconditionally (broker URL synthesized from the Auth0 environment). Used by 5 native-Kafka handlers.                                              |
| `allOf(hasDirectConfluentCloud, hasKafkaAuth)` | `canCreateDirectConnector` | Requires both `confluent_cloud` (the `/connect/v1` endpoint) and `kafka.auth` (the connector spec carries kafka API credentials). Strict-direct — OAuth answers `OAuthNotDirectCapable` because the handler calls `getSoleDirectConnection()`. Used by `CreateConnectorHandler`. |
| `allOf(hasFlink, hasTelemetry)`                | `flinkWithTelemetry`       | Requires both blocks — the tool reads telemetry metrics about Flink statements. Used by `QueryProfilerHandler`.                                                                                                                                                                  |

The `<basePredicate>OrOAuth` shape on the first row is intended as a scaling convention: as more handlers are brought into the OAuth fold, the suffix tells a reader at a glance "this gate has been widened — here's the base it widens." The name avoids overstating with terms like "capable" or "client" — the disjunction is exactly what the predicate implements.

## Predicate-level tests

A new `describe` block per named composite in `connection-predicates.test.ts`, each modeled on the existing `hasKafka` / `hasFlink` shape:

- `kafkaBootstrapOrOAuth` — direct enabled (`KAFKA_CONN`), direct disabled with `MissingKafkaBootstrap` (`KAFKA_REST_CONN`), direct disabled with `MissingKafkaBlock` (`SCHEMA_REGISTRY_CONN`), OAuth enabled (proves the widening).
- `canCreateDirectConnector` — direct enabled (new `DIRECT_CCLOUD_KAFKA_AUTH_CONN` fixture), direct disabled with `MissingConfluentCloudBlock` via first-conjunct fail, direct disabled with `MissingKafkaBlock` via second-conjunct fail, OAuth disabled with `OAuthNotDirectCapable`.
- `flinkWithTelemetry` — direct enabled (new `FLINK_AND_TELEMETRY_CONN` fixture), direct disabled with `MissingFlinkBlock` via first-conjunct fail, direct disabled with `MissingTelemetryBlock` via second-conjunct fail, OAuth disabled with `OAuthNoServiceBlocks`.

Twelve new test cases total, fail/pass reasons matching what the underlying combinators produce — the same depth and shape as the rest of `connection-predicates.test.ts`.

## Use-site swaps

Seven handlers updated:

- 5 native-Kafka leaves (`consume-kafka-messages-handler.ts`, `create-topics-handler.ts`, `delete-topics-handler.ts`, `list-topics-handler.ts`, `produce-kafka-message-handler.ts`) — `readonly predicate = kafkaBootstrapOrOAuth;`
- `connect/create-connector-handler.ts` — `override readonly predicate = canCreateDirectConnector;` (preserves `override` since the leaf supersedes `ConnectToolHandler`'s domain predicate). The handler's stale internal comment that referenced `hasKafkaAuth in enabledConnectionIds()` was retargeted to the new predicate name.
- `flink/diagnostics/query-profiler-handler.ts` — `override readonly predicate = flinkWithTelemetry;`

After this PR every handler's `predicate` property is a bare named-export reference. No `widenForOAuth(...)` or `allOf(...)` at handler use sites.

## Documentation updates

The PR establishes a hard rule across three docs: the `predicate` property must reference a named export from `connection-predicates.ts`. No inline `allOf(...)` or `widenForOAuth(...)` at handler use sites. When no existing export fits, the path is "add a named `const` export → add a per-predicate test → reference the new export"; promotion is a precondition of landing the handler, not a followup. The rule's enforcement is the new `predicate property` block in `tool-registry.test.ts` (see "Whole-tool-spanning enforcement" below) — inline composition produces a fresh closure that fails the membership check, with the offending tool name in the row label.

- The `predicate` docstring on `BaseToolHandler` ([base-tools.ts](src/confluent/tools/base-tools.ts)) leads with three illustrative one-liners (`hasKafka`, `kafkaBootstrapOrOAuth`, `alwaysEnabled`) and states the rule directly.
- [.claude/rules/tool-handlers.md](.claude/rules/tool-handlers.md) carries the same rule under "Implement these members" and re-frames the "Connection Predicates" bullets so `allOf` / `widenForOAuth` are documented as construction tools used inside `connection-predicates.ts`, not handler-side glue.
- The top-of-file comment in [connection-predicates.ts](src/confluent/tools/connection-predicates.ts) is updated to match — handlers consume named exports; combinators stay inside the library.

## Whole-tool-spanning enforcement

A new `describe("predicate property")` block in [tool-registry.test.ts](src/confluent/tools/tool-registry.test.ts) makes the "must be a named export" rule executable rather than aspirational. It maintains an explicit `NAMED_PREDICATES` allow-list typed as `ReadonlySet<ConnectionPredicate>` and asserts per tool (via `it.each(ALL_TOOL_NAMES)`) that `handler.predicate` is a member. The instanceof narrowing to `BaseToolHandler` runs first — that's the class where `predicate` lives — and is itself a useful invariant.

The type annotation is the load-bearing piece. `allOf` has signature `(...preds: ConnectionPredicate[]) => ConnectionPredicate` and `widenForOAuth` has signature `(p: ConnectionPredicate) => ConnectionPredicate`; neither is assignable to `(conn: ConnectionConfig) => PredicateResult`. So the combinators (and any future helper that returns a predicate rather than is one) cannot be added to the set even by mistake.

Failure modes the test catches:

- **Inline composition at a handler use site.** `readonly predicate = allOf(...)` returns a fresh closure not in the allow-list; the per-tool row fails with the offending tool name in the label.
- **Allow-list drift after adding a new predicate.** Adding a named predicate to `connection-predicates.ts` without adding it to `NAMED_PREDICATES` causes loud per-handler failures for every tool that uses the new predicate. The assertion message distinguishes the two causes so a maintainer reading the failure can act without diagnosis.

Red-step verified: temporarily flipping `list-topics-handler.ts` back to `widenForOAuth(hasKafkaBootstrap)` caused exactly that one row to fail with the documented remediation in the assertion message.

## Behavior preservation

The OAuth tool-surface partition test in [src/index.test.ts](src/index.test.ts) (`describe("against configured OAuth connection")`) runs through `getToolHandlersToRegister(ccloudOAuthRuntime())` and asserts the aggregate enabled set against `EXPECTED_OAUTH_ENABLED`. It's predicate-spelling-agnostic: any name swap that accidentally widened or narrowed a gate would surface there. Combined with the per-predicate unit tests and the new whole-tool-spanning enforcement, behavioral drift has nowhere to hide. Suite stays green at 1332 tests (was 1265 pre-PR; +12 from the new predicate-test cases, +55 from the per-handler `predicate property` block plus its two sanity tests).

## Relationships

- Closes #389
- Child of #357 (which established the `predicate`-property API)
- Unblocks #390 (per-handler test slim-down) — every handler's `predicate` is now a bare named-export reference, so the next PR's `expect(handler.predicate).toBe(theNamedPredicate)` identity assertion works uniformly.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
