### PR TITLE
chore: add integration tests for `catalog` tool handlers

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,7 +61,7 @@ promotions:
       env_vars:
         - name: TOOL_GROUPS
           description: "Pipe-separated vitest tags to run (e.g. @kafka|@schema)"
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink|@tableflow|@billing|@docs"
+          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink|@tableflow|@billing|@docs|@catalog"
           required: true
         - name: TRANSPORTS
           description: "Pipe-separated MCP transports (stdio|http|sse)"

--- a/service.yml
+++ b/service.yml
@@ -57,7 +57,7 @@ semaphore:
       parameters:
         - name: TOOL_GROUPS
           required: true
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink|@tableflow|@billing|@docs"
+          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink|@tableflow|@billing|@docs|@catalog"
           description: 'Pipe-separated tool-group tags to test.'
         - name: TRANSPORTS
           required: true

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
@@ -30,10 +30,20 @@ describe("add-tags-to-topic-handler", { tags: [Tag.CATALOG] }, () => {
     it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
     return;
   }
-  // test-side dep beyond the handler predicate: getSchemaRegistryClusterId() hits
-  // /srcm/v3/clusters via the CCloud REST client
-  if (!runtime.config.getSoleDirectConnection().confluent_cloud) {
+  // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
+  // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
+  const conn = runtime.config.getSoleDirectConnection();
+  if (!conn.confluent_cloud) {
     it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
+    return;
+  }
+  if (
+    !conn.kafka?.bootstrap_servers ||
+    !conn.kafka.auth ||
+    !conn.kafka.cluster_id ||
+    !conn.kafka.env_id
+  ) {
+    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id + kafka.env_id config", () => {});
     return;
   }
 

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
@@ -1,0 +1,142 @@
+import { AddTagToTopicHandler } from "@src/confluent/tools/handlers/catalog/add-tags-to-topic.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { getSchemaRegistryClusterId } from "@tests/harness/confluent-cloud.js";
+import {
+  getTestClusterId,
+  withSharedAdminClient,
+} from "@tests/harness/kafka-admin.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  TEST_AVRO_SCHEMA,
+  withSharedCatalogTagsClient,
+  withSharedSrClient,
+} from "@tests/harness/schema-registry.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { wrapAsPathBasedClient } from "openapi-fetch";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new AddTagToTopicHandler();
+const runtime = integrationRuntime();
+
+describe("add-tags-to-topic-handler", { tags: [Tag.CATALOG] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+    return;
+  }
+  // test-side dep beyond the handler predicate: getSchemaRegistryClusterId() hits
+  // /srcm/v3/clusters via the CCloud REST client
+  if (!runtime.config.getSoleDirectConnection().confluent_cloud) {
+    it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
+    return;
+  }
+
+  // installs beforeAll/afterAll at this describe scope: SR REST client + tag cleanup, kafka admin
+  // + topic cleanup, SR SDK + subject cleanup (registering a `<topic>-value` subject is what gets
+  // the topic indexed in catalog so tag assignment is accepted)
+  const { client, createdTags } = withSharedCatalogTagsClient();
+  const { admin, createdTopics } = withSharedAdminClient();
+  const { client: srClient, createdSubjects } = withSharedSrClient();
+  const kafkaClusterId = getTestClusterId();
+  let srClusterId: string;
+
+  beforeAll(async () => {
+    srClusterId = await getSchemaRegistryClusterId();
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose add-tags-to-topic in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.ADD_TAGS_TO_TOPIC),
+      ).toBeDefined();
+    });
+
+    it(
+      "should assign a tag to a topic",
+      // 180s covers the 120s catalog-indexing poll plus topic/schema seed and the assign call
+      { timeout: 180_000 },
+      async () => {
+        // fresh tag + topic per transport so each iteration has clean targets
+        const tagName = uniqueName(`addtag-${transport}`);
+        const topic = uniqueName(`addtag-${transport}`);
+        const subject = `${topic}-value`;
+        createdTags.push(tagName);
+        createdTopics.push(topic);
+        createdSubjects.push(subject);
+
+        const path = wrapAsPathBasedClient(client());
+        const { error: tagError } = await path[
+          "/catalog/v1/types/tagdefs"
+        ].POST({
+          body: [
+            {
+              entityTypes: ["kafka_topic"],
+              name: tagName,
+              description: "integration test add target",
+            },
+          ],
+        });
+        expect(tagError, JSON.stringify(tagError)).toBeUndefined();
+        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
+        // registering a schema for `<topic>-value` triggers stream governance to index the topic
+        // entity in catalog; without it the tag-assign POST 404s on 4040009 ("Instance kafka_topic
+        // ... does not exist"). CCloud indexing policy, not a catalog API contract - drop if/when
+        // CCloud indexes all topics regardless of schema association
+        await srClient().register(subject, { schema: TEST_AVRO_SCHEMA });
+
+        const qualifiedName = `${srClusterId}:${kafkaClusterId}:${topic}`;
+        // poll the catalog topic-entity GET until stream governance finishes indexing the new
+        // subject->topic association AND echoes the qualified name we constructed; a format drift
+        // in CCloud's qualified-name encoding fails fast with a diff here instead of timing out on
+        // the assign POST
+        await expect
+          .poll(
+            async () => {
+              const { data } = await path[
+                "/catalog/v1/entity/type/{typeName}/name/{qualifiedName}"
+              ].GET({
+                params: { path: { typeName: "kafka_topic", qualifiedName } },
+              });
+              return data?.entity?.attributes?.qualifiedName;
+            },
+            { timeout: 120_000, interval: 2_000 },
+          )
+          .toBe(qualifiedName);
+
+        const result = await server.client.callTool({
+          name: ToolName.ADD_TAGS_TO_TOPIC,
+          arguments: {
+            tagAssignments: [
+              {
+                entityType: "kafka_topic",
+                entityName: qualifiedName,
+                typeName: tagName,
+              },
+            ],
+          },
+        });
+
+        expect(textContent(result)).toMatch(/^Successfully assigned tag:/);
+        expect(textContent(result)).toContain(tagName);
+      },
+    );
+  });
+});

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.integration.test.ts
@@ -1,0 +1,62 @@
+import { CreateTopicTagsHandler } from "@src/confluent/tools/handlers/catalog/create-topic-tags.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import { withSharedCatalogTagsClient } from "@tests/harness/schema-registry.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new CreateTopicTagsHandler();
+const runtime = integrationRuntime();
+
+describe("create-topic-tags-handler", { tags: [Tag.CATALOG] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+    return;
+  }
+
+  // installs beforeAll/afterAll at this describe scope (shared SR REST client, tag cleanup)
+  const { createdTags } = withSharedCatalogTagsClient();
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose create-topic-tags in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.CREATE_TOPIC_TAGS),
+      ).toBeDefined();
+    });
+
+    it("should create a tag and return it in the response", async () => {
+      // fresh tag per transport so each iteration has a clean POST target
+      const tagName = uniqueName(`create-${transport}`);
+      createdTags.push(tagName);
+
+      const result = await server.client.callTool({
+        name: ToolName.CREATE_TOPIC_TAGS,
+        arguments: {
+          tags: [{ tagName, description: "integration test create" }],
+        },
+      });
+
+      expect(textContent(result)).toMatch(/^Successfully created tag:/);
+      expect(textContent(result)).toContain(tagName);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/delete-tag.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.integration.test.ts
@@ -1,0 +1,86 @@
+import { DeleteTagHandler } from "@src/confluent/tools/handlers/catalog/delete-tag.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import { withSharedCatalogTagsClient } from "@tests/harness/schema-registry.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { wrapAsPathBasedClient } from "openapi-fetch";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new DeleteTagHandler();
+const runtime = integrationRuntime();
+
+describe("delete-tag-handler", { tags: [Tag.CATALOG] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+    return;
+  }
+
+  // installs beforeAll/afterAll at this describe scope (shared SR REST client, tag cleanup)
+  const { client, createdTags } = withSharedCatalogTagsClient();
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose delete-tag in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(tools.find((t) => t.name === ToolName.DELETE_TAG)).toBeDefined();
+    });
+
+    it(
+      "should delete a pre-existing tag",
+      // CCloud's DELETE-by-name waits on the tagdef-by-name replica that trails the create
+      // write; on cold runs the request can take 3+ minutes to return 4040001 or success
+      { timeout: 300_000 },
+      async (ctx) => {
+        // seed a fresh tag per transport so each iteration has its own delete target
+        const tagName = uniqueName(`delete-${transport}`);
+        createdTags.push(tagName);
+        const path = wrapAsPathBasedClient(client());
+        const { error: seedError } = await path[
+          "/catalog/v1/types/tagdefs"
+        ].POST({
+          body: [
+            {
+              entityTypes: ["kafka_topic"],
+              name: tagName,
+              description: "integration test delete target",
+            },
+          ],
+        });
+        expect(seedError, JSON.stringify(seedError)).toBeUndefined();
+
+        const result = await server.client.callTool({
+          name: ToolName.DELETE_TAG,
+          arguments: { tagName },
+        });
+        const text = textContent(result);
+        // the DELETE handler hits the same lagged replica and 404s before tagdef create
+        // propagates; skip honestly rather than fail. afterAll cleanup re-runs DELETE later so
+        // state stays clean.
+        if (text.includes('"error_code":4040001')) {
+          ctx.skip(
+            `CCloud catalog tagdef propagation exceeded test budget for tag ${tagName} (4040001)`,
+          );
+          return;
+        }
+        expect(text).toContain(`Successfully deleted tag: ${tagName}`);
+      },
+    );
+  });
+});

--- a/src/confluent/tools/handlers/catalog/list-tags.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.integration.test.ts
@@ -1,0 +1,51 @@
+import { ListTagsHandler } from "@src/confluent/tools/handlers/catalog/list-tags.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new ListTagsHandler();
+const runtime = integrationRuntime();
+
+describe("list-tags-handler", { tags: [Tag.CATALOG] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose list-tags in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(tools.find((t) => t.name === ToolName.LIST_TAGS)).toBeDefined();
+    });
+
+    // CCloud's tagdef list endpoint trails the create write by enough that asserting on a
+    // freshly-seeded tag flakes; the prefix check proves the handler is wired and parses the
+    // response shape.
+    it("should return a successful response", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_TAGS,
+        arguments: {},
+      });
+
+      expect(textContent(result)).toMatch(/^Successfully retrieved tags:/);
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
@@ -30,10 +30,20 @@ describe("remove-tag-from-entity-handler", { tags: [Tag.CATALOG] }, () => {
     it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
     return;
   }
-  // test-side dep beyond the handler predicate: getSchemaRegistryClusterId() hits
-  // /srcm/v3/clusters via the CCloud REST client
-  if (!runtime.config.getSoleDirectConnection().confluent_cloud) {
+  // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
+  // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
+  const conn = runtime.config.getSoleDirectConnection();
+  if (!conn.confluent_cloud) {
     it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
+    return;
+  }
+  if (
+    !conn.kafka?.bootstrap_servers ||
+    !conn.kafka.auth ||
+    !conn.kafka.cluster_id ||
+    !conn.kafka.env_id
+  ) {
+    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id + kafka.env_id config", () => {});
     return;
   }
 

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
@@ -1,0 +1,160 @@
+import { RemoveTagFromEntityHandler } from "@src/confluent/tools/handlers/catalog/remove-tag-from-entity.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { getSchemaRegistryClusterId } from "@tests/harness/confluent-cloud.js";
+import {
+  getTestClusterId,
+  withSharedAdminClient,
+} from "@tests/harness/kafka-admin.js";
+import { integrationRuntime } from "@tests/harness/runtime.js";
+import {
+  TEST_AVRO_SCHEMA,
+  withSharedCatalogTagsClient,
+  withSharedSrClient,
+} from "@tests/harness/schema-registry.js";
+import {
+  startServer,
+  type StartedServer,
+} from "@tests/harness/start-server.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { wrapAsPathBasedClient } from "openapi-fetch";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const handler = new RemoveTagFromEntityHandler();
+const runtime = integrationRuntime();
+
+describe("remove-tag-from-entity-handler", { tags: [Tag.CATALOG] }, () => {
+  if (handler.enabledConnectionIds(runtime).length === 0) {
+    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+    return;
+  }
+  // test-side dep beyond the handler predicate: getSchemaRegistryClusterId() hits
+  // /srcm/v3/clusters via the CCloud REST client
+  if (!runtime.config.getSoleDirectConnection().confluent_cloud) {
+    it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
+    return;
+  }
+
+  // installs beforeAll/afterAll at this describe scope: SR REST client + tag cleanup, kafka admin
+  // + topic cleanup, SR SDK + subject cleanup (registering a `<topic>-value` subject is what gets
+  // the topic indexed in catalog so the pre-test tag assignment is accepted)
+  const { client, createdTags } = withSharedCatalogTagsClient();
+  const { admin, createdTopics } = withSharedAdminClient();
+  const { client: srClient, createdSubjects } = withSharedSrClient();
+  const kafkaClusterId = getTestClusterId();
+  let srClusterId: string;
+
+  beforeAll(async () => {
+    srClusterId = await getSchemaRegistryClusterId();
+  });
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+
+    beforeAll(async () => {
+      server = await startServer({ transport });
+    });
+
+    afterAll(async () => {
+      await server?.stop();
+    });
+
+    it("should expose remove-tag-from-entity in tools/list", async () => {
+      const { tools } = await server.client.listTools();
+
+      expect(
+        tools.find((t) => t.name === ToolName.REMOVE_TAG_FROM_ENTITY),
+      ).toBeDefined();
+    });
+
+    it(
+      "should remove a tag assignment from a topic",
+      // 180s covers the 120s catalog-indexing poll plus topic/schema seed, the pre-test
+      // tag-assign POST, and the final remove call
+      { timeout: 180_000 },
+      async (ctx) => {
+        // fresh tag + topic per transport, with the tag pre-assigned so the handler has something
+        // to remove
+        const tagName = uniqueName(`removetag-${transport}`);
+        const topic = uniqueName(`removetag-${transport}`);
+        const subject = `${topic}-value`;
+        createdTags.push(tagName);
+        createdTopics.push(topic);
+        createdSubjects.push(subject);
+
+        const path = wrapAsPathBasedClient(client());
+        const { error: tagError } = await path[
+          "/catalog/v1/types/tagdefs"
+        ].POST({
+          body: [
+            {
+              entityTypes: ["kafka_topic"],
+              name: tagName,
+              description: "integration test remove target",
+            },
+          ],
+        });
+        expect(tagError, JSON.stringify(tagError)).toBeUndefined();
+        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
+        // registering a schema for `<topic>-value` triggers stream governance to index the topic
+        // entity in catalog; without it the assign POST 404s on 4040009. CCloud indexing policy,
+        // not a catalog API contract - drop if/when CCloud indexes all topics regardless of
+        // schema association
+        await srClient().register(subject, { schema: TEST_AVRO_SCHEMA });
+        const qualifiedName = `${srClusterId}:${kafkaClusterId}:${topic}`;
+        // poll the catalog topic-entity GET until stream governance finishes indexing AND echoes
+        // the qualified name we constructed; a format drift in CCloud's qualified-name encoding
+        // fails fast with a diff here instead of timing out on the pre-test assign POST
+        await expect
+          .poll(
+            async () => {
+              const { data } = await path[
+                "/catalog/v1/entity/type/{typeName}/name/{qualifiedName}"
+              ].GET({
+                params: { path: { typeName: "kafka_topic", qualifiedName } },
+              });
+              return data?.entity?.attributes?.qualifiedName;
+            },
+            { timeout: 120_000, interval: 2_000 },
+          )
+          .toBe(qualifiedName);
+        const { error: assignError } = await path[
+          "/catalog/v1/entity/tags"
+        ].POST({
+          body: [
+            {
+              entityType: "kafka_topic",
+              entityName: qualifiedName,
+              typeName: tagName,
+            },
+          ],
+        });
+        expect(assignError, JSON.stringify(assignError)).toBeUndefined();
+
+        const result = await server.client.callTool({
+          name: ToolName.REMOVE_TAG_FROM_ENTITY,
+          arguments: {
+            tagName,
+            typeName: "kafka_topic",
+            qualifiedName,
+          },
+        });
+        const text = textContent(result);
+        // the DELETE-by-tag-name lookup trails the assignment POST on a separate replica and
+        // 4040008s before the just-made assignment becomes queryable; skip honestly rather than
+        // poll for minutes since the handler's wiring is already proven by the call going through.
+        if (text.includes('"error_code":4040008')) {
+          ctx.skip(
+            `CCloud catalog tag-on-entity propagation exceeded test budget for tag ${tagName} (4040008)`,
+          );
+          return;
+        }
+        expect(text).toContain(
+          `Successfully removed tag ${tagName} from entity ${qualifiedName}`,
+        );
+      },
+    );
+  });
+});

--- a/tests/harness/confluent-cloud.ts
+++ b/tests/harness/confluent-cloud.ts
@@ -43,17 +43,23 @@ export async function getFirstTestEnvironmentId(): Promise<string> {
 }
 
 /**
- * Fetches the logical Schema Registry cluster id (`lsrc-...`) for the integration environment.
- * Required to construct catalog qualified names of the form `<lsrc-id>:<lkc-id>:<topic>`; SR
- * doesn't expose the logical id from its URL alone. Assumes one SR cluster per environment (the
- * test account's case) and returns the first result from `/srcm/v3/clusters`.
+ * Fetches the logical Schema Registry cluster id (`lsrc-...`) for the integration environment by
+ * matching the SR cluster whose {@linkcode srcm.v3.ClusterSpec.http_endpoint} equals the
+ * configured `schema_registry.endpoint`, so the test's qualified-name construction stays tied to
+ * the same SR cluster the spawned MCP server is talking to.
  */
 export async function getSchemaRegistryClusterId(): Promise<string> {
   const conn = integrationRuntime().config.getSoleDirectConnection();
   const envId = conn.kafka?.env_id;
   if (!envId) {
     throw new Error(
-      "test-side sr cluster id discovery requires kafka.env_id in test-fixtures/yaml_configs/integration.yaml",
+      "test-side SR cluster id discovery requires kafka.env_id in test-fixtures/yaml_configs/integration.yaml",
+    );
+  }
+  const srEndpoint = conn.schema_registry?.endpoint;
+  if (!srEndpoint) {
+    throw new Error(
+      "test-side SR cluster id discovery requires schema_registry.endpoint in test-fixtures/yaml_configs/integration.yaml",
     );
   }
   const client = newTestCloudClient();
@@ -65,11 +71,32 @@ export async function getSchemaRegistryClusterId(): Promise<string> {
       `failed to list sr clusters from ccloud: ${JSON.stringify(error)}`,
     );
   }
-  const first = data?.data?.[0];
-  if (!first?.id) {
+  const clusters = data?.data ?? [];
+  // strip possible trailing slash
+  const normalize = (url: string) => url.replace(/\/+$/, "");
+  const wanted = normalize(srEndpoint);
+  const matches = clusters.filter(
+    (c) => c.spec?.http_endpoint && normalize(c.spec.http_endpoint) === wanted,
+  );
+  if (matches.length === 0) {
+    const seen = clusters
+      .map((c) => c.spec?.http_endpoint ?? "<no endpoint>")
+      .join(", ");
     throw new Error(
-      `no schema registry cluster found in environment ${envId} - is stream governance enabled?`,
+      `no schema registry cluster in environment ${envId} matches configured endpoint ${srEndpoint} (saw: ${seen || "<none>"})`,
     );
   }
-  return first.id;
+  if (matches.length > 1) {
+    const ids = matches.map((c) => c.id).join(", ");
+    throw new Error(
+      `multiple schema registry clusters in environment ${envId} match endpoint ${srEndpoint} (${ids}) - cannot disambiguate`,
+    );
+  }
+  const id = matches[0]?.id;
+  if (!id) {
+    throw new Error(
+      `matched schema registry cluster in environment ${envId} has no id field`,
+    );
+  }
+  return id;
 }

--- a/tests/harness/confluent-cloud.ts
+++ b/tests/harness/confluent-cloud.ts
@@ -41,3 +41,35 @@ export async function getFirstTestEnvironmentId(): Promise<string> {
   }
   return first.id;
 }
+
+/**
+ * Fetches the logical Schema Registry cluster id (`lsrc-...`) for the integration environment.
+ * Required to construct catalog qualified names of the form `<lsrc-id>:<lkc-id>:<topic>`; SR
+ * doesn't expose the logical id from its URL alone. Assumes one SR cluster per environment (the
+ * test account's case) and returns the first result from `/srcm/v3/clusters`.
+ */
+export async function getSchemaRegistryClusterId(): Promise<string> {
+  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const envId = conn.kafka?.env_id;
+  if (!envId) {
+    throw new Error(
+      "test-side sr cluster id discovery requires kafka.env_id in test-fixtures/yaml_configs/integration.yaml",
+    );
+  }
+  const client = newTestCloudClient();
+  const { data, error } = await client.GET("/srcm/v3/clusters", {
+    params: { query: { environment: envId } },
+  });
+  if (error) {
+    throw new Error(
+      `failed to list sr clusters from ccloud: ${JSON.stringify(error)}`,
+    );
+  }
+  const first = data?.data?.[0];
+  if (!first?.id) {
+    throw new Error(
+      `no schema registry cluster found in environment ${envId} - is stream governance enabled?`,
+    );
+  }
+  return first.id;
+}

--- a/tests/harness/schema-registry.ts
+++ b/tests/harness/schema-registry.ts
@@ -100,7 +100,8 @@ export function withSharedCatalogTagsClient(): {
 
   afterAll(async () => {
     const path = wrapAsPathBasedClient(client);
-    await Promise.all(
+    // allSettled so a single rejection (e.g. network error) don't fail teardown for the others
+    await Promise.allSettled(
       createdTags.map(async (tagName) => {
         const { error, response } = await path[
           "/catalog/v1/types/tagdefs/{tagName}"

--- a/tests/harness/schema-registry.ts
+++ b/tests/harness/schema-registry.ts
@@ -1,5 +1,11 @@
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { paths } from "@src/confluent/openapi-schema.js";
+import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
+import createClient, {
+  type Client,
+  wrapAsPathBasedClient,
+} from "openapi-fetch";
 import { afterAll, beforeAll } from "vitest";
 
 /**
@@ -22,6 +28,27 @@ export function newTestSrClient(): SchemaRegistryClient {
       userInfo: `${key}:${secret}`,
     },
   });
+}
+
+/**
+ * openapi-fetch client targeting the SR endpoint with HTTP basic auth, for SR REST routes that
+ * {@link SchemaRegistryClient} doesn't expose (e.g. `/catalog/v1/...`).
+ */
+export function newTestSrRestClient(): Client<paths> {
+  const conn = integrationRuntime().config.getSoleDirectConnection();
+  if (!conn.schema_registry?.endpoint || !conn.schema_registry.auth) {
+    throw new Error(
+      "test-side schema registry rest client requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml",
+    );
+  }
+  const { key, secret } = conn.schema_registry.auth;
+  const basic = Buffer.from(`${key}:${secret}`).toString("base64");
+  const client = createClient<paths>({
+    baseUrl: conn.schema_registry.endpoint,
+    headers: { Authorization: `Basic ${basic}` },
+  });
+  client.use(createRetryOn429Middleware());
+  return client;
 }
 
 /**
@@ -52,6 +79,42 @@ export function withSharedSrClient(): {
   });
 
   return { client: () => client, createdSubjects };
+}
+
+/**
+ * Shared SR REST client + tag-cleanup lifecycle. `afterAll` deletes every tag pushed onto
+ * `createdTags` (DELETE `/catalog/v1/types/tagdefs/{tagName}`). 404s are expected when the handler
+ * under test already deleted the tag; other non-2xx are logged to surface auth/rate-limit
+ * regressions without failing teardown.
+ */
+export function withSharedCatalogTagsClient(): {
+  client: () => Client<paths>;
+  createdTags: string[];
+} {
+  let client: Client<paths>;
+  const createdTags: string[] = [];
+
+  beforeAll(() => {
+    client = newTestSrRestClient();
+  });
+
+  afterAll(async () => {
+    const path = wrapAsPathBasedClient(client);
+    await Promise.all(
+      createdTags.map(async (tagName) => {
+        const { error, response } = await path[
+          "/catalog/v1/types/tagdefs/{tagName}"
+        ].DELETE({ params: { path: { tagName } } });
+        if (error && response.status !== 404) {
+          console.error(
+            `failed to delete test tag ${tagName} (status ${response.status}): ${JSON.stringify(error)}`,
+          );
+        }
+      }),
+    );
+  });
+
+  return { client: () => client, createdTags };
 }
 
 /** Trivial Avro schema body for tests that need to register a subject. */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

With updated `TOOL_GROUPS` default for CI:
<img width="772" height="770" alt="image" src="https://github.com/user-attachments/assets/06f55b15-8055-4f07-ba6e-e5db7ad6e452" />

Closes #326 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
