### PR TITLE
`describe-tool-gating` diagnostic tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this MCP server will be documented in this file.
 - Confluent product documentation tools (support `docs.confluent.io`, `developer.confluent.io`, `support.confluent.io`):
   - `search-product-docs` for keyword search across product docs.
   - `get-product-doc-page` for fetching the full markdown content of a single page.
+- New tool `describe-tool-gating` to diagnose why possible tools are not enabled at this time due to mismatches in configuration.
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
 | **Kafka**           | `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages` | Manage topics, produce/consume messages                   |
 | **Schema Registry** | `list-schemas`, `delete-schema`                                                        | List, inspect, and delete data schemas                    |
 | **Documentation**   | `search-product-docs`, `get-product-doc-page`                                          | Search Confluent product docs and fetch full page content |
+| **Diagnostics**     | `describe-tool-gating`                                                                 | Explain why specific tools are absent from `tools/list`   |
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These tools require endpoints and authentication against specific Confluent Clou
 | **Metrics**                                | `list-available-metrics`, `query-metrics`                                                                                                                                                           | Discover and query Confluent Cloud operational metrics            |
 | **Billing**                                | `list-billing-costs`                                                                                                                                                                                | Query billing and cost data                                       |
 | **Documentation**                          | `search-product-docs`, `get-product-doc-page`                                                                                                                                                       | Search Confluent product docs and fetch full page content         |
+| **Diagnostics**                            | `describe-tool-gating`                                                                                                                                                                              | Explain why specific tools are absent from `tools/list`           |
 
 ### Available Tools for Confluent Local
 
@@ -252,6 +253,7 @@ Run with `--config oauth.yaml` and the browser sign-in opens on first start.
 | **Kafka REST**                             | `get-topic-config`, `alter-topic-config`                                               |
 | **Organizations, Environments & Clusters** | `list-organizations`, `list-environments`, `read-environment`, `list-clusters`         |
 | **Billing**                                | `list-billing-costs`                                                                   |
+| **Diagnostics**                            | `describe-tool-gating`                                                                 |
 
 Under OAuth, native-Kafka tools require both `cluster_id` (`lkc-...`) and `environment_id` (`env-...`) at call time. The REST topic-config tools require `clusterId` and `environmentId` (camelCase, matching their existing direct-mode arg names). Discover both via `list-environments` then `list-clusters`.
 
@@ -401,6 +403,7 @@ read-tableflow-catalog-integration: Make a request to read a catalog integration
 update-tableflow-catalog-integration: Make a request to update a catalog integration.
 delete-tableflow-catalog-integration: Make a request to delete a tableflow catalog integration.
 list-organizations: List Confluent Cloud organizations the current credentials can see. Paginated; if the response includes a nextPageToken, pass it back as pageToken to fetch additional pages.
+describe-tool-gating: When you can't find a tool to answer a user's request — e.g., the user asks "why can't I list Kafka topics?", "where are the Flink tools?", "I don't see anything for schema registry" — call this tool first. Returns the disabled tools grouped by what each tool's predicate found missing in the connection config (a kafka/flink/schema_registry/tableflow/telemetry block, a required field within one, or an OAuth-vs-direct-only mismatch). Tell the user the exact YAML to add or change. Always call this rather than speculating about credentials, network, or auth — the server already knows the verdict for every tool.
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See [Getting Started](#getting-started) for full setup instructions and [Configu
 
 - [Quick Start](#quick-start)
 - [Available Tools](#available-tools)
+  - [Always Available](#always-available-tools)
   - [Confluent Cloud](#available-tools-for-confluent-cloud)
   - [Confluent Local](#available-tools-for-confluent-local)
 - [Getting Started](#getting-started)
@@ -51,6 +52,15 @@ You can list all available tools via the CLI:
 npx -y @confluentinc/mcp-confluent --list-tools
 ```
 
+### Always-Available Tools
+
+These tools need no service blocks or authentication — they're enabled even on a bare config, regardless of which deployment the rest of your config targets.
+
+| Category          | Tools                                         | Description                                               |
+| ----------------- | --------------------------------------------- | --------------------------------------------------------- |
+| **Documentation** | `search-product-docs`, `get-product-doc-page` | Search Confluent product docs and fetch full page content |
+| **Diagnostics**   | `describe-tool-gating`                        | Explain why specific tools are absent from `tools/list`   |
+
 ### Available Tools for Confluent Cloud
 
 These tools require endpoints and authentication against specific Confluent Cloud components. Refer to [`config.example.yaml`](config.example.yaml) for the full set of configuration variables, or to [OAuth Authentication for Confluent Cloud](#oauth-authentication-for-confluent-cloud) below to authenticate as a logged-in user instead of via API keys (currently supported by the native-broker **Kafka** tools — `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages`).
@@ -69,8 +79,6 @@ These tools require endpoints and authentication against specific Confluent Clou
 | **Tableflow Catalog**                      | `create-tableflow-catalog-integration`, `list-tableflow-catalog-integrations`, `read-tableflow-catalog-integration`, `update-tableflow-catalog-integration`, `delete-tableflow-catalog-integration` | Manage Tableflow catalog integrations (e.g., AWS Glue)            |
 | **Metrics**                                | `list-available-metrics`, `query-metrics`                                                                                                                                                           | Discover and query Confluent Cloud operational metrics            |
 | **Billing**                                | `list-billing-costs`                                                                                                                                                                                | Query billing and cost data                                       |
-| **Documentation**                          | `search-product-docs`, `get-product-doc-page`                                                                                                                                                       | Search Confluent product docs and fetch full page content         |
-| **Diagnostics**                            | `describe-tool-gating`                                                                                                                                                                              | Explain why specific tools are absent from `tools/list`           |
 
 ### Available Tools for Confluent Local
 
@@ -82,12 +90,10 @@ BOOTSTRAP_SERVERS="localhost:9092"
 SCHEMA_REGISTRY_ENDPOINT="http://localhost:8081"
 ```
 
-| Category            | Tools                                                                                  | Description                                               |
-| ------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| **Kafka**           | `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages` | Manage topics, produce/consume messages                   |
-| **Schema Registry** | `list-schemas`, `delete-schema`                                                        | List, inspect, and delete data schemas                    |
-| **Documentation**   | `search-product-docs`, `get-product-doc-page`                                          | Search Confluent product docs and fetch full page content |
-| **Diagnostics**     | `describe-tool-gating`                                                                 | Explain why specific tools are absent from `tools/list`   |
+| Category            | Tools                                                                                  | Description                             |
+| ------------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Kafka**           | `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages` | Manage topics, produce/consume messages |
+| **Schema Registry** | `list-schemas`, `delete-schema`                                                        | List, inspect, and delete data schemas  |
 
 ## Getting Started
 
@@ -254,7 +260,6 @@ Run with `--config oauth.yaml` and the browser sign-in opens on first start.
 | **Kafka REST**                             | `get-topic-config`, `alter-topic-config`                                               |
 | **Organizations, Environments & Clusters** | `list-organizations`, `list-environments`, `read-environment`, `list-clusters`         |
 | **Billing**                                | `list-billing-costs`                                                                   |
-| **Diagnostics**                            | `describe-tool-gating`                                                                 |
 
 Under OAuth, native-Kafka tools require both `cluster_id` (`lkc-...`) and `environment_id` (`env-...`) at call time. The REST topic-config tools require `clusterId` and `environmentId` (camelCase, matching their existing direct-mode arg names). Discover both via `list-environments` then `list-clusters`.
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "generate:openapi-types": "openapi-typescript ./openapi.json -o ./src/confluent/openapi-schema.d.ts --empty-objects-unknown",
     "print:schema": "node dist/print-md-schema.js",
     "inspector": "npx @modelcontextprotocol/inspector node dist/index.js --env-file .env",
-    "//inspector:yaml": "Pre-checks the yaml file exists before launching the inspector. Without this guard, a missing config file lets the server exit non-zero on startup, which @modelcontextprotocol/inspector treats as a transient crash and respawns endlessly — masking the real cause from anyone trying to figure out why the inspector is misbehaving.",
-    "inspector:yaml": "bash -c 'config=\"${1:-config.yaml}\"; [ -f \"$config\" ] || { echo \"inspector:yaml: config file not found: $config\" >&2; echo \"  cwd: $(pwd)\" >&2; echo \"  hint: pass an explicit path with: npm run inspector:yaml -- path/to/your.yaml\" >&2; exit 1; }; exec npx @modelcontextprotocol/inspector node dist/index.js -- --config \"$config\"' _",
+    "inspector:yaml": "node scripts/inspector-yaml.mjs",
     "prepare": "husky",
     "prepack": "npm run build && node scripts/inject-build-config.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "generate:openapi-types": "openapi-typescript ./openapi.json -o ./src/confluent/openapi-schema.d.ts --empty-objects-unknown",
     "print:schema": "node dist/print-md-schema.js",
     "inspector": "npx @modelcontextprotocol/inspector node dist/index.js --env-file .env",
+    "//inspector:yaml": "Pre-checks the yaml file exists before launching the inspector. Without this guard, a missing config file lets the server exit non-zero on startup, which @modelcontextprotocol/inspector treats as a transient crash and respawns endlessly — masking the real cause from anyone trying to figure out why the inspector is misbehaving.",
+    "inspector:yaml": "bash -c 'config=\"${1:-config.yaml}\"; [ -f \"$config\" ] || { echo \"inspector:yaml: config file not found: $config\" >&2; echo \"  cwd: $(pwd)\" >&2; echo \"  hint: pass an explicit path with: npm run inspector:yaml -- path/to/your.yaml\" >&2; exit 1; }; exec npx @modelcontextprotocol/inspector node dist/index.js -- --config \"$config\"' _",
     "prepare": "husky",
     "prepack": "npm run build && node scripts/inject-build-config.mjs"
   },

--- a/scripts/inspector-yaml.mjs
+++ b/scripts/inspector-yaml.mjs
@@ -49,6 +49,17 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
   process.on(signal, () => child.kill(signal));
 }
 
+// `error` fires when spawn itself fails (e.g. ENOENT because npx is not on
+// PATH). Without this handler the script hangs without explaining why the
+// inspector never came up.
+child.on("error", (err) => {
+  process.stderr.write(
+    `inspector:yaml: failed to launch the MCP Inspector: ${err.message}\n` +
+      `  hint: ensure npx is on PATH (it ships with Node)\n`,
+  );
+  process.exit(1);
+});
+
 child.on("exit", (code, signal) => {
   if (signal !== null) {
     // Surface the killing signal in the parent's exit so the shell sees the

--- a/scripts/inspector-yaml.mjs
+++ b/scripts/inspector-yaml.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+// Launches @modelcontextprotocol/inspector against a YAML config, defaulting
+// to ./config.yaml when no argument is given. Pre-checks the file exists
+// before spawning so the inspector doesn't restart-loop on a missing config
+// (its default behaviour when the spawned server exits non-zero on startup,
+// which obscures the real cause).
+//
+// Cross-platform replacement for the previous `bash -c` wrapper in
+// package.json. Driven by `npm run inspector:yaml [-- path/to/your.yaml]`.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const configPath = process.argv[2] ?? "config.yaml";
+const absolutePath = resolve(configPath);
+
+if (!existsSync(absolutePath)) {
+  process.stderr.write(
+    `inspector:yaml: config file not found: ${configPath}\n` +
+      `  cwd: ${process.cwd()}\n` +
+      `  hint: pass an explicit path with: npm run inspector:yaml -- path/to/your.yaml\n`,
+  );
+  process.exit(1);
+}
+
+// `npx` is `npx.cmd` on Windows; spawning the bare name there fails with
+// ENOENT unless the platform-specific extension is supplied.
+const npx = process.platform === "win32" ? "npx.cmd" : "npx";
+
+const child = spawn(
+  npx,
+  [
+    "@modelcontextprotocol/inspector",
+    "node",
+    "dist/index.js",
+    "--config",
+    configPath,
+  ],
+  { stdio: "inherit" },
+);
+
+// Forward Ctrl-C / kill signals to the inspector so it can shut down its
+// own child (the spawned mcp-confluent server) cleanly. Without this the
+// parent exits before the child has a chance to clean up its localhost
+// listener.
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => child.kill(signal));
+}
+
+child.on("exit", (code, signal) => {
+  if (signal !== null) {
+    // Surface the killing signal in the parent's exit so the shell sees the
+    // expected 128+N convention.
+    process.exit(128 + (signalNumber(signal) ?? 0));
+  }
+  process.exit(code ?? 0);
+});
+
+/**
+ * Best-effort numeric value for a Node signal name, so the parent can
+ * exit with the conventional 128+N when the child was killed by signal.
+ * Falls back to undefined for signals not in this small set; the caller
+ * substitutes 0 in that case.
+ */
+function signalNumber(signal) {
+  return { SIGINT: 2, SIGTERM: 15, SIGHUP: 1, SIGQUIT: 3 }[signal];
+}

--- a/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.test.ts
@@ -1,0 +1,159 @@
+import { CallToolResult } from "@src/confluent/schema.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
+import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
+import { DescribeToolGatingHandler } from "@src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.js";
+import type { ToolGatingReport } from "@src/confluent/tools/tool-availability.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
+import {
+  KAFKA_CONN,
+  bareRuntime,
+  ccloudOAuthRuntime,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import { describe, expect, it } from "vitest";
+
+function getText(result: CallToolResult): string {
+  const item = result.content[0]!;
+  if (item.type !== "text") throw new Error("expected text content");
+  return item.text;
+}
+
+/** Escape regex metacharacters in a literal string so it can be embedded
+ *  inside a `new RegExp(...)` pattern without partial-match surprises
+ *  from `'.'` or `'('` inside enum string values. */
+function escapeForRegex(literal: string): string {
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+function getReport(result: CallToolResult): ToolGatingReport {
+  const meta = result._meta;
+  if (meta === undefined) throw new Error("expected _meta on result");
+  return meta as unknown as ToolGatingReport;
+}
+
+describe("describe-tool-gating-handler.ts", () => {
+  describe("DescribeToolGatingHandler", () => {
+    const handler = new DescribeToolGatingHandler(() =>
+      ToolHandlerRegistry.allHandlers(),
+    );
+
+    describe("getToolConfig()", () => {
+      it("should be a read-only tool named DESCRIBE_TOOL_GATING with no input fields", () => {
+        const config = handler.getToolConfig();
+        expect(config.name).toBe(ToolName.DESCRIBE_TOOL_GATING);
+        expect(config.annotations).toBe(READ_ONLY);
+        expect(config.inputSchema).toEqual({});
+        expect(config.description.length).toBeGreaterThan(10);
+      });
+    });
+
+    describe("handle()", () => {
+      it("should report kafka-gated tools under MissingKafkaBlock when run against a bare runtime", async () => {
+        const result = handler.handle(bareRuntime());
+        const report = getReport(result);
+
+        const kafkaGroup = report.disabled_groups.find(
+          (g) => g.reason === ToolDisabledReason.MissingKafkaBlock,
+        );
+        expect(
+          kafkaGroup,
+          "expected a disabled_groups entry for MissingKafkaBlock against a bare runtime",
+        ).toBeDefined();
+        expect(kafkaGroup!.tools).toContain(ToolName.LIST_TOPICS);
+        expect(kafkaGroup!.tools).toContain(ToolName.PRODUCE_MESSAGE);
+        expect(report.disabled_count).toBeGreaterThan(0);
+      });
+
+      it("should not list alwaysEnabled tools (search-product-docs, get-product-doc-page, describe-tool-gating) under any disabled group", async () => {
+        const result = handler.handle(bareRuntime());
+        const report = getReport(result);
+
+        const allDisabledTools = report.disabled_groups.flatMap((g) => g.tools);
+        expect(allDisabledTools).not.toContain(ToolName.SEARCH_PRODUCT_DOCS);
+        expect(allDisabledTools).not.toContain(ToolName.GET_PRODUCT_DOC_PAGE);
+        expect(allDisabledTools).not.toContain(ToolName.DESCRIBE_TOOL_GATING);
+      });
+
+      it("should remove kafka tools from disabled_groups when the connection carries a kafka block", async () => {
+        const result = handler.handle(runtimeWith(KAFKA_CONN));
+        const report = getReport(result);
+
+        const allDisabledTools = report.disabled_groups.flatMap((g) => g.tools);
+        expect(allDisabledTools).not.toContain(ToolName.LIST_TOPICS);
+        expect(allDisabledTools).not.toContain(ToolName.PRODUCE_MESSAGE);
+
+        const flinkGroup = report.disabled_groups.find(
+          (g) => g.reason === ToolDisabledReason.MissingFlinkBlock,
+        );
+        expect(flinkGroup).toBeDefined();
+        expect(flinkGroup!.tools).toContain(ToolName.LIST_FLINK_STATEMENTS);
+      });
+
+      it("should report OAuthNoServiceBlocks against an OAuth-typed connection for tools that need a service block", async () => {
+        const result = handler.handle(ccloudOAuthRuntime());
+        const report = getReport(result);
+
+        const oauthGroup = report.disabled_groups.find(
+          (g) => g.reason === ToolDisabledReason.OAuthNoServiceBlocks,
+        );
+        expect(oauthGroup).toBeDefined();
+        expect(oauthGroup!.tools).toContain(ToolName.LIST_FLINK_STATEMENTS);
+      });
+
+      it("should account for every registered tool in the enabled and disabled counts (no double-counting, no skips)", async () => {
+        const result = handler.handle(bareRuntime());
+        const report = getReport(result);
+
+        const totalRegistered = Array.from(
+          ToolHandlerRegistry.allHandlers(),
+        ).length;
+        expect(report.enabled_count + report.disabled_count).toBe(
+          totalRegistered,
+        );
+        const flatDisabledCount = report.disabled_groups.reduce(
+          (sum, g) => sum + g.tools.length,
+          0,
+        );
+        expect(flatDisabledCount).toBe(report.disabled_count);
+      });
+
+      it("should render the disabled-count summary header with both totals", async () => {
+        const text = getText(handler.handle(bareRuntime()));
+        const totalRegistered = Array.from(
+          ToolHandlerRegistry.allHandlers(),
+        ).length;
+        expect(text).toMatch(
+          new RegExp(
+            String.raw`^\d+ of ${totalRegistered} tools disabled for the following reasons:`,
+          ),
+        );
+      });
+
+      it("should render each disabled group as a header line plus indented '    - <tool>' bullets", async () => {
+        const text = getText(handler.handle(bareRuntime()));
+        // Pin the specific kafka group: header ends with `(<n>):` (no inline
+        // tool list), and each tool lives on its own bullet line indented
+        // four spaces. A future regression that reverts to the old
+        // comma-joined form fails on the bullet expectation.
+        expect(text).toMatch(
+          new RegExp(
+            String.raw`\n  ${escapeForRegex(ToolDisabledReason.MissingKafkaBlock)} \(\d+\):\n`,
+          ),
+        );
+        expect(text).toContain("\n    - list-topics\n");
+        expect(text).toContain("tools advertised via tools/list.");
+      });
+
+      it("should render a single 'all tools enabled' summary when nothing is disabled", async () => {
+        // Build a no-tool registry-thunk so every tool is trivially absent
+        // from the disabled set; the flat-summary branch fires.
+        const empty = new DescribeToolGatingHandler(() => []);
+        const text = getText(empty.handle(bareRuntime()));
+        expect(text).toBe(
+          "All 0 registered tools are advertised via tools/list.",
+        );
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.test.ts
@@ -53,37 +53,37 @@ describe("describe-tool-gating-handler.ts", () => {
         const result = handler.handle(bareRuntime());
         const report = getReport(result);
 
-        const kafkaGroup = report.disabled_groups.find(
+        const kafkaGroup = report.disabledGroups.find(
           (g) => g.reason === ToolDisabledReason.MissingKafkaBlock,
         );
         expect(
           kafkaGroup,
-          "expected a disabled_groups entry for MissingKafkaBlock against a bare runtime",
+          "expected a disabledGroups entry for MissingKafkaBlock against a bare runtime",
         ).toBeDefined();
         expect(kafkaGroup!.tools).toContain(ToolName.LIST_TOPICS);
         expect(kafkaGroup!.tools).toContain(ToolName.PRODUCE_MESSAGE);
-        expect(report.disabled_count).toBeGreaterThan(0);
+        expect(report.disabledCount).toBeGreaterThan(0);
       });
 
       it("should not list alwaysEnabled tools (search-product-docs, get-product-doc-page, describe-tool-gating) under any disabled group", async () => {
         const result = handler.handle(bareRuntime());
         const report = getReport(result);
 
-        const allDisabledTools = report.disabled_groups.flatMap((g) => g.tools);
+        const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
         expect(allDisabledTools).not.toContain(ToolName.SEARCH_PRODUCT_DOCS);
         expect(allDisabledTools).not.toContain(ToolName.GET_PRODUCT_DOC_PAGE);
         expect(allDisabledTools).not.toContain(ToolName.DESCRIBE_TOOL_GATING);
       });
 
-      it("should remove kafka tools from disabled_groups when the connection carries a kafka block", async () => {
+      it("should remove kafka tools from disabledGroups when the connection carries a kafka block", async () => {
         const result = handler.handle(runtimeWith(KAFKA_CONN));
         const report = getReport(result);
 
-        const allDisabledTools = report.disabled_groups.flatMap((g) => g.tools);
+        const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
         expect(allDisabledTools).not.toContain(ToolName.LIST_TOPICS);
         expect(allDisabledTools).not.toContain(ToolName.PRODUCE_MESSAGE);
 
-        const flinkGroup = report.disabled_groups.find(
+        const flinkGroup = report.disabledGroups.find(
           (g) => g.reason === ToolDisabledReason.MissingFlinkBlock,
         );
         expect(flinkGroup).toBeDefined();
@@ -94,7 +94,7 @@ describe("describe-tool-gating-handler.ts", () => {
         const result = handler.handle(ccloudOAuthRuntime());
         const report = getReport(result);
 
-        const oauthGroup = report.disabled_groups.find(
+        const oauthGroup = report.disabledGroups.find(
           (g) => g.reason === ToolDisabledReason.OAuthNoServiceBlocks,
         );
         expect(oauthGroup).toBeDefined();
@@ -108,14 +108,14 @@ describe("describe-tool-gating-handler.ts", () => {
         const totalRegistered = Array.from(
           ToolHandlerRegistry.allHandlers(),
         ).length;
-        expect(report.enabled_count + report.disabled_count).toBe(
+        expect(report.enabledCount + report.disabledCount).toBe(
           totalRegistered,
         );
-        const flatDisabledCount = report.disabled_groups.reduce(
+        const flatDisabledCount = report.disabledGroups.reduce(
           (sum, g) => sum + g.tools.length,
           0,
         );
-        expect(flatDisabledCount).toBe(report.disabled_count);
+        expect(flatDisabledCount).toBe(report.disabledCount);
       });
 
       it("should render the disabled-count summary header with both totals", async () => {

--- a/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
@@ -1,0 +1,130 @@
+import { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  READ_ONLY,
+  ToolConfig,
+  ToolHandler,
+} from "@src/confluent/tools/base-tools.js";
+import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
+import {
+  buildToolGatingReport,
+  type DisabledToolsByReason,
+  type ToolGatingReport,
+} from "@src/confluent/tools/tool-availability.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { ServerRuntime } from "@src/server-runtime.js";
+import { z } from "zod";
+
+const describeToolGatingArguments = z.object({});
+
+/**
+ * Diagnostic tool that surfaces *why* tools are absent from `tools/list`.
+ *
+ * The MCP protocol already advertises the enabled tool set via `tools/list`;
+ * what it does not surface is the predicate-driven decision behind every
+ * absence — which config piece is missing, and which tools each gap would
+ * unlock. This handler returns that view.
+ *
+ * v1 scope (today's release): the server enforces a single configured
+ * connection (see `enforceSingleConnectionOnly()` in
+ * `src/config/models.ts`), so the output is a flat list of disabled tools
+ * grouped by the missing config piece (kafka block, flink block, schema
+ * registry block, …). Tools enabled on the active connection are
+ * intentionally absent — `tools/list` already advertises them.
+ *
+ * v2 plan (when multi-connection support lands — issue #151's follow-ups):
+ * regrow output around connections. The text body becomes one block per
+ * connection (header + per-connection gaps) plus a `Cross-connection
+ * deltas` section that surfaces tools enabled on some connections but not
+ * others — the canonical "what does connection B need to reach parity with
+ * connection A?" view. The structured `_meta` shape mirrors that change;
+ * see the {@linkcode ToolGatingReport} JSDoc in `tool-availability.ts` for
+ * the exact target type. Until then this handler keeps a flat, single-
+ * connection view, but the helper already iterates `runtime.config.connections`
+ * defensively so multi-connection runtimes degrade gracefully (every
+ * connection's verdict feeds into the same flat groups) rather than
+ * crashing.
+ *
+ * Always enabled (predicate is `alwaysEnabled`) so an operator can call it
+ * to diagnose a config that left every other tool disabled.
+ *
+ * The handlers iterable is supplied at construction time via a thunk so
+ * this module does not need to import `ToolHandlerRegistry`. Importing the
+ * registry from a registered handler would create an ESM cycle, leaving
+ * the registry's static initializer running before this class's binding
+ * is set. The thunk is invoked at request time, after every module is
+ * fully loaded, sidestepping the cycle entirely.
+ */
+export class DescribeToolGatingHandler extends BaseToolHandler {
+  private readonly listHandlers: () => Iterable<
+    readonly [ToolName, ToolHandler]
+  >;
+
+  constructor(listHandlers: () => Iterable<readonly [ToolName, ToolHandler]>) {
+    super();
+    this.listHandlers = listHandlers;
+  }
+
+  handle(runtime: ServerRuntime): CallToolResult {
+    const report = buildToolGatingReport(this.listHandlers(), runtime);
+    return this.createResponse(
+      renderReport(report),
+      false,
+      report as unknown as Record<string, unknown>,
+    );
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: ToolName.DESCRIBE_TOOL_GATING,
+      description:
+        'When you can\'t find a tool to answer a user\'s request — e.g., the user asks "why can\'t I list Kafka topics?", "where are the Flink tools?", "I don\'t see anything for schema registry" — call this tool first. Returns the disabled tools grouped by what each tool\'s predicate found missing in the connection config (a kafka/flink/schema_registry/tableflow/telemetry block, a required field within one, or an OAuth-vs-direct-only mismatch). Tell the user the exact YAML to add or change. Always call this rather than speculating about credentials, network, or auth — the server already knows the verdict for every tool.',
+      inputSchema: describeToolGatingArguments.shape,
+      annotations: READ_ONLY,
+    };
+  }
+
+  readonly predicate = alwaysEnabled;
+}
+
+/**
+ * Render a {@linkcode ToolGatingReport} as the human-readable text body of
+ * the tool's response. Format is stable — handler tests pin specific
+ * substrings so the AI/script-facing structure does not drift silently.
+ *
+ * v1 (single-connection) shape:
+ *
+ *   {disabled} of {total} tools disabled for the following reasons:
+ *
+ *     {reason} ({n}): {tool, tool, ...}
+ *     ...
+ *
+ *   {enabled} tools advertised via tools/list.
+ *
+ * v2 (multi-connection): grow a connection header per per-connection
+ * section and an optional `Cross-connection deltas` section. See the
+ * handler's class JSDoc for the migration sketch.
+ */
+function renderReport(report: ToolGatingReport): string {
+  const total = report.enabled_count + report.disabled_count;
+  if (report.disabled_count === 0) {
+    return `All ${total} registered tools are advertised via tools/list.`;
+  }
+
+  // Each group's render contains its own header line + indented bullets;
+  // joining with a blank line separates groups visually so long bullet
+  // lists from one group don't bleed into the next.
+  return [
+    `${report.disabled_count} of ${total} tools disabled for the following reasons:`,
+    "",
+    report.disabled_groups.map(renderGroup).join("\n\n"),
+    "",
+    `${report.enabled_count} tools advertised via tools/list.`,
+  ].join("\n");
+}
+
+function renderGroup(group: DisabledToolsByReason): string {
+  const header = `  ${group.reason} (${group.tools.length}):`;
+  const bullets = group.tools.map((tool) => `    - ${tool}`);
+  return [header, ...bullets].join("\n");
+}

--- a/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
@@ -74,11 +74,7 @@ export class DescribeToolGatingHandler extends BaseToolHandler {
 
   handle(runtime: ServerRuntime): CallToolResult {
     const report = buildToolGatingReport(this.listHandlers(), runtime);
-    return this.createResponse(
-      renderReport(report),
-      false,
-      report as unknown as Record<string, unknown>,
-    );
+    return this.createResponse(renderReport(report), false, { ...report });
   }
 
   getToolConfig(): ToolConfig {

--- a/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
@@ -39,11 +39,18 @@ const describeToolGatingArguments = z.object({});
  * others — the canonical "what does connection B need to reach parity with
  * connection A?" view. The structured `_meta` shape mirrors that change;
  * see the {@linkcode ToolGatingReport} JSDoc in `tool-availability.ts` for
- * the exact target type. Until then this handler keeps a flat, single-
- * connection view, but the helper already iterates `runtime.config.connections`
- * defensively so multi-connection runtimes degrade gracefully (every
- * connection's verdict feeds into the same flat groups) rather than
- * crashing.
+ * the exact target type.
+ *
+ * Until v2 lands, the helper accepts a multi-connection runtime without
+ * crashing, but the v1 flatten is *lossy*: a tool whose predicate is
+ * enabled on at least one configured connection is reported as enabled
+ * (and therefore omitted from `disabled_groups` entirely), and a tool
+ * disabled on multiple connections with different reasons is bucketed
+ * under the first disabled verdict its iteration produces — the
+ * cross-connection asymmetry vanishes from the output. Today's
+ * single-connection invariant means neither lossy case can fire in
+ * production; this paragraph exists so a future reader does not mistake
+ * defensive iteration for parity reporting.
  *
  * Always enabled (predicate is `alwaysEnabled`) so an operator can call it
  * to diagnose a config that left every other tool disabled.
@@ -96,10 +103,21 @@ export class DescribeToolGatingHandler extends BaseToolHandler {
  *
  *   {disabled} of {total} tools disabled for the following reasons:
  *
- *     {reason} ({n}): {tool, tool, ...}
- *     ...
+ *     {reason} ({n}):
+ *       - {tool}
+ *       - {tool}
+ *       …
+ *
+ *     {next reason} ({n}):
+ *       - {tool}
+ *       …
  *
  *   {enabled} tools advertised via tools/list.
+ *
+ * Each disabled-reason group is a header line followed by one tool per
+ * indented bullet (two-space indent on the reason header, four-space
+ * indent on the bullets). Groups are separated by a blank line so
+ * adjacent buckets stay visually distinct.
  *
  * v2 (multi-connection): grow a connection header per per-connection
  * section and an optional `Cross-connection deltas` section. See the

--- a/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.ts
@@ -44,7 +44,7 @@ const describeToolGatingArguments = z.object({});
  * Until v2 lands, the helper accepts a multi-connection runtime without
  * crashing, but the v1 flatten is *lossy*: a tool whose predicate is
  * enabled on at least one configured connection is reported as enabled
- * (and therefore omitted from `disabled_groups` entirely), and a tool
+ * (and therefore omitted from `disabledGroups` entirely), and a tool
  * disabled on multiple connections with different reasons is bucketed
  * under the first disabled verdict its iteration produces — the
  * cross-connection asymmetry vanishes from the output. Today's
@@ -124,8 +124,8 @@ export class DescribeToolGatingHandler extends BaseToolHandler {
  * handler's class JSDoc for the migration sketch.
  */
 function renderReport(report: ToolGatingReport): string {
-  const total = report.enabled_count + report.disabled_count;
-  if (report.disabled_count === 0) {
+  const total = report.enabledCount + report.disabledCount;
+  if (report.disabledCount === 0) {
     return `All ${total} registered tools are advertised via tools/list.`;
   }
 
@@ -133,11 +133,11 @@ function renderReport(report: ToolGatingReport): string {
   // joining with a blank line separates groups visually so long bullet
   // lists from one group don't bleed into the next.
   return [
-    `${report.disabled_count} of ${total} tools disabled for the following reasons:`,
+    `${report.disabledCount} of ${total} tools disabled for the following reasons:`,
     "",
-    report.disabled_groups.map(renderGroup).join("\n\n"),
+    report.disabledGroups.map(renderGroup).join("\n\n"),
     "",
-    `${report.enabled_count} tools advertised via tools/list.`,
+    `${report.enabledCount} tools advertised via tools/list.`,
   ].join("\n");
 }
 

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -2,6 +2,7 @@ import type { DirectConnectionConfig } from "@src/config/index.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectionPredicate,
+  PredicateResult,
   ToolDisabledReason,
   alwaysEnabled,
 } from "@src/confluent/tools/connection-predicates.js";
@@ -48,6 +49,24 @@ const enabledOnlyWithKafka: ConnectionPredicate = (conn) =>
         enabled: false,
         reason: ToolDisabledReason.MissingKafkaBlock,
       };
+
+/**
+ * Returns a {@linkcode ToolHandler} whose `connectionVerdicts()` resolves
+ * to an empty map — the invariant-violation shape the diagnostic tool
+ * guards against. `BaseToolHandler.connectionVerdicts` is documented as
+ * `@final` but the test deliberately monkey-patches the instance method
+ * to reach a branch that should be unreachable in production (every
+ * runtime carries at least one connection by `enforceSingleConnectionOnly`).
+ */
+function handlerWithEmptyVerdicts(): ToolHandler {
+  const handler = new StubHandler();
+  (
+    handler as unknown as {
+      connectionVerdicts: () => Map<string, PredicateResult>;
+    }
+  ).connectionVerdicts = () => new Map();
+  return handler;
+}
 
 /**
  * Splice an additional `direct`-typed connection into a runtime built by
@@ -234,6 +253,47 @@ describe("tool-availability.ts", () => {
         enabled_count: 0,
         disabled_count: 3,
       });
+    });
+
+    it("should classify a tool as enabled when at least one configured connection passes its predicate, omitting it from disabled_groups (lossy v1 flatten)", () => {
+      // Pins the v1 single-connection-scope behaviour against a synthesised
+      // multi-connection runtime: a tool enabled on `with-kafka` and
+      // disabled on `without-kafka` is reported as enabled overall, with
+      // no entry in `disabled_groups`. The asymmetry is dropped — the v2
+      // per-connection / cross-connection-deltas shape (see
+      // ToolGatingReport JSDoc) is the proper fix for this. This test
+      // exists so the lossy aggregation is documented in code rather
+      // than implied by prose.
+      const handler = stubWithPredicate(enabledOnlyWithKafka);
+      const runtime = runtimeWith(KAFKA_CONN, "with-kafka");
+      addConnection(runtime, "without-kafka", {});
+
+      const report = buildToolGatingReport(
+        [[ToolName.LIST_TOPICS, handler]],
+        runtime,
+      );
+
+      expect(report).toEqual({
+        disabled_groups: [],
+        enabled_count: 1,
+        disabled_count: 0,
+      });
+    });
+
+    it("should throw a 'Wacky --' error when a handler returns an empty verdict map (invariant violation)", () => {
+      // The empty-verdict-map case means a tool's `connectionVerdicts()`
+      // returned no entries — which only happens if `runtime.config.connections`
+      // is empty, which `enforceSingleConnectionOnly()` should have prevented
+      // at bootstrap. The diagnostic tool fails loudly with a `Wacky --`
+      // message rather than fabricating a misleading reason (e.g. the
+      // never-applicable `OAuthNoServiceBlocks`) and shipping it in the
+      // operator-facing report.
+      expect(() =>
+        buildToolGatingReport(
+          [[ToolName.LIST_TOPICS, handlerWithEmptyVerdicts()]],
+          runtimeWith({}),
+        ),
+      ).toThrow(/Wacky --.*empty verdict map/i);
     });
 
     it("should preserve handler iteration order for tools within a single reason group", () => {

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -1,10 +1,14 @@
+import type { DirectConnectionConfig } from "@src/config/index.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectionPredicate,
   ToolDisabledReason,
   alwaysEnabled,
 } from "@src/confluent/tools/connection-predicates.js";
-import { groupDisabledToolsByReason } from "@src/confluent/tools/tool-availability.js";
+import {
+  buildToolGatingReport,
+  groupDisabledToolsByReason,
+} from "@src/confluent/tools/tool-availability.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   KAFKA_CONN,
@@ -31,6 +35,39 @@ const disabledForFlink: ConnectionPredicate = () => ({
   enabled: false,
   reason: ToolDisabledReason.MissingFlinkBlock,
 });
+
+/**
+ * Predicate that enables only on direct connections carrying a `kafka` block.
+ * Used to fabricate the "tool is enabled on connection A but not B" shape
+ * that drives partial-enable / cross-connection-delta tests.
+ */
+const enabledOnlyWithKafka: ConnectionPredicate = (conn) =>
+  conn.type === "direct" && conn.kafka !== undefined
+    ? { enabled: true }
+    : {
+        enabled: false,
+        reason: ToolDisabledReason.MissingKafkaBlock,
+      };
+
+/**
+ * Splice an additional `direct`-typed connection into a runtime built by
+ * `runtimeWith`. The factory's `Readonly<Record<…>>` typing is widened with
+ * a cast so the helper can mutate the map in-place — the helpers under test
+ * only read `runtime.config.connections`, so a fresh multi-connection
+ * `MCPServerConfiguration` would be ceremony for no behavioural difference.
+ */
+function addConnection(
+  runtime: ReturnType<typeof runtimeWith>,
+  id: string,
+  block: Omit<DirectConnectionConfig, "type">,
+): void {
+  (
+    runtime.config.connections as Record<
+      string,
+      (typeof runtime.config.connections)[string]
+    >
+  )[id] = { type: "direct", ...block };
+}
 
 describe("tool-availability.ts", () => {
   describe("groupDisabledToolsByReason()", () => {
@@ -107,29 +144,11 @@ describe("tool-availability.ts", () => {
     });
 
     it("should omit tools that are enabled on at least one connection (only fully-disabled tools group)", () => {
-      // Predicate enables only on connections carrying a kafka block.
-      const partiallyEnabled: ConnectionPredicate = (conn) =>
-        conn.type === "direct" && conn.kafka !== undefined
-          ? { enabled: true }
-          : {
-              enabled: false,
-              reason: ToolDisabledReason.MissingKafkaBlock,
-            };
-      const handler = stubWithPredicate(partiallyEnabled);
+      const handler = stubWithPredicate(enabledOnlyWithKafka);
       const runtime = runtimeWith(KAFKA_CONN);
-      // Cast because `connections` is typed as `Readonly<Record<…>>`. We
-      // splice in a second connection here rather than building a fresh
-      // multi-connection ServerRuntime — the test only exercises the
-      // grouping helper's read path.
-      (
-        runtime.config.connections as Record<
-          string,
-          (typeof runtime.config.connections)[string]
-        >
-      )["other"] = {
-        type: "direct",
+      addConnection(runtime, "other", {
         schema_registry: { endpoint: "http://sr" },
-      };
+      });
       expect(
         groupDisabledToolsByReason([[ToolName.LIST_TOPICS, handler]], runtime),
       ).toEqual([]);
@@ -145,15 +164,9 @@ describe("tool-availability.ts", () => {
       const kafkaTool = stubWithPredicate(disabledForKafka);
       const flinkTool = stubWithPredicate(disabledForFlink);
       const runtime = runtimeWith({}, "zeta");
-      (
-        runtime.config.connections as Record<
-          string,
-          (typeof runtime.config.connections)[string]
-        >
-      )["alpha"] = {
-        type: "direct",
+      addConnection(runtime, "alpha", {
         schema_registry: { endpoint: "http://sr-alpha" },
-      };
+      });
 
       const groups = groupDisabledToolsByReason(
         [
@@ -168,6 +181,86 @@ describe("tool-availability.ts", () => {
         ["alpha", ToolDisabledReason.MissingFlinkBlock],
         ["zeta", ToolDisabledReason.MissingKafkaBlock],
         ["zeta", ToolDisabledReason.MissingFlinkBlock],
+      ]);
+    });
+  });
+
+  describe("buildToolGatingReport()", () => {
+    it("should produce an empty report with zero counts when no tools are passed", () => {
+      const report = buildToolGatingReport([], runtimeWith({}, "default"));
+      expect(report).toEqual({
+        disabled_groups: [],
+        enabled_count: 0,
+        disabled_count: 0,
+      });
+    });
+
+    it("should report each tool as enabled and emit no disabled_groups when every tool passes its predicate", () => {
+      const handler = stubWithPredicate(alwaysEnabled);
+      const report = buildToolGatingReport(
+        [[ToolName.LIST_TOPICS, handler]],
+        runtimeWith(KAFKA_CONN),
+      );
+      expect(report).toEqual({
+        disabled_groups: [],
+        enabled_count: 1,
+        disabled_count: 0,
+      });
+    });
+
+    it("should group fully-disabled tools by reason, sorted lex by reason", () => {
+      const kafkaTool = stubWithPredicate(disabledForKafka);
+      const otherKafkaTool = stubWithPredicate(disabledForKafka);
+      const flinkTool = stubWithPredicate(disabledForFlink);
+      const report = buildToolGatingReport(
+        [
+          [ToolName.LIST_TOPICS, kafkaTool],
+          [ToolName.CREATE_TOPICS, otherKafkaTool],
+          [ToolName.LIST_FLINK_STATEMENTS, flinkTool],
+        ],
+        runtimeWith({}, "default"),
+      );
+      expect(report).toEqual({
+        disabled_groups: [
+          {
+            reason: ToolDisabledReason.MissingFlinkBlock,
+            tools: [ToolName.LIST_FLINK_STATEMENTS],
+          },
+          {
+            reason: ToolDisabledReason.MissingKafkaBlock,
+            tools: [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+          },
+        ],
+        enabled_count: 0,
+        disabled_count: 3,
+      });
+    });
+
+    it("should preserve handler iteration order for tools within a single reason group", () => {
+      // Insertion order matters for the rendered text: handlers iterate in
+      // registry-declaration order, and the diagnostic surface should show
+      // tools in that same order so adjacent tools (e.g. all kafka tools)
+      // stay visually grouped.
+      const handlerA = stubWithPredicate(disabledForKafka);
+      const handlerB = stubWithPredicate(disabledForKafka);
+      const handlerC = stubWithPredicate(disabledForKafka);
+      const report = buildToolGatingReport(
+        [
+          [ToolName.PRODUCE_MESSAGE, handlerA],
+          [ToolName.LIST_TOPICS, handlerB],
+          [ToolName.CREATE_TOPICS, handlerC],
+        ],
+        runtimeWith({}, "default"),
+      );
+      expect(report.disabled_groups).toEqual([
+        {
+          reason: ToolDisabledReason.MissingKafkaBlock,
+          tools: [
+            ToolName.PRODUCE_MESSAGE,
+            ToolName.LIST_TOPICS,
+            ToolName.CREATE_TOPICS,
+          ],
+        },
       ]);
     });
   });

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -208,22 +208,22 @@ describe("tool-availability.ts", () => {
     it("should produce an empty report with zero counts when no tools are passed", () => {
       const report = buildToolGatingReport([], runtimeWith({}, "default"));
       expect(report).toEqual({
-        disabled_groups: [],
-        enabled_count: 0,
-        disabled_count: 0,
+        disabledGroups: [],
+        enabledCount: 0,
+        disabledCount: 0,
       });
     });
 
-    it("should report each tool as enabled and emit no disabled_groups when every tool passes its predicate", () => {
+    it("should report each tool as enabled and emit no disabledGroups when every tool passes its predicate", () => {
       const handler = stubWithPredicate(alwaysEnabled);
       const report = buildToolGatingReport(
         [[ToolName.LIST_TOPICS, handler]],
         runtimeWith(KAFKA_CONN),
       );
       expect(report).toEqual({
-        disabled_groups: [],
-        enabled_count: 1,
-        disabled_count: 0,
+        disabledGroups: [],
+        enabledCount: 1,
+        disabledCount: 0,
       });
     });
 
@@ -240,7 +240,7 @@ describe("tool-availability.ts", () => {
         runtimeWith({}, "default"),
       );
       expect(report).toEqual({
-        disabled_groups: [
+        disabledGroups: [
           {
             reason: ToolDisabledReason.MissingFlinkBlock,
             tools: [ToolName.LIST_FLINK_STATEMENTS],
@@ -250,16 +250,16 @@ describe("tool-availability.ts", () => {
             tools: [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
           },
         ],
-        enabled_count: 0,
-        disabled_count: 3,
+        enabledCount: 0,
+        disabledCount: 3,
       });
     });
 
-    it("should classify a tool as enabled when at least one configured connection passes its predicate, omitting it from disabled_groups (lossy v1 flatten)", () => {
+    it("should classify a tool as enabled when at least one configured connection passes its predicate, omitting it from disabledGroups (lossy v1 flatten)", () => {
       // Pins the v1 single-connection-scope behaviour against a synthesised
       // multi-connection runtime: a tool enabled on `with-kafka` and
       // disabled on `without-kafka` is reported as enabled overall, with
-      // no entry in `disabled_groups`. The asymmetry is dropped — the v2
+      // no entry in `disabledGroups`. The asymmetry is dropped — the v2
       // per-connection / cross-connection-deltas shape (see
       // ToolGatingReport JSDoc) is the proper fix for this. This test
       // exists so the lossy aggregation is documented in code rather
@@ -274,9 +274,9 @@ describe("tool-availability.ts", () => {
       );
 
       expect(report).toEqual({
-        disabled_groups: [],
-        enabled_count: 1,
-        disabled_count: 0,
+        disabledGroups: [],
+        enabledCount: 1,
+        disabledCount: 0,
       });
     });
 
@@ -312,7 +312,7 @@ describe("tool-availability.ts", () => {
         ],
         runtimeWith({}, "default"),
       );
-      expect(report.disabled_groups).toEqual([
+      expect(report.disabledGroups).toEqual([
         {
           reason: ToolDisabledReason.MissingKafkaBlock,
           tools: [

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -18,36 +18,17 @@ export interface DisabledToolsByReason {
 }
 
 /**
- * Output shape of {@linkcode buildToolGatingReport} — drives the
- * `describe-tool-gating` diagnostic tool.
+ * Output of {@linkcode buildToolGatingReport}; drives the
+ * `describe-tool-gating` diagnostic tool. Tools advertised via
+ * `tools/list` are intentionally absent — the report carries the
+ * negative signal only.
  *
- * v1 scope (today's release): the server enforces a single configured
- * connection (see `enforceSingleConnectionOnly()` in
- * `src/config/models.ts`), so the report flattens across that connection.
- * `disabledGroups` carries one entry per `(reason → tools)` bucket; tools
- * already advertised via `tools/list` are intentionally absent.
- *
- * v2 plan (when multi-connection support lands — issue #151's follow-ups):
- * replace `disabledGroups` with
- *   `per_connection: ReadonlyArray<{
- *      connection_id: string;
- *      enabledCount: number;
- *      disabledCount: number;
- *      gaps: ReadonlyArray<DisabledToolsByReason>;
- *    }>`
- * and add
- *   `cross_connection_deltas: ReadonlyArray<{
- *      tool: ToolName;
- *      enabled_for: ReadonlyArray<string>;
- *      disabled_for: ReadonlyArray<{ connection_id: string; reason: ToolDisabledReason }>;
- *    }>`
- * populated only for tools enabled on some connections but not others
- * (the canonical "what does connection B need to reach parity with
- * connection A?" view). The text rendering grows a per-connection header
- * per section and an optional `Cross-connection deltas` section. The
- * handler tests under `describe-tool-gating-handler.test.ts` already
- * include synthesised multi-connection fixtures retained as scaffolding
- * for that work.
+ * Single-connection scope today (the server enforces one connection; see
+ * `enforceSingleConnectionOnly()` in `src/config/models.ts`). When
+ * multi-connection support lands as part of issue #151's follow-ups the
+ * shape regrows around connections — per-connection sections plus a
+ * cross-connection-deltas section calling out tools enabled on some
+ * connections but not others.
  */
 export interface ToolGatingReport {
   readonly disabledGroups: readonly DisabledToolsByReason[];
@@ -56,10 +37,9 @@ export interface ToolGatingReport {
 }
 
 /**
- * One bucket of tools that all share the same `(connectionId, reason)` pair —
- * the unit of one log line at startup and one row in the
- * `describe-tool-gating` diagnostic surface. `toolNames` preserves the order
- * tools appeared in the input iterable.
+ * One bucket of tools sharing the same `(connectionId, reason)` pair — the
+ * unit of one grouped log line at server startup. `toolNames` preserves
+ * input iteration order.
  */
 export interface DisabledToolGroup {
   readonly connectionId: string;

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -118,15 +118,19 @@ export function groupDisabledToolsByReason(
  * the configured connection.
  *
  * v1 (single-connection scope):
- * - `disabled_groups` aggregates disabled tools from every configured
- *   connection's predicate verdict — under today's invariant of exactly one
- *   configured connection, that is just "the connection". Sorted lex by
- *   reason; tools within a group follow handler iteration order.
- * - `enabled_count` / `disabled_count` count distinct tools (a tool that
- *   resolves to the same verdict on every connection contributes once).
- *
- * See the {@linkcode ToolGatingReport} JSDoc for the v2 (multi-connection)
- * shape and how this function will grow when issue #151's follow-ups land.
+ * - `disabled_groups` is sorted lex by reason; tools within a group follow
+ *   handler iteration order.
+ * - Each tool contributes once to `enabled_count` *or* `disabled_count`:
+ *   a tool whose predicate produces an `enabled: true` verdict on at
+ *   least one configured connection counts as enabled (and is omitted
+ *   from `disabled_groups`); otherwise it counts as disabled and lands
+ *   under the first disabled verdict's reason. This flatten is lossy
+ *   on a multi-connection runtime — see the handler module-doc for
+ *   the consequences and the v2 (multi-connection) shape on
+ *   {@linkcode ToolGatingReport}.
+ * - Throws `Wacky -- ...` if any handler returns an empty verdict map
+ *   (a runtime-shaped invariant violation rather than a tool-state
+ *   condition; see `classifyTool` for the rationale).
  */
 export function buildToolGatingReport(
   handlers: Iterable<readonly [ToolName, ToolHandler]>,
@@ -146,10 +150,8 @@ export function buildToolGatingReport(
     }
     disabledCount += 1;
     let bucket = groupsByReason.get(classification.reason);
-    if (bucket === undefined) {
-      bucket = [];
-      groupsByReason.set(classification.reason, bucket);
-    }
+    bucket ??= [];
+    groupsByReason.set(classification.reason, bucket);
     bucket.push(toolName);
   }
 
@@ -191,14 +193,19 @@ function classifyTool(
   if (firstDisabledReason === undefined) {
     // Wacky -- handler returned an empty verdict map. BaseToolHandler builds
     // verdicts directly from `runtime.config.connections`, so an empty map
-    // means there are zero configured connections. Bootstrapping enforces
-    // at least one connection, so this branch should be unreachable in
-    // production; treat the tool as disabled with a placeholder reason
-    // rather than throwing inside a diagnostic tool.
-    return {
-      kind: "disabled",
-      reason: ToolDisabledReason.OAuthNoServiceBlocks,
-    };
+    // means there are zero configured connections, which
+    // `enforceSingleConnectionOnly()` in `src/config/models.ts` should have
+    // prevented at bootstrap. Fail loudly rather than fabricate a
+    // misleading `ToolDisabledReason` and ship it in the operator-facing
+    // report — a wrong-by-name reason is harder to diagnose than a stack
+    // trace.
+    throw new Error(
+      "Wacky -- classifyTool received an empty verdict map: a handler's " +
+        "connectionVerdicts() returned no entries. BaseToolHandler derives " +
+        "verdicts from runtime.config.connections; an empty map implies zero " +
+        "configured connections, which enforceSingleConnectionOnly() in " +
+        "src/config/models.ts should have rejected at bootstrap.",
+    );
   }
   return { kind: "disabled", reason: firstDisabledReason };
 }

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -1,13 +1,65 @@
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
+import {
+  PredicateResult,
+  ToolDisabledReason,
+} from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
 /**
+ * One bucket of disabled tools sharing a single {@linkcode ToolDisabledReason}
+ * — the unit operators use to read the diagnostic surface ("what would I add
+ * to the connection config to unlock these tools?"). Tool order within
+ * `tools` follows the order handlers were iterated.
+ */
+export interface DisabledToolsByReason {
+  readonly reason: ToolDisabledReason;
+  readonly tools: readonly ToolName[];
+}
+
+/**
+ * Output shape of {@linkcode buildToolGatingReport} — drives the
+ * `describe-tool-gating` diagnostic tool.
+ *
+ * v1 scope (today's release): the server enforces a single configured
+ * connection (see `enforceSingleConnectionOnly()` in
+ * `src/config/models.ts`), so the report flattens across that connection.
+ * `disabled_groups` carries one entry per `(reason → tools)` bucket; tools
+ * already advertised via `tools/list` are intentionally absent.
+ *
+ * v2 plan (when multi-connection support lands — issue #151's follow-ups):
+ * replace `disabled_groups` with
+ *   `per_connection: ReadonlyArray<{
+ *      connection_id: string;
+ *      enabled_count: number;
+ *      disabled_count: number;
+ *      gaps: ReadonlyArray<DisabledToolsByReason>;
+ *    }>`
+ * and add
+ *   `cross_connection_deltas: ReadonlyArray<{
+ *      tool: ToolName;
+ *      enabled_for: ReadonlyArray<string>;
+ *      disabled_for: ReadonlyArray<{ connection_id: string; reason: ToolDisabledReason }>;
+ *    }>`
+ * populated only for tools enabled on some connections but not others
+ * (the canonical "what does connection B need to reach parity with
+ * connection A?" view). The text rendering grows a per-connection header
+ * per section and an optional `Cross-connection deltas` section. The
+ * handler tests under `describe-tool-gating-handler.test.ts` already
+ * include synthesised multi-connection fixtures retained as scaffolding
+ * for that work.
+ */
+export interface ToolGatingReport {
+  readonly disabled_groups: readonly DisabledToolsByReason[];
+  readonly enabled_count: number;
+  readonly disabled_count: number;
+}
+
+/**
  * One bucket of tools that all share the same `(connectionId, reason)` pair —
- * the unit of one log line at startup and one row in the `describe-tool-
- * availability` diagnostic surface. `toolNames` preserves the order tools
- * appeared in the input iterable.
+ * the unit of one log line at startup and one row in the
+ * `describe-tool-gating` diagnostic surface. `toolNames` preserves the order
+ * tools appeared in the input iterable.
  */
 export interface DisabledToolGroup {
   readonly connectionId: string;
@@ -59,4 +111,94 @@ export function groupDisabledToolsByReason(
   return Array.from(groups.values()).sort((a, b) =>
     a.connectionId.localeCompare(b.connectionId),
   );
+}
+
+/**
+ * Assemble a {@linkcode ToolGatingReport} for the given handler set against
+ * the configured connection.
+ *
+ * v1 (single-connection scope):
+ * - `disabled_groups` aggregates disabled tools from every configured
+ *   connection's predicate verdict — under today's invariant of exactly one
+ *   configured connection, that is just "the connection". Sorted lex by
+ *   reason; tools within a group follow handler iteration order.
+ * - `enabled_count` / `disabled_count` count distinct tools (a tool that
+ *   resolves to the same verdict on every connection contributes once).
+ *
+ * See the {@linkcode ToolGatingReport} JSDoc for the v2 (multi-connection)
+ * shape and how this function will grow when issue #151's follow-ups land.
+ */
+export function buildToolGatingReport(
+  handlers: Iterable<readonly [ToolName, ToolHandler]>,
+  runtime: ServerRuntime,
+): ToolGatingReport {
+  // Map<reason, ToolName[]>; insertion order doesn't matter — the projection
+  // step below sorts groups lex by reason.
+  const groupsByReason = new Map<ToolDisabledReason, ToolName[]>();
+  let enabledCount = 0;
+  let disabledCount = 0;
+
+  for (const [toolName, handler] of handlers) {
+    const classification = classifyTool(handler.connectionVerdicts(runtime));
+    if (classification.kind === "enabled") {
+      enabledCount += 1;
+      continue;
+    }
+    disabledCount += 1;
+    let bucket = groupsByReason.get(classification.reason);
+    if (bucket === undefined) {
+      bucket = [];
+      groupsByReason.set(classification.reason, bucket);
+    }
+    bucket.push(toolName);
+  }
+
+  const disabled_groups: DisabledToolsByReason[] = Array.from(
+    groupsByReason.entries(),
+  )
+    .map(([reason, tools]) => ({ reason, tools }))
+    .sort((a, b) => a.reason.localeCompare(b.reason));
+
+  return {
+    disabled_groups,
+    enabled_count: enabledCount,
+    disabled_count: disabledCount,
+  };
+}
+
+/**
+ * Reduce a tool's per-connection verdict map to a single classification for
+ * the v1 flat report. Under the single-connection invariant the verdict map
+ * has exactly one entry, so this is a pass-through; the implementation
+ * tolerates multi-entry maps (test fixtures synthesise them) by treating
+ * "enabled on at least one connection" as enabled and otherwise reporting
+ * the first disabled verdict's reason.
+ *
+ * v2 multi-connection: drop this helper. The aggregation moves into the
+ * caller, which builds per-connection rows and cross-connection deltas
+ * directly from the verdict map.
+ */
+function classifyTool(
+  verdicts: Map<string, PredicateResult>,
+): { kind: "enabled" } | { kind: "disabled"; reason: ToolDisabledReason } {
+  let firstDisabledReason: ToolDisabledReason | undefined;
+  for (const verdict of verdicts.values()) {
+    if (verdict.enabled) return { kind: "enabled" };
+    if (firstDisabledReason === undefined) {
+      firstDisabledReason = verdict.reason;
+    }
+  }
+  if (firstDisabledReason === undefined) {
+    // Wacky -- handler returned an empty verdict map. BaseToolHandler builds
+    // verdicts directly from `runtime.config.connections`, so an empty map
+    // means there are zero configured connections. Bootstrapping enforces
+    // at least one connection, so this branch should be unreachable in
+    // production; treat the tool as disabled with a placeholder reason
+    // rather than throwing inside a diagnostic tool.
+    return {
+      kind: "disabled",
+      reason: ToolDisabledReason.OAuthNoServiceBlocks,
+    };
+  }
+  return { kind: "disabled", reason: firstDisabledReason };
 }

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -24,15 +24,15 @@ export interface DisabledToolsByReason {
  * v1 scope (today's release): the server enforces a single configured
  * connection (see `enforceSingleConnectionOnly()` in
  * `src/config/models.ts`), so the report flattens across that connection.
- * `disabled_groups` carries one entry per `(reason → tools)` bucket; tools
+ * `disabledGroups` carries one entry per `(reason → tools)` bucket; tools
  * already advertised via `tools/list` are intentionally absent.
  *
  * v2 plan (when multi-connection support lands — issue #151's follow-ups):
- * replace `disabled_groups` with
+ * replace `disabledGroups` with
  *   `per_connection: ReadonlyArray<{
  *      connection_id: string;
- *      enabled_count: number;
- *      disabled_count: number;
+ *      enabledCount: number;
+ *      disabledCount: number;
  *      gaps: ReadonlyArray<DisabledToolsByReason>;
  *    }>`
  * and add
@@ -50,9 +50,9 @@ export interface DisabledToolsByReason {
  * for that work.
  */
 export interface ToolGatingReport {
-  readonly disabled_groups: readonly DisabledToolsByReason[];
-  readonly enabled_count: number;
-  readonly disabled_count: number;
+  readonly disabledGroups: readonly DisabledToolsByReason[];
+  readonly enabledCount: number;
+  readonly disabledCount: number;
 }
 
 /**
@@ -118,12 +118,12 @@ export function groupDisabledToolsByReason(
  * the configured connection.
  *
  * v1 (single-connection scope):
- * - `disabled_groups` is sorted lex by reason; tools within a group follow
+ * - `disabledGroups` is sorted lex by reason; tools within a group follow
  *   handler iteration order.
- * - Each tool contributes once to `enabled_count` *or* `disabled_count`:
+ * - Each tool contributes once to `enabledCount` *or* `disabledCount`:
  *   a tool whose predicate produces an `enabled: true` verdict on at
  *   least one configured connection counts as enabled (and is omitted
- *   from `disabled_groups`); otherwise it counts as disabled and lands
+ *   from `disabledGroups`); otherwise it counts as disabled and lands
  *   under the first disabled verdict's reason. This flatten is lossy
  *   on a multi-connection runtime — see the handler module-doc for
  *   the consequences and the v2 (multi-connection) shape on
@@ -155,17 +155,13 @@ export function buildToolGatingReport(
     bucket.push(toolName);
   }
 
-  const disabled_groups: DisabledToolsByReason[] = Array.from(
+  const disabledGroups: DisabledToolsByReason[] = Array.from(
     groupsByReason.entries(),
   )
     .map(([reason, tools]) => ({ reason, tools }))
     .sort((a, b) => a.reason.localeCompare(b.reason));
 
-  return {
-    disabled_groups,
-    enabled_count: enabledCount,
-    disabled_count: disabledCount,
-  };
+  return { disabledGroups, enabledCount, disabledCount };
 }
 
 /**

--- a/src/confluent/tools/tool-name.ts
+++ b/src/confluent/tools/tool-name.ts
@@ -52,4 +52,5 @@ export enum ToolName {
   SEARCH_PRODUCT_DOCS = "search-product-docs",
   GET_PRODUCT_DOC_PAGE = "get-product-doc-page",
   LIST_ORGANIZATIONS = "list-organizations",
+  DESCRIBE_TOOL_GATING = "describe-tool-gating",
 }

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -230,6 +230,8 @@ describe("tool-registry.ts", () => {
         // Documentation (no service-block requirement)
         [ToolName.SEARCH_PRODUCT_DOCS]: alwaysEnabled,
         [ToolName.GET_PRODUCT_DOC_PAGE]: alwaysEnabled,
+        // Diagnostics (no service-block requirement)
+        [ToolName.DESCRIBE_TOOL_GATING]: alwaysEnabled,
       };
 
       it.each(
@@ -318,6 +320,11 @@ describe("tool-registry.ts", () => {
     type SmokeFixture = {
       outcome: HandleOutcome;
       setup?: (cm: MockedClientManager) => Promise<void> | void;
+      /** Set for handlers that legitimately resolve without touching the
+       *  client layer (e.g. meta/diagnostic tools that read the registry
+       *  rather than calling Confluent Cloud). Skips the
+       *  "must have called a client getter" assertion in `assertHandleCase`. */
+      bypassesClientLayer?: boolean;
     };
 
     /** Stubs the Flink REST client to return a completed empty SQL query result.
@@ -491,6 +498,13 @@ describe("tool-registry.ts", () => {
       // Documentation
       [ToolName.SEARCH_PRODUCT_DOCS]: { outcome: { throws: "ZodError" } },
       [ToolName.GET_PRODUCT_DOC_PAGE]: { outcome: { throws: "ZodError" } },
+      // Diagnostics — no client calls; the handler walks the registry's
+      // own predicate map. Against `allServicesRuntime` every gate passes
+      // and the handler emits its all-enabled summary.
+      [ToolName.DESCRIBE_TOOL_GATING]: {
+        outcome: { resolves: "registered tools are advertised via tools/list" },
+        bypassesClientLayer: true,
+      },
       // Organizations
       [ToolName.LIST_ORGANIZATIONS]: {
         outcome: { resolves: "Retrieved 0 organizations" },
@@ -532,7 +546,12 @@ describe("tool-registry.ts", () => {
           runtime: allServicesRuntime(clientManager),
           args: {},
           outcome: fixture.outcome,
-          clientManager,
+          // Pass clientManager only when the handler exercises the client
+          // layer; meta/diagnostic tools that read the registry instead are
+          // exempt from the "must have called a client getter" assertion.
+          clientManager: fixture.bypassesClientLayer
+            ? undefined
+            : clientManager,
           name,
         });
       },

--- a/src/confluent/tools/tool-registry.ts
+++ b/src/confluent/tools/tool-registry.ts
@@ -59,7 +59,7 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
  * Central registry for all tool call handlers.
  */
 export class ToolHandlerRegistry {
-  private static handlers: Map<ToolName, ToolHandler> = new Map<
+  private static readonly handlers: Map<ToolName, ToolHandler> = new Map<
     ToolName,
     ToolHandler
   >([

--- a/src/confluent/tools/tool-registry.ts
+++ b/src/confluent/tools/tool-registry.ts
@@ -10,6 +10,7 @@ import { CreateConnectorHandler } from "@src/confluent/tools/handlers/connect/cr
 import { DeleteConnectorHandler } from "@src/confluent/tools/handlers/connect/delete-connector-handler.js";
 import { ListConnectorsHandler } from "@src/confluent/tools/handlers/connect/list-connectors-handler.js";
 import { ReadConnectorHandler } from "@src/confluent/tools/handlers/connect/read-connectors-handler.js";
+import { DescribeToolGatingHandler } from "@src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.js";
 import { GetProductDocPageHandler } from "@src/confluent/tools/handlers/docs/get-product-doc-page-handler.js";
 import { SearchProductDocsHandler } from "@src/confluent/tools/handlers/docs/search-product-docs-handler.js";
 import { ListEnvironmentsHandler } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
@@ -58,7 +59,10 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
  * Central registry for all tool call handlers.
  */
 export class ToolHandlerRegistry {
-  private static handlers: Map<ToolName, ToolHandler> = new Map([
+  private static handlers: Map<ToolName, ToolHandler> = new Map<
+    ToolName,
+    ToolHandler
+  >([
     [ToolName.LIST_TOPICS, new ListTopicsHandler()],
     [ToolName.CREATE_TOPICS, new CreateTopicsHandler()],
     [ToolName.DELETE_TOPICS, new DeleteTopicsHandler()],
@@ -127,6 +131,10 @@ export class ToolHandlerRegistry {
     [ToolName.SEARCH_PRODUCT_DOCS, new SearchProductDocsHandler()],
     [ToolName.GET_PRODUCT_DOC_PAGE, new GetProductDocPageHandler()],
     [ToolName.LIST_ORGANIZATIONS, new ListOrganizationsHandler()],
+    [
+      ToolName.DESCRIBE_TOOL_GATING,
+      new DescribeToolGatingHandler(() => ToolHandlerRegistry.allHandlers()),
+    ],
   ]);
 
   static getToolHandler(toolName: ToolName): ToolHandler {
@@ -135,5 +143,15 @@ export class ToolHandlerRegistry {
 
   static getToolConfig(toolName: ToolName): ToolConfig {
     return this.getToolHandler(toolName).getToolConfig();
+  }
+
+  /**
+   * Iterable over every (ToolName, ToolHandler) pair in the registry, in
+   * declaration order. Consumed by the `describe-tool-gating` diagnostic
+   * tool to walk the full handler set without a back-channel into the
+   * private map. Read-only — callers must not mutate the underlying map.
+   */
+  static allHandlers(): Iterable<readonly [ToolName, ToolHandler]> {
+    return this.handlers.entries();
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -223,6 +223,7 @@ describe("index.ts", () => {
         ToolName.ALTER_TOPIC_CONFIG,
         ToolName.GET_TOPIC_CONFIG,
         ToolName.LIST_CLUSTERS,
+        ToolName.DESCRIBE_TOOL_GATING,
       ];
 
       const EXPECTED_OAUTH_DISABLED: readonly ToolName[] = [


### PR DESCRIPTION
## Summary

## `describe-tool-gating` diagnostic tool

- Adds a meta-tool that surfaces the _negative_ signal MCP doesn't carry:
  for each tool absent from `tools/list`, which `ToolDisabledReason`
  excluded it and which config piece (kafka block, flink block, schema
  registry block, …) would unlock it. Operators and AI assistants can read
  the response and act on it directly, instead of guessing why a tool isn't
  showing up.
- Output emphasises the "what's missing" view because `tools/list` already
  advertises the enabled set. Each disabled-reason group renders as a
  header line followed by indented bullets — long groups stay scannable
  in the Inspector instead of wrapping into an unreadable comma-list.
  Captured live against the [`sample-oauth.yaml`](sample-oauth.yaml)
  starter (PKCE, no service blocks):

  ```
  39 of 54 tools disabled for the following reasons:

    OAuth connection cannot satisfy a direct-only requirement (4):
      - list-connectors
      - read-connector
      - create-connector
      - delete-connector

    OAuth connections carry no service blocks (35):
      - list-flink-statements
      - create-flink-statement
      - read-flink-statement
      - delete-flink-statements
      - get-flink-statement-exceptions
     - ...

  15 tools advertised via tools/list.
  ```

  Against a `direct` connection with missing service blocks, the report
  groups by `MissingKafkaBlock`, `MissingFlinkBlock`, etc. — one bucket
  per missing config piece, each listing the tools it would unlock. When
  every gate passes the body collapses to
  `All N registered tools are advertised via tools/list.`. Structured
  shape mirrors the text body in `_meta.disabledGroups[]` plus
  `enabledCount` / `disabledCount`.

- The individual negative enablement reason strings (`OAuth connection
cannot satisfy a direct-only requirement`, `no 'kafka' block in
connection config`, …) are not introduced by this tool. They are the
  pre-existing `ToolDisabledReason` enum values in
  [`connection-predicates.ts`](src/confluent/tools/connection-predicates.ts),
  already consumed by `groupDisabledToolsByReason()` for startup-log
  grouping. This handler simply exposes the same taxonomy through a new
  MCP-facing surface — no string changes here. Wordsmithing those
  reason strings to read more directly as user-facing advice is a
  deliberate follow-up effort, separate from #358.

- Predicate is `alwaysEnabled` so an operator can call it on a config that
  left every other tool gated. Tool annotations are `READ_ONLY`. No tool
  arguments.

## v1 scope: single-connection only

- Output is intentionally _flat_ — no per-connection sections, no
  cross-connection deltas. The server still enforces a single configured
  connection (`enforceSingleConnectionOnly()` in `src/config/models.ts`),
  so reporting around connection ids would be premature complexity that
  reads weirdly to today's operators.
- Comments applied providing guidance when this restriction is lifted.

## Helper: `buildToolGatingReport`

- New export in `src/confluent/tools/tool-availability.ts` alongside the
  existing `groupDisabledToolsByReason` (which keeps powering startup-log
  grouping, unchanged). Both consume the
  `BaseToolHandler.connectionVerdicts(runtime)` map already exposed for
  exactly this kind of diagnostic surface.
- Pure function over the handler iterable + runtime — no client calls, no
  side effects. Tests stub `ConnectionPredicate` directly via the existing
  `StubHandler` helper.

## Wiring through the registry tables

- `ToolHandlerRegistry` gains a `static allHandlers()` accessor returning
  `entries()` of its private map. The diagnostic handler can't reach back
  through the registry's class import without inducing an ESM cycle (the
  registry's static initializer runs `new DescribeToolGatingHandler(...)`
  before the handler module's binding has been set), so the constructor
  takes a thunk: `new DescribeToolGatingHandler(() =>
ToolHandlerRegistry.allHandlers())`. Tests use the same idiom, which has
  the side-benefit of letting them swap in a fixed handler iterable for
  branch coverage of the all-enabled / no-tools paths.
- Pinned in the existing exhaustive guards:
  - `EXPECTED_PREDICATES` row in `tool-registry.test.ts` set to
    `alwaysEnabled` (the `Record<ToolName, ConnectionPredicate>` typing
    makes a missing row a `tsc --noEmit` failure, not just a test failure).
  - `EXPECTED_OAUTH_ENABLED` in `src/index.test.ts` (the partition test
    enforces every `ToolName` lives in exactly one of the two source-of-
    truth lists).
  - `ZERO_ARG_OUTCOMES` smoke fixture: a new `bypassesClientLayer` opt-out
    flag on `SmokeFixture` skips the "must have called a client getter"
    assertion for meta tools that legitimately resolve without touching
    the client layer. Used here, with a clear comment for the next
    diagnostic-tool author.

## While here

- Revised [README.md](README.md) with a new section describing the tools which require no configuration at all.
- New `npm run inspector:yaml` script for launching the MCP Inspector
  against a YAML config (defaults to `./config.yaml`, override with
  `-- path/to/your.yaml`). Backed by [`scripts/inspector-yaml.mjs`](scripts/inspector-yaml.mjs)
  — a small Node script (cross-platform, alongside the existing
  `scripts/inject-build-config.mjs`) that pre-checks the yaml exists
  before spawning the inspector. Without that guard, a missing config
  lets the server exit non-zero on startup, which the inspector
  interprets as a transient crash and respawns endlessly — masking the
  real cause. Found while dogfooding `describe-tool-gating` against a
  yaml that had been renamed mid-session.

## Manual verification with the MCP Inspector

The new `npm run inspector:yaml` script (see "While here") reduces this
to a 30-second loop. Pre-req: a `config.yaml` at the repo root —
`cp config.example.yaml config.yaml` for a `direct` connection, or use
the OAuth shape from the inspector script's docs (single block:
`connections.default.type: oauth`, optional `ccloud_env`).

1. `npm run build && npm run inspector:yaml` (or
   `npm run inspector:yaml -- path/to/your.yaml` to point at a non-default
   path). The Inspector prints a token-protected localhost URL — open it.
2. The Inspector spawns and connects to the server automatically. Click
   **Tools** in the left nav.
3. Confirm `describe-tool-gating` appears in the list. Selecting it
   should show the full description (the trigger-pattern prose for AI
   assistants) and an empty input schema.
4. Click **Run**. The text response should be in the format documented
   above (header line + per-reason indented bullets + `N tools advertised
via tools/list.` footer); the structured payload mirrors the text in
   the response's `_meta` field — `disabledGroups[]`, `enabledCount`,
   `disabledCount`.
5. Sanity-check the totals: `enabledCount + disabledCount` should
   match the registered tool count (currently 54 — confirmable via
   `npm run -- --list-tools` or by counting the `Tools` panel). Tools
   you expect to be missing (e.g. all Flink tools when no `flink`
   block is configured) should appear under the matching reason
   header.
6. Optional — exercise the AI-trigger angle: connect the same server to
   Claude Desktop / VS Code Claude / etc. and ask "why can't I list
   Kafka topics?" or "where are the Flink tools?". The AI should call
   `describe-tool-gating` first and translate its output into actionable
   config advice, rather than guessing about credentials, network, or
   auth.

## Relationships

- Closes #358.
- Closes #355, being the last child.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
