### PR TITLE
Defer OAuth browser launch to first tool invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The MCP server can authenticate to Confluent Cloud via **OAuth (PKCE)** instead 
 
 ### How it works
 
-On startup, the server opens your browser to the Confluent Cloud sign-in page and waits for the redirect callback. Supported tools begin working only after sign-in completes — calls made before then will fail with an `"OAuth token is not currently available"` error.
+On the first tool call that needs Confluent access, the server opens your browser to the Confluent Cloud sign-in page and waits for the redirect callback. Subsequent tool calls reuse the resulting session.
 
 ### YAML setup
 
@@ -242,7 +242,7 @@ connections:
     type: oauth
 ```
 
-Run with `--config oauth.yaml` and the browser sign-in opens on first start.
+Run with `--config oauth.yaml`. The server starts immediately; the browser sign-in opens on the first tool call that needs Confluent access.
 
 ### Supported tools under OAuth
 

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -324,22 +324,6 @@ describe("oauth-client-manager.ts", () => {
       });
     });
 
-    describe("requireDataPlaneToken (via getConfluentCloudKafkaRestClient)", () => {
-      it("should reject with a descriptive error when no DPAT is available", async () => {
-        const manager = buildManager();
-        // Override the holder's DPAT to be empty (e.g., shutdown raced with
-        // the tool call, or a non-transient refresh error invalidated the
-        // token between the gate and this accessor).
-        manager["holder"].getDataPlaneToken = vi
-          .fn()
-          .mockReturnValue(undefined);
-
-        await expect(
-          manager.getConfluentCloudKafkaRestClient("lkc-1", "env-1"),
-        ).rejects.toThrow(/No data-plane token available/);
-      });
-    });
-
     describe("disconnect()", () => {
       it("should be a no-op (no caches to drain — clients are caller-owned)", async () => {
         const manager = buildManager();

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -9,24 +9,12 @@ import { describe, expect, it, vi } from "vitest";
 describe("oauth-client-manager.ts", () => {
   describe("OAuthClientManager", () => {
     function buildManager(): OAuthClientManager {
-      // OAuthHolder has a private constructor (factory pattern via .start()),
-      // so we widen the constructor signature for createMockInstance which
-      // expects an externally-callable ctor.
-      const holder = createMockInstance(
-        OAuthHolder as unknown as new (...args: never[]) => OAuthHolder,
-      );
-      // OAuthHolder.bootstrapPromise is an instance field set in the real
-      // constructor, which createMockInstance bypasses. Define it here so
-      // the OAuth manager's `await this.holder.bootstrapPromise` resolves.
-      Object.defineProperty(holder, "bootstrapPromise", {
-        value: Promise.resolve(),
-        writable: true,
-        configurable: true,
-      });
-      // Provide a non-empty data-plane token so buildOAuthKafkaClient passes
-      // its post-bootstrap guard.
+      const holder = createMockInstance(OAuthHolder);
+      // Provide a non-empty data-plane token so the post-gate guard in
+      // requireDataPlaneToken passes (the gate would have populated it
+      // before any tool call reaches this manager in production).
       holder.getDataPlaneToken.mockReturnValue("dpat");
-      return new OAuthClientManager(holder as unknown as OAuthHolder, "devel");
+      return new OAuthClientManager(holder, "devel");
     }
 
     describe("getKafkaAdminClient()", () => {
@@ -254,28 +242,18 @@ describe("oauth-client-manager.ts", () => {
         );
       });
 
-      it("should throw when DPAT is unavailable after bootstrap", async () => {
+      it("should throw when DPAT is unavailable", async () => {
         // Symmetric with the Kafka-side guard — prevents constructing an SR
         // SDK client with `Authorization: Bearer ` (empty) baked into axios
-        // defaults during initial login or after a non-transient refresh
-        // failure.
-        const holder = createMockInstance(
-          OAuthHolder as unknown as new (...args: never[]) => OAuthHolder,
-        );
-        Object.defineProperty(holder, "bootstrapPromise", {
-          value: Promise.resolve(),
-          writable: true,
-          configurable: true,
-        });
+        // defaults if the holder has been cleared or hit a non-transient
+        // refresh failure between the gate check and this method.
+        const holder = createMockInstance(OAuthHolder);
         holder.getDataPlaneToken.mockReturnValue(undefined);
-        const manager = new OAuthClientManager(
-          holder as unknown as OAuthHolder,
-          "devel",
-        );
+        const manager = new OAuthClientManager(holder, "devel");
 
         await expect(
           manager.getSchemaRegistrySdkClient("lsrc-1", "env-1"),
-        ).rejects.toThrow("OAuth login did not produce a data-plane token");
+        ).rejects.toThrow("No data-plane token available");
       });
 
       it("should build a SchemaRegistryClient against the resolved endpoint", async () => {
@@ -347,16 +325,18 @@ describe("oauth-client-manager.ts", () => {
     });
 
     describe("requireDataPlaneToken (via getConfluentCloudKafkaRestClient)", () => {
-      it("should reject with a descriptive error when bootstrap completes without a DPAT", async () => {
+      it("should reject with a descriptive error when no DPAT is available", async () => {
         const manager = buildManager();
-        // Override the holder's DPAT to be empty even after bootstrap.
+        // Override the holder's DPAT to be empty (e.g., shutdown raced with
+        // the tool call, or a non-transient refresh error invalidated the
+        // token between the gate and this accessor).
         manager["holder"].getDataPlaneToken = vi
           .fn()
           .mockReturnValue(undefined);
 
         await expect(
           manager.getConfluentCloudKafkaRestClient("lkc-1", "env-1"),
-        ).rejects.toThrow(/OAuth login did not produce a data-plane token/);
+        ).rejects.toThrow(/No data-plane token available/);
       });
     });
 

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -107,7 +107,7 @@ export class OAuthClientManager extends BaseClientManager {
     // `createAxiosDefaults` at construction time, so a build during initial
     // login or a broken refresh would freeze an empty bearer into every
     // subsequent request — fail fast here before that can happen.
-    const dpat = await this.requireDataPlaneToken();
+    const dpat = this.requireDataPlaneToken();
     const endpoint = await resolveSchemaRegistryEndpoint(
       this.getConfluentCloudRestClient(),
       clusterId!,
@@ -133,7 +133,7 @@ export class OAuthClientManager extends BaseClientManager {
     // The bearer middleware reads `auth.getToken()` per-request, but failing
     // fast here gives the agent a clear error rather than letting an empty
     // bearer go out on the wire.
-    await this.requireDataPlaneToken();
+    this.requireDataPlaneToken();
     const baseUrl = await resolveKafkaRestEndpoint(
       this.getConfluentCloudRestClient(),
       clusterId!,
@@ -211,18 +211,23 @@ export class OAuthClientManager extends BaseClientManager {
   }
 
   /**
-   * Awaits the holder's bootstrap promise and returns the current data-plane
-   * token, throwing when the bootstrap completes without one. Used by every
-   * OAuth-side client accessor to fail fast before constructing a client
-   * with an empty bearer.
+   * Returns the current data-plane token, throwing when none is available.
+   * Used by every OAuth-side client accessor to fail fast before
+   * constructing a client with an empty bearer.
+   *
+   * The MCP tool-call gate calls `holder.ensureLoggedIn()` before any
+   * handler that needs Confluent access, so by the time this method runs
+   * login has already completed. A missing DPAT here means the holder was
+   * cleared mid-call (shutdown raced with a tool call) or a non-transient
+   * refresh error has invalidated the token between the gate check and
+   * the client construction — both rare and surface a clear message.
    */
-  private async requireDataPlaneToken(): Promise<string> {
-    await this.holder.bootstrapPromise;
+  private requireDataPlaneToken(): string {
     const dpat = this.holder.getDataPlaneToken();
     if (!dpat) {
       throw new Error(
-        "OAuth login did not produce a data-plane token. " +
-          "Check the OAuth login flow status (browser sign-in must complete).",
+        "No data-plane token available. The OAuth holder may have been " +
+          "shut down or an authentication error has invalidated the token.",
       );
     }
     return dpat;
@@ -253,7 +258,7 @@ export class OAuthClientManager extends BaseClientManager {
     // handshake — the synchronous `oauthbearer_token_refresh_cb` (configured
     // below) reads it on demand, so an empty token here would surface as a
     // broker-side auth failure with no useful diagnostic.
-    await this.requireDataPlaneToken();
+    this.requireDataPlaneToken();
     // librdkafka debug logs — gated by env var so they don't pollute normal
     // server stderr. Set OAUTH_KAFKA_DEBUG=security,broker,protocol (or
     // "all") to see the full SASL/OAUTHBEARER handshake and broker traffic.

--- a/src/confluent/oauth/oauth-holder.test.ts
+++ b/src/confluent/oauth/oauth-holder.test.ts
@@ -1,11 +1,14 @@
 import { AuthContext } from "@src/confluent/oauth/auth-context.js";
 import { OAUTH_CALLBACK_PATH } from "@src/confluent/oauth/auth0-config.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
+import { REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS } from "@src/confluent/oauth/token-lifetimes.js";
 import {
   mockFetch,
   mockHttpServer,
   mockOpen,
   type MockedFetch,
+  type MockedHttpServer,
+  type MockedOpen,
 } from "@tests/stubs/index.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -30,6 +33,31 @@ function stubFullChain(fetchSpy: MockedFetch): void {
   fetchSpy.mockResolvedValueOnce(jsonResponse({ token: "dp" }));
 }
 
+/**
+ * Drives one PKCE round-trip end-to-end against the mocked HTTP server / open
+ * spy / fetch chain. Production code wraps PKCE through the holder, so this
+ * helper just shuttles the test state forward by firing the OAuth callback
+ * request once the production code reaches the listening + open phase.
+ *
+ * Reads the *most recent* `openSpy` call so tests that drive two sequential
+ * PKCE flows (e.g., a failure-then-retry) pick up the second flow's state.
+ */
+async function completePkce(
+  httpMock: MockedHttpServer,
+  openSpy: MockedOpen,
+): Promise<void> {
+  await httpMock.listening;
+  // Two microtask flushes: the first lets the pkce-login Promise.race resolve
+  // bind, the second lets `nodeOpen.open` complete so its mock URL is recorded.
+  await Promise.resolve();
+  await Promise.resolve();
+  const openedUrl = openSpy.mock.calls.at(-1)![0];
+  const state = new URL(openedUrl).searchParams.get("state")!;
+  await httpMock.fireRequest(
+    `${OAUTH_CALLBACK_PATH}?code=auth-code&state=${state}`,
+  );
+}
+
 describe("oauth/oauth-holder.ts", () => {
   let fetchSpy: MockedFetch;
 
@@ -41,104 +69,244 @@ describe("oauth/oauth-holder.ts", () => {
     vi.useRealTimers();
   });
 
-  describe("start", () => {
-    it("should return a holder synchronously in the bootstrapping state with undefined tokens", async () => {
-      mockHttpServer();
-      mockOpen();
-      stubFullChain(fetchSpy);
+  describe("constructor", () => {
+    it("should not start PKCE; tokens are undefined and no browser opens", () => {
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
 
-      const holder = OAuthHolder.start("devel");
-      // Sync observables, asserted before any await so the bootstrap is still in flight.
-      expect(holder.getControlPlaneToken()).toBeUndefined();
-      expect(holder.getDataPlaneToken()).toBeUndefined();
-
-      // shutdown() aborts the in-flight PKCE via AbortSignal; bootstrap settles
-      // promptly without waiting for the 120s PKCE timeout.
-      holder.shutdown();
-      await holder.bootstrapPromise;
+      const holder = new OAuthHolder("devel");
+      try {
+        expect(holder.getControlPlaneToken()).toBeUndefined();
+        expect(holder.getDataPlaneToken()).toBeUndefined();
+        // Constructor must be side-effect-free: no callback server bound, no
+        // browser opened. This is the entire point of issue #413.
+        expect(httpMock.spy).not.toHaveBeenCalled();
+        expect(openSpy).not.toHaveBeenCalled();
+      } finally {
+        holder.shutdown();
+      }
     });
+  });
 
-    it("should expose tokens after a successful bootstrap settles", async () => {
+  describe("ensureLoggedIn()", () => {
+    it("should drive PKCE end-to-end and populate tokens on success", async () => {
       const httpMock = mockHttpServer();
       const openSpy = mockOpen();
       stubFullChain(fetchSpy);
 
-      const holder = OAuthHolder.start("devel");
+      const holder = new OAuthHolder("devel");
       try {
-        await httpMock.listening;
-        await Promise.resolve();
-        await Promise.resolve();
-        const openedUrl = openSpy.mock.calls[0]![0];
-        const state = new URL(openedUrl).searchParams.get("state")!;
-        await httpMock.fireRequest(
-          `${OAUTH_CALLBACK_PATH}?code=auth-code&state=${state}`,
-        );
-        await holder.bootstrapPromise;
+        const inFlight = holder.ensureLoggedIn();
+        await completePkce(httpMock, openSpy);
+        await inFlight;
 
         expect(holder.getControlPlaneToken()).toBe("cp");
         expect(holder.getDataPlaneToken()).toBe("dp");
+        expect(openSpy).toHaveBeenCalledOnce();
       } finally {
         holder.shutdown();
       }
     });
 
-    it("should leave tokens undefined and resolve (not reject) when bootstrap fails", async () => {
-      mockHttpServer();
-      const openSpy = mockOpen();
-      openSpy.mockRejectedValueOnce(new Error("browser-open-failed"));
-      stubFullChain(fetchSpy);
-
-      const holder = OAuthHolder.start("devel");
-      try {
-        await expect(holder.bootstrapPromise).resolves.toBeUndefined();
-        expect(holder.getControlPlaneToken()).toBeUndefined();
-        expect(holder.getDataPlaneToken()).toBeUndefined();
-      } finally {
-        holder.shutdown();
-      }
-    });
-
-    it("should be safe to call shutdown twice", async () => {
+    it("should share one in-flight PKCE flow across concurrent callers", async () => {
       const httpMock = mockHttpServer();
       const openSpy = mockOpen();
       stubFullChain(fetchSpy);
 
-      const holder = OAuthHolder.start("devel");
+      const holder = new OAuthHolder("devel");
       try {
-        await httpMock.listening;
-        await Promise.resolve();
-        await Promise.resolve();
-        const openedUrl = openSpy.mock.calls[0]![0];
-        const state = new URL(openedUrl).searchParams.get("state")!;
-        await httpMock.fireRequest(
-          `${OAUTH_CALLBACK_PATH}?code=auth-code&state=${state}`,
-        );
-        await holder.bootstrapPromise;
+        const a = holder.ensureLoggedIn();
+        const b = holder.ensureLoggedIn();
+        const c = holder.ensureLoggedIn();
+        await completePkce(httpMock, openSpy);
+        await Promise.all([a, b, c]);
 
-        expect(() => {
-          holder.shutdown();
-          holder.shutdown();
-        }).not.toThrow();
-        expect(holder.getControlPlaneToken()).toBeUndefined();
+        // Only one browser tab; only one full token-chain fetch sequence.
+        expect(openSpy).toHaveBeenCalledOnce();
+        expect(fetchSpy).toHaveBeenCalledTimes(3); // auth0 + cp + dp
       } finally {
         holder.shutdown();
       }
     });
 
-    it("should not start a refresh loop when shutdown happens before bootstrap settles", async () => {
-      mockHttpServer();
-      mockOpen();
+    it("should be a no-op when called again after a successful login", async () => {
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
+      stubFullChain(fetchSpy);
+
+      const holder = new OAuthHolder("devel");
+      try {
+        const first = holder.ensureLoggedIn();
+        await completePkce(httpMock, openSpy);
+        await first;
+
+        await holder.ensureLoggedIn();
+        await holder.ensureLoggedIn();
+
+        // No additional PKCE attempts.
+        expect(openSpy).toHaveBeenCalledOnce();
+        expect(fetchSpy).toHaveBeenCalledTimes(3);
+      } finally {
+        holder.shutdown();
+      }
+    });
+
+    it("should reject when PKCE fails and replay on the next call", async () => {
+      const httpMock1 = mockHttpServer();
+      const openSpy = mockOpen();
+      // First attempt: browser open rejects → PkceLoginError("configuration").
+      openSpy.mockRejectedValueOnce(new Error("browser-open-failed"));
+
+      const holder = new OAuthHolder("devel");
+      try {
+        await expect(holder.ensureLoggedIn()).rejects.toThrow(
+          /browser-open-failed|Failed to open browser/,
+        );
+        // Holder is back in Idle — tokens still undefined, no leaked state.
+        expect(holder.getControlPlaneToken()).toBeUndefined();
+        expect(holder.getDataPlaneToken()).toBeUndefined();
+        // Sanity: the failed attempt did try to bind once.
+        expect(httpMock1.spy).toHaveBeenCalledOnce();
+
+        // Second attempt succeeds. Re-arm spies that aren't auto-restored
+        // because they're test-local mocks (the `mockHttpServer` returns a
+        // fresh fake each call).
+        const httpMock2 = mockHttpServer();
+        stubFullChain(fetchSpy);
+        const second = holder.ensureLoggedIn();
+        await completePkce(httpMock2, openSpy);
+        await second;
+
+        expect(holder.getControlPlaneToken()).toBe("cp");
+        expect(holder.getDataPlaneToken()).toBe("dp");
+        // Two PKCE flows total: failed first + successful second.
+        expect(openSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        holder.shutdown();
+      }
+    });
+
+    it("should clear an expired ctx and start a fresh PKCE", async () => {
+      vi.useFakeTimers({ now: 0 });
+      const httpMock1 = mockHttpServer();
+      const openSpy = mockOpen();
+      stubFullChain(fetchSpy);
+
+      const holder = new OAuthHolder("devel");
+      try {
+        const first = holder.ensureLoggedIn();
+        await completePkce(httpMock1, openSpy);
+        await first;
+        expect(holder.getControlPlaneToken()).toBe("cp");
+
+        // Jump past the refresh-family absolute lifetime so refreshTokenExpired()
+        // returns true. Stop refresh loop first to avoid a stray timer firing.
+        const ctx = (holder as unknown as { ctx: AuthContext | undefined }).ctx;
+        ctx?.stopRefreshLoop();
+        vi.setSystemTime(REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS + 1);
+
+        // Re-arm mocks for the fresh PKCE round-trip. Distinct cp/dp tokens
+        // on the second chain so the assertion below proves the ctx was
+        // rebuilt (rather than some stale cache returning the old value).
+        const httpMock2 = mockHttpServer();
+        fetchSpy
+          .mockResolvedValueOnce(
+            jsonResponse({
+              id_token: "id-2",
+              refresh_token: "refresh-2",
+              access_token: "access-2",
+              token_type: "Bearer",
+              expires_in: 60,
+            }),
+          )
+          .mockResolvedValueOnce(jsonResponse({ token: "cp-2" }))
+          .mockResolvedValueOnce(jsonResponse({ token: "dp-2" }));
+
+        const second = holder.ensureLoggedIn();
+        await completePkce(httpMock2, openSpy);
+        await second;
+
+        expect(openSpy).toHaveBeenCalledTimes(2);
+        expect(holder.getControlPlaneToken()).toBe("cp-2");
+        expect(holder.getDataPlaneToken()).toBe("dp-2");
+      } finally {
+        holder.shutdown();
+      }
+    });
+
+    it("should reject after shutdown without launching PKCE", async () => {
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
+
+      const holder = new OAuthHolder("devel");
+      holder.shutdown();
+      await expect(holder.ensureLoggedIn()).rejects.toThrow(/shut down/);
+      expect(httpMock.spy).not.toHaveBeenCalled();
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it("should start the refresh loop only on successful login", async () => {
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
       stubFullChain(fetchSpy);
       const startRefreshLoopSpy = vi.spyOn(
         AuthContext.prototype,
         "startRefreshLoop",
       );
 
-      const holder = OAuthHolder.start("devel");
-      holder.shutdown();
-      await holder.bootstrapPromise;
+      const holder = new OAuthHolder("devel");
+      try {
+        // No login attempted yet → refresh loop never started.
+        expect(startRefreshLoopSpy).not.toHaveBeenCalled();
 
-      expect(startRefreshLoopSpy).not.toHaveBeenCalled();
+        const inFlight = holder.ensureLoggedIn();
+        await completePkce(httpMock, openSpy);
+        await inFlight;
+
+        expect(startRefreshLoopSpy).toHaveBeenCalledOnce();
+      } finally {
+        holder.shutdown();
+      }
+    });
+  });
+
+  describe("shutdown()", () => {
+    it("should be safe to call before any login attempt", () => {
+      mockHttpServer();
+      mockOpen();
+
+      const holder = new OAuthHolder("devel");
+      expect(() => holder.shutdown()).not.toThrow();
+    });
+
+    it("should be safe to call twice", async () => {
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
+      stubFullChain(fetchSpy);
+
+      const holder = new OAuthHolder("devel");
+      const inFlight = holder.ensureLoggedIn();
+      await completePkce(httpMock, openSpy);
+      await inFlight;
+
+      expect(() => {
+        holder.shutdown();
+        holder.shutdown();
+      }).not.toThrow();
+      expect(holder.getControlPlaneToken()).toBeUndefined();
+    });
+
+    it("should abort an in-flight login", async () => {
+      mockHttpServer();
+      mockOpen();
+      stubFullChain(fetchSpy);
+
+      const holder = new OAuthHolder("devel");
+      const inFlight = holder.ensureLoggedIn();
+      // Shutdown immediately — the PkceLoginError("user_aborted") path
+      // settles inFlight without waiting on the 120s callback timeout.
+      holder.shutdown();
+      await expect(inFlight).rejects.toThrow(/aborted|shut down/);
       expect(holder.getControlPlaneToken()).toBeUndefined();
       expect(holder.getDataPlaneToken()).toBeUndefined();
     });

--- a/src/confluent/oauth/oauth-holder.test.ts
+++ b/src/confluent/oauth/oauth-holder.test.ts
@@ -1,7 +1,10 @@
 import { AuthContext } from "@src/confluent/oauth/auth-context.js";
 import { OAUTH_CALLBACK_PATH } from "@src/confluent/oauth/auth0-config.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
-import { REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS } from "@src/confluent/oauth/token-lifetimes.js";
+import {
+  CONTROL_PLANE_TOKEN_LIFETIME_MS,
+  REFRESH_TOKEN_ABSOLUTE_LIFETIME_MS,
+} from "@src/confluent/oauth/token-lifetimes.js";
 import {
   mockFetch,
   mockHttpServer,
@@ -229,6 +232,95 @@ describe("oauth/oauth-holder.ts", () => {
         expect(openSpy).toHaveBeenCalledTimes(2);
         expect(holder.getControlPlaneToken()).toBe("cp-2");
         expect(holder.getDataPlaneToken()).toBe("dp-2");
+      } finally {
+        holder.shutdown();
+      }
+    });
+
+    it("should refresh tokens (without re-launching PKCE) when CP/DP have expired but the refresh token is still alive", async () => {
+      // Edge case from system sleep / clock jump: setTimeout for the refresh
+      // loop is suspended during sleep; on wake, CP/DP are stale until the
+      // queued refresh fires. ensureLoggedIn covers this gap by triggering an
+      // on-demand refresh rather than returning success on a stale ctx.
+      vi.useFakeTimers({ now: 0 });
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
+      stubFullChain(fetchSpy);
+
+      const holder = new OAuthHolder("devel");
+      try {
+        const first = holder.ensureLoggedIn();
+        await completePkce(httpMock, openSpy);
+        await first;
+
+        // Stop the existing refresh-loop timer so it doesn't fire on its own
+        // when we advance time — we're testing the gate's on-demand refresh.
+        const ctx = (holder as unknown as { ctx: AuthContext }).ctx;
+        ctx.stopRefreshLoop();
+
+        // Advance past CP expiry but stay within refresh-family lifetime
+        // (DP has a longer TTL — ~10min — so it's still alive at this
+        // point; the gate correctly triggers refresh on either being
+        // missing, so CP-only expiry is sufficient to exercise the path).
+        vi.setSystemTime(CONTROL_PLANE_TOKEN_LIFETIME_MS + 1);
+        expect(holder.getControlPlaneToken()).toBeUndefined();
+
+        // Stub the refresh-token rotation chain (auth0 + cp + dp).
+        fetchSpy
+          .mockResolvedValueOnce(
+            jsonResponse({
+              id_token: "id-2",
+              refresh_token: "refresh-2",
+              access_token: "access-2",
+              token_type: "Bearer",
+              expires_in: 60,
+            }),
+          )
+          .mockResolvedValueOnce(jsonResponse({ token: "cp-2" }))
+          .mockResolvedValueOnce(jsonResponse({ token: "dp-2" }));
+
+        await holder.ensureLoggedIn();
+
+        // No new PKCE — refresh restored bearer tokens via the refresh-token
+        // grant, no browser launched.
+        expect(openSpy).toHaveBeenCalledOnce();
+        expect(holder.getControlPlaneToken()).toBe("cp-2");
+        expect(holder.getDataPlaneToken()).toBe("dp-2");
+      } finally {
+        holder.shutdown();
+      }
+    });
+
+    it("should reject (without launching PKCE) when refresh fails to restore tokens", async () => {
+      // Refresh attempt fails transiently (e.g., auth0 unreachable). The
+      // gate surfaces a retry-friendly error so the next tool call retries.
+      // Re-PKCE only happens once the failure becomes non-transient.
+      vi.useFakeTimers({ now: 0 });
+      const httpMock = mockHttpServer();
+      const openSpy = mockOpen();
+      stubFullChain(fetchSpy);
+
+      const holder = new OAuthHolder("devel");
+      try {
+        const first = holder.ensureLoggedIn();
+        await completePkce(httpMock, openSpy);
+        await first;
+
+        const ctx = (holder as unknown as { ctx: AuthContext }).ctx;
+        ctx.stopRefreshLoop();
+        vi.setSystemTime(CONTROL_PLANE_TOKEN_LIFETIME_MS + 1);
+
+        // Refresh attempt fails on the first auth0 call.
+        fetchSpy.mockRejectedValueOnce(new Error("network blip"));
+
+        await expect(holder.ensureLoggedIn()).rejects.toThrow(
+          /tokens unavailable/i,
+        );
+
+        // No re-PKCE — gate surfaced an error rather than launch a browser
+        // for what may be a transient network blip.
+        expect(openSpy).toHaveBeenCalledOnce();
+        expect(httpMock.spy).toHaveBeenCalledOnce();
       } finally {
         holder.shutdown();
       }

--- a/src/confluent/oauth/oauth-holder.test.ts
+++ b/src/confluent/oauth/oauth-holder.test.ts
@@ -279,23 +279,6 @@ describe("oauth/oauth-holder.ts", () => {
       expect(() => holder.shutdown()).not.toThrow();
     });
 
-    it("should be safe to call twice", async () => {
-      const httpMock = mockHttpServer();
-      const openSpy = mockOpen();
-      stubFullChain(fetchSpy);
-
-      const holder = new OAuthHolder("devel");
-      const inFlight = holder.ensureLoggedIn();
-      await completePkce(httpMock, openSpy);
-      await inFlight;
-
-      expect(() => {
-        holder.shutdown();
-        holder.shutdown();
-      }).not.toThrow();
-      expect(holder.getControlPlaneToken()).toBeUndefined();
-    });
-
     it("should abort an in-flight login", async () => {
       mockHttpServer();
       mockOpen();

--- a/src/confluent/oauth/oauth-holder.ts
+++ b/src/confluent/oauth/oauth-holder.ts
@@ -2,7 +2,11 @@ import { AuthContext } from "@src/confluent/oauth/auth-context.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 import { generateOpaqueToken } from "@src/confluent/oauth/crypto-utils.js";
 import { hasNonTransientError } from "@src/confluent/oauth/errors.js";
-import { runPkceLogin } from "@src/confluent/oauth/pkce-login.js";
+import {
+  PkceLoginError,
+  runPkceLogin,
+} from "@src/confluent/oauth/pkce-login.js";
+import type { TokenChainResult } from "@src/confluent/oauth/token-chain.js";
 import type {
   Auth0Environment,
   ConfluentTokenSet,
@@ -10,18 +14,15 @@ import type {
 import { logger } from "@src/logger.js";
 
 /**
- * Owns the current {@link AuthContext} reference for the process and gates
- * when PKCE login runs. Construction is side-effect-free; callers drive the
- * lifecycle through {@link ensureLoggedIn}, which the MCP tool-call wrapper
- * invokes lazily before any handler that needs Confluent access.
+ * Owns the process's {@link AuthContext} and lazily drives PKCE on demand.
+ * Construction is side-effect-free; callers go through {@link ensureLoggedIn}.
  *
  * State machine:
- *   - Idle (no ctx, no in-flight login): `ensureLoggedIn()` starts PKCE.
- *   - Logging in: concurrent callers share the cached Promise.
- *   - Logged in (ctx usable): `ensureLoggedIn()` is a no-op.
- *   - Failed / expired (ctx unusable): `ensureLoggedIn()` clears the dead
- *     ctx, transitions back to Idle, and starts a fresh PKCE.
- *   - Shut down: `ensureLoggedIn()` rejects.
+ *   - Idle: starts PKCE.
+ *   - Logging in: concurrent callers share the in-flight Promise.
+ *   - Logged in: no-op (or single-flight refresh if bearer tokens are stale).
+ *   - Failed / refresh-family expired: clears ctx and starts a fresh PKCE.
+ *   - Shut down: rejects.
  */
 export class OAuthHolder {
   private ctx: AuthContext | undefined;
@@ -31,27 +32,17 @@ export class OAuthHolder {
 
   constructor(private readonly env: Auth0Environment) {}
 
-  /** Live control-plane bearer token; `undefined` until `ensureLoggedIn()` resolves. */
   getControlPlaneToken(): string | undefined {
     return this.ctx?.getControlPlaneToken();
   }
 
-  /** Live data-plane bearer token; `undefined` until `ensureLoggedIn()` resolves. */
   getDataPlaneToken(): string | undefined {
     return this.ctx?.getDataPlaneToken();
   }
 
   /**
-   * Ensure the holder has a usable {@link AuthContext}, starting PKCE on
-   * demand. Single-flight: concurrent calls share the same in-flight login.
-   * Replayable: rejects when PKCE fails, but the next call starts a fresh
-   * attempt rather than locking the holder permanently. Rejects after
-   * {@link shutdown}.
-   *
-   * The PKCE failure path resets `inFlightLogin` to `null` (via `.finally`)
-   * so a subsequent caller observes Idle state and can retry. The
-   * AbortController is shared across attempts; once `shutdown()` aborts it,
-   * the holder is permanently terminal.
+   * Ensure the holder has usable bearer tokens, starting PKCE on demand.
+   * Single-flight, replayable after a PKCE failure, rejects after shutdown.
    */
   async ensureLoggedIn(): Promise<void> {
     if (this.cleared) {
@@ -61,19 +52,39 @@ export class OAuthHolder {
       return this.inFlightLogin;
     }
     if (this.ctx) {
-      // Usable contexts are a no-op fast path. Unusable contexts (refresh
-      // family expired, non-transient error recorded) are cleared so the
-      // next steps start from a clean Idle state. Atomically clearing here
-      // — before the await on `runLogin()` — ensures concurrent callers
-      // don't race into two parallel PKCE flows after a state transition.
       if (
-        !this.ctx.refreshTokenExpired() &&
-        !hasNonTransientError(this.ctx.getErrors())
+        this.ctx.refreshTokenExpired() ||
+        hasNonTransientError(this.ctx.getErrors())
+      ) {
+        this.ctx.clear();
+        this.ctx = undefined;
+        // fall through to PKCE
+      } else if (
+        this.ctx.getControlPlaneToken() !== undefined &&
+        this.ctx.getDataPlaneToken() !== undefined
       ) {
         return;
+      } else {
+        // Refresh token alive but bearer tokens stale (e.g., system sleep
+        // suspended the refresh-loop tick). Refresh on demand rather than
+        // re-prompt; `AuthContext.refresh()` joins any in-flight refresh.
+        await this.ctx.refresh();
+        if (this.cleared) {
+          throw new Error("OAuthHolder is shut down");
+        }
+        if (
+          this.ctx.getControlPlaneToken() !== undefined &&
+          this.ctx.getDataPlaneToken() !== undefined
+        ) {
+          return;
+        }
+        // Refresh didn't restore tokens. Surface a retry-friendly error
+        // rather than launch a browser; if the failure becomes
+        // non-transient, the next call falls through to PKCE.
+        throw new Error(
+          "OAuth bearer tokens unavailable after refresh; retry the tool call",
+        );
       }
-      this.ctx.clear();
-      this.ctx = undefined;
     }
     this.inFlightLogin = this.runLogin().finally(() => {
       this.inFlightLogin = null;
@@ -82,9 +93,8 @@ export class OAuthHolder {
   }
 
   /**
-   * Stops the refresh loop, clears the held context, and aborts any
-   * in-flight PKCE login. Idempotent. Once shut down, `ensureLoggedIn()`
-   * rejects — the holder is terminal.
+   * Terminal — clears ctx (which stops the refresh loop) and aborts any
+   * in-flight PKCE. Idempotent.
    */
   shutdown(): void {
     this.ctx?.clear();
@@ -96,10 +106,21 @@ export class OAuthHolder {
   private async runLogin(): Promise<void> {
     const auth0Config = getAuth0Config(this.env);
     logger.info({ env: this.env }, "Starting OAuth login");
-    const tokenChain = await runPkceLogin(
-      auth0Config,
-      this.abortController.signal,
-    );
+    let tokenChain: TokenChainResult;
+    try {
+      tokenChain = await runPkceLogin(auth0Config, this.abortController.signal);
+    } catch (err) {
+      // The MCP tool-call wrapper rethrows but doesn't log; surface the
+      // failure here so server stderr captures the cause (timeout,
+      // port_in_use, configuration, user_aborted).
+      if (this.cleared) {
+        logger.info({ env: this.env }, "OAuth login aborted by shutdown");
+      } else {
+        const reason = err instanceof PkceLoginError ? err.reason : undefined;
+        logger.error({ env: this.env, err, reason }, "OAuth login failed");
+      }
+      throw err;
+    }
     if (this.cleared) {
       // shutdown() raced with PKCE completion — discard the tokens we just
       // obtained rather than attaching them to a holder that's been

--- a/src/confluent/oauth/oauth-holder.ts
+++ b/src/confluent/oauth/oauth-holder.ts
@@ -1,6 +1,7 @@
 import { AuthContext } from "@src/confluent/oauth/auth-context.js";
 import { getAuth0Config } from "@src/confluent/oauth/auth0-config.js";
 import { generateOpaqueToken } from "@src/confluent/oauth/crypto-utils.js";
+import { hasNonTransientError } from "@src/confluent/oauth/errors.js";
 import { runPkceLogin } from "@src/confluent/oauth/pkce-login.js";
 import type {
   Auth0Environment,
@@ -9,51 +10,81 @@ import type {
 import { logger } from "@src/logger.js";
 
 /**
- * Owns the current {@link AuthContext} reference for the process. Builds the
- * first context from a PKCE login and exposes the read-side accessors that
- * the bearer middleware uses.
+ * Owns the current {@link AuthContext} reference for the process and gates
+ * when PKCE login runs. Construction is side-effect-free; callers drive the
+ * lifecycle through {@link ensureLoggedIn}, which the MCP tool-call wrapper
+ * invokes lazily before any handler that needs Confluent access.
  *
- * Constructed via {@link OAuthHolder.start}, which returns synchronously and
- * runs PKCE in the background. The {@link bootstrapPromise} field always
- * resolves (never rejects) — callers inspect the holder's accessors after the
- * await to know whether bootstrap succeeded.
+ * State machine:
+ *   - Idle (no ctx, no in-flight login): `ensureLoggedIn()` starts PKCE.
+ *   - Logging in: concurrent callers share the cached Promise.
+ *   - Logged in (ctx usable): `ensureLoggedIn()` is a no-op.
+ *   - Failed / expired (ctx unusable): `ensureLoggedIn()` clears the dead
+ *     ctx, transitions back to Idle, and starts a fresh PKCE.
+ *   - Shut down: `ensureLoggedIn()` rejects.
  */
 export class OAuthHolder {
   private ctx: AuthContext | undefined;
   private cleared = false;
   private readonly abortController = new AbortController();
-  readonly bootstrapPromise: Promise<void>;
+  private inFlightLogin: Promise<void> | null = null;
 
-  private constructor(env: Auth0Environment) {
-    // Idiomatic async-init: `bootstrapPromise` is the documented completion
-    // handle (see class JSDoc). Holder is fully usable immediately after
-    // construction — every method correctly handles the bootstrapping state.
-    this.bootstrapPromise = this.runBootstrap(env); // NOSONAR(S7059)
-  }
+  constructor(private readonly env: Auth0Environment) {}
 
-  /**
-   * Construct a holder synchronously and run PKCE login in the background.
-   * Returned holder has undefined tokens until {@link bootstrapPromise}
-   * settles. Shutdown is safe at any point.
-   */
-  static start(env: Auth0Environment): OAuthHolder {
-    return new OAuthHolder(env);
-  }
-
-  /** Live control-plane bearer token; `undefined` while broken. */
+  /** Live control-plane bearer token; `undefined` until `ensureLoggedIn()` resolves. */
   getControlPlaneToken(): string | undefined {
     return this.ctx?.getControlPlaneToken();
   }
 
-  /** Live data-plane bearer token; `undefined` while broken. */
+  /** Live data-plane bearer token; `undefined` until `ensureLoggedIn()` resolves. */
   getDataPlaneToken(): string | undefined {
     return this.ctx?.getDataPlaneToken();
   }
 
   /**
-   * Stops the refresh loop, clears the held context, and aborts any in-flight
-   * PKCE login (so a `^C` before browser sign-in completes doesn't leave a
-   * 120s zombie timer / port-bound HTTP server). Safe to double-call.
+   * Ensure the holder has a usable {@link AuthContext}, starting PKCE on
+   * demand. Single-flight: concurrent calls share the same in-flight login.
+   * Replayable: rejects when PKCE fails, but the next call starts a fresh
+   * attempt rather than locking the holder permanently. Rejects after
+   * {@link shutdown}.
+   *
+   * The PKCE failure path resets `inFlightLogin` to `null` (via `.finally`)
+   * so a subsequent caller observes Idle state and can retry. The
+   * AbortController is shared across attempts; once `shutdown()` aborts it,
+   * the holder is permanently terminal.
+   */
+  async ensureLoggedIn(): Promise<void> {
+    if (this.cleared) {
+      throw new Error("OAuthHolder is shut down");
+    }
+    if (this.inFlightLogin) {
+      return this.inFlightLogin;
+    }
+    if (this.ctx) {
+      // Usable contexts are a no-op fast path. Unusable contexts (refresh
+      // family expired, non-transient error recorded) are cleared so the
+      // next steps start from a clean Idle state. Atomically clearing here
+      // — before the await on `runLogin()` — ensures concurrent callers
+      // don't race into two parallel PKCE flows after a state transition.
+      if (
+        !this.ctx.refreshTokenExpired() &&
+        !hasNonTransientError(this.ctx.getErrors())
+      ) {
+        return;
+      }
+      this.ctx.clear();
+      this.ctx = undefined;
+    }
+    this.inFlightLogin = this.runLogin().finally(() => {
+      this.inFlightLogin = null;
+    });
+    return this.inFlightLogin;
+  }
+
+  /**
+   * Stops the refresh loop, clears the held context, and aborts any
+   * in-flight PKCE login. Idempotent. Once shut down, `ensureLoggedIn()`
+   * rejects — the holder is terminal.
    */
   shutdown(): void {
     this.ctx?.clear();
@@ -62,39 +93,30 @@ export class OAuthHolder {
     this.abortController.abort();
   }
 
-  private async runBootstrap(env: Auth0Environment): Promise<void> {
-    try {
-      const auth0Config = getAuth0Config(env);
-      logger.info({ env }, "Starting OAuth login");
-      const tokenChain = await runPkceLogin(
-        auth0Config,
-        this.abortController.signal,
+  private async runLogin(): Promise<void> {
+    const auth0Config = getAuth0Config(this.env);
+    logger.info({ env: this.env }, "Starting OAuth login");
+    const tokenChain = await runPkceLogin(
+      auth0Config,
+      this.abortController.signal,
+    );
+    if (this.cleared) {
+      // shutdown() raced with PKCE completion — discard the tokens we just
+      // obtained rather than attaching them to a holder that's been
+      // explicitly torn down.
+      logger.info(
+        { env: this.env },
+        "OAuth login completed but holder was cleared; discarding tokens",
       );
-      // shutdown() may have fired during PKCE — discard the in-flight context.
-      if (this.cleared) {
-        logger.info(
-          { env },
-          "OAuth login completed but holder was cleared; discarding tokens",
-        );
-        return;
-      }
-      const tokens: ConfluentTokenSet = {
-        ...tokenChain,
-        accessToken: generateOpaqueToken(),
-      };
-      const ctx = AuthContext.fromTokens(auth0Config, tokens);
-      ctx.startRefreshLoop();
-      this.ctx = ctx;
-      logger.info({ env }, "OAuth login successful");
-    } catch (err) {
-      // shutdown() aborts the in-flight PKCE via AbortSignal — when the catch
-      // fires after shutdown, the error is the expected user_aborted signal
-      // we triggered ourselves. Log a terse line without the stack trace.
-      if (this.cleared) {
-        logger.info({ env }, "OAuth login aborted by shutdown");
-        return;
-      }
-      logger.error({ env, err }, "OAuth login failed");
+      return;
     }
+    const tokens: ConfluentTokenSet = {
+      ...tokenChain,
+      accessToken: generateOpaqueToken(),
+    };
+    const ctx = AuthContext.fromTokens(auth0Config, tokens);
+    ctx.startRefreshLoop();
+    this.ctx = ctx;
+    logger.info({ env: this.env }, "OAuth login successful");
   }
 }

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -38,6 +38,15 @@ export interface ToolHandler {
   getToolConfig(): ToolConfig;
 
   /**
+   * The connection predicate that gates this tool's enablement. Lifted onto
+   * the interface so the MCP tool-call wrapper can compare it against
+   * `alwaysEnabled` to skip the OAuth login gate for tools that don't touch
+   * the client manager (currently the doc-lookup tools). See
+   * {@linkcode BaseToolHandler.predicate} for the rules around setting it.
+   */
+  readonly predicate: ConnectionPredicate;
+
+  /**
    * IDs of connections that satisfy this tool's service requirements. A
    * non-empty result enables the tool; an empty result disables it. Always a
    * subset of `runtime.config.connections` keys.

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,25 +1,14 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
-import type { CallToolResult } from "@src/confluent/schema.js";
-import {
-  BaseToolHandler,
-  READ_ONLY,
-  type ToolConfig,
-  type ToolHandler,
-} from "@src/confluent/tools/base-tools.js";
-import {
-  alwaysEnabled,
-  ToolDisabledReason,
-  type ConnectionPredicate,
-} from "@src/confluent/tools/connection-predicates.js";
+import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { initEnv } from "@src/env.js";
 import { createMcpServer, type ToolCallProps } from "@src/mcp/server.js";
 import { ServerRuntime } from "@src/server-runtime.js";
-import { runtimeWith } from "@tests/factories/runtime.js";
+import { ccloudOAuthRuntime, runtimeWith } from "@tests/factories/runtime.js";
 import { createTestServer, TestServerContext } from "@tests/server.js";
-import { createMockInstance } from "@tests/stubs/index.js";
+import { createMockInstance, StubHandler } from "@tests/stubs/index.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
@@ -49,43 +38,6 @@ describe("MCP server", () => {
     expect(tools).toHaveLength(ALL_TOOL_NAMES.length);
   });
 });
-
-/**
- * Concrete BaseToolHandler with a configurable predicate, used to drive
- * gate-behavior tests without depending on the shape of any one production
- * handler. Records every {@linkcode handle} invocation so tests can assert
- * gate-vs-handle ordering.
- */
-class GateTestHandler extends BaseToolHandler {
-  readonly handleSpy = vi.fn();
-  readonly predicate: ConnectionPredicate;
-
-  constructor(
-    private readonly toolName: ToolName,
-    predicate: ConnectionPredicate,
-  ) {
-    super();
-    // Explicit assignment (rather than a parameter property) because
-    // BaseToolHandler declares `predicate` abstract; with
-    // useDefineForClassFields=true a subclass parameter property would be
-    // shadowed by the base's class-field declaration.
-    this.predicate = predicate;
-  }
-
-  getToolConfig(): ToolConfig {
-    return {
-      name: this.toolName,
-      description: "test",
-      inputSchema: {},
-      annotations: READ_ONLY,
-    };
-  }
-
-  handle(): CallToolResult {
-    this.handleSpy();
-    return this.createResponse("ok");
-  }
-}
 
 /**
  * Spins up an {@linkcode createMcpServer} with a custom handler map (rather
@@ -122,38 +74,23 @@ async function startServerWith(
 }
 
 describe("MCP server tool-call gate", () => {
-  // Distinct from `alwaysEnabled` so the gate fires for the test handler;
-  // the actual return value doesn't matter (the gate doesn't call the
-  // predicate, only compares against `alwaysEnabled`).
-  const stubPredicate: ConnectionPredicate = () => ({
-    enabled: false,
-    reason: ToolDisabledReason.MissingFlinkBlock,
-  });
-
+  // StubHandler({ enabled: false }) yields a predicate that's not
+  // `alwaysEnabled` (it returns a disabled-result), which is the condition
+  // the gate uses to decide to launch the OAuth login. The "tool disabled"
+  // semantics are incidental — the gate doesn't read the predicate's
+  // result, only its identity.
   it("should call ensureLoggedIn() before handle() when an OAuth holder is present and predicate is not alwaysEnabled", async () => {
     const holder = createMockInstance(OAuthHolder);
     holder.ensureLoggedIn.mockResolvedValue(undefined);
-    const handler = new GateTestHandler(ToolName.LIST_TOPICS, stubPredicate);
-
-    const runtime = runtimeWith();
-    Object.defineProperty(runtime, "oauthHolder", {
-      value: holder,
-      configurable: true,
-    });
+    const handler = new StubHandler({ enabled: false });
 
     const { client, shutdown } = await startServerWith(
       new Map([[ToolName.LIST_TOPICS, handler]]),
-      runtime,
+      ccloudOAuthRuntime(holder),
     );
     try {
       await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
-
       expect(holder.ensureLoggedIn).toHaveBeenCalledOnce();
-      expect(handler.handleSpy).toHaveBeenCalledOnce();
-      // Order matters: gate must run before handle.
-      expect(holder.ensureLoggedIn.mock.invocationCallOrder[0]).toBeLessThan(
-        handler.handleSpy.mock.invocationCallOrder[0]!,
-      );
     } finally {
       await shutdown();
     }
@@ -165,45 +102,31 @@ describe("MCP server tool-call gate", () => {
     // browser tab on what looks like a pure-search call.
     const holder = createMockInstance(OAuthHolder);
     holder.ensureLoggedIn.mockResolvedValue(undefined);
-    const handler = new GateTestHandler(
-      ToolName.SEARCH_PRODUCT_DOCS,
-      alwaysEnabled,
-    );
-
-    const runtime = runtimeWith();
-    Object.defineProperty(runtime, "oauthHolder", {
-      value: holder,
-      configurable: true,
-    });
+    const handler = new StubHandler({ enabled: true });
 
     const { client, shutdown } = await startServerWith(
-      new Map([[ToolName.SEARCH_PRODUCT_DOCS, handler]]),
-      runtime,
+      new Map([[ToolName.LIST_TOPICS, handler]]),
+      ccloudOAuthRuntime(holder),
     );
     try {
-      await client.callTool({
-        name: ToolName.SEARCH_PRODUCT_DOCS,
-        arguments: {},
-      });
+      await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
       expect(holder.ensureLoggedIn).not.toHaveBeenCalled();
-      expect(handler.handleSpy).toHaveBeenCalledOnce();
     } finally {
       await shutdown();
     }
   });
 
   it("should be a no-op when runtime.oauthHolder is undefined (api_key path)", async () => {
-    const handler = new GateTestHandler(ToolName.LIST_TOPICS, stubPredicate);
-    const runtime = runtimeWith(); // No oauthHolder.
-    expect(runtime.oauthHolder).toBeUndefined();
+    const handler = new StubHandler({ enabled: false });
+    const handleSpy = vi.spyOn(handler, "handle");
 
     const { client, shutdown } = await startServerWith(
       new Map([[ToolName.LIST_TOPICS, handler]]),
-      runtime,
+      runtimeWith(), // No oauthHolder.
     );
     try {
       await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
-      expect(handler.handleSpy).toHaveBeenCalledOnce();
+      expect(handleSpy).toHaveBeenCalledOnce();
     } finally {
       await shutdown();
     }
@@ -214,18 +137,13 @@ describe("MCP server tool-call gate", () => {
     holder.ensureLoggedIn.mockRejectedValue(
       new Error("PKCE login timed out after 120000ms"),
     );
-    const handler = new GateTestHandler(ToolName.LIST_TOPICS, stubPredicate);
-
-    const runtime = runtimeWith();
-    Object.defineProperty(runtime, "oauthHolder", {
-      value: holder,
-      configurable: true,
-    });
+    const handler = new StubHandler({ enabled: false });
+    const handleSpy = vi.spyOn(handler, "handle");
 
     const trackSpy = vi.fn();
     const { client, shutdown } = await startServerWith(
       new Map([[ToolName.LIST_TOPICS, handler]]),
-      runtime,
+      ccloudOAuthRuntime(holder),
       trackSpy,
     );
     try {
@@ -237,7 +155,7 @@ describe("MCP server tool-call gate", () => {
       // MCP SDK converts thrown errors into an error result with isError=true.
       expect(result.isError).toBe(true);
       // Handler must NOT have run — gate failure is terminal for this call.
-      expect(handler.handleSpy).not.toHaveBeenCalled();
+      expect(handleSpy).not.toHaveBeenCalled();
       // Telemetry hook records the failure.
       expect(trackSpy).toHaveBeenCalledOnce();
       expect(trackSpy.mock.calls[0]![0]).toMatchObject({

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,7 +1,26 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import {
+  BaseToolHandler,
+  READ_ONLY,
+  type ToolConfig,
+  type ToolHandler,
+} from "@src/confluent/tools/base-tools.js";
+import {
+  alwaysEnabled,
+  ToolDisabledReason,
+  type ConnectionPredicate,
+} from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { initEnv } from "@src/env.js";
+import { createMcpServer, type ToolCallProps } from "@src/mcp/server.js";
+import { ServerRuntime } from "@src/server-runtime.js";
 import { runtimeWith } from "@tests/factories/runtime.js";
 import { createTestServer, TestServerContext } from "@tests/server.js";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createMockInstance } from "@tests/stubs/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ALL_TOOL_NAMES = Object.values(ToolName);
 
@@ -28,5 +47,205 @@ describe("MCP server", () => {
     const { tools } = await ctx.client.listTools();
 
     expect(tools).toHaveLength(ALL_TOOL_NAMES.length);
+  });
+});
+
+/**
+ * Concrete BaseToolHandler with a configurable predicate, used to drive
+ * gate-behavior tests without depending on the shape of any one production
+ * handler. Records every {@linkcode handle} invocation so tests can assert
+ * gate-vs-handle ordering.
+ */
+class GateTestHandler extends BaseToolHandler {
+  readonly handleSpy = vi.fn();
+  readonly predicate: ConnectionPredicate;
+
+  constructor(
+    private readonly toolName: ToolName,
+    predicate: ConnectionPredicate,
+  ) {
+    super();
+    // Explicit assignment (rather than a parameter property) because
+    // BaseToolHandler declares `predicate` abstract; with
+    // useDefineForClassFields=true a subclass parameter property would be
+    // shadowed by the base's class-field declaration.
+    this.predicate = predicate;
+  }
+
+  getToolConfig(): ToolConfig {
+    return {
+      name: this.toolName,
+      description: "test",
+      inputSchema: {},
+      annotations: READ_ONLY,
+    };
+  }
+
+  handle(): CallToolResult {
+    this.handleSpy();
+    return this.createResponse("ok");
+  }
+}
+
+/**
+ * Spins up an {@linkcode createMcpServer} with a custom handler map (rather
+ * than the full registry) over an InMemoryTransport pair.
+ */
+async function startServerWith(
+  toolHandlers: Map<ToolName, ToolHandler>,
+  runtime: ServerRuntime,
+  track?: (props: ToolCallProps) => void,
+): Promise<{
+  client: Client;
+  shutdown: () => Promise<void>;
+}> {
+  await initEnv();
+  const server = createMcpServer({
+    serverVersion: "0.0.0-test",
+    toolHandlers,
+    runtime,
+    track,
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0-test" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    shutdown: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("MCP server tool-call gate", () => {
+  // Distinct from `alwaysEnabled` so the gate fires for the test handler;
+  // the actual return value doesn't matter (the gate doesn't call the
+  // predicate, only compares against `alwaysEnabled`).
+  const stubPredicate: ConnectionPredicate = () => ({
+    enabled: false,
+    reason: ToolDisabledReason.MissingFlinkBlock,
+  });
+
+  it("should call ensureLoggedIn() before handle() when an OAuth holder is present and predicate is not alwaysEnabled", async () => {
+    const holder = createMockInstance(OAuthHolder);
+    holder.ensureLoggedIn.mockResolvedValue(undefined);
+    const handler = new GateTestHandler(ToolName.LIST_TOPICS, stubPredicate);
+
+    const runtime = runtimeWith();
+    Object.defineProperty(runtime, "oauthHolder", {
+      value: holder,
+      configurable: true,
+    });
+
+    const { client, shutdown } = await startServerWith(
+      new Map([[ToolName.LIST_TOPICS, handler]]),
+      runtime,
+    );
+    try {
+      await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
+
+      expect(holder.ensureLoggedIn).toHaveBeenCalledOnce();
+      expect(handler.handleSpy).toHaveBeenCalledOnce();
+      // Order matters: gate must run before handle.
+      expect(holder.ensureLoggedIn.mock.invocationCallOrder[0]).toBeLessThan(
+        handler.handleSpy.mock.invocationCallOrder[0]!,
+      );
+    } finally {
+      await shutdown();
+    }
+  });
+
+  it("should NOT call ensureLoggedIn() when handler.predicate is alwaysEnabled (e.g., docs lookups)", async () => {
+    // Doc-lookup tools have predicate = alwaysEnabled and never touch the
+    // OAuth client manager. Gating them would surprise the user with a
+    // browser tab on what looks like a pure-search call.
+    const holder = createMockInstance(OAuthHolder);
+    holder.ensureLoggedIn.mockResolvedValue(undefined);
+    const handler = new GateTestHandler(
+      ToolName.SEARCH_PRODUCT_DOCS,
+      alwaysEnabled,
+    );
+
+    const runtime = runtimeWith();
+    Object.defineProperty(runtime, "oauthHolder", {
+      value: holder,
+      configurable: true,
+    });
+
+    const { client, shutdown } = await startServerWith(
+      new Map([[ToolName.SEARCH_PRODUCT_DOCS, handler]]),
+      runtime,
+    );
+    try {
+      await client.callTool({
+        name: ToolName.SEARCH_PRODUCT_DOCS,
+        arguments: {},
+      });
+      expect(holder.ensureLoggedIn).not.toHaveBeenCalled();
+      expect(handler.handleSpy).toHaveBeenCalledOnce();
+    } finally {
+      await shutdown();
+    }
+  });
+
+  it("should be a no-op when runtime.oauthHolder is undefined (api_key path)", async () => {
+    const handler = new GateTestHandler(ToolName.LIST_TOPICS, stubPredicate);
+    const runtime = runtimeWith(); // No oauthHolder.
+    expect(runtime.oauthHolder).toBeUndefined();
+
+    const { client, shutdown } = await startServerWith(
+      new Map([[ToolName.LIST_TOPICS, handler]]),
+      runtime,
+    );
+    try {
+      await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
+      expect(handler.handleSpy).toHaveBeenCalledOnce();
+    } finally {
+      await shutdown();
+    }
+  });
+
+  it('should propagate ensureLoggedIn() rejection as a tool-call error and track status:"error"', async () => {
+    const holder = createMockInstance(OAuthHolder);
+    holder.ensureLoggedIn.mockRejectedValue(
+      new Error("PKCE login timed out after 120000ms"),
+    );
+    const handler = new GateTestHandler(ToolName.LIST_TOPICS, stubPredicate);
+
+    const runtime = runtimeWith();
+    Object.defineProperty(runtime, "oauthHolder", {
+      value: holder,
+      configurable: true,
+    });
+
+    const trackSpy = vi.fn();
+    const { client, shutdown } = await startServerWith(
+      new Map([[ToolName.LIST_TOPICS, handler]]),
+      runtime,
+      trackSpy,
+    );
+    try {
+      const result = await client.callTool({
+        name: ToolName.LIST_TOPICS,
+        arguments: {},
+      });
+
+      // MCP SDK converts thrown errors into an error result with isError=true.
+      expect(result.isError).toBe(true);
+      // Handler must NOT have run — gate failure is terminal for this call.
+      expect(handler.handleSpy).not.toHaveBeenCalled();
+      // Telemetry hook records the failure.
+      expect(trackSpy).toHaveBeenCalledOnce();
+      expect(trackSpy.mock.calls[0]![0]).toMatchObject({
+        toolName: ToolName.LIST_TOPICS,
+        status: "error",
+      });
+    } finally {
+      await shutdown();
+    }
   });
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
@@ -62,6 +63,14 @@ export function createMcpServer({
           clientVersion: clientInfo?.version,
         };
         try {
+          // Gate launch of the browser OAuth login flow only on the
+          // first tool call that needs Confluent OAuth tokens.
+          if (
+            runtime.oauthHolder !== undefined &&
+            handler.predicate !== alwaysEnabled
+          ) {
+            await runtime.oauthHolder.ensureLoggedIn();
+          }
           const result = await handler.handle(
             runtime,
             args,

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -8,14 +8,7 @@ import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
-import { describe, expect, it, vi } from "vitest";
-
-function fakeOAuthHolder(): OAuthHolder {
-  return {
-    getControlPlaneToken: () => "cp-token",
-    getDataPlaneToken: () => "dp-token",
-  } as unknown as OAuthHolder;
-}
+import { describe, expect, it } from "vitest";
 
 function connWith(
   fields: Omit<DirectConnectionConfig, "type">,
@@ -241,12 +234,7 @@ describe("ServerRuntime", () => {
       expect(runtime.oauthHolder).toBeUndefined();
     });
 
-    it("should call OAuthHolder.start and expose oauthHolder when a connection has type 'oauth'", () => {
-      const fakeHolder = fakeOAuthHolder();
-      const startSpy = vi
-        .spyOn(OAuthHolder, "start")
-        .mockReturnValue(fakeHolder);
-
+    it("should construct an OAuthHolder when a connection has type 'oauth'", () => {
       const oauthConfig = new MCPServerConfiguration({
         connections: {
           "env-connection": { type: "oauth", ccloud_env: "devel" },
@@ -255,12 +243,12 @@ describe("ServerRuntime", () => {
 
       const runtime = ServerRuntime.fromConfig(oauthConfig);
 
-      expect(startSpy).toHaveBeenCalledWith("devel");
-      expect(runtime.oauthHolder).toBe(fakeHolder);
+      expect(runtime.oauthHolder).toBeInstanceOf(OAuthHolder);
+      expect(runtime.oauthHolder?.getControlPlaneToken()).toBeUndefined();
+      expect(runtime.oauthHolder?.getDataPlaneToken()).toBeUndefined();
     });
 
     it("should construct OAuthClientManager instances for every connection when an oauth connection is present", () => {
-      vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
         connections: {
           "env-connection": { type: "oauth", ccloud_env: "stag" },

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -18,9 +18,9 @@ export class ServerRuntime {
   /**
    * The active OAuth holder when any connection in the config has `type === "oauth"`.
    * Constructed by {@link ServerRuntime.fromConfig}; `undefined` on api_key paths.
-   * The holder runs PKCE in the background — callers can await
-   * `holder.bootstrapPromise` to know the bootstrap attempt has finished, then
-   * inspect the token accessors to determine whether tokens are available.
+   * Construction is side-effect-free — PKCE runs lazily on the first
+   * `holder.ensureLoggedIn()` call, which the MCP tool-call wrapper invokes
+   * before any handler that needs Confluent access.
    */
   readonly oauthHolder: OAuthHolder | undefined;
 
@@ -67,7 +67,7 @@ export class ServerRuntime {
     }
     const oauthConn = oauthConns[0];
     const oauthHolder = oauthConn
-      ? OAuthHolder.start(oauthConn.ccloud_env)
+      ? new OAuthHolder(oauthConn.ccloud_env)
       : undefined;
 
     // Construct a client manager for each connection in the config.

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -5,6 +5,7 @@ import {
 import { MCPServerConfiguration } from "@src/config/models.js";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
+import type { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance, type HandleCase } from "@tests/stubs/index.js";
 import { fileURLToPath } from "node:url";
@@ -173,11 +174,14 @@ export type FlinkGetCase = HandleCaseWithConn & {
  * enables the expected set of tools against an OAuth runtime. A stub
  * `OAuthClientManager` is supplied solely to satisfy `ServerRuntime`'s
  * constructor — `enabledConnectionIds()` reads `runtime.config.connections`
- * and never touches the client manager.
+ * and never touches the client manager. Pass `holder` to install a specific
+ * {@link OAuthHolder} on the runtime (used by the gate-behavior tests).
  */
-export function ccloudOAuthRuntime(): ServerRuntime {
+export function ccloudOAuthRuntime(holder?: OAuthHolder): ServerRuntime {
   const config = loadConfigFromYaml(CCLOUD_OAUTH_FIXTURE, {});
-  return new ServerRuntime(config, {
-    [DEFAULT_CONNECTION_ID]: createMockInstance(OAuthClientManager),
-  });
+  return new ServerRuntime(
+    config,
+    { [DEFAULT_CONNECTION_ID]: createMockInstance(OAuthClientManager) },
+    holder,
+  );
 }


### PR DESCRIPTION
## Summary of Changes

- Defer the OAuth (PKCE) browser launch from server startup to the first tool invocation that needs Confluent access.
  - `OAuthHolder` becomes a lazy state machine: construction is side-effect-free; new single-flight `ensureLoggedIn()` drives PKCE on demand and is replayable after non-transient failure or refresh-family expiry. Removes `start()`, `bootstrapPromise`, and the private `runBootstrap()`.
- Add an OAuth login gate inside the MCP tool-call wrapper in `src/mcp/server.ts`. It awaits `runtime.oauthHolder?.ensureLoggedIn()` before delegating to `handler.handle(...)`, but skips when `handler.predicate === alwaysEnabled` (so doc-lookup tools don't surprise users with a browser tab).
  - Lifts `predicate: ConnectionPredicate` from `BaseToolHandler` onto the `ToolHandler` interface so the gate can read it without a cast.
- Remove dead `await this.holder.bootstrapPromise` calls in `OAuthClientManager`. The post-gate guard (`requireDataPlaneToken`) is now sync and surfaces a clearer error for the rare "token went away mid-call" race.
- README OAuth section updated: login launches on first tool needing Confluent access, not at startup.
- Harden the gate against stale bearer tokens. `ensureLoggedIn()` now verifies CP/DP availability and triggers an on-demand `AuthContext.refresh()` when the refresh token is alive but the bearer tokens have expired (e.g., after system sleep suspended the refresh-loop tick). PKCE only relaunches when the refresh token itself is gone or has hit a non-transient error. 

Fixes #413

https://github.com/user-attachments/assets/08534358-e188-4a26-9d95-3a9b04d55d0f

### Manual testing instructions

1. Build this branch:
   ```sh
   cd <mcp-confluent worktree>
   npm install
   npm run build
   ```
2. Add this branch's build to Cursor's MCP config (`~/.cursor/mcp.json`), pointing `args[0]` at the worktree's `dist/index.js` and `args[2]` at any existing `oauth.yaml` (a config with a `type: oauth` connection):
   ```json
   {
     "mcpServers": {
       "mcp-confluent-oauth": {
         "command": "node",
         "args": [
           "<absolute path to worktree>/dist/index.js",
           "-c",
           "<absolute path to your oauth.yaml>"
         ]
       }
     }
   }
   ```
3. In Cursor: open Settings → MCP → reload `mcp-confluent-oauth`. Verify the server starts and the tools list populates **without** a browser tab opening.
4. In a Cursor chat, ask the agent to call `search-product-docs` (e.g., "look up Kafka quickstart docs"). Verify the tool returns results **without** opening a browser tab — `search-product-docs` has `predicate = alwaysEnabled` and is exempt from the gate.
5. Now ask the agent to call `list-environments` (e.g., "list my Confluent environments").
6. Verify a browser tab **opens** to the Confluent Cloud sign-in page. Complete sign-in.
7. Verify `list-environments` returns the environments after sign-in completes.
8. Ask the agent to call `list-environments` again (or any other Confluent tool). Verify **no new browser tab opens** — the cached session is reused.
9. Concurrency — single in-flight login: reload `mcp-confluent-oauth` so the holder is fresh again. In a single Cursor turn, prompt the agent to do something that fans out into multiple Confluent tool calls at once (e.g., "list my environments and clusters and connectors"). The agent should issue the tool calls in parallel. Verify exactly **one** browser tab opens, not three; complete sign-in once; verify all parallel tool calls then resolve.
10. Edge case — dismiss the sign-in tab on a fresh start: in Cursor, restart the `mcp-confluent-oauth` server, ask for `list-environments`, and immediately close the browser tab without signing in. Verify the tool fails with a timeout error (~120s), and a follow-up tool call **launches a fresh sign-in flow** (replayability after failure).
11. Sanity — swap the `mcp-confluent-oauth` entry to point at an `api_key`-based `config.yaml`. Verify behavior is unchanged: no gate, no browser, tools work as before.

### Optional: Any additional details or context that should be provided?

- Before: opening the server with an OAuth config always launched a browser tab at startup, even when the user planned to invoke an OAuth-free tool (e.g., a docs lookup) or didn't get to invoke anything.
- After: the server boots cleanly. The browser launches only on the first tool call that needs Confluent access, and concurrent first-time tool calls share a single sign-in flow rather than opening multiple tabs.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new — gate-behavior tests in `src/mcp/server.test.ts`; lazy/replayable `OAuthHolder` tests in `oauth-holder.test.ts`.
- [x] Updated existing — `oauth-holder.test.ts` rewritten around the new contract; `oauth-client-manager.test.ts` cleaned up; `server-runtime.test.ts` updated to assert the new construction shape.
- [x] Deleted existing — redundant shutdown-idempotency test and duplicate DPAT-unavailable test.

#### Release notes

- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?