### PR TITLE
chore: rename env-path connection to `_default` and pin fallback shape

### DIFF
--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1,4 +1,7 @@
-import { buildConfigFromEnvAndCli } from "@src/config/env-config.js";
+import {
+  buildConfigFromEnvAndCli,
+  DEFAULT_CONNECTION_NAME,
+} from "@src/config/env-config.js";
 import { describe, expect, it } from "vitest";
 
 type EnvInput = Parameters<typeof buildConfigFromEnvAndCli>[0];
@@ -64,12 +67,14 @@ describe("config/env-config.ts", () => {
         expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       });
 
-      it("should use '_default' as the connection name", () => {
+      it("should use the default connection name", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
         );
 
-        expect(Object.keys(config.connections)).toEqual(["_default"]);
+        expect(Object.keys(config.connections)).toEqual([
+          DEFAULT_CONNECTION_NAME,
+        ]);
       });
 
       it("should build a kafka-only config when only BOOTSTRAP_SERVERS is set", () => {

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -64,12 +64,12 @@ describe("config/env-config.ts", () => {
         expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       });
 
-      it("should use 'env-connection' as the connection name", () => {
+      it("should use '_default' as the connection name", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
         );
 
-        expect(Object.keys(config.connections)).toEqual(["env-connection"]);
+        expect(Object.keys(config.connections)).toEqual(["_default"]);
       });
 
       it("should build a kafka-only config when only BOOTSTRAP_SERVERS is set", () => {

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -13,15 +13,16 @@ import { type KeyValuePairObject } from "properties-file";
  * Connection name synthesized by the env-var path. Chosen as `"_default"` so
  * the YAML loader can reuse the same name as the zero-config fallback.
  *
- * Fallback contract: with no CLI args and no env vars, this module
- * produces `{ connections: { _default: { type: "direct" } } }` — a valid
- * config with no service blocks, enabling only connection-agnostic tools.
- * When the env-var path is retired, the YAML loader must preserve this same shape.
+ * Fallback contract: with no CLI args and no env vars, this module produces
+ * `connections: { _default: { type: "direct" } }` alongside the
+ * always-present `server` block. This yields a config with no service
+ * blocks, so only connection-agnostic tools are enabled. When the env-var
+ * path is retired, the YAML loader must preserve this connection shape.
  */
-const ENV_CONNECTION_NAME = "_default";
+export const DEFAULT_CONNECTION_NAME = "_default";
 
 /** The manufactured document path prefix for the single connection configured from env vars. */
-const CONN = `connections.${ENV_CONNECTION_NAME}`;
+const CONN = `connections.${DEFAULT_CONNECTION_NAME}`;
 
 /**
  * Maps each environment variable in type Environment (and handled by buildConfigFromEnvAndCli)
@@ -93,7 +94,7 @@ function buildConfigFromEnv(
   if (oauth) {
     const rawDocument: Record<string, unknown> = {
       connections: {
-        [ENV_CONNECTION_NAME]: {
+        [DEFAULT_CONNECTION_NAME]: {
           type: "oauth",
           ...(oauth.ccloudEnv && {
             ccloud_env: oauth.ccloudEnv,
@@ -146,7 +147,7 @@ function buildConfigFromEnv(
   // authOverrides are folded in here so Zod validates the final combined state,
   // including the disabled+api_key mutual exclusion refine.
   const rawDocument: Record<string, unknown> = {
-    connections: { [ENV_CONNECTION_NAME]: connection },
+    connections: { [DEFAULT_CONNECTION_NAME]: connection },
     ...buildServerBlock(env, authOverrides),
   };
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -9,7 +9,16 @@ import {
 import type { Environment } from "@src/env.js";
 import { type KeyValuePairObject } from "properties-file";
 
-const ENV_CONNECTION_NAME = "env-connection";
+/**
+ * Connection name synthesized by the env-var path. Chosen as `"_default"` so
+ * the YAML loader can reuse the same name as the zero-config fallback.
+ *
+ * Fallback contract: with no CLI args and no env vars, this module
+ * produces `{ connections: { _default: { type: "direct" } } }` — a valid
+ * config with no service blocks, enabling only connection-agnostic tools.
+ * When the env-var path is retired, the YAML loader must preserve this same shape.
+ */
+const ENV_CONNECTION_NAME = "_default";
 
 /** The manufactured document path prefix for the single connection configured from env vars. */
 const CONN = `connections.${ENV_CONNECTION_NAME}`;

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -687,7 +687,7 @@ describe("config/models.ts", () => {
       it("should throw when the sole connection is OAuth-typed", () => {
         const config = new MCPServerConfiguration({
           connections: {
-            "env-connection": { type: "oauth", ccloud_env: "devel" },
+            _default: { type: "oauth", ccloud_env: "devel" },
           },
         });
 

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CONNECTION_NAME } from "@src/config/env-config.js";
 import type { DirectConnectionConfig } from "@src/config/models.js";
 import {
   KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
@@ -687,7 +688,7 @@ describe("config/models.ts", () => {
       it("should throw when the sole connection is OAuth-typed", () => {
         const config = new MCPServerConfiguration({
           connections: {
-            _default: { type: "oauth", ccloud_env: "devel" },
+            [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "devel" },
           },
         });
 

--- a/src/confluent/tools/cluster-arg-resolvers.test.ts
+++ b/src/confluent/tools/cluster-arg-resolvers.test.ts
@@ -1,4 +1,5 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
+import { DEFAULT_CONNECTION_NAME } from "@src/config/env-config.js";
 import { MCPServerConfiguration } from "@src/config/index.js";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import {
@@ -13,7 +14,7 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 
-const CONN_ID = "_default";
+const CONN_ID = DEFAULT_CONNECTION_NAME;
 
 function directRuntime(
   connOverrides: Record<string, unknown> = {},

--- a/src/confluent/tools/cluster-arg-resolvers.test.ts
+++ b/src/confluent/tools/cluster-arg-resolvers.test.ts
@@ -13,7 +13,7 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 
-const CONN_ID = "env-connection";
+const CONN_ID = "_default";
 
 function directRuntime(
   connOverrides: Record<string, unknown> = {},

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -232,7 +232,7 @@ describe("ServerRuntime", () => {
     it("should leave oauthHolder undefined when the config has no ccloud-oauth", () => {
       const noOauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": connWith({
+          _default: connWith({
             kafka: { bootstrap_servers: "broker:9092" },
           }),
         },
@@ -249,7 +249,7 @@ describe("ServerRuntime", () => {
 
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": { type: "oauth", ccloud_env: "devel" },
+          _default: { type: "oauth", ccloud_env: "devel" },
         },
       });
 
@@ -263,13 +263,13 @@ describe("ServerRuntime", () => {
       vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          "env-connection": { type: "oauth", ccloud_env: "stag" },
+          _default: { type: "oauth", ccloud_env: "stag" },
         },
       });
 
       const runtime = ServerRuntime.fromConfig(oauthConfig);
 
-      expect(runtime.clientManagers["env-connection"]).toBeInstanceOf(
+      expect(runtime.clientManagers["_default"]).toBeInstanceOf(
         OAuthClientManager,
       );
     });

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CONNECTION_NAME } from "@src/config/env-config.js";
 import { type DirectConnectionConfig } from "@src/config/index.js";
 import { MCPServerConfiguration } from "@src/config/models.js";
 import {
@@ -232,7 +233,7 @@ describe("ServerRuntime", () => {
     it("should leave oauthHolder undefined when the config has no ccloud-oauth", () => {
       const noOauthConfig = new MCPServerConfiguration({
         connections: {
-          _default: connWith({
+          [DEFAULT_CONNECTION_NAME]: connWith({
             kafka: { bootstrap_servers: "broker:9092" },
           }),
         },
@@ -249,7 +250,7 @@ describe("ServerRuntime", () => {
 
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          _default: { type: "oauth", ccloud_env: "devel" },
+          [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "devel" },
         },
       });
 
@@ -263,13 +264,13 @@ describe("ServerRuntime", () => {
       vi.spyOn(OAuthHolder, "start").mockReturnValue(fakeOAuthHolder());
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          _default: { type: "oauth", ccloud_env: "stag" },
+          [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "stag" },
         },
       });
 
       const runtime = ServerRuntime.fromConfig(oauthConfig);
 
-      expect(runtime.clientManagers["_default"]).toBeInstanceOf(
+      expect(runtime.clientManagers[DEFAULT_CONNECTION_NAME]).toBeInstanceOf(
         OAuthClientManager,
       );
     });


### PR DESCRIPTION
## Summary of Changes

- Renames the env-path connection name from `"env-connection"` to `"_default"` so the same identifier can serve as the zero-config fallback the YAML loader will eventually use when no config file is supplied.
- Adds a doc-comment on `ENV_CONNECTION_NAME` pinning the fallback-shape contract.
- Followed discussions from [🧵](https://confluent.slack.com/archives/C0AM4H57XT8/p1778266037905849?thread_ts=1778265315.647609&cid=C0AM4H57XT8).

### Manual testing instructions

`npm run build`, then verify the synthesized connection id surfaces as `_default` in startup logs
 
**Test Zero-config startup**
-    `node dist/index.js --env-file /dev/null 2>&1 | grep "connection"`
-    Expect log lines referencing `'_default'` (e.g., `Tools disabled on connection '_default' — ...`).



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
