### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
   nvm install 22
   nvm use 22
   ```
-- A **Confluent Cloud** account with appropriate API keys to access your resources, or your login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
+- A local development environment with Kafka or Schema Registry running, or a **Confluent Cloud** account with appropriate API keys or login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
 
 ### General Setup Steps
 
 This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copilot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using.
 
-The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
+The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** in addition to static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
 
 The general steps to configure (if not using OAuth) and run this MCP are:
 
@@ -126,9 +126,9 @@ npx @confluentinc/mcp-confluent --init-config
 
 4. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
 
-5. **Start your MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
+5. **Start your MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with resources on your behalf.
 
-6. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
+6. **Interact with your resources through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud or local resources. The client will send requests to this MCP server, which will then interact with the available connections on your behalf.
 
 ### Configuration Details
 
@@ -144,9 +144,9 @@ If you have this repo cloned, `cp config.example.yaml config.yaml` works just as
 
 Flat environment variables can only express a single implicit connection. A YAML file can define multiple named connections, which is necessary for real-world workflows — for example, a `local-dev` connection pointing at a local Docker Kafka alongside a `staging` connection to a Confluent Cloud cluster, all in one file.
 
-#### All Configuration Variables
+#### All Legacy Environment Variables for Configuration
 
-You can configure the MCP server using the following variables:
+You can configure the MCP server using the following variables in your `.env` file. The `.env` file will be deprecated in favor of yaml config in the near future. See details above and update your project to configure these items in `config.yaml` instead.
 
 <details>
 <summary>Show Table</summary>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An open-source [MCP server](https://modelcontextprotocol.io/) that enables AI as
 > **Prerequisites:** [Node.js 22+](https://nodejs.org/). If you want to interact with [Confluent Cloud](https://confluent.cloud/), you need to create an account first.
 
 ```bash
+# generate a quick config file in your project root:
 npx @confluentinc/mcp-confluent --init-config
 # edit ./config.yaml with your connection details, then:
 npx @confluentinc/mcp-confluent --config ./config.yaml
@@ -38,7 +39,7 @@ See [Getting Started](#getting-started) for full setup instructions and [Configu
 
 ## Available Tools
 
-**Only the tools whose required environment variables are provided in the configuration file will be enabled.** 
+**Only the tools whose required environment variables are provided in the configuration file will be enabled.**
 
 You can list all available tools via the CLI:
 
@@ -84,11 +85,12 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
 
 ## Getting Started
 
-### General Usage
+### General Steps
 
 This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using. However, the general steps are:
 
-1. **Start the Server:** You can run the MCP server in one of two ways:
+1. **Populate the Server Options:** Setup a yaml configuration file with the appropriate variables for the tools and resources you want to use.
+2. **Start the Server:** You can run the MCP server in one of two ways:
    - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
      - Installing dependencies (`npm install`)
      - Building the project (`npm run build` or `npm run dev`)
@@ -98,11 +100,11 @@ This MCP server is designed to be used with various MCP clients, such as Claude 
      npx -y @confluentinc/mcp-confluent -e /path/to/confluent-mcp-server/.env
      ```
 
-2. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
+3. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
 
-3. **Start the MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
+4. **Start the MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
 
-4. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
+5. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
 
 ### Prerequisites
 
@@ -111,39 +113,42 @@ This MCP server is designed to be used with various MCP clients, such as Claude 
   nvm install 22
   nvm use 22
   ```
-- A **Confluent Cloud** account with appropriate API keys to access your resources
+- A [**Confluent Cloud**](https://confluent.cloud) account with appropriate API keys to access your resources or login credentials if using [OAuth](#oauth-authentication-for-confluent-cloud) to authenticate.
 
 ### Setup
 
-1. **Create a configuration file:** Copy the provided [`config.yaml` example](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml) file to the root of your project
-2. **Populate the file:** Fill in the necessary values for your Confluent Cloud environment. Different tools will require & use different configuration variables. See the [Configuration](#configuration) section for details on which variables to fill in based on the tools you want to enable.
-
-### Configuration
-
-> **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
-
-The fastest way to get a starter `config.yaml` is to let the CLI bootstrap one in your current directory — no checkout required:
+1. **Create a configuration file:** Copy the provided [`config.yaml` example](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml) file to the root of your project. You can use the CLI to bootstrap one in your current directory — no git checkout required:
 
 ```bash
 npx @confluentinc/mcp-confluent --init-config
 ```
+
+2. **Populate the file:** Fill in the necessary values for your Confluent Cloud environment. Different tools will require & use different configuration variables. See the [Configuration](#configuration) section for details on which variables to fill in based on the tools you want to enable.
+
 After editing to include your variables, pass your YAML config file path at server startup with the `--config` flag:
 
 ```bash
 npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
 ```
 
-`--init-config` creates a copy of [`config.example.yaml`](config.example.yaml) in `./config.yaml`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment. 
+### Configuration Details
+
+> **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
+
+`--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in `./config.yaml`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
 
 It also adds this file it to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It refuses to overwrite an existing `config.yaml`, so a stray rerun won't overwrite edits.
 
 If you have this repo cloned, `cp config.example.yaml config.yaml` works just as well. Every `*.yaml`/`*.yml` file at the repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
 
 #### Side note: Why YAML over environment variables?
+
 Flat environment variables can only express a single implicit connection. A YAML file can define multiple named connections, which is necessary for real-world workflows — for example, a `local-dev` connection pointing at a local Docker Kafka alongside a `staging` connection to a Confluent Cloud cluster, all in one file.
 
 #### All Configuration Options
+
 You can configure the MCP server using the following environment variables:
+
 <details>
 <summary>Show Table</summary>
 | Variable                      | Description                                                                                                                                                                                                                                                       | Default Value                           | Required |
@@ -186,6 +191,7 @@ You can configure the MCP server using the following environment variables:
 </details>
 
 #### Examples
+
 For more focused reference snippets, browse [test-fixtures/yaml_configs/valid/](test-fixtures/yaml_configs/valid/) — these files are executed as part of the test suite on every CI run, so they are always valid and current.
 
 #### Env-var interpolation in YAML

--- a/README.md
+++ b/README.md
@@ -29,15 +29,14 @@ See [Getting Started](#getting-started) for full setup instructions and [Configu
 - [Available Tools](#available-tools)
   - [Confluent Cloud](#available-tools-for-confluent-cloud)
   - [Confluent Local](#available-tools-for-confluent-local)
-- [User Guide](#user-guide)
-  - [Getting Started](#getting-started)
-  - [Configuration](#configuration)
-    - [YAML Configuration](#yaml-configuration)
-  - [OAuth Authentication for Confluent Cloud](#oauth-authentication-for-confluent-cloud)
-  - [Authentication for HTTP/SSE Transports](#authentication-for-httpsse-transports)
-  - [Usage](#usage)
-  - [CLI Usage](#cli-usage)
-  - [Configuring MCP Clients](#configuring-mcp-clients)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [General Setup Steps](#general-setup-steps)
+  - [Configuration Details](#configuration-details)
+- [OAuth Authentication for Confluent Cloud](#oauth-authentication-for-confluent-cloud)
+- [CLI Usage](#cli-usage)
+- [Configuring MCP Clients](#configuring-mcp-clients)
+- [Authentication for HTTP/SSE Client Transports](#authentication-for-httpsse-client-transports)
 - [Telemetry](#telemetry)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
@@ -109,7 +108,7 @@ This MCP server is designed to be used with various MCP clients, such as Claude 
 npx @confluentinc/mcp-confluent --init-config
 ```
 
-2. **Populate the file:** Fill in the necessary values for your Confluent Cloud environment. Different tools will require & use different configuration variables. See the [Configuration](#configuration) section for details on which variables to fill in based on the tools you want to enable.
+2. **Populate the file:** Fill in the necessary values for your Confluent Cloud environment. Different tools will require & use different configuration variables. See the [Configuration Details](#configuration-details) section for details on which variables to fill in based on the tools you want to enable.
 
 3. **Start the Server:** You can run the MCP server in one of two ways:
    - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
@@ -131,11 +130,13 @@ npx @confluentinc/mcp-confluent --init-config
 
 > **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
 
-The `--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in `./config.yaml`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
+The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
+
+The `--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in ./config.yaml, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
 
 It also adds this file it to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It will not overwrite an existing `config.yaml`, so a rerun won't overwrite your edits.
 
-If you have this repo cloned, `cp config.example.yaml config.yaml` works just as well. Every `*.yaml`/`*.yml` file at the repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
+If you have this repo cloned, `cp config.example.yaml config.yaml` works just as well. Every `*.yaml`/`*.yml` file at this repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
 
 #### Side note: Why YAML over environment variables?
 
@@ -143,12 +144,11 @@ Flat environment variables can only express a single implicit connection. A YAML
 
 #### All Configuration Variables
 
-The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
-
 You can configure the MCP server using the following variables:
 
 <details>
 <summary>Show Table</summary>
+
 | Variable                      | Description                                                                                                                                                                                                                                                       | Default Value                           | Required |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------- |
 | HTTP_HOST                     | Host to bind for HTTP transport. Defaults to localhost only for security.                                                                                                                                                                                         | "127.0.0.1"                             | Yes      |
@@ -186,6 +186,7 @@ You can configure the MCP server using the following variables:
 | TELEMETRY_API_KEY             | Optional API key for telemetry access. Falls back to CONFLUENT_CLOUD_API_KEY if not set. (See [Metrics API authentication docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#create-an-api-key-to-authenticate-to-the-metrics-api).)       |                                         | No       |
 | TELEMETRY_API_SECRET          | Optional API secret for telemetry access. Falls back to CONFLUENT_CLOUD_API_SECRET if not set. (See [Metrics API authentication docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#create-an-api-key-to-authenticate-to-the-metrics-api).) |                                         | No       |
 | DO_NOT_TRACK                  | Set to `true` to opt out of anonymous telemetry data collection. See [Telemetry](#telemetry) for details.                                                                                                                                                         |                                         | No       |
+
 </details>
 
 #### Examples
@@ -253,78 +254,7 @@ Run with `--config oauth.yaml` and the browser sign-in opens on first start.
 - **Schema Registry (de)serialization** is not yet exposed under OAuth. `produce-message` / `consume-messages` calls with `useSchemaRegistry: true` return a clear capability error. Use a direct connection if schema-aware (de)serialization is required.
 - **Other REST-only tool categories** (`list-clusters`, Connect, Tableflow, Flink, Schema Registry, Metrics, Catalog & Tags) are still being migrated to OAuth and currently require a `direct` connection.
 
-## Authentication for HTTP/SSE Transports
-
-When using HTTP or SSE transports, the MCP server requires API key authentication to prevent unauthorized access and protect against DNS rebinding attacks. This is **enabled by default**.
-
-### Generating an API Key
-
-Generate a secure API key using the built-in utility:
-
-```bash
-npx @confluentinc/mcp-confluent --generate-key
-```
-
-This will output a 64-character key generated using secure cryptography:
-
-```
-Generated MCP API Key:
-================================================================
-a1b2c3d4e5f6...your-64-char-key-here...
-================================================================
-
-```
-
-### Configuring Authentication
-
-Add the generated key to your `config.yaml` file:
-
-```properties
-# MCP Server Authentication (required for HTTP/SSE transports)
-MCP_API_KEY=your-generated-64-char-key-here
-```
-
-### Making Authenticated Requests
-
-Include the API key in the `cflt-mcp-api-Key` header for all HTTP/SSE requests:
-
-```bash
-curl -H "cflt-mcp-api-Key: your-api-key" http://localhost:8080/mcp
-```
-
-### DNS Rebinding Protection
-
-The server includes additional protections against DNS rebinding attacks:
-
-- **Host Header Validation**: Only requests with allowed Host headers are accepted
-
-Configure allowed hosts if needed:
-
-```properties
-# Allow additional hosts (comma-separated)
-MCP_ALLOWED_HOSTS=localhost,127.0.0.1,myhost.local
-```
-
-### Additional security to prevent internet exposure of MCP server
-
-- **Localhost Binding**: Server binds to `127.0.0.1` by default (not `0.0.0.0`)
-
-### Disabling Authentication (Development Only)
-
-For local development, you can disable authentication:
-
-```bash
-# Via CLI flag
-npx @confluentinc/mcp-confluent -e .env --transport http --disable-auth
-
-# Or via environment variable
-MCP_AUTH_DISABLED=true
-```
-
-> [!WARNING]
-> Never disable authentication in production or when the server is network-accessible.
-
-### CLI Usage
+## CLI Usage
 
 The MCP server provides a flexible command line interface (CLI) for advanced configuration and control. The CLI allows you to specify environment files, transports, and fine-tune which tools are enabled or blocked.
 
@@ -483,6 +413,77 @@ Please refer to the following guides for step-by-step instructions on setting up
 - [VS Code](docs/configuring-vs-code.md)
 - [Windsurf](docs/configuring-windsurf.md)
 
+## Authentication for HTTP/SSE Client Transports
+
+When using HTTP or SSE transports, the MCP server requires API key authentication to prevent unauthorized access and protect against DNS rebinding attacks. This is **enabled by default**.
+
+### Generating an API Key
+
+Generate a secure API key using the built-in utility:
+
+```bash
+npx @confluentinc/mcp-confluent --generate-key
+```
+
+This will output a 64-character key generated using secure cryptography:
+
+```
+Generated MCP API Key:
+================================================================
+a1b2c3d4e5f6...your-64-char-key-here...
+================================================================
+
+```
+
+### Configuring Authentication
+
+Add the generated key to your `config.yaml` file:
+
+```properties
+# MCP Server Authentication (required for HTTP/SSE transports)
+MCP_API_KEY=your-generated-64-char-key-here
+```
+
+### Making Authenticated Requests
+
+Include the API key in the `cflt-mcp-api-Key` header for all HTTP/SSE requests:
+
+```bash
+curl -H "cflt-mcp-api-Key: your-api-key" http://localhost:8080/mcp
+```
+
+### DNS Rebinding Protection
+
+The server includes additional protections against DNS rebinding attacks:
+
+- **Host Header Validation**: Only requests with allowed Host headers are accepted
+
+Configure allowed hosts if needed:
+
+```properties
+# Allow additional hosts (comma-separated)
+MCP_ALLOWED_HOSTS=localhost,127.0.0.1,myhost.local
+```
+
+### Additional security to prevent internet exposure of MCP server
+
+- **Localhost Binding**: Server binds to `127.0.0.1` by default (not `0.0.0.0`)
+
+### Disabling Authentication (Development Only)
+
+For local development, you can disable authentication:
+
+```bash
+# Via CLI flag
+npx @confluentinc/mcp-confluent -e .env --transport http --disable-auth
+
+# Or via environment variable
+MCP_AUTH_DISABLED=true
+```
+
+> [!WARNING]
+> Never disable authentication in production or when the server is network-accessible.
+
 ## Telemetry
 
 This MCP server collects anonymous usage data to help make improvements. No personally identifiable information is collected. You can opt out by setting `DO_NOT_TRACK=true` in your environment. See [telemetry.md](telemetry.md) for full details on what is collected.
@@ -493,7 +494,7 @@ This MCP server collects anonymous usage data to help make improvements. No pers
 
 **Tools not appearing** -- Ensure the required environment variables for those tools are set in your `config.yaml` file. Tools are only enabled when their dependencies are configured. Run `--list-tools` to see which tools are active.
 
-**Authentication errors on HTTP/SSE** -- Generate an API key with `npx @confluentinc/mcp-confluent --generate-key` and add it to your `config.yaml` file as `MCP_API_KEY`. See [Authentication for HTTP/SSE Transports](#authentication-for-httpsse-transports).
+**Authentication errors on HTTP/SSE** -- Generate an API key with `npx @confluentinc/mcp-confluent --generate-key` and add it to your `config.yaml` file as `MCP_API_KEY`. See [Authentication for HTTP/SSE Client Transports](#authentication-for-httpsse-client-transports).
 
 **Connection refused / port conflicts** -- The default HTTP port is 8080. If it's already in use, set a different port via `HTTP_PORT` in your `config.yaml` file.
 

--- a/README.md
+++ b/README.md
@@ -99,33 +99,9 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
   ```
 - A [**Confluent Cloud**](https://confluent.cloud) account with appropriate API keys to access your resources, or your login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
 
-### General Overview
+### General Setup Steps
 
 This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using. However, the general steps are:
-
-1. **Populate the Server Options:** Setup a `config.yaml` file in your project root with the appropriate variables for the tools and resources you want to use. You can bootstrap the file using the CLI with:
-
-```bash
-npx @confluentinc/mcp-confluent --init-config
-```
-
-2. **Start the Server:** You can run the MCP server in one of two ways:
-   - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
-     - Installing dependencies (`npm install`)
-     - Building the project (`npm run build` or `npm run dev`)
-   - **With npx:** You can start the server directly using npx, no build required:
-
-     ```bash
-     npx -y @confluentinc/mcp-confluent -e /path/to/confluent-mcp-server/.env
-     ```
-
-3. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
-
-4. **Start your MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
-
-5. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
-
-### Detailed Setup
 
 1. **Create a configuration file:** Copy the provided [`config.yaml` example](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml) file to the root of your project. You can use the CLI to bootstrap one in your current directory — no git checkout required:
 
@@ -135,13 +111,23 @@ npx @confluentinc/mcp-confluent --init-config
 
 2. **Populate the file:** Fill in the necessary values for your Confluent Cloud environment. Different tools will require & use different configuration variables. See the [Configuration](#configuration) section for details on which variables to fill in based on the tools you want to enable.
 
-After editing to include your variables, pass your YAML config file path at server startup with the `--config` flag:
+3. **Start the Server:** You can run the MCP server in one of two ways:
+   - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
+     - Installing dependencies (`npm install`)
+     - Building the project (`npm run build` or `npm run dev`)
+   - **With npx:** You can start the server directly using npx, no build required:
 
-```bash
-npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
-```
+     ```bash
+     npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
+     ```
 
-### Configuration Options
+4. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
+
+5. **Start your MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
+
+6. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
+
+### Configuration Details
 
 > **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
 
@@ -157,7 +143,9 @@ Flat environment variables can only express a single implicit connection. A YAML
 
 #### All Configuration Variables
 
-You can configure the MCP server using the following environment variables:
+The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
+
+You can configure the MCP server using the following variables:
 
 <details>
 <summary>Show Table</summary>

--- a/README.md
+++ b/README.md
@@ -505,3 +505,7 @@ This MCP server collects anonymous usage data to help make improvements. No pers
 ## Contributing
 
 Bug reports and feedback is appreciated in the form of Github Issues. For guidelines on contributing please see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+### Pre-release testing
+
+To run the MCP server against a pre-release version for beta testing or early feedback, download the release tarball file to a local directory. Then, when running any of the `npx` commands above, replace `@confluentinc/mcp-confluent` with the path to that tarball, e.g. `npx @~path/to/my/tarball --list-tools`

--- a/README.md
+++ b/README.md
@@ -96,11 +96,15 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
   nvm install 22
   nvm use 22
   ```
-- A [**Confluent Cloud**](https://confluent.cloud) account with appropriate API keys to access your resources, or your login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
+- A **Confluent Cloud** account with appropriate API keys to access your resources, or your login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
 
 ### General Setup Steps
 
-This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using. However, the general steps are:
+This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using.
+
+The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
+
+The general steps to configure (if not using OAuth) and run this MCP are:
 
 1. **Create a configuration file:** Copy the provided [`config.yaml` example](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml) file to the root of your project. You can use the CLI to bootstrap one in your current directory — no git checkout required:
 
@@ -129,8 +133,6 @@ npx @confluentinc/mcp-confluent --init-config
 ### Configuration Details
 
 > **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
-
-The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
 
 The `--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in ./config.yaml, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ An open-source [MCP server](https://modelcontextprotocol.io/) that enables AI as
 > **Prerequisites:** [Node.js 22+](https://nodejs.org/). If you want to interact with [Confluent Cloud](https://confluent.cloud/), you need to create an account first.
 
 ```bash
-# Install and run
-npx -y @confluentinc/mcp-confluent -e /path/to/.env
+npx @confluentinc/mcp-confluent --init-config
+# edit ./config.yaml with your connection details, then:
+npx @confluentinc/mcp-confluent --config ./config.yaml
 ```
 
-Or install the [npm package](https://www.npmjs.com/package/@confluentinc/mcp-confluent) directly. See [Getting Started](#getting-started) for full setup instructions and [Configuring MCP Clients](#configuring-mcp-clients) for integration with your preferred AI tool.
+See [Getting Started](#getting-started) for full setup instructions and [Configuring MCP Clients](#configuring-mcp-clients) for integration with your preferred AI tool.
 
 ## Table of Contents
 
@@ -37,7 +38,9 @@ Or install the [npm package](https://www.npmjs.com/package/@confluentinc/mcp-con
 
 ## Available Tools
 
-Only the tools whose required environment variables are configured will be enabled. You can also list all available tools via the CLI:
+**Only the tools whose required environment variables are provided in the configuration file will be enabled.** 
+
+You can list all available tools via the CLI:
 
 ```bash
 npx -y @confluentinc/mcp-confluent --list-tools
@@ -45,7 +48,7 @@ npx -y @confluentinc/mcp-confluent --list-tools
 
 ### Available Tools for Confluent Cloud
 
-These tools require endpoints and authentication against specific Confluent Cloud components. Refer to [`.env.example`](.env.example) for the full set of configuration variables, or to [OAuth Authentication for Confluent Cloud](#oauth-authentication-for-confluent-cloud) below to authenticate as a logged-in user instead of via API keys (currently supported by the native-broker **Kafka** tools — `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages`).
+These tools require endpoints and authentication against specific Confluent Cloud components. Refer to [`config.example.yaml`](config.example.yaml) for the full set of configuration variables, or to [OAuth Authentication for Confluent Cloud](#oauth-authentication-for-confluent-cloud) below to authenticate as a logged-in user instead of via API keys (currently supported by the native-broker **Kafka** tools — `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages`).
 
 | Category                                   | Tools                                                                                                                                                                                               | Description                                                       |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -79,31 +82,70 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
 | **Schema Registry** | `list-schemas`, `delete-schema`                                                        | List, inspect, and delete data schemas                    |
 | **Documentation**   | `search-product-docs`, `get-product-doc-page`                                          | Search Confluent product docs and fetch full page content |
 
-## User Guide
+## Getting Started
 
-### Getting Started
+### General Usage
 
-#### Prerequisites
+This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using. However, the general steps are:
+
+1. **Start the Server:** You can run the MCP server in one of two ways:
+   - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
+     - Installing dependencies (`npm install`)
+     - Building the project (`npm run build` or `npm run dev`)
+   - **With npx:** You can start the server directly using npx, no build required:
+
+     ```bash
+     npx -y @confluentinc/mcp-confluent -e /path/to/confluent-mcp-server/.env
+     ```
+
+2. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
+
+3. **Start the MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
+
+4. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
+
+### Prerequisites
 
 - **Node.js 22 or later** -- we recommend using [NVM](https://github.com/nvm-sh/nvm) to manage versions:
   ```bash
   nvm install 22
   nvm use 22
   ```
-- A **Confluent Cloud** account with appropriate API keys
+- A **Confluent Cloud** account with appropriate API keys to access your resources
 
-#### Setup
+### Setup
 
-1. **Create a `.env` file:** Copy the provided `.env.example` file to `.env` in the root of your project:
-   ```bash
-   cp .env.example .env
-   ```
-2. **Populate the `.env` file:** Fill in the necessary values for your Confluent Cloud environment. See the [Configuration](#configuration) section for details on each variable.
+1. **Create a configuration file:** Copy the provided [`config.yaml` example](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml) file to the root of your project
+2. **Populate the file:** Fill in the necessary values for your Confluent Cloud environment. Different tools will require & use different configuration variables. See the [Configuration](#configuration) section for details on which variables to fill in based on the tools you want to enable.
 
 ### Configuration
 
-You can configure the MCP server using the following environment variables:
+> **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
 
+The fastest way to get a starter `config.yaml` is to let the CLI bootstrap one in your current directory — no checkout required:
+
+```bash
+npx @confluentinc/mcp-confluent --init-config
+```
+After editing to include your variables, pass your YAML config file path at server startup with the `--config` flag:
+
+```bash
+npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
+```
+
+`--init-config` creates a copy of [`config.example.yaml`](config.example.yaml) in `./config.yaml`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment. 
+
+It also adds this file it to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It refuses to overwrite an existing `config.yaml`, so a stray rerun won't overwrite edits.
+
+If you have this repo cloned, `cp config.example.yaml config.yaml` works just as well. Every `*.yaml`/`*.yml` file at the repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
+
+#### Side note: Why YAML over environment variables?
+Flat environment variables can only express a single implicit connection. A YAML file can define multiple named connections, which is necessary for real-world workflows — for example, a `local-dev` connection pointing at a local Docker Kafka alongside a `staging` connection to a Confluent Cloud cluster, all in one file.
+
+#### All Configuration Options
+You can configure the MCP server using the following environment variables:
+<details>
+<summary>Show Table</summary>
 | Variable                      | Description                                                                                                                                                                                                                                                       | Default Value                           | Required |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------- |
 | HTTP_HOST                     | Host to bind for HTTP transport. Defaults to localhost only for security.                                                                                                                                                                                         | "127.0.0.1"                             | Yes      |
@@ -141,35 +183,9 @@ You can configure the MCP server using the following environment variables:
 | TELEMETRY_API_KEY             | Optional API key for telemetry access. Falls back to CONFLUENT_CLOUD_API_KEY if not set. (See [Metrics API authentication docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#create-an-api-key-to-authenticate-to-the-metrics-api).)       |                                         | No       |
 | TELEMETRY_API_SECRET          | Optional API secret for telemetry access. Falls back to CONFLUENT_CLOUD_API_SECRET if not set. (See [Metrics API authentication docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#create-an-api-key-to-authenticate-to-the-metrics-api).) |                                         | No       |
 | DO_NOT_TRACK                  | Set to `true` to opt out of anonymous telemetry data collection. See [Telemetry](#telemetry) for details.                                                                                                                                                         |                                         | No       |
+</details>
 
-### YAML Configuration
-
-> **Note:** YAML-based configuration is actively being built out as the replacement for env-var-only startup. The two modes coexist during the transition — the server accepts both.
-
-Pass a YAML config file at startup with the `--config` flag:
-
-```bash
-npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
-```
-
-#### Why YAML over environment variables
-
-Flat environment variables can only express a single implicit connection. A YAML file can define multiple named connections, which is necessary for real-world workflows — for example, a `local-dev` connection pointing at a local Docker Kafka alongside a `staging` connection to a Confluent Cloud cluster, all in one file.
-
-#### Configuration examples
-
-The fastest way to get a starter `config.yaml` is to let the CLI bootstrap one in your current directory — no checkout required:
-
-```bash
-npx @confluentinc/mcp-confluent --init-config
-# edit ./config.yaml, then:
-npx @confluentinc/mcp-confluent --config ./config.yaml
-```
-
-`--init-config` drops a copy of [`config.example.yaml`](config.example.yaml) — the YAML analogue of `.env.example`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) annotated and wired up with `${VAR}` placeholders so credentials stay in your environment — into `./config.yaml` and adds it to a `.gitignore` next to it (creating one if needed) so your filled-in copy can't slip into git. It refuses to overwrite an existing `config.yaml`, so a stray rerun won't clobber edits.
-
-If you already have this repo cloned, `cp config.example.yaml config.yaml` works just as well — every `*.yaml`/`*.yml` file at the repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
-
+#### Examples
 For more focused reference snippets, browse [test-fixtures/yaml_configs/valid/](test-fixtures/yaml_configs/valid/) — these files are executed as part of the test suite on every CI run, so they are always valid and current.
 
 #### Env-var interpolation in YAML
@@ -201,15 +217,15 @@ Please refer to the following Confluent Cloud documentation for detailed instruc
 
 Ensuring these prerequisites are met will prevent authorization errors when the `mcp-server` attempts to provision or manage Tableflow-enabled tables.
 
-### OAuth Authentication for Confluent Cloud
+## OAuth Authentication for Confluent Cloud
 
-The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys.
+The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config.
 
-#### How it works
+### How it works
 
 On startup, the server opens your browser to the Confluent Cloud sign-in page and waits for the redirect callback. Supported tools begin working only after sign-in completes — calls made before then will fail with an `"OAuth token is not currently available"` error.
 
-#### YAML setup
+### YAML setup
 
 Add the following to the yaml file to enable an OAuth Connection:
 
@@ -221,23 +237,23 @@ connections:
 
 Run with `--config oauth.yaml` and the browser sign-in opens on first start.
 
-#### Supported tools under OAuth
+### Supported tools under OAuth
 
 | Category               | Tools                                                                                  |
 | ---------------------- | -------------------------------------------------------------------------------------- |
 | **Kafka (native)**     | `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages` |
 | **Control plane REST** | `list-organizations`, `list-environments`, `read-environment`, `list-billing-costs`    |
 
-#### Limitations
+### Limitations
 
 - **Schema Registry (de)serialization** is not yet exposed under OAuth. `produce-message` / `consume-messages` calls with `useSchemaRegistry: true` return a clear capability error. Use a direct connection if schema-aware (de)serialization is required.
 - **Other REST-only tool categories** (`list-clusters`, Connect, Tableflow, Flink, Schema Registry, Metrics, Catalog & Tags) are still being migrated to OAuth and currently require a `direct` connection.
 
-### Authentication for HTTP/SSE Transports
+## Authentication for HTTP/SSE Transports
 
 When using HTTP or SSE transports, the MCP server requires API key authentication to prevent unauthorized access and protect against DNS rebinding attacks. This is **enabled by default**.
 
-#### Generating an API Key
+### Generating an API Key
 
 Generate a secure API key using the built-in utility:
 
@@ -255,16 +271,16 @@ a1b2c3d4e5f6...your-64-char-key-here...
 
 ```
 
-#### Configuring Authentication
+### Configuring Authentication
 
-Add the generated key to your `.env` file:
+Add the generated key to your `config.yaml` file:
 
 ```properties
 # MCP Server Authentication (required for HTTP/SSE transports)
 MCP_API_KEY=your-generated-64-char-key-here
 ```
 
-#### Making Authenticated Requests
+### Making Authenticated Requests
 
 Include the API key in the `cflt-mcp-api-Key` header for all HTTP/SSE requests:
 
@@ -272,7 +288,7 @@ Include the API key in the `cflt-mcp-api-Key` header for all HTTP/SSE requests:
 curl -H "cflt-mcp-api-Key: your-api-key" http://localhost:8080/mcp
 ```
 
-#### DNS Rebinding Protection
+### DNS Rebinding Protection
 
 The server includes additional protections against DNS rebinding attacks:
 
@@ -285,11 +301,11 @@ Configure allowed hosts if needed:
 MCP_ALLOWED_HOSTS=localhost,127.0.0.1,myhost.local
 ```
 
-#### Additional security to prevent internet exposure of MCP server
+### Additional security to prevent internet exposure of MCP server
 
 - **Localhost Binding**: Server binds to `127.0.0.1` by default (not `0.0.0.0`)
 
-#### Disabling Authentication (Development Only)
+### Disabling Authentication (Development Only)
 
 For local development, you can disable authentication:
 
@@ -303,26 +319,6 @@ MCP_AUTH_DISABLED=true
 
 > [!WARNING]
 > Never disable authentication in production or when the server is network-accessible.
-
-### Usage
-
-This MCP server is designed to be used with various MCP clients, such as Claude Desktop or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using. However, the general steps are:
-
-1. **Start the Server:** You can run the MCP server in one of two ways:
-   - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
-     - Installing dependencies (`npm install`)
-     - Building the project (`npm run build` or `npm run dev`)
-   - **With npx:** You can start the server directly using npx (no build required):
-
-     ```bash
-     npx -y @confluentinc/mcp-confluent -e /path/to/confluent-mcp-server/.env
-     ```
-
-2. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on may be configured by an environment variable.
-
-3. **Start the MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup - it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
-
-4. **Interact with Confluent through the Client:** Once the client is connected, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
 
 ### CLI Usage
 
@@ -471,7 +467,7 @@ list-organizations: List Confluent Cloud organizations the current credentials c
 
 > **Tip:** The allow-list is applied before the block-list. If neither is provided, all tools are enabled by default.
 
-### Configuring MCP Clients
+## Configuring MCP Clients
 
 Please refer to the following guides for step-by-step instructions on setting up and using this MCP server with your preferred client:
 
@@ -491,11 +487,11 @@ This MCP server collects anonymous usage data to help make improvements. No pers
 
 **"Node.js version not supported"** -- This project requires Node.js 22 or later. Check your version with `node -v` and upgrade if needed.
 
-**Tools not appearing** -- Ensure the required environment variables for those tools are set in your `.env` file. Tools are only enabled when their dependencies are configured. Run `--list-tools` to see which tools are active.
+**Tools not appearing** -- Ensure the required environment variables for those tools are set in your `config.yaml` file. Tools are only enabled when their dependencies are configured. Run `--list-tools` to see which tools are active.
 
-**Authentication errors on HTTP/SSE** -- Generate an API key with `npx @confluentinc/mcp-confluent --generate-key` and add it to your `.env` file as `MCP_API_KEY`. See [Authentication for HTTP/SSE Transports](#authentication-for-httpsse-transports).
+**Authentication errors on HTTP/SSE** -- Generate an API key with `npx @confluentinc/mcp-confluent --generate-key` and add it to your `config.yaml` file as `MCP_API_KEY`. See [Authentication for HTTP/SSE Transports](#authentication-for-httpsse-transports).
 
-**Connection refused / port conflicts** -- The default HTTP port is 8080. If it's already in use, set a different port via `HTTP_PORT` in your `.env` file.
+**Connection refused / port conflicts** -- The default HTTP port is 8080. If it's already in use, set a different port via `HTTP_PORT` in your `config.yaml` file.
 
 **Tableflow authorization errors** -- Tableflow tools require specific IAM permissions in your cloud environment. See [Prerequisites & Setup for Tableflow Commands](#prerequisites--setup-for-tableflow-commands).
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ An open-source [MCP server](https://modelcontextprotocol.io/) that enables AI as
 
 > **Prerequisites:** [Node.js 22+](https://nodejs.org/). If you want to interact with [Confluent Cloud](https://confluent.cloud/), you need to create an account first.
 
+1. Generate a quick `config.yaml` file in your project root:
+
 ```bash
-# generate a quick config file in your project root:
 npx @confluentinc/mcp-confluent --init-config
-# edit ./config.yaml with your connection details, then:
+```
+
+2. Edit the `config.yaml` file with your connection details, then:
+
+```bash
 npx @confluentinc/mcp-confluent --config ./config.yaml
 ```
 
@@ -135,9 +140,9 @@ npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
 
 > **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
 
-`--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in `./config.yaml`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
+The `--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in `./config.yaml`, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
 
-It also adds this file it to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It refuses to overwrite an existing `config.yaml`, so a stray rerun won't overwrite edits.
+It also adds this file it to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It will not overwrite an existing `config.yaml`, so a rerun won't overwrite your edits.
 
 If you have this repo cloned, `cp config.example.yaml config.yaml` works just as well. Every `*.yaml`/`*.yml` file at the repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,25 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
 
 ## Getting Started
 
-### General Steps
+### Prerequisites
+
+- **Node.js 22 or later** -- we recommend using [NVM](https://github.com/nvm-sh/nvm) to manage versions:
+  ```bash
+  nvm install 22
+  nvm use 22
+  ```
+- A [**Confluent Cloud**](https://confluent.cloud) account with appropriate API keys to access your resources, or your login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
+
+### General Overview
 
 This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using. However, the general steps are:
 
-1. **Populate the Server Options:** Setup a yaml configuration file with the appropriate variables for the tools and resources you want to use.
+1. **Populate the Server Options:** Setup a `config.yaml` file in your project root with the appropriate variables for the tools and resources you want to use. You can bootstrap the file using the CLI with:
+
+```bash
+npx @confluentinc/mcp-confluent --init-config
+```
+
 2. **Start the Server:** You can run the MCP server in one of two ways:
    - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source. This typically involves:
      - Installing dependencies (`npm install`)
@@ -107,20 +121,11 @@ This MCP server is designed to be used with various MCP clients, such as Claude 
 
 3. **Configure your MCP Client:** Each client will have its own way of specifying the MCP server's address and any required credentials. You'll need to configure your client (e.g., Claude, Goose) to connect to the address where this server is running (likely `localhost` with a specific port). The port the server runs on can be configured by an environment variable.
 
-4. **Start the MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
+4. **Start your MCP Client:** Once your client is configured to connect to the MCP server, you can start your mcp client and on startup it will stand up an instance of this MCP server locally. This instance will be responsible for managing data schemas and interacting with Confluent Cloud on your behalf.
 
 5. **Interact with Confluent through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud resources. The client will send requests to this MCP server, which will then interact with Confluent Cloud on your behalf.
 
-### Prerequisites
-
-- **Node.js 22 or later** -- we recommend using [NVM](https://github.com/nvm-sh/nvm) to manage versions:
-  ```bash
-  nvm install 22
-  nvm use 22
-  ```
-- A [**Confluent Cloud**](https://confluent.cloud) account with appropriate API keys to access your resources or login credentials if using [OAuth](#oauth-authentication-for-confluent-cloud) to authenticate.
-
-### Setup
+### Detailed Setup
 
 1. **Create a configuration file:** Copy the provided [`config.yaml` example](https://github.com/confluentinc/mcp-confluent/blob/main/config.example.yaml) file to the root of your project. You can use the CLI to bootstrap one in your current directory — no git checkout required:
 
@@ -136,7 +141,7 @@ After editing to include your variables, pass your YAML config file path at serv
 npx @confluentinc/mcp-confluent --config /path/to/myconfig.yaml
 ```
 
-### Configuration Details
+### Configuration Options
 
 > **Note:** YAML-based configuration is actively being built out as the replacement for `.env`-based config. The two modes coexist during the transition — the server accepts both - but we plan to deprecate the latter in a near-future release.
 
@@ -150,7 +155,7 @@ If you have this repo cloned, `cp config.example.yaml config.yaml` works just as
 
 Flat environment variables can only express a single implicit connection. A YAML file can define multiple named connections, which is necessary for real-world workflows — for example, a `local-dev` connection pointing at a local Docker Kafka alongside a `staging` connection to a Confluent Cloud cluster, all in one file.
 
-#### All Configuration Options
+#### All Configuration Variables
 
 You can configure the MCP server using the following environment variables:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
 
 ### General Setup Steps
 
-This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copliot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using.
+This MCP server is designed to be used with various MCP clients, such as Claude Desktop, Copilot, or Goose CLI/Desktop. The specific configuration and interaction will depend on the client you are using.
 
 The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead of static API keys defined in the YAML config. See [OAuth Authentication For Confluent Cloud](#oauth-authentication-for-confluent-cloud) for more details.
 
@@ -136,7 +136,7 @@ npx @confluentinc/mcp-confluent --init-config
 
 The `--init-config` CLI flag creates a copy of [`config.example.yaml`](config.example.yaml) in ./config.yaml, with every supported sub-block (`kafka`, `schema_registry`, `confluent_cloud`, `flink`, `tableflow`, `telemetry`) present, annotated and wired up with [`${ENV_VAR}` placeholders](#env-var-interpolation-in-yaml) so credentials can stay in your environment.
 
-It also adds this file it to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It will not overwrite an existing `config.yaml`, so a rerun won't overwrite your edits.
+It also adds this file to a `.gitignore` (creating one if needed), so your filled-in copy can't slip into git. It will not overwrite an existing `config.yaml`, so a rerun won't overwrite your edits.
 
 If you have this repo cloned, `cp config.example.yaml config.yaml` works just as well. Every `*.yaml`/`*.yml` file at this repo root is gitignored by default, so an accidental `prod.yaml` or `secrets.yaml` cannot slip into a commit either.
 

--- a/docs/configuring-vs-code.md
+++ b/docs/configuring-vs-code.md
@@ -16,3 +16,5 @@ Add the MCP server to your VS Code user settings (`settings.json`) or workspace 
 ```
 
 See the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for more details.
+
+For starting and restarting the server within VS Code, you can open the `mcp.json` settings file and use the IDE's built-in codelens actions.


### PR DESCRIPTION
## Summary of Changes

- Sweeping updates across the README to improve readability, remove assumptions and redundancy, and promote OAuth and YAML Config as first class features. 
- I imagine we'll continue to iterate as things change. Please feel free to critique or edit or suggest any changes. I still think some parts (ahem, Configuration Details) are quite verbose. 
- Easiest to view the file as rendered instead of trying to parse the diff in md: https://github.com/confluentinc/mcp-confluent/blob/ncothren/update-readme/README.md
- ⚠️ Not ready to merge until I work out all the `env` vs `yaml` config parts - or is it? We may need to follow up since this change will cause pain in merge conflicts for any parallel README updates coming in...

