### PR TITLE
fix(tests): wait for Flink statement `RUNNING` phase

### DIFF
--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
@@ -33,8 +33,10 @@ describe("query-profiler-handler", { tags: [Tag.FLINK] }, () => {
   beforeAll(async () => {
     await provisionTestFlinkStatement(statementName);
     createdStatements.push(statementName);
-    // profiler reads the task graph, which only materializes once the statement is RUNNING
-    await waitForFlinkStatementPhase(statementName, "RUNNING");
+    // profiler needs the task graph, which materializes once the statement leaves PENDING.
+    // SELECT 1 is bounded and can blow through RUNNING into COMPLETED between polls, so accept
+    // both - either state means the task graph exists.
+    await waitForFlinkStatementPhase(statementName, ["RUNNING", "COMPLETED"]);
   });
 
   describe.each(activeTransports)("via %s transport", (transport) => {

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
@@ -2,6 +2,7 @@ import { QueryProfilerHandler } from "@src/confluent/tools/handlers/flink/diagno
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   provisionTestFlinkStatement,
+  waitForFlinkStatementPhase,
   withSharedFlinkStatementCleanup,
 } from "@tests/harness/flink.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
@@ -32,6 +33,8 @@ describe("query-profiler-handler", { tags: [Tag.FLINK] }, () => {
   beforeAll(async () => {
     await provisionTestFlinkStatement(statementName);
     createdStatements.push(statementName);
+    // profiler reads the task graph, which only materializes once the statement is RUNNING
+    await waitForFlinkStatementPhase(statementName, "RUNNING");
   });
 
   describe.each(activeTransports)("via %s transport", (transport) => {

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -2,7 +2,14 @@ import type { paths } from "@src/confluent/openapi-schema.js";
 import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import createClient, { type Client } from "openapi-fetch";
-import { afterAll } from "vitest";
+import { afterAll, expect } from "vitest";
+
+type FlinkStatementPhase =
+  | "PENDING"
+  | "RUNNING"
+  | "COMPLETED"
+  | "FAILED"
+  | "STOPPED";
 
 interface FlinkScope {
   organizationId: string;
@@ -81,6 +88,42 @@ export async function provisionTestFlinkStatement(
       `failed to provision test flink statement ${name}: ${JSON.stringify(error)}`,
     );
   }
+}
+
+/** Polls the statement state endpoint until phase matches `targetPhase` or the timeout fires. */
+export async function waitForFlinkStatementPhase(
+  name: string,
+  targetPhase: FlinkStatementPhase,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const { timeoutMs = 30_000, intervalMs = 2_000 } = opts;
+  const scope = getFlinkScope();
+  const client = newTestFlinkClient(scope);
+  await expect
+    .poll(
+      async () => {
+        const { data, error } = await client.GET(
+          "/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}",
+          {
+            params: {
+              path: {
+                organization_id: scope.organizationId,
+                environment_id: scope.environmentId,
+                statement_name: name,
+              },
+            },
+          },
+        );
+        if (error) {
+          throw new Error(
+            `failed to GET flink statement ${name}: ${JSON.stringify(error)}`,
+          );
+        }
+        return data?.status?.phase;
+      },
+      { timeout: timeoutMs, interval: intervalMs },
+    )
+    .toBe(targetPhase);
 }
 
 /**

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -5,12 +5,22 @@ import { setTimeout as sleep } from "node:timers/promises";
 import createClient, { type Client } from "openapi-fetch";
 import { afterAll } from "vitest";
 
+// mirrors the documented phase values on `sql.v1.StatementStatus.phase` in
+// `src/confluent/openapi-schema.d.ts` (typed as `string` upstream; we keep an explicit union here
+// for autocomplete and typo detection at call sites)
 type FlinkStatementPhase =
   | "PENDING"
   | "RUNNING"
   | "COMPLETED"
+  | "DELETING"
+  | "FAILING"
   | "FAILED"
   | "STOPPED";
+
+const TERMINAL_FAILURE_PHASES: readonly FlinkStatementPhase[] = [
+  "FAILED",
+  "FAILING",
+];
 
 interface FlinkScope {
   organizationId: string;
@@ -130,6 +140,13 @@ export async function waitForFlinkStatementPhase(
     lastPhase = data?.status?.phase;
     if (acceptable.includes(lastPhase as FlinkStatementPhase)) {
       return;
+    }
+    // short-circuit on terminal-failure phases the caller didn't ask for, so CI surfaces the
+    // real failure (with the API's `status.detail`) instead of waiting out the timeout
+    if (TERMINAL_FAILURE_PHASES.includes(lastPhase as FlinkStatementPhase)) {
+      throw new Error(
+        `flink statement ${name} entered ${lastPhase} while waiting for [${acceptable.join(", ")}]: ${data?.status?.detail ?? "no detail"}`,
+      );
     }
     await sleep(intervalMs);
   }

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -1,8 +1,9 @@
 import type { paths } from "@src/confluent/openapi-schema.js";
 import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
+import { setTimeout as sleep } from "node:timers/promises";
 import createClient, { type Client } from "openapi-fetch";
-import { afterAll, expect } from "vitest";
+import { afterAll } from "vitest";
 
 type FlinkStatementPhase =
   | "PENDING"
@@ -90,40 +91,51 @@ export async function provisionTestFlinkStatement(
   }
 }
 
-/** Polls the statement state endpoint until phase matches `targetPhase` or the timeout fires. */
+/**
+ * Polls until the statement reaches one of `targetPhases`, or throws on
+ * timeout. Uses a vanilla async loop rather than `expect.poll` so it's
+ * callable from outside of a test context (e.g. before/after hooks).
+ */
 export async function waitForFlinkStatementPhase(
   name: string,
-  targetPhase: FlinkStatementPhase,
+  targetPhases: FlinkStatementPhase | readonly FlinkStatementPhase[],
   opts: { timeoutMs?: number; intervalMs?: number } = {},
 ): Promise<void> {
   const { timeoutMs = 30_000, intervalMs = 2_000 } = opts;
+  const acceptable = Array.isArray(targetPhases)
+    ? targetPhases
+    : [targetPhases];
   const scope = getFlinkScope();
   const client = newTestFlinkClient(scope);
-  await expect
-    .poll(
-      async () => {
-        const { data, error } = await client.GET(
-          "/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}",
-          {
-            params: {
-              path: {
-                organization_id: scope.organizationId,
-                environment_id: scope.environmentId,
-                statement_name: name,
-              },
-            },
+  const deadline = Date.now() + timeoutMs;
+  let lastPhase: string | undefined;
+  while (Date.now() < deadline) {
+    const { data, error } = await client.GET(
+      "/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}",
+      {
+        params: {
+          path: {
+            organization_id: scope.organizationId,
+            environment_id: scope.environmentId,
+            statement_name: name,
           },
-        );
-        if (error) {
-          throw new Error(
-            `failed to GET flink statement ${name}: ${JSON.stringify(error)}`,
-          );
-        }
-        return data?.status?.phase;
+        },
       },
-      { timeout: timeoutMs, interval: intervalMs },
-    )
-    .toBe(targetPhase);
+    );
+    if (error) {
+      throw new Error(
+        `failed to GET flink statement ${name}: ${JSON.stringify(error)}`,
+      );
+    }
+    lastPhase = data?.status?.phase;
+    if (acceptable.includes(lastPhase as FlinkStatementPhase)) {
+      return;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `flink statement ${name} did not reach any of phases [${acceptable.join(", ")}] within ${timeoutMs}ms (last phase: ${lastPhase ?? "unknown"})`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We were starting to see some flaky test failures in CI associated with the phase of the Flink statements created before running actual test logic:
<img width="702" height="317" alt="image" src="https://github.com/user-attachments/assets/b6927da6-2d9d-4951-a92e-f1025e38538f" />

This PR adds another polling helper function  -- (but not `expect.poll` because that can't be used outside of the individual tests) -- to wait for the phase of a statement to be a certain value, which is currently only being used to make sure we see a `RUNNING` phase before starting the `query-profiler-handler` tests.

(Also including `COMPLETED` for statements that may not stay in `RUNNING` very long.)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
