### PR TITLE
Tests/404 cover missing bit of env config

### DIFF
--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1070,7 +1070,7 @@ describe("config/env-config.ts", () => {
         expect(conn).toEqual({ type: "oauth", ccloud_env: "devel" });
       });
 
-      describe("server-block validation failures (closes #404 coverage gap)", () => {
+      describe("server-block validation failures", () => {
         // The OAuth path constructs `{ type: "oauth" }` for the connection plus
         // a server block from env vars; if Zod rejects the manufactured config,
         // env-config.ts throws via a *different* branch than the direct path

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1069,6 +1069,49 @@ describe("config/env-config.ts", () => {
         const conn = config.getSoleConnection();
         expect(conn).toEqual({ type: "oauth", ccloud_env: "devel" });
       });
+
+      describe("server-block validation failures (closes #404 coverage gap)", () => {
+        // The OAuth path constructs `{ type: "oauth" }` for the connection plus
+        // a server block from env vars; if Zod rejects the manufactured config,
+        // env-config.ts throws via a *different* branch than the direct path
+        // (the OAuth-prefixed message via humanizeEnvConfigPaths). These tests
+        // pin that branch — both that it fires, and that the humanizer
+        // actually replaces the schema-space token (`server.auth.api_key`) with
+        // the env-var-space token (`MCP_API_KEY`) before surfacing the error.
+        it.each([
+          {
+            label: "MCP_API_KEY is shorter than 32 characters",
+            overrides: { MCP_API_KEY: "short" },
+            humanizedExpect: /MCP_API_KEY/,
+          },
+          {
+            label: "MCP_AUTH_DISABLED:true and MCP_API_KEY are both set",
+            overrides: {
+              MCP_AUTH_DISABLED: true,
+              MCP_API_KEY: "a".repeat(32),
+            },
+            humanizedExpect: /MCP_AUTH_DISABLED.*MCP_API_KEY/,
+          },
+        ])(
+          "should throw a humanized OAuth-path error when $label",
+          ({ overrides, humanizedExpect }) => {
+            let message = "";
+            try {
+              buildConfigFromEnvAndCli(envWith(overrides), { oauth: true });
+            } catch (err) {
+              message = (err as Error).message;
+            }
+
+            // Branch identification: the OAuth-fail path emits the longer prefix.
+            expect(message).toContain(
+              "Failed to construct OAuth MCPServerConfiguration from environment variables",
+            );
+            // Humanizer ran AND landed: env-var name appears, schema path does not.
+            expect(message).toMatch(humanizedExpect);
+            expect(message).not.toContain("server.auth.api_key");
+          },
+        );
+      });
     });
   });
 });

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1071,13 +1071,10 @@ describe("config/env-config.ts", () => {
       });
 
       describe("server-block validation failures", () => {
-        // The OAuth path constructs `{ type: "oauth" }` for the connection plus
-        // a server block from env vars; if Zod rejects the manufactured config,
-        // env-config.ts throws via a *different* branch than the direct path
-        // (the OAuth-prefixed message via humanizeEnvConfigPaths). These tests
-        // pin that branch — both that it fires, and that the humanizer
-        // actually replaces the schema-space token (`server.auth.api_key`) with
-        // the env-var-space token (`MCP_API_KEY`) before surfacing the error.
+        // The OAuth path takes a different validation-failure branch from the
+        // direct path (OAuth-prefixed message via humanizeEnvConfigPaths).
+        // These tests pin that branch fires AND that the humanizer replaced
+        // the schema-space token with the env-var-space token.
         it.each([
           {
             label: "MCP_API_KEY is shorter than 32 characters",
@@ -1095,20 +1092,20 @@ describe("config/env-config.ts", () => {
         ])(
           "should throw a humanized OAuth-path error when $label",
           ({ overrides, humanizedExpect }) => {
-            let message = "";
-            try {
+            const call = () =>
               buildConfigFromEnvAndCli(envWith(overrides), { oauth: true });
-            } catch (err) {
-              message = (err as Error).message;
-            }
 
             // Branch identification: the OAuth-fail path emits the longer prefix.
-            expect(message).toContain(
+            expect(call).toThrow(
               "Failed to construct OAuth MCPServerConfiguration from environment variables",
             );
-            // Humanizer ran AND landed: env-var name appears, schema path does not.
-            expect(message).toMatch(humanizedExpect);
-            expect(message).not.toContain("server.auth.api_key");
+            // Humanizer landed: env-var name appears in the message.
+            expect(call).toThrow(humanizedExpect);
+            // ...and the schema-space token is gone. The two positive .toThrow
+            // assertions above pin that `call` does throw, so this reads as
+            // "threw, but not with this token" rather than the ambiguous
+            // "didn't throw OR threw without this token".
+            expect(call).not.toThrow(/server\.auth\.api_key/);
           },
         );
       });


### PR DESCRIPTION

## Coverage

- Pin the OAuth-path fail branch in `buildConfigFromEnv()` — the one
  calling `humanizeEnvConfigPaths()`. `it.each` over the two realistic
  server-block failure modes; each asserts the OAuth-prefixed error
  _and_ that the env-var name replaced the schema path. `env-config.ts`
  → 100%.

## Relationships

Closes #404.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
