### PR TITLE
Close off env var access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Detailed conventions (handler structure, input schema rules, registration checkl
 - Prettier + ESLint enforced; pre-commit hook runs both automatically via Husky. `eslint --fix` auto-removes unused imports via `eslint-plugin-unused-imports`, so stale imports left during a migration are cleaned up at commit time without manual intervention. Pre-push hook runs full-repo `lint` + `typecheck` so CI failures on those checks are nearly impossible.
 - `noImplicitAny` is disabled in tsconfig due to OpenAPI type resolution issues.
 - REST API calls use `openapi-fetch` with typed paths from the generated schema — prefer this over raw fetch.
+- Application code reads configuration from `MCPServerConfiguration` / `ConnectionConfig`, never from `process.env`. A `no-restricted-syntax` rule in `eslint.config.mjs` enforces this; the only bootstrap files exempt are `src/index.ts`, `src/cli.ts`, `src/env.ts`, `src/logger.ts`. The `-e` dotenv mutation in `cli.ts` is intentional — it seeds env vars for linked C/Node libraries (OpenSSL, cyrus-sasl, krb5, undici) that read `process.env` outside our control.
 
 ## Unit Test Conventions
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,21 @@ connections:
         secret: "${KAFKA_API_SECRET}"
 ```
 
+#### Using `-e` for linked-library env vars
+
+mcp-confluent's own configuration flows through YAML (or, on the legacy path, through the env-var-to-config bridge). The `-e <file>` flag has a second job too: its entries land in `process.env`, which lets you supply env vars consumed by **linked libraries** that mcp-confluent has no explicit YAML knob for. Typical examples:
+
+- TLS: `SSL_CERT_FILE`, `SSL_CERT_DIR`, `NODE_EXTRA_CA_CERTS`, `NODE_TLS_REJECT_UNAUTHORIZED`
+- SASL plugin search: `SASL_PATH`, `SASL_CONF_PATH`
+- Kerberos / GSSAPI: `KRB5_CONFIG`, `KRB5CCNAME`, `KRB5_KTNAME`, `KRB5_TRACE`
+- HTTP proxy: `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`
+
+These are read directly by the C/Node libraries we link against (OpenSSL, cyrus-sasl, krb5, undici, librdkafka transitively) — outside mcp-confluent's control — so a corporate-environment user can drop them in `-e` alongside their interpolation tokens and have them honored.
+
+The same file feeds `${VAR}` interpolation inside YAML, so `-e` consistently serves both audiences from a single source.
+
+**Caveat**: env vars consumed by the dynamic linker (`LD_LIBRARY_PATH`, `LD_PRELOAD`, macOS `DYLD_*`) are read **before** Node starts and cannot be set via `-e`; supply those in the shell that launches mcp-confluent.
+
 #### Prerequisites & Setup for Tableflow Commands
 
 In order to leverage **Tableflow commands** to interact with your data ecosystem and successfully execute these Tableflow commands and manage resources (e.g., interacting with data storage like AWS S3 and metadata catalogs like AWS Glue), certain **IAM (Identity and Access Management) permissions** and configurations are essential.

--- a/config.oauth.example.yaml
+++ b/config.oauth.example.yaml
@@ -36,3 +36,10 @@ connections:
   # required field.
   ccloud-oauth:
     type: oauth
+
+    # librdkafka `debug` contexts to emit on stderr for this OAuth connection's
+    # native Kafka client. Reach for it when an OAuth/OAUTHBEARER SASL handshake
+    # misbehaves and you need to see which side broke — works the same in
+    # production as in dev. Common values: "security,broker,protocol", "all".
+    # The output is verbose; turn it off again once the investigation is done.
+    # kafka_debug: "${OAUTH_KAFKA_DEBUG:-security,broker,protocol}"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,4 +65,33 @@ export default [
       ],
     },
   },
+  // Production code reads configuration from `MCPServerConfiguration` /
+  // `ConnectionConfig`, never from `process.env`. The bootstrap allowlist
+  // below is the only place that consults it: index.ts orchestrates startup,
+  // cli.ts performs the -e dotenv mutation, env.ts parses the legacy env-var
+  // schema, logger.ts reads LOG_LEVEL/LOG_PRETTY at module-load (before
+  // main()). The dotenv mutation in cli.ts is intentional — it seeds
+  // linked-library env-var consumption (OpenSSL, cyrus-sasl, krb5, undici)
+  // outside our control. See #186 for the full rationale.
+  {
+    files: ["src/**/*.ts"],
+    ignores: [
+      "src/index.ts",
+      "src/cli.ts",
+      "src/env.ts",
+      "src/logger.ts",
+      "**/*.test.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "MemberExpression[object.name='process'][property.name='env']",
+          message:
+            "process.env may only be read in the bootstrap allowlist (src/index.ts, src/cli.ts, src/env.ts, src/logger.ts). Read from MCPServerConfiguration or ConnectionConfig instead.",
+        },
+      ],
+    },
+  },
 ];

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,7 +2,7 @@ import { CommanderError } from "@commander-js/extra-typings";
 import {
   DisplayedCommandLineUsageError,
   getFilteredToolNames,
-  loadDotEnvIntoProcessEnv,
+  loadDotEnvFile,
   parseCliArgs,
 } from "@src/cli.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
@@ -108,7 +108,7 @@ describe("cli.ts", () => {
     });
   });
 
-  describe("loadDotEnvIntoProcessEnv()", () => {
+  describe("loadDotEnvFile()", () => {
     let existsSyncSpy: MockInstance<typeof nodeDeps.fs.existsSync>;
     let resolveSpy: MockInstance<typeof nodeDeps.path.resolve>;
     let dotenvConfigSpy: MockedDotenv;
@@ -123,7 +123,7 @@ describe("cli.ts", () => {
       resolveSpy.mockReturnValue("/resolved/.env");
       existsSyncSpy.mockReturnValue(false);
 
-      expect(() => loadDotEnvIntoProcessEnv(".env")).toThrow(
+      expect(() => loadDotEnvFile(".env")).toThrow(
         "Environment file not found: /resolved/.env",
       );
     });
@@ -132,7 +132,7 @@ describe("cli.ts", () => {
       resolveSpy.mockReturnValue("/abs/path/.env");
       existsSyncSpy.mockReturnValue(false);
 
-      expect(() => loadDotEnvIntoProcessEnv("relative/.env")).toThrow();
+      expect(() => loadDotEnvFile("relative/.env")).toThrow();
 
       expect(resolveSpy).toHaveBeenCalledWith("relative/.env");
       expect(existsSyncSpy).toHaveBeenCalledWith("/abs/path/.env");
@@ -143,7 +143,7 @@ describe("cli.ts", () => {
       existsSyncSpy.mockReturnValue(true);
       dotenvConfigSpy.mockReturnValue({ error: new Error("parse error") });
 
-      expect(() => loadDotEnvIntoProcessEnv(".env")).toThrow(
+      expect(() => loadDotEnvFile(".env")).toThrow(
         "Error loading environment variables:",
       );
     });
@@ -153,7 +153,7 @@ describe("cli.ts", () => {
       existsSyncSpy.mockReturnValue(true);
       dotenvConfigSpy.mockReturnValue({ parsed: {} });
 
-      loadDotEnvIntoProcessEnv("relative/.env");
+      loadDotEnvFile("relative/.env");
 
       // Should call with the resolved absolute path and override: true
       // to ensure CLI env vars take precedence over existing ones in process.env
@@ -169,7 +169,7 @@ describe("cli.ts", () => {
       existsSyncSpy.mockReturnValue(true);
       dotenvConfigSpy.mockReturnValue({ parsed: { FOO: "bar", BAZ: "qux" } });
 
-      const result = loadDotEnvIntoProcessEnv(".env");
+      const result = loadDotEnvFile(".env");
 
       expect(result).toEqual({ FOO: "bar", BAZ: "qux" });
     });
@@ -179,7 +179,7 @@ describe("cli.ts", () => {
       existsSyncSpy.mockReturnValue(true);
       dotenvConfigSpy.mockReturnValue({ parsed: undefined });
 
-      const result = loadDotEnvIntoProcessEnv(".env");
+      const result = loadDotEnvFile(".env");
 
       expect(result).toEqual({});
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -310,24 +310,36 @@ export function parseCliArgs(argv: string[]): CLIOptions {
 }
 
 /**
- * Load dotenv keys/values from file into process.env.
- * Throws if file not found or if dotenv returns an error.
- * Overwrites preexisting keys in process.env as a side effect.
+ * Parse a dotenv file, returning its entries as a `Record<string,string>` and
+ * (intentionally) writing the same entries into `process.env` with `override:
+ * true` so preexisting shell-environment values are replaced.
+ *
+ * Two channels, one source. The return value is what mcp-confluent application
+ * code consumes — fed into `buildConfigFromEnvAndCli` on the legacy env-var
+ * path, and supplied as the env source for `${VAR}` interpolation inside YAML.
+ * The `process.env` mutation exists for a different audience: **external
+ * libraries** (OpenSSL via `SSL_CERT_FILE` / `NODE_EXTRA_CA_CERTS`, cyrus-sasl
+ * via `SASL_PATH`, krb5 via `KRB5_CONFIG` / `KRB5CCNAME` / `KRB5_KTNAME`,
+ * undici via `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY`, librdkafka transitively
+ * through these) read `process.env` directly outside our control, and a user
+ * supplying `-e` reasonably expects those settings to be honored.
+ *
+ * Do not "clean up" the side effect: application code is forbidden by lint
+ * from reading `process.env` outside the bootstrap allowlist, but the linked
+ * libraries that need this seed are unaffected by that rule.
+ *
+ * Throws if the file does not exist or `dotenv` returns an error.
+ *
  * @param envFile Path to the environment file
- * @returns Object containing the parsed key-value pairs from the environment file
- *          (primarily for test purposes, but updates process.env as a side effect)
+ * @returns The parsed entries — also reflected into `process.env`
  */
-export function loadDotEnvIntoProcessEnv(
-  envFile: string,
-): Record<string, string> {
+export function loadDotEnvFile(envFile: string): Record<string, string> {
   const envPath = path.resolve(envFile);
 
-  // Check if file exists
   if (!fs.existsSync(envPath)) {
     throw new Error(`Environment file not found: ${envPath}`);
   }
 
-  // Load environment variables from file
   const result = dotenvLib.config({ path: envPath, override: true });
 
   if (result.error) {
@@ -336,7 +348,6 @@ export function loadDotEnvIntoProcessEnv(
 
   logger.info(`Loaded environment variables from ${envPath}`);
 
-  // Return the parsed variables that are also now in process.env.
   return result.parsed || {};
 }
 

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -32,6 +32,8 @@ function envWith(overrides: Partial<EnvInput> = {}): EnvInput {
     TELEMETRY_ENDPOINT: undefined,
     TELEMETRY_API_KEY: undefined,
     TELEMETRY_API_SECRET: undefined,
+    TELEMETRY_WRITE_KEY: undefined,
+    OAUTH_KAFKA_DEBUG: undefined,
     // Server vars — non-optional in Environment (have envSchema defaults), so must be provided
     LOG_LEVEL: "info",
     HTTP_PORT: 8080,
@@ -820,6 +822,20 @@ describe("config/env-config.ts", () => {
         ).toThrow(/TELEMETRY_API_KEY/);
       });
     });
+
+    describe("analytics env vars (Segment write key)", () => {
+      it("should populate server.analytics.write_key from TELEMETRY_WRITE_KEY", () => {
+        const config = buildConfigFromEnvAndCli(
+          envWith({ TELEMETRY_WRITE_KEY: "segment-write-key" }),
+        );
+        expect(config.server.analytics?.write_key).toBe("segment-write-key");
+      });
+
+      it("should leave server.analytics undefined when TELEMETRY_WRITE_KEY is absent", () => {
+        const config = buildConfigFromEnvAndCli(envWith());
+        expect(config.server.analytics).toBeUndefined();
+      });
+    });
   });
 
   describe("buildConfigFromEnvAndCli", () => {
@@ -1068,6 +1084,25 @@ describe("config/env-config.ts", () => {
         );
         const conn = config.getSoleConnection();
         expect(conn).toEqual({ type: "oauth", ccloud_env: "devel" });
+      });
+
+      it("should thread OAUTH_KAFKA_DEBUG into the synthesized OAuth connection's kafka_debug", () => {
+        const config = buildConfigFromEnvAndCli(
+          envWith({ OAUTH_KAFKA_DEBUG: "security,broker" }),
+          { oauth: true },
+        );
+        const conn = config.getSoleConnection();
+        expect(conn).toEqual({
+          type: "oauth",
+          ccloud_env: "prod",
+          kafka_debug: "security,broker",
+        });
+      });
+
+      it("should leave kafka_debug unset on the OAuth connection when OAUTH_KAFKA_DEBUG is absent", () => {
+        const config = buildConfigFromEnvAndCli(envWith({}), { oauth: true });
+        const conn = config.getSoleConnection();
+        expect(conn).not.toHaveProperty("kafka_debug");
       });
     });
   });

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -50,6 +50,11 @@ const ENV_VAR_TO_ZPATH = {
   TELEMETRY_ENDPOINT: `${CONN}.telemetry.endpoint`,
   TELEMETRY_API_KEY: `${CONN}.telemetry.auth.key`,
   TELEMETRY_API_SECRET: `${CONN}.telemetry.auth.secret`,
+  // Analytics (internal-dev-only: Segment write key override)
+  TELEMETRY_WRITE_KEY: "server.analytics.write_key",
+  // OAuth diagnostic knob — only meaningful when --oauth is also set, in which
+  // case buildConfigFromEnv synthesizes the OAuth connection arm that carries it.
+  OAUTH_KAFKA_DEBUG: `${CONN}.kafka_debug`,
   // Server configuration
   LOG_LEVEL: "server.log_level",
   HTTP_PORT: "server.http.port",
@@ -88,6 +93,9 @@ function buildConfigFromEnv(
           type: "oauth",
           ...(oauth.ccloudEnv && {
             ccloud_env: oauth.ccloudEnv,
+          }),
+          ...(env.OAUTH_KAFKA_DEBUG !== undefined && {
+            kafka_debug: env.OAUTH_KAFKA_DEBUG,
           }),
         },
       },
@@ -454,6 +462,9 @@ function buildServerBlock(
         disabled: authOverrides.disableAuth ?? env.MCP_AUTH_DISABLED,
         allowed_hosts: authOverrides.allowedHosts ?? env.MCP_ALLOWED_HOSTS,
       },
+      ...(env.TELEMETRY_WRITE_KEY !== undefined && {
+        analytics: { write_key: env.TELEMETRY_WRITE_KEY },
+      }),
     },
   };
 }

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -556,6 +556,55 @@ describe("config/models.ts", () => {
     });
   });
 
+  describe("server.analytics block", () => {
+    const validConnection = {
+      type: "direct" as const,
+      kafka: { bootstrap_servers: "broker:9092" },
+    };
+
+    it("should accept server.analytics.write_key when supplied", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { analytics: { write_key: "segment-write-key" } },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.server.analytics?.write_key).toBe(
+          "segment-write-key",
+        );
+      }
+    });
+
+    it("should leave server.analytics undefined when the block is omitted", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.server.analytics).toBeUndefined();
+      }
+    });
+
+    it("should reject unknown keys in server.analytics", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { analytics: { write_key: "k", bogus: 1 } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject empty server.analytics.write_key", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { production: validConnection },
+        server: { analytics: { write_key: "" } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(formatZodIssues(result.error.issues)).toMatch(/write_key/);
+      }
+    });
+  });
+
   describe("confluent_cloud block", () => {
     const baseCC = {
       auth: { type: "api_key" as const, key: "k", secret: "s" },
@@ -757,6 +806,50 @@ describe("config/models.ts", () => {
         >;
         expect(conn).not.toHaveProperty("confluent_cloud");
         expect(conn).not.toHaveProperty("telemetry");
+      }
+    });
+
+    it("should accept kafka_debug as an optional librdkafka debug-contexts string", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: {
+          foo: {
+            type: "oauth",
+            ccloud_env: "prod",
+            kafka_debug: "security,broker",
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.connections.foo).toEqual({
+          type: "oauth",
+          ccloud_env: "prod",
+          kafka_debug: "security,broker",
+        });
+      }
+    });
+
+    it("should leave kafka_debug undefined when omitted on an oauth connection", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { foo: { type: "oauth" } },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const conn = result.data.connections.foo as unknown as Record<
+          string,
+          unknown
+        >;
+        expect(conn.kafka_debug).toBeUndefined();
+      }
+    });
+
+    it("should reject empty kafka_debug string", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: { foo: { type: "oauth", kafka_debug: "" } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(formatZodIssues(result.error.issues)).toMatch(/kafka_debug/);
       }
     });
   });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -36,10 +36,16 @@ export interface DirectConnectionConfig {
  * connections supply via blocks must be passed as tool arguments under OAuth.
  *
  * `ccloud_env` defaults to "prod"
+ *
+ * `kafka_debug` is the optional librdkafka `debug` contexts string (e.g.
+ * "security,broker,protocol", or "all") used as a diagnostic knob when an
+ * OAuth/OAUTHBEARER SASL handshake misbehaves. Surfaced through to the
+ * `OAuthClientManager` and threaded into the rdkafka client config.
  */
 export interface OAuthConnectionConfig {
   readonly type: "oauth";
   readonly ccloud_env: "devel" | "stag" | "prod";
+  readonly kafka_debug?: string;
 }
 
 /**
@@ -132,6 +138,22 @@ export interface ServerConfig {
   readonly do_not_track: boolean;
   readonly http: ServerHttpConfig;
   readonly auth: ServerAuthConfig;
+  readonly analytics?: ServerAnalyticsConfig;
+}
+
+/**
+ * Internal-developer-only override for the Segment write key used to emit
+ * anonymous usage analytics from this MCP server. Normal builds inject the
+ * right value at `npm pack` time via build-config injection; this knob exists
+ * so contributors can point analytics at a non-production Segment project
+ * during local development. End users should not set it.
+ *
+ * Deliberately undocumented in the user-facing example YAML templates
+ * (`config.example.yaml`, `config.oauth.example.yaml`) — surfacing it there
+ * would legitimize a knob that exists only for internal mcp-confluent dev.
+ */
+export interface ServerAnalyticsConfig {
+  readonly write_key: string;
 }
 
 /**
@@ -411,6 +433,11 @@ const oauthConnectionSchema = z
   .object({
     type: z.literal("oauth"),
     ccloud_env: z.enum(["devel", "stag", "prod"]).default("prod"),
+    kafka_debug: z
+      .string()
+      .trim()
+      .min(1, "kafka_debug cannot be empty")
+      .optional(),
   })
   .strict();
 
@@ -519,6 +546,15 @@ const serverAuthConfigSchema = z
       "server.auth.disabled and server.auth.api_key cannot both be set — remove the api_key or set disabled: false",
   });
 
+const serverAnalyticsConfigSchema = z
+  .object({
+    write_key: z
+      .string()
+      .trim()
+      .min(1, "server.analytics.write_key cannot be empty"),
+  })
+  .strict();
+
 // Zod v4 requires .default() to receive a value (or factory) matching the schema's
 // output type. Since each sub-schema's output type has required fields (those with
 // their own .default() calls), we use factory functions so Zod resolves field-level
@@ -551,6 +587,7 @@ const serverConfigSchema = z
     auth: serverAuthConfigSchema.default(() =>
       serverAuthConfigSchema.parse({}),
     ),
+    analytics: serverAnalyticsConfigSchema.optional(),
   })
   .strict();
 

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -62,6 +62,64 @@ describe("oauth-client-manager.ts", () => {
         expect(kafkaSpy).toHaveBeenCalledTimes(2);
       });
 
+      it("should pass librdkafka `debug` contexts through when kafka_debug is configured on the OAuth connection", async () => {
+        vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
+          "broker:9092",
+        );
+        const fakeAdmin = {
+          connect: vi.fn().mockResolvedValue(undefined),
+          disconnect: vi.fn().mockResolvedValue(undefined),
+          listTopics: vi.fn().mockResolvedValue([]),
+        };
+        let capturedConfig: Record<string, unknown> | undefined;
+        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function (
+          config: Record<string, unknown>,
+        ) {
+          capturedConfig = config;
+          return { admin: () => fakeAdmin } as unknown as KafkaJS.Kafka;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        const holder = createMockInstance(OAuthHolder);
+        holder.getDataPlaneToken.mockReturnValue("dpat");
+        const manager = new OAuthClientManager(
+          holder,
+          "devel",
+          "security,broker,protocol",
+        );
+        await manager.getKafkaAdminClient("lkc-1", "env-1");
+
+        expect(capturedConfig).toBeDefined();
+        expect(capturedConfig!["debug"]).toBe("security,broker,protocol");
+      });
+
+      it("should omit `debug` from the rdkafka config when kafka_debug is undefined", async () => {
+        vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
+          "broker:9092",
+        );
+        const fakeAdmin = {
+          connect: vi.fn().mockResolvedValue(undefined),
+          disconnect: vi.fn().mockResolvedValue(undefined),
+          listTopics: vi.fn().mockResolvedValue([]),
+        };
+        let capturedConfig: Record<string, unknown> | undefined;
+        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function (
+          config: Record<string, unknown>,
+        ) {
+          capturedConfig = config;
+          return { admin: () => fakeAdmin } as unknown as KafkaJS.Kafka;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        const manager = buildManager();
+        await manager.getKafkaAdminClient("lkc-1", "env-1");
+
+        expect(capturedConfig).toBeDefined();
+        // The key must be absent — not present-but-undefined — so the
+        // rdkafka client never receives a stray `debug` property.
+        expect(Object.hasOwn(capturedConfig!, "debug")).toBe(false);
+      });
+
       it("should configure KafkaJS.Kafka with librdkafka-native SASL keys, not the kafkaJS-compat async provider", async () => {
         // Regression guard: re-introducing `kafkaJS.sasl.oauthBearerProvider`
         // would resurrect the SASL race that previously required a warmup

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -67,8 +67,15 @@ type PostProcessTokenRefresh = (
  */
 export class OAuthClientManager extends BaseClientManager {
   private readonly holder: OAuthHolder;
+  private readonly kafkaDebug: string | undefined;
 
-  constructor(holder: OAuthHolder, env: Auth0Environment) {
+  /**
+   * @param kafkaDebug Optional librdkafka `debug` contexts string, threaded
+   *   through to every native Kafka client built by this manager. Sourced
+   *   from `connections.<name>.kafka_debug` on the OAuth YAML arm; used as a
+   *   diagnostic knob when a SASL/OAUTHBEARER handshake misbehaves.
+   */
+  constructor(holder: OAuthHolder, env: Auth0Environment, kafkaDebug?: string) {
     const cpToken = (): string | undefined => holder.getControlPlaneToken();
     const dpToken = (): string | undefined => holder.getDataPlaneToken();
     super({
@@ -91,6 +98,7 @@ export class OAuthClientManager extends BaseClientManager {
     });
 
     this.holder = holder;
+    this.kafkaDebug = kafkaDebug;
 
     // Eager construction: surface the cloud REST client at startup so a bad
     // endpoint or middleware wiring fails fast rather than at first tool call.
@@ -259,10 +267,11 @@ export class OAuthClientManager extends BaseClientManager {
     // below) reads it on demand, so an empty token here would surface as a
     // broker-side auth failure with no useful diagnostic.
     this.requireDataPlaneToken();
-    // librdkafka debug logs — gated by env var so they don't pollute normal
-    // server stderr. Set OAUTH_KAFKA_DEBUG=security,broker,protocol (or
-    // "all") to see the full SASL/OAUTHBEARER handshake and broker traffic.
-    const debug = process.env.OAUTH_KAFKA_DEBUG;
+    // librdkafka debug logs — gated by `kafka_debug` on the OAuth YAML arm so
+    // they don't pollute normal server stderr. Set
+    // `connections.<name>.kafka_debug: "security,broker,protocol"` (or "all")
+    // to see the full SASL/OAUTHBEARER handshake and broker traffic.
+    const debug = this.kafkaDebug;
     const bootstrap = await resolveKafkaBootstrap(
       this.getConfluentCloudRestClient(),
       clusterId,

--- a/src/confluent/telemetry.test.ts
+++ b/src/confluent/telemetry.test.ts
@@ -5,7 +5,6 @@ import {
   TelemetryService,
 } from "@src/confluent/telemetry.js";
 import {
-  afterEach,
   beforeEach,
   describe,
   expect,
@@ -66,19 +65,7 @@ describe("TelemetryService", () => {
       );
     vi.spyOn(nodeDeps.os, "homedir").mockReturnValue("/tmp/test-home");
 
-    // default: no built-in write key (simulates unpacked/dev build)
-    vi.spyOn(
-      nodeDeps.buildConfig,
-      "TELEMETRY_WRITE_KEY",
-      "get",
-    ).mockReturnValue("");
-
     TelemetryService["instance"] = undefined;
-  });
-
-  afterEach(() => {
-    // not managed by restoreMocks, so clean up manually to avoid affecting other tests
-    delete process.env.TELEMETRY_WRITE_KEY;
   });
 
   describe("initialize / getInstance contract", () => {
@@ -89,14 +76,14 @@ describe("TelemetryService", () => {
     });
 
     it("should throw when initialize is called a second time", () => {
-      TelemetryService.initialize(false);
-      expect(() => TelemetryService.initialize(false)).toThrow(
-        /already been initialized/,
-      );
+      TelemetryService.initialize({ doNotTrack: false, writeKey: undefined });
+      expect(() =>
+        TelemetryService.initialize({ doNotTrack: false, writeKey: undefined }),
+      ).toThrow(/already been initialized/);
     });
 
     it("should return the same instance across multiple getInstance calls", () => {
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: undefined });
       const a = TelemetryService.getInstance();
       const b = TelemetryService.getInstance();
       expect(a).toBe(b);
@@ -104,25 +91,11 @@ describe("TelemetryService", () => {
   });
 
   describe("activation", () => {
-    it("should be enabled when the TELEMETRY_WRITE_KEY env var is set", () => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(false);
-
-      const service = TelemetryService.getInstance();
-      service.track(TelemetryEvent.TOOL_CALL, {
-        toolName: "list_topics",
+    it("should be enabled when initialize receives a writeKey", () => {
+      TelemetryService.initialize({
+        doNotTrack: false,
+        writeKey: "real-key",
       });
-
-      expect(trackStub).toHaveBeenCalledOnce();
-    });
-
-    it("should be enabled when the built-in write key is present (no env var)", () => {
-      vi.spyOn(
-        nodeDeps.buildConfig,
-        "TELEMETRY_WRITE_KEY",
-        "get",
-      ).mockReturnValue("packed-key");
-      TelemetryService.initialize(false);
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -131,32 +104,12 @@ describe("TelemetryService", () => {
 
       expect(trackStub).toHaveBeenCalledOnce();
       expect(analyticsConstructorStub).toHaveBeenCalledWith(
-        expect.objectContaining({ writeKey: "packed-key" }),
+        expect.objectContaining({ writeKey: "real-key" }),
       );
     });
 
-    it("should prefer the env var over the built-in key", () => {
-      process.env.TELEMETRY_WRITE_KEY = "env-key";
-      vi.spyOn(
-        nodeDeps.buildConfig,
-        "TELEMETRY_WRITE_KEY",
-        "get",
-      ).mockReturnValue("packed-key");
-      TelemetryService.initialize(false);
-
-      const service = TelemetryService.getInstance();
-      service.track(TelemetryEvent.TOOL_CALL, {
-        toolName: "list_topics",
-      });
-
-      expect(trackStub).toHaveBeenCalledOnce();
-      expect(analyticsConstructorStub).toHaveBeenCalledWith(
-        expect.objectContaining({ writeKey: "env-key" }),
-      );
-    });
-
-    it("should be disabled when neither env var nor built-in key is set", () => {
-      TelemetryService.initialize(false);
+    it("should be disabled when initialize receives writeKey: undefined", () => {
+      TelemetryService.initialize({ doNotTrack: false, writeKey: undefined });
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -164,11 +117,23 @@ describe("TelemetryService", () => {
       });
 
       expect(trackStub).not.toHaveBeenCalled();
+      expect(analyticsConstructorStub).not.toHaveBeenCalled();
     });
 
-    it("should be disabled when initialized with doNotTrack: true, even with a valid write key", () => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(true);
+    it("should be disabled when initialize receives an empty-string writeKey", () => {
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "" });
+
+      const service = TelemetryService.getInstance();
+      service.track(TelemetryEvent.TOOL_CALL, {
+        toolName: "list_topics",
+      });
+
+      expect(trackStub).not.toHaveBeenCalled();
+      expect(analyticsConstructorStub).not.toHaveBeenCalled();
+    });
+
+    it("should be disabled when initialized with doNotTrack: true, even with a valid writeKey", () => {
+      TelemetryService.initialize({ doNotTrack: true, writeKey: "real-key" });
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {
@@ -183,8 +148,7 @@ describe("TelemetryService", () => {
     let service: TelemetryService;
 
     beforeEach(() => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
       service = TelemetryService.getInstance();
     });
 
@@ -223,7 +187,7 @@ describe("TelemetryService", () => {
 
     it("should skip identify calls when initialized with doNotTrack: true", () => {
       TelemetryService["instance"] = undefined;
-      TelemetryService.initialize(true);
+      TelemetryService.initialize({ doNotTrack: true, writeKey: "real-key" });
 
       const disabled = TelemetryService.getInstance();
       disabled.identify("user-123", { org: "acme" });
@@ -234,8 +198,7 @@ describe("TelemetryService", () => {
 
   describe("machine ID persistence", () => {
     it("should generate and write a new UUID when no machine-id file exists", () => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
 
       TelemetryService.getInstance();
 
@@ -248,9 +211,8 @@ describe("TelemetryService", () => {
     });
 
     it("should reuse an existing UUID when a machine-id file exists", () => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
       readFileSyncStub.mockReturnValue("existing-uuid");
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {});
@@ -261,11 +223,10 @@ describe("TelemetryService", () => {
     });
 
     it("should fall back to an anonymous ID when the file system is not writable", () => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
       mkdirSyncStub.mockImplementation(() => {
         throw new Error("EACCES");
       });
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
 
       const service = TelemetryService.getInstance();
       service.track(TelemetryEvent.TOOL_CALL, {});
@@ -278,8 +239,7 @@ describe("TelemetryService", () => {
 
   describe("shutdown", () => {
     it("should flush the analytics client on shutdown", async () => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
 
       await TelemetryService.getInstance().shutdown();
 
@@ -288,7 +248,7 @@ describe("TelemetryService", () => {
     });
 
     it("should be a no-op when telemetry is disabled", async () => {
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: undefined });
 
       await TelemetryService.getInstance().shutdown();
 
@@ -300,8 +260,7 @@ describe("TelemetryService", () => {
     let service: TelemetryService;
 
     beforeEach(() => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
       service = TelemetryService.getInstance();
     });
 
@@ -360,8 +319,7 @@ describe("TelemetryService", () => {
     let service: TelemetryService;
 
     beforeEach(() => {
-      process.env.TELEMETRY_WRITE_KEY = "real-key";
-      TelemetryService.initialize(false);
+      TelemetryService.initialize({ doNotTrack: false, writeKey: "real-key" });
       service = TelemetryService.getInstance();
     });
 

--- a/src/confluent/telemetry.ts
+++ b/src/confluent/telemetry.ts
@@ -1,15 +1,20 @@
-import {
-  buildConfig,
-  fs,
-  os,
-  path,
-  segment,
-} from "@src/confluent/node-deps.js";
+import { fs, os, path, segment } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
 import { randomUUID } from "node:crypto";
 
 export enum TelemetryEvent {
   TOOL_CALL = "Tool Call",
+}
+
+/**
+ * Inputs to {@link TelemetryService.initialize}. `writeKey` is whatever the
+ * caller resolved (YAML override, build-config injected value, or undefined);
+ * the service treats `undefined`/`""` as "telemetry off" and otherwise hands
+ * the value to the Segment Analytics constructor.
+ */
+export interface TelemetryInitOptions {
+  readonly doNotTrack: boolean;
+  readonly writeKey: string | undefined;
 }
 
 export const FALLBACK_MACHINE_ID = "00000000-0000-0000-0000-000000000000";
@@ -57,11 +62,8 @@ export class TelemetryService {
   private serverSessionId: string;
   private commonProperties: Record<string, unknown>;
 
-  private constructor(doNotTrack: boolean) {
-    // runtime env var can override the build-time value for local dev/testing
-    const writeKey =
-      process.env.TELEMETRY_WRITE_KEY || buildConfig.TELEMETRY_WRITE_KEY;
-    const enabled = !doNotTrack && !!writeKey;
+  private constructor(opts: TelemetryInitOptions) {
+    const enabled = !opts.doNotTrack && !!opts.writeKey;
 
     this.machineId = getOrCreateMachineId();
     this.serverSessionId = randomUUID();
@@ -73,20 +75,27 @@ export class TelemetryService {
     };
 
     if (enabled) {
-      this.analytics = new segment.Analytics({ writeKey });
+      this.analytics = new segment.Analytics({ writeKey: opts.writeKey });
       logger.info("Telemetry enabled");
     } else {
       logger.info("Telemetry disabled");
     }
   }
 
-  static initialize(doNotTrack: boolean): void {
+  /**
+   * Bootstrap-time entry point. The caller (main()) is responsible for
+   * resolving `writeKey` from its sources — typically
+   * `mcpConfig.server.analytics?.write_key ?? buildConfig.TELEMETRY_WRITE_KEY`
+   * — before invoking this. A falsy `writeKey` (`undefined` or `""`) keeps
+   * analytics disabled even when `doNotTrack` is false.
+   */
+  static initialize(opts: TelemetryInitOptions): void {
     if (TelemetryService.instance) {
       throw new Error(
         "TelemetryService has already been initialized — initialize() must be called exactly once before getInstance()",
       );
     }
-    TelemetryService.instance = new TelemetryService(doNotTrack);
+    TelemetryService.instance = new TelemetryService(opts);
   }
 
   static getInstance(): TelemetryService {

--- a/src/env-schema.ts
+++ b/src/env-schema.ts
@@ -256,6 +256,20 @@ const configSchema = z
       )
       .trim()
       .min(1),
+    TELEMETRY_WRITE_KEY: z
+      .string()
+      .describe(
+        "Developer-only override for the Segment write key used to emit anonymous usage analytics from this MCP server. Normal builds inject the right value at npm pack time; setting this is only useful when developing mcp-confluent against a non-production telemetry sink.",
+      )
+      .trim()
+      .min(1),
+    OAUTH_KAFKA_DEBUG: z
+      .string()
+      .describe(
+        "librdkafka `debug` contexts for the native Kafka client of an --oauth-synthesized connection. Common values: 'security,broker,protocol', 'all'. Useful when diagnosing a SASL/OAUTHBEARER handshake failure under OAuth. YAML configs supply this via the OAuth connection's kafka_debug field instead.",
+      )
+      .trim()
+      .min(1),
   })
   .partial();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,8 @@
 import type { CLIOptions } from "@src/cli.js";
+import {
+  DEFAULT_SERVER_CONFIG,
+  MCPServerConfiguration,
+} from "@src/config/models.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import { nodeCrypto } from "@src/confluent/node-deps.js";
 import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
@@ -10,6 +14,7 @@ import {
   outputApiKey,
   outputInitConfig,
   outputToolList,
+  resolveTelemetryWriteKey,
 } from "@src/index.js";
 import { logger } from "@src/logger.js";
 import { ccloudOAuthRuntime, runtimeWith } from "@tests/factories/runtime.js";
@@ -681,6 +686,62 @@ describe("index.ts", () => {
       expect(allArgs).toContain("Generated MCP API Key:");
       // The init-config branch is bypassed entirely.
       expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveTelemetryWriteKey()", () => {
+    // Build a minimal MCPServerConfiguration whose only point of variation is
+    // the `server.analytics.write_key` field. Spreads DEFAULT_SERVER_CONFIG so
+    // the literal-type widening on transports/log_level/etc. is sidestepped.
+    function configWithAnalytics(
+      writeKey: string | undefined,
+    ): MCPServerConfiguration {
+      return new MCPServerConfiguration({
+        connections: { default: { type: "direct" } },
+        server:
+          writeKey === undefined
+            ? DEFAULT_SERVER_CONFIG
+            : { ...DEFAULT_SERVER_CONFIG, analytics: { write_key: writeKey } },
+      });
+    }
+
+    it("should return the YAML-supplied write_key when server.analytics is present", () => {
+      vi.spyOn(
+        nodeDeps.buildConfig,
+        "TELEMETRY_WRITE_KEY",
+        "get",
+      ).mockReturnValue("packed-key");
+
+      const result = resolveTelemetryWriteKey(configWithAnalytics("yaml-key"));
+
+      expect(result).toBe("yaml-key");
+    });
+
+    it("should fall back to buildConfig.TELEMETRY_WRITE_KEY when server.analytics is absent", () => {
+      vi.spyOn(
+        nodeDeps.buildConfig,
+        "TELEMETRY_WRITE_KEY",
+        "get",
+      ).mockReturnValue("packed-key");
+
+      const result = resolveTelemetryWriteKey(configWithAnalytics(undefined));
+
+      expect(result).toBe("packed-key");
+    });
+
+    it("should return undefined when neither YAML nor buildConfig supplies a key", () => {
+      vi.spyOn(
+        nodeDeps.buildConfig,
+        "TELEMETRY_WRITE_KEY",
+        "get",
+      ).mockReturnValue("");
+
+      const result = resolveTelemetryWriteKey(configWithAnalytics(undefined));
+
+      // Empty-string buildConfig is the unpacked/dev-build shape; treat it as
+      // "no key supplied" so the caller routes through TelemetryService's
+      // falsy-writeKey disabled path rather than passing "" to Segment.
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   DisplayedCommandLineUsageError,
   getFilteredToolNames,
   getPackageVersion,
-  loadDotEnvIntoProcessEnv,
+  loadDotEnvFile,
   parseCliArgs,
 } from "@src/cli.js";
 import {
@@ -13,7 +13,7 @@ import {
   loadConfigFromYaml,
   MCPServerConfiguration,
 } from "@src/config/index.js";
-import { fs, path } from "@src/confluent/node-deps.js";
+import { buildConfig, fs, path } from "@src/confluent/node-deps.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { groupDisabledToolsByReason } from "@src/confluent/tools/tool-availability.js";
@@ -266,8 +266,7 @@ async function main() {
     );
 
     if (cliOptions.envFile) {
-      // NOW load env vars into process.env!
-      loadDotEnvIntoProcessEnv(cliOptions.envFile);
+      loadDotEnvFile(cliOptions.envFile);
     }
 
     // Convert our known env vars into a typed Environment obj.
@@ -297,9 +296,16 @@ async function main() {
 
     // DO_NOT_TRACK is a cross-tool user preference (consoledonottrack.com);
     // the env var acts as a floor so it is honored even when --config is used.
-    TelemetryService.initialize(
-      mcpConfig.server.do_not_track || env.DO_NOT_TRACK,
-    );
+    // writeKey precedence: explicit config wins over the build-time injected
+    // value. The config value reaches us either from a YAML declaration or
+    // from the legacy TELEMETRY_WRITE_KEY → server.analytics.write_key bridge
+    // in env-config.ts.
+    TelemetryService.initialize({
+      doNotTrack: mcpConfig.server.do_not_track || env.DO_NOT_TRACK,
+      writeKey:
+        mcpConfig.server.analytics?.write_key ??
+        buildConfig.TELEMETRY_WRITE_KEY,
+    });
 
     logger.info(
       `${mcpConfig.getConnectionNames().length} connections loaded successfully`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,26 @@ export function getToolHandlersToRegister(
   return toolHandlers;
 }
 
+/**
+ * Resolve the Segment write key handed to `TelemetryService.initialize`.
+ *
+ * Precedence: an explicit YAML `server.analytics.write_key` wins; otherwise
+ * fall back to `buildConfig.TELEMETRY_WRITE_KEY` (the value `npm pack` injects
+ * at release time). On unpacked / dev builds the build-time value is empty,
+ * so an absent YAML field produces an empty-string fallback that
+ * `TelemetryService` treats as "no key supplied" — analytics stays off.
+ *
+ * Extracted from `main()` so the precedence is unit-testable without booting
+ * the full server.
+ */
+export function resolveTelemetryWriteKey(
+  mcpConfig: MCPServerConfiguration,
+): string | undefined {
+  return (
+    mcpConfig.server.analytics?.write_key ?? buildConfig.TELEMETRY_WRITE_KEY
+  );
+}
+
 export function outputApiKey(): void {
   const apiKey = generateApiKey();
   console.log("\nGenerated MCP API Key:");
@@ -296,15 +316,9 @@ async function main() {
 
     // DO_NOT_TRACK is a cross-tool user preference (consoledonottrack.com);
     // the env var acts as a floor so it is honored even when --config is used.
-    // writeKey precedence: explicit config wins over the build-time injected
-    // value. The config value reaches us either from a YAML declaration or
-    // from the legacy TELEMETRY_WRITE_KEY → server.analytics.write_key bridge
-    // in env-config.ts.
     TelemetryService.initialize({
       doNotTrack: mcpConfig.server.do_not_track || env.DO_NOT_TRACK,
-      writeKey:
-        mcpConfig.server.analytics?.write_key ??
-        buildConfig.TELEMETRY_WRITE_KEY,
+      writeKey: resolveTelemetryWriteKey(mcpConfig),
     });
 
     logger.info(

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -79,7 +79,11 @@ export class ServerRuntime {
         if (oauthHolder && oauthConn) {
           return [
             id,
-            new OAuthClientManager(oauthHolder, oauthConn.ccloud_env),
+            new OAuthClientManager(
+              oauthHolder,
+              oauthConn.ccloud_env,
+              oauthConn.kafka_debug,
+            ),
           ] as const;
         }
         // No OAuth connection found, so every connection is direct.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Model two "newly" (past few weeks) snuck in env vars to be yaml configurable:
  -  `OAUTH_KAFKA_DEBUG ` -> `<oauth-ccloud-connname>. kafka_debug` for oauth connection <--> Kafka native client debugging, exposed and doc'd for end users.
  - `TELEMETRY_WRITE_KEY ` -> `server.analytics.write_key` -- Only internal dev team needs to touch, so not doc'd for end-users.  
- Simplify the name of `loadDotEnvIntoProcessEnv` -> `loadDotEnvFile`
  - Document rationale as to why we legit need to still have it manipulate the process env vars -- users would expect it to on behalf of setting env vars for derivative libraries where we can't provide explicit configuration hooks. Or even if we did, they'd still expect dotEnv files to DTRT.
- But for this codebase, **now lock down Process.env access to only the portions of the codebase involved with the env var -> yaml config promotion portion of the bootstrapping phase of `main()`,** so as to help guarantee that now that this codebase is weaned off of env vars beyond main bootstrapping, it should now remain that way!


Closes #186

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
