### PR TITLE
fix: handle `cloud` being undefined when invoking `list-tableflow-regions`

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -27,8 +27,49 @@ paths:
   - `expect(mock).toHaveBeenCalledWith(arg)`
   - `expect(mock).toHaveBeenCalledTimes(n)`
   - `expect(mock).not.toHaveBeenCalled()`
-- For argument matching inside calls: `expect.any(String)`, `expect.objectContaining({...})`,
-  `expect.stringContaining("...")`, `expect.anything()`
+
+### Literal arguments over loose matchers (default)
+
+When the test owns the inputs to the unit under test, assert the resulting call with
+**literal deep-equality**, not partial matchers. `toHaveBeenCalledWith` uses `toEqual`
+semantics, so a literal object pins the exact contract and produces precise diffs on
+drift. Vitest treats `{ k: undefined }` and `{}` as equal, so an explicit `undefined`
+in the expected literal stays robust whether the call site passes the key or omits
+it.
+
+```typescript
+// Prefer: literal pins the contract — extra keys, renamed keys, regressed shapes all fail loudly.
+expect(client.GET).toHaveBeenCalledWith("/tableflow/v1/regions", {
+  params: {
+    query: { cloud: "AWS", page_size: undefined, page_token: undefined },
+  },
+});
+
+// Avoid: lets a buggy call shape slip through silently.
+expect(client.GET).toHaveBeenCalledWith(
+  expect.any(String),
+  expect.objectContaining({
+    params: expect.objectContaining({
+      query: expect.objectContaining({ cloud: "AWS" }),
+    }),
+  }),
+);
+```
+
+Reach for `expect.any(...)`, `expect.objectContaining(...)`, `expect.stringContaining(...)`,
+or `expect.anything()` only when there is **genuine non-determinism** the test can't
+compute — timestamps, generated UUIDs, opaque tokens minted by the unit under test, or
+fields whose value the test deliberately doesn't pin (e.g. a free-port-allocated URL).
+"I don't want to spell out the full object" is not non-determinism.
+
+**Cautionary tale.** Issue #129 (`ListTableFlowRegions sends cloud=undefined`) was a path
+key built via template literal — the colocated test used `expect.any(String)` for that
+path and `expect.objectContaining({ params: { path: { cloud: "AWS" } } })` for the
+options. The matchers were internally consistent with the broken implementation, so the
+test passed even though the call sent `/tableflow/v1/regions?cloud=undefined` to CCloud.
+A literal assertion on the path string and the options object would have failed against
+the buggy code and prevented the bug from shipping. The loose matcher and the bug were
+two sides of the same coin.
 
 ## Key Patterns
 

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.integration.test.ts
@@ -39,18 +39,31 @@ describe("list-tableflow-regions-handler", { tags: [Tag.TABLEFLOW] }, () => {
     });
 
     it("should return AWS regions when filtered by cloud=AWS", async () => {
-      // pass `cloud` explicitly: omitting it sends the literal string "undefined" to the API
-      // (issue #129). once that lands we can drop the arg. CCloud's REST surface expects
-      // uppercase cloud codes ("AWS", "GCP", "AZURE").
+      // CCloud's REST surface expects uppercase cloud codes ("AWS", "GCP", "AZURE").
       const result = await server.client.callTool({
         name: ToolName.LIST_TABLEFLOW_REGIONS,
         arguments: { cloud: "AWS" },
       });
 
-      expect(result.isError).not.toBe(true);
       const text = textContent(result);
       expect(text).toMatch(/^Tableflow Regions:/);
       expect(text).toContain("us-east-2");
+    });
+
+    it("should return regions across clouds when cloud is omitted", async () => {
+      // regression for #129: omitted cloud must not send `?cloud=undefined`,
+      // which CCloud rejects. With the fix, the call returns regions across
+      // all clouds — assert two distinct clouds appear so a future regression
+      // to default-cloud filtering would fail this test.
+      const result = await server.client.callTool({
+        name: ToolName.LIST_TABLEFLOW_REGIONS,
+        arguments: {},
+      });
+
+      const text = textContent(result);
+      expect(text).toMatch(/^Tableflow Regions:/);
+      expect(text).toMatch(/"cloud":"AWS"/);
+      expect(text).toMatch(/"cloud":"GCP"/);
     });
   });
 });

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.test.ts
@@ -34,20 +34,22 @@ describe("list-tableflow-regions-handler.ts", () => {
         clientManager
           .getConfluentCloudTableflowRestClient()
           .GET.mockResolvedValue({ error: { message: "unauthorized" } });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
           args: { cloud: "AWS" },
-          outcome: { resolves: "Failed to list Tableflow regions for  AWS" },
+          outcome: { resolves: "Failed to list Tableflow regions:" },
           clientManager,
         });
       });
 
-      it("should pass the cloud filter in the request path", async () => {
+      it("should send cloud as a query parameter when provided", async () => {
         const clientManager = getMockedClientManager();
         const tableflowRest: MockedRestClient =
           clientManager.getConfluentCloudTableflowRestClient();
         tableflowRest.GET.mockResolvedValue({ data: [] });
+
         await assertHandleCase({
           handler,
           runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
@@ -55,14 +57,79 @@ describe("list-tableflow-regions-handler.ts", () => {
           outcome: { resolves: "Tableflow Regions" },
           clientManager,
         });
+
         expect(tableflowRest.GET).toHaveBeenCalledOnce();
         expect(tableflowRest.GET).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.objectContaining({
-            params: expect.objectContaining({
-              path: expect.objectContaining({ cloud: "AWS" }),
-            }),
-          }),
+          "/tableflow/v1/regions",
+          {
+            params: {
+              query: {
+                cloud: "AWS",
+                page_size: undefined,
+                page_token: undefined,
+              },
+            },
+          },
+        );
+      });
+
+      it("should not encode cloud in the request path when omitted", async () => {
+        const clientManager = getMockedClientManager();
+        const tableflowRest: MockedRestClient =
+          clientManager.getConfluentCloudTableflowRestClient();
+        tableflowRest.GET.mockResolvedValue({ data: [] });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          args: {},
+          outcome: { resolves: "Tableflow Regions" },
+          clientManager,
+        });
+
+        // regression for #129: an omitted `cloud` must not be encoded into the
+        // path key as `?cloud=undefined`, and must not regress to `params.path`
+        expect(tableflowRest.GET).toHaveBeenCalledOnce();
+        expect(tableflowRest.GET).toHaveBeenCalledWith(
+          "/tableflow/v1/regions",
+          {
+            params: {
+              query: {
+                cloud: undefined,
+                page_size: undefined,
+                page_token: undefined,
+              },
+            },
+          },
+        );
+      });
+
+      it("should send pagination as snake_case query parameters", async () => {
+        const clientManager = getMockedClientManager();
+        const tableflowRest: MockedRestClient =
+          clientManager.getConfluentCloudTableflowRestClient();
+        tableflowRest.GET.mockResolvedValue({ data: [] });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          args: { pageSize: 20, pageToken: "abc" },
+          outcome: { resolves: "Tableflow Regions" },
+          clientManager,
+        });
+
+        expect(tableflowRest.GET).toHaveBeenCalledOnce();
+        expect(tableflowRest.GET).toHaveBeenCalledWith(
+          "/tableflow/v1/regions",
+          {
+            params: {
+              query: {
+                cloud: undefined,
+                page_size: 20,
+                page_token: "abc",
+              },
+            },
+          },
         );
       });
     });

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -13,17 +13,19 @@ const listTableFlowRegionsArguments = z.object({
     .optional()
     .describe("Filter the results by exact match for cloud."),
   pageSize: z
-    .string()
-    .trim()
+    .number()
+    .int()
+    .positive()
     .optional()
-    .default("10")
-    .describe("The pagination size of collection requests."),
+    .describe(
+      "Maximum regions to return in this response. Server-side default applies if omitted.",
+    ),
   pageToken: z
     .string()
-    .trim()
     .optional()
-    .default("0")
-    .describe("An opaque pagination token for collection requests."),
+    .describe(
+      "Opaque pagination token from a previous response. Omit on first request.",
+    ),
 });
 
 export class ListTableFlowRegionsHandler extends TableflowToolHandler {
@@ -32,24 +34,27 @@ export class ListTableFlowRegionsHandler extends TableflowToolHandler {
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
     const clientManager = runtime.clientManager;
-    const { cloud } = listTableFlowRegionsArguments.parse(toolArguments);
+    const { cloud, pageSize, pageToken } =
+      listTableFlowRegionsArguments.parse(toolArguments);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),
     );
 
     const { data: response, error } = await pathBasedClient[
-      `/tableflow/v1/regions?cloud=${cloud}`
+      "/tableflow/v1/regions"
     ].GET({
       params: {
-        path: {
-          cloud: cloud,
+        query: {
+          cloud,
+          page_size: pageSize,
+          page_token: pageToken,
         },
       },
     });
     if (error) {
       return this.createResponse(
-        `Failed to list Tableflow regions for  ${cloud}: ${JSON.stringify(error)}`,
+        `Failed to list Tableflow regions: ${JSON.stringify(error)}`,
         true,
       );
     }

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -16,15 +16,17 @@ const listTableFlowRegionsArguments = z.object({
     .number()
     .int()
     .positive()
+    .max(100)
     .optional()
     .describe(
-      "Maximum regions to return in this response. Server-side default applies if omitted.",
+      "Maximum regions to return in this response (1-100). Server-side default applies if omitted.",
     ),
   pageToken: z
     .string()
+    .max(255)
     .optional()
     .describe(
-      "Opaque pagination token from a previous response. Omit on first request.",
+      "Opaque pagination token from a previous response (max 255 characters). Omit on first request.",
     ),
 });
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Now correctly passes `cloud` as a `query` param (not `path`) while also passing any provided pagination params through to the request. (The latter also needs to apply to some others, see #435.)

Closes #129 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
