### PR TITLE
Cleanup residual test components no longer needed.

### DIFF
--- a/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
@@ -5,7 +5,7 @@ import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   bareRuntime,
-  flinkRuntime,
+  FLINK_CONN,
   runtimeWith,
 } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
@@ -65,7 +65,7 @@ describe("flink-tool-handler.ts", () => {
 
     describe("getFlinkDirectConfig()", () => {
       it("should return the flink block when present", () => {
-        const runtime = flinkRuntime();
+        const runtime = runtimeWith(FLINK_CONN);
         const flink = handler["getFlinkDirectConfig"](runtime.config);
         expect(flink).toBe(runtime.config.getSoleDirectConnection().flink);
       });

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -41,90 +41,15 @@ export function runtimeWith(
   );
 }
 
-/** Runtime with no service blocks — the disabled case in enabledConnectionIds() tests. */
+/** Runtime with no service blocks — the disabled-baseline shape used by predicate-derivation tests in `base-tools.test.ts` and as a no-config runtime by handlers that don't read connection state. */
 export function bareRuntime(): ServerRuntime {
   return runtimeWith();
-}
-
-/** Runtime with a schema_registry block. */
-export function schemaRegistryRuntime(): ServerRuntime {
-  return runtimeWith({
-    schema_registry: { endpoint: "https://schema-registry.example.com" },
-  });
-}
-
-/** Runtime with a confluent_cloud block. */
-export function confluentCloudRuntime(): ServerRuntime {
-  return runtimeWith({
-    confluent_cloud: {
-      endpoint: "https://api.confluent.cloud",
-      auth: { type: "api_key", key: "k", secret: "s" },
-    },
-  });
-}
-
-/** Runtime with a CCloud-hosted schema_registry (api_key auth) — the minimal enabled case for catalog-API tools. */
-export function ccloudSchemaRegistryRuntime(): ServerRuntime {
-  return runtimeWith({
-    schema_registry: {
-      endpoint: "https://psrc-abc.us-east-1.aws.confluent.cloud",
-      auth: { type: "api_key", key: "k", secret: "s" },
-    },
-  });
 }
 
 /** Runtime with a kafka block. */
 export function kafkaRuntime(): ServerRuntime {
   return runtimeWith({
     kafka: { bootstrap_servers: "broker:9092" },
-  });
-}
-
-/** Runtime with a kafka block containing only a rest_endpoint (no bootstrap_servers) — the disabled case for admin-client handlers. */
-export function kafkaRestOnlyRuntime(): ServerRuntime {
-  return runtimeWith({
-    kafka: { rest_endpoint: "https://kafka-rest.example.com" },
-  });
-}
-
-/** Runtime with a kafka block including a rest_endpoint and auth. */
-export function kafkaRestRuntime(): ServerRuntime {
-  return runtimeWith({
-    kafka: {
-      bootstrap_servers: "broker:9092",
-      rest_endpoint: "https://kafka-rest.example.com",
-      auth: { type: "api_key", key: "k", secret: "s" },
-    },
-  });
-}
-
-/** Runtime with a tableflow block. */
-export function tableflowRuntime(): ServerRuntime {
-  return runtimeWith({
-    tableflow: { auth: { type: "api_key", key: "k", secret: "s" } },
-  });
-}
-
-/** Runtime with a flink block. */
-export function flinkRuntime(): ServerRuntime {
-  return runtimeWith({
-    flink: {
-      endpoint: "https://flink.us-east-1.aws.confluent.cloud",
-      auth: { type: "api_key", key: "k", secret: "s" },
-      environment_id: "env-abc123",
-      organization_id: "org-xyz789",
-      compute_pool_id: "lfcp-pool01",
-    },
-  });
-}
-
-/** Runtime with a telemetry block. */
-export function telemetryRuntime(): ServerRuntime {
-  return runtimeWith({
-    telemetry: {
-      endpoint: "https://api.telemetry.confluent.cloud",
-      auth: { type: "api_key", key: "k", secret: "s" },
-    },
   });
 }
 
@@ -243,9 +168,9 @@ export type FlinkGetCase = HandleCaseWithConn & {
 
 /**
  * Runtime whose sole connection is an OAuth-typed `ConnectionConfig`, loaded
- * from the `ccloud-oauth.yaml` fixture. Used by handler tests to assert that
- * handlers wrapped in `widenForOAuth(...)` see the connection as enabled and
- * that strict-predicate handlers see it as disabled. A stub
+ * from the `ccloud-oauth.yaml` fixture. Used by the OAuth tool-surface
+ * partition test in `src/index.test.ts` to confirm `getToolHandlersToRegister`
+ * enables the expected set of tools against an OAuth runtime. A stub
  * `OAuthClientManager` is supplied solely to satisfy `ServerRuntime`'s
  * constructor — `enabledConnectionIds()` reads `runtime.config.connections`
  * and never touches the client manager.


### PR DESCRIPTION
### Cleanup pass: retire dead runtime-fixture factories

After #390 (per-handler test slim-down) auto-stripped factory imports across handler test files, several factory **definitions** in `tests/factories/runtime.ts` were left orphaned. Caller-file counts after #390:

| Factory                       | Caller files | Decision                                                                    |
| ----------------------------- | -----------: | --------------------------------------------------------------------------- |
| `bareRuntime`                 |            5 | keep — multiple callers                                                     |
| `kafkaRuntime`                |            1 | keep — caller is `base-tools.test.ts`, outside the handler-test layer       |
| `ccloudOAuthRuntime`          |            1 | keep — caller is `src/index.test.ts`, outside the handler-test layer        |
| `flinkRuntime`                |            1 | **delete** — caller is in the handler-test layer; replace with `FLINK_CONN` |
| `schemaRegistryRuntime`       |            0 | **delete**                                                                  |
| `confluentCloudRuntime`       |            0 | **delete**                                                                  |
| `ccloudSchemaRegistryRuntime` |            0 | **delete**                                                                  |
| `kafkaRestOnlyRuntime`        |            0 | **delete**                                                                  |
| `kafkaRestRuntime`            |            0 | **delete**                                                                  |
| `tableflowRuntime`            |            0 | **delete**                                                                  |
| `telemetryRuntime`            |            0 | **delete**                                                                  |

**8 factories deleted** (7 zero-caller + 1 single-caller-inside-handler-test-layer).

The single `flinkRuntime()` call in [flink-tool-handler.test.ts:68](src/confluent/tools/handlers/flink/flink-tool-handler.test.ts#L68) tests `getFlinkDirectConfig(runtime.config)` and only depends on the presence of a flink block, not on its specific values. Replaced with `runtimeWith(FLINK_CONN)` — `FLINK_CONN` is the established Flink fixture used by 51 other call sites, so the substitution consolidates test data on a single shared shape.

## Stale-comment sweep

Two stale `enabledConnectionIds() tests` references in `tests/factories/runtime.ts` docstrings updated:

- `bareRuntime` — was "the disabled case in enabledConnectionIds() tests" (those tests are gone). Now points at the predicate-derivation tests in `base-tools.test.ts` and notes its handler-side use as a no-config baseline.
- `ccloudOAuthRuntime` — was "Used by handler tests to assert that handlers wrapped in `widenForOAuth(...)` see the connection as enabled..." (those handler tests were deleted in #390). Now points at the OAuth tool-surface partition test in `src/index.test.ts` (the actual remaining caller).

A grep pass over the whole repo for `enabledConnectionIds`-in-prose confirmed no other stale references remain (the one legitimate hit is `describe("predicate-derived enabledConnectionIds()", ...)` in `base-tools.test.ts`, which still tests the live derivation function on `BaseToolHandler`).

## Stats

- Suite: 1186 → 1186 (unchanged — no test changes; only test-infra deletions and one fixture-substitution that's runtime-equivalent)
- Lines removed from `tests/factories/runtime.ts`: ~50 (8 factory bodies + 1 leading docblock)
- `tests/factories/runtime.ts` exports: 18 → 10 (removed: 8 factory functions; kept: `runtimeWith`, `DEFAULT_CONNECTION_ID`, `bareRuntime`, `kafkaRuntime`, `ccloudOAuthRuntime`, the 6 `*_CONN` constants, and the 4 type aliases for handle-case shapes)

## Relationships

- Closes #391
- Child of #355


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
