### PR TITLE
 Rename `describe-tool-gating` → `explain-disabled-tools` + tighten description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this MCP server will be documented in this file.
 - Confluent product documentation tools (support `docs.confluent.io`, `developer.confluent.io`, `support.confluent.io`):
   - `search-product-docs` for keyword search across product docs.
   - `get-product-doc-page` for fetching the full markdown content of a single page.
-- New tool `describe-tool-gating` to diagnose why possible tools are not enabled at this time due to mismatches in configuration.
+- New tool `explain-disabled-tools` to diagnose why possible tools are not enabled at this time due to mismatches in configuration.
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These tools need no service blocks or authentication — they're enabled even on
 | Category          | Tools                                         | Description                                               |
 | ----------------- | --------------------------------------------- | --------------------------------------------------------- |
 | **Documentation** | `search-product-docs`, `get-product-doc-page` | Search Confluent product docs and fetch full page content |
-| **Diagnostics**   | `describe-tool-gating`                        | Explain why specific tools are absent from `tools/list`   |
+| **Diagnostics**   | `explain-disabled-tools`                      | Explain why specific tools are absent from `tools/list`   |
 
 ### Available Tools for Confluent Cloud
 
@@ -422,7 +422,7 @@ read-tableflow-catalog-integration: Make a request to read a catalog integration
 update-tableflow-catalog-integration: Make a request to update a catalog integration.
 delete-tableflow-catalog-integration: Make a request to delete a tableflow catalog integration.
 list-organizations: List Confluent Cloud organizations the current credentials can see. Paginated; if the response includes a nextPageToken, pass it back as pageToken to fetch additional pages.
-describe-tool-gating: When you can't find a tool to answer a user's request — e.g., the user asks "why can't I list Kafka topics?", "where are the Flink tools?", "I don't see anything for schema registry" — call this tool first. Returns the disabled tools grouped by what each tool's predicate found missing in the connection config (a kafka/flink/schema_registry/tableflow/telemetry block, a required field within one, or an OAuth-vs-direct-only mismatch). Tell the user the exact YAML to add or change. Always call this rather than speculating about credentials, network, or auth — the server already knows the verdict for every tool.
+explain-disabled-tools: Call when the user asks why a tool is missing or unavailable (e.g., "why can't I list Kafka topics?", "where are the Flink tools?"). Returns disabled tools grouped by the config gap each one is waiting on, so you can tell the user the exact YAML block or field to add. Prefer this over guessing about credentials, network, or auth.
 ```
 
 </details>

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -1,7 +1,7 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
-import { DescribeToolGatingHandler } from "@src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.js";
+import { ExplainDisabledToolsHandler } from "@src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.js";
 import type { ToolGatingReport } from "@src/confluent/tools/tool-availability.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
@@ -32,16 +32,16 @@ function getReport(result: CallToolResult): ToolGatingReport {
   return meta as unknown as ToolGatingReport;
 }
 
-describe("describe-tool-gating-handler.ts", () => {
-  describe("DescribeToolGatingHandler", () => {
-    const handler = new DescribeToolGatingHandler(() =>
+describe("explain-disabled-tools-handler.ts", () => {
+  describe("ExplainDisabledToolsHandler", () => {
+    const handler = new ExplainDisabledToolsHandler(() =>
       ToolHandlerRegistry.allHandlers(),
     );
 
     describe("getToolConfig()", () => {
-      it("should be a read-only tool named DESCRIBE_TOOL_GATING with no input fields", () => {
+      it("should be a read-only tool named EXPLAIN_DISABLED_TOOLS with no input fields", () => {
         const config = handler.getToolConfig();
-        expect(config.name).toBe(ToolName.DESCRIBE_TOOL_GATING);
+        expect(config.name).toBe(ToolName.EXPLAIN_DISABLED_TOOLS);
         expect(config.annotations).toBe(READ_ONLY);
         expect(config.inputSchema).toEqual({});
         expect(config.description.length).toBeGreaterThan(10);
@@ -65,14 +65,14 @@ describe("describe-tool-gating-handler.ts", () => {
         expect(report.disabledCount).toBeGreaterThan(0);
       });
 
-      it("should not list alwaysEnabled tools (search-product-docs, get-product-doc-page, describe-tool-gating) under any disabled group", async () => {
+      it("should not list alwaysEnabled tools (search-product-docs, get-product-doc-page, explain-disabled-tools) under any disabled group", async () => {
         const result = handler.handle(bareRuntime());
         const report = getReport(result);
 
         const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
         expect(allDisabledTools).not.toContain(ToolName.SEARCH_PRODUCT_DOCS);
         expect(allDisabledTools).not.toContain(ToolName.GET_PRODUCT_DOC_PAGE);
-        expect(allDisabledTools).not.toContain(ToolName.DESCRIBE_TOOL_GATING);
+        expect(allDisabledTools).not.toContain(ToolName.EXPLAIN_DISABLED_TOOLS);
       });
 
       it("should remove kafka tools from disabledGroups when the connection carries a kafka block", async () => {
@@ -148,7 +148,7 @@ describe("describe-tool-gating-handler.ts", () => {
       it("should render a single 'all tools enabled' summary when nothing is disabled", async () => {
         // Build a no-tool registry-thunk so every tool is trivially absent
         // from the disabled set; the flat-summary branch fires.
-        const empty = new DescribeToolGatingHandler(() => []);
+        const empty = new ExplainDisabledToolsHandler(() => []);
         const text = getText(empty.handle(bareRuntime()));
         expect(text).toBe(
           "All 0 registered tools are advertised via tools/list.",

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
@@ -15,7 +15,7 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
-const describeToolGatingArguments = z.object({});
+const explainDisabledToolsArguments = z.object({});
 
 /**
  * Diagnostic tool that surfaces *why* tools are absent from `tools/list`.
@@ -62,7 +62,7 @@ const describeToolGatingArguments = z.object({});
  * is set. The thunk is invoked at request time, after every module is
  * fully loaded, sidestepping the cycle entirely.
  */
-export class DescribeToolGatingHandler extends BaseToolHandler {
+export class ExplainDisabledToolsHandler extends BaseToolHandler {
   private readonly listHandlers: () => Iterable<
     readonly [ToolName, ToolHandler]
   >;
@@ -79,10 +79,10 @@ export class DescribeToolGatingHandler extends BaseToolHandler {
 
   getToolConfig(): ToolConfig {
     return {
-      name: ToolName.DESCRIBE_TOOL_GATING,
+      name: ToolName.EXPLAIN_DISABLED_TOOLS,
       description:
-        'When you can\'t find a tool to answer a user\'s request — e.g., the user asks "why can\'t I list Kafka topics?", "where are the Flink tools?", "I don\'t see anything for schema registry" — call this tool first. Returns the disabled tools grouped by what each tool\'s predicate found missing in the connection config (a kafka/flink/schema_registry/tableflow/telemetry block, a required field within one, or an OAuth-vs-direct-only mismatch). Tell the user the exact YAML to add or change. Always call this rather than speculating about credentials, network, or auth — the server already knows the verdict for every tool.',
-      inputSchema: describeToolGatingArguments.shape,
+        'Call when the user asks why a tool is missing or unavailable (e.g., "why can\'t I list Kafka topics?", "where are the Flink tools?"). Returns disabled tools grouped by the config gap each one is waiting on, so you can tell the user the exact YAML block or field to add. Prefer this over guessing about credentials, network, or auth.',
+      inputSchema: explainDisabledToolsArguments.shape,
       annotations: READ_ONLY,
     };
   }

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -19,7 +19,7 @@ export interface DisabledToolsByReason {
 
 /**
  * Output of {@linkcode buildToolGatingReport}; drives the
- * `describe-tool-gating` diagnostic tool. Tools advertised via
+ * `explain-disabled-tools` diagnostic tool. Tools advertised via
  * `tools/list` are intentionally absent — the report carries the
  * negative signal only.
  *

--- a/src/confluent/tools/tool-name.ts
+++ b/src/confluent/tools/tool-name.ts
@@ -52,5 +52,5 @@ export enum ToolName {
   SEARCH_PRODUCT_DOCS = "search-product-docs",
   GET_PRODUCT_DOC_PAGE = "get-product-doc-page",
   LIST_ORGANIZATIONS = "list-organizations",
-  DESCRIBE_TOOL_GATING = "describe-tool-gating",
+  EXPLAIN_DISABLED_TOOLS = "explain-disabled-tools",
 }

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -100,6 +100,7 @@ describe("tool-registry.ts", () => {
           "get",
           "search",
           "describe",
+          "explain",
           "check",
           "detect",
           "query",
@@ -231,7 +232,7 @@ describe("tool-registry.ts", () => {
         [ToolName.SEARCH_PRODUCT_DOCS]: alwaysEnabled,
         [ToolName.GET_PRODUCT_DOC_PAGE]: alwaysEnabled,
         // Diagnostics (no service-block requirement)
-        [ToolName.DESCRIBE_TOOL_GATING]: alwaysEnabled,
+        [ToolName.EXPLAIN_DISABLED_TOOLS]: alwaysEnabled,
       };
 
       it.each(
@@ -499,7 +500,7 @@ describe("tool-registry.ts", () => {
       // Diagnostics — no client calls; the handler walks the registry's
       // own predicate map. Against `allServicesRuntime` every gate passes
       // and the handler emits its all-enabled summary.
-      [ToolName.DESCRIBE_TOOL_GATING]: {
+      [ToolName.EXPLAIN_DISABLED_TOOLS]: {
         outcome: { resolves: "registered tools are advertised via tools/list" },
         bypassesClientLayer: true,
       },

--- a/src/confluent/tools/tool-registry.ts
+++ b/src/confluent/tools/tool-registry.ts
@@ -10,7 +10,7 @@ import { CreateConnectorHandler } from "@src/confluent/tools/handlers/connect/cr
 import { DeleteConnectorHandler } from "@src/confluent/tools/handlers/connect/delete-connector-handler.js";
 import { ListConnectorsHandler } from "@src/confluent/tools/handlers/connect/list-connectors-handler.js";
 import { ReadConnectorHandler } from "@src/confluent/tools/handlers/connect/read-connectors-handler.js";
-import { DescribeToolGatingHandler } from "@src/confluent/tools/handlers/diagnostics/describe-tool-gating-handler.js";
+import { ExplainDisabledToolsHandler } from "@src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.js";
 import { GetProductDocPageHandler } from "@src/confluent/tools/handlers/docs/get-product-doc-page-handler.js";
 import { SearchProductDocsHandler } from "@src/confluent/tools/handlers/docs/search-product-docs-handler.js";
 import { ListEnvironmentsHandler } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
@@ -132,8 +132,8 @@ export class ToolHandlerRegistry {
     [ToolName.GET_PRODUCT_DOC_PAGE, new GetProductDocPageHandler()],
     [ToolName.LIST_ORGANIZATIONS, new ListOrganizationsHandler()],
     [
-      ToolName.DESCRIBE_TOOL_GATING,
-      new DescribeToolGatingHandler(() => ToolHandlerRegistry.allHandlers()),
+      ToolName.EXPLAIN_DISABLED_TOOLS,
+      new ExplainDisabledToolsHandler(() => ToolHandlerRegistry.allHandlers()),
     ],
   ]);
 
@@ -147,7 +147,7 @@ export class ToolHandlerRegistry {
 
   /**
    * Iterable over every (ToolName, ToolHandler) pair in the registry, in
-   * declaration order. Consumed by the `describe-tool-gating` diagnostic
+   * declaration order. Consumed by the `explain-disabled-tools` diagnostic
    * tool to walk the full handler set without a back-channel into the
    * private map. Read-only — callers must not mutate the underlying map.
    */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -242,7 +242,7 @@ describe("index.ts", () => {
         ToolName.ALTER_TOPIC_CONFIG,
         ToolName.GET_TOPIC_CONFIG,
         ToolName.LIST_CLUSTERS,
-        ToolName.DESCRIBE_TOOL_GATING,
+        ToolName.EXPLAIN_DISABLED_TOOLS,
       ];
 
       const EXPECTED_OAUTH_DISABLED: readonly ToolName[] = [


### PR DESCRIPTION
## Summary of Changes

Two coupled revisions to the diagnostic tool shipped in [PR #414](https://github.com/confluentinc/mcp-confluent/pull/414), based on review feedback from @shouples. The tool's behaviour is unchanged; only its name and AI-facing description text move.

 - `describe-tool-gating` → `explain-disabled-tools`. Per @shouples's suggestion, refined through review.
 - Enum + class + filename move in lockstep: `ToolName.EXPLAIN_DISABLED_TOOLS`, `ExplainDisabledToolsHandler`, `src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts`.
 - Better / simpler tool description text.


## Relationships

- Follow-up to [PR #414](https://github.com/confluentinc/mcp-confluent/pull/414).
- Addresses @shouples's approval-comment feedback on the tool name and description.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
