### PR TITLE
Remove unneeded BaseClientManager.confluentCloudTableflowBaseUrl

### DIFF
--- a/src/confluent/base-client-manager.ts
+++ b/src/confluent/base-client-manager.ts
@@ -51,7 +51,6 @@ export abstract class BaseClientManager
   implements ConfluentCloudRestClientManager, SchemaRegistryClientHandler
 {
   private confluentCloudBaseUrl: string | undefined;
-  private confluentCloudTableflowBaseUrl: string | undefined;
   private confluentCloudFlinkBaseUrl: string | undefined;
   private confluentCloudSchemaRegistryBaseUrl: string | undefined;
   private confluentCloudKafkaRestBaseUrl: string | undefined;
@@ -78,7 +77,6 @@ export abstract class BaseClientManager
 
   constructor(config: BaseClientManagerConfig) {
     this.confluentCloudBaseUrl = config.endpoints.cloud;
-    this.confluentCloudTableflowBaseUrl = config.endpoints.cloud; // at the time of writing, apis are exposed on the same base url as confluent cloud
     this.confluentCloudFlinkBaseUrl = config.endpoints.flink;
     this.confluentCloudSchemaRegistryBaseUrl = config.endpoints.schemaRegistry;
     this.confluentCloudKafkaRestBaseUrl = config.endpoints.kafka;
@@ -99,16 +97,16 @@ export abstract class BaseClientManager
     });
 
     this.confluentCloudTableflowRestClient = new Lazy(() => {
-      if (!this.confluentCloudTableflowBaseUrl) {
+      if (!this.confluentCloudBaseUrl) {
         throw new Error(
           "Confluent Cloud Tableflow REST endpoint not configured",
         );
       }
       logger.info(
-        `Initializing Confluent Cloud Tableflow REST client for base URL ${this.confluentCloudTableflowBaseUrl}`,
+        `Initializing Confluent Cloud Tableflow REST client for base URL ${this.confluentCloudBaseUrl}`,
       );
       const client = createClient<paths>({
-        baseUrl: this.confluentCloudTableflowBaseUrl,
+        baseUrl: this.confluentCloudBaseUrl,
       });
       client.use(createAuthMiddleware(config.auth.tableflow));
       return client;

--- a/src/confluent/direct-client-manager.ts
+++ b/src/confluent/direct-client-manager.ts
@@ -159,7 +159,6 @@ export function constructDirectClientManager(
   return new DirectClientManager({
     kafka: kafkaClientConfig,
     endpoints: {
-      // BaseClientManager uses this as the Tableflow base URL too (see its constructor), so always supply the default.
       cloud: conn.confluent_cloud?.endpoint ?? CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
       flink: conn.flink?.endpoint,
       schemaRegistry: conn.schema_registry?.endpoint,

--- a/src/confluent/middleware.ts
+++ b/src/confluent/middleware.ts
@@ -42,7 +42,6 @@ export const createBearerMiddleware = (
 
 export interface ConfluentEndpoints {
   cloud?: string;
-  tableflow?: string;
   flink?: string;
   schemaRegistry?: string;
   kafka?: string;

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -118,17 +118,6 @@ describe("constructDirectClientManager()", () => {
     );
   });
 
-  it("should set confluentCloudTableflowBaseUrl to https://api.confluent.cloud when only tableflow is configured", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        tableflow: { auth: { type: "api_key", key: "k", secret: "s" } },
-      }),
-    );
-    expect(manager["confluentCloudTableflowBaseUrl"]).toBe(
-      "https://api.confluent.cloud",
-    );
-  });
-
   it("should set confluentCloudTelemetryBaseUrl from the telemetry block", () => {
     const manager = constructDirectClientManager(
       connWith({


### PR DESCRIPTION
## Summary of Changes

## Refactor

- `BaseClientManager.confluentCloudTableflowBaseUrl` was always assigned
  `config.endpoints.cloud` — same source as `confluentCloudBaseUrl`,
  never diverged. Drop the duplicate field and re-point the Tableflow
  REST client at `confluentCloudBaseUrl` directly. Also drop the unused
  `tableflow?: string` member from `ConfluentEndpoints` (never set
  anywhere) and the redundant assertion test in `server-runtime.test.ts`.
  Pure refactor; behavior unchanged; suite stays green.

## Relationships

Closes #240.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
