### PR TITLE
feat(264): emit boot-time config dimensions as SERVER_START payload

### DIFF
--- a/src/confluent/config-telemetry.test.ts
+++ b/src/confluent/config-telemetry.test.ts
@@ -1,0 +1,96 @@
+import type { CLIOptions } from "@src/cli.js";
+import { MCPServerConfiguration } from "@src/config/models.js";
+import { buildConfigTelemetry } from "@src/confluent/config-telemetry.js";
+import { TransportType } from "@src/mcp/transports/types.js";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Minimal `CLIOptions` shape. `buildConfigTelemetry` only reads `config`, so
+ * the rest of the fields are filled with cheap defaults.
+ */
+function makeCliOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
+  return {
+    transports: [],
+    listTools: false,
+    generateKey: false,
+    initConfig: false,
+    initOauthConfig: false,
+    ...overrides,
+  };
+}
+
+function configWithConnections(
+  connectionTypes: Array<"direct" | "oauth">,
+): MCPServerConfiguration {
+  const connections = Object.fromEntries(
+    connectionTypes.map((type, i) => [
+      `conn-${i}`,
+      type === "oauth"
+        ? { type: "oauth" as const, ccloud_env: "prod" as const }
+        : { type: "direct" as const },
+    ]),
+  );
+  return new MCPServerConfiguration({ connections });
+}
+
+describe("config-telemetry.ts", () => {
+  describe("buildConfigTelemetry()", () => {
+    it("should set configSource to 'yaml' when cliOptions.config is provided", () => {
+      const result = buildConfigTelemetry(
+        makeCliOptions({ config: "/path/to/config.yaml" }),
+        configWithConnections(["direct"]),
+        [TransportType.STDIO],
+      );
+
+      expect(result.configSource).toBe("yaml");
+    });
+
+    it("should set configSource to 'env-vars' when cliOptions.config is absent", () => {
+      const result = buildConfigTelemetry(
+        makeCliOptions(),
+        configWithConnections(["direct"]),
+        [TransportType.STDIO],
+      );
+
+      expect(result.configSource).toBe("env-vars");
+    });
+
+    it("should report a direct connection as ['direct']", () => {
+      const result = buildConfigTelemetry(
+        makeCliOptions(),
+        configWithConnections(["direct"]),
+        [TransportType.STDIO],
+      );
+
+      expect(result.connectionTypes).toEqual(["direct"]);
+    });
+
+    it("should map an internal 'oauth' connection type to the wire label 'ccloud-oauth'", () => {
+      // The user-facing telemetry label is 'ccloud-oauth' even though the
+      // discriminated-union arm in the schema is 'oauth' — today's OAuth
+      // arm is specifically Confluent Cloud OAuth via PKCE, and the wire
+      // label is honest about it.
+      const result = buildConfigTelemetry(
+        makeCliOptions(),
+        configWithConnections(["oauth"]),
+        [TransportType.STDIO],
+      );
+
+      expect(result.connectionTypes).toEqual(["ccloud-oauth"]);
+    });
+
+    it("should return the transports list sorted for cross-event comparability", () => {
+      const result = buildConfigTelemetry(
+        makeCliOptions(),
+        configWithConnections(["direct"]),
+        [TransportType.HTTP, TransportType.STDIO, TransportType.SSE],
+      );
+
+      expect(result.transports).toEqual([
+        TransportType.HTTP,
+        TransportType.SSE,
+        TransportType.STDIO,
+      ]);
+    });
+  });
+});

--- a/src/confluent/config-telemetry.ts
+++ b/src/confluent/config-telemetry.ts
@@ -21,7 +21,11 @@ export type ConnectionTelemetryType = "direct" | "ccloud-oauth";
 export interface ConfigTelemetry {
   /** Which branch of `main()` built the `MCPServerConfiguration`. */
   configSource: "yaml" | "env-vars";
-  /** Sorted, deduplicated list of active MCP serving listeners. */
+  /**
+   * Sorted list of active MCP serving listeners. Inputs are already unique by
+   * construction (Zod rejects duplicates on the YAML path; `parseTransportList`
+   * dedupes on the CLI path), so this helper does not enforce uniqueness.
+   */
   transports: TransportType[];
   /**
    * Sorted list of each declared connection's wire type. Length equals the
@@ -49,7 +53,7 @@ export function buildConfigTelemetry(
     .sort(byLocale);
   return {
     configSource: cliOptions.config ? "yaml" : "env-vars",
-    transports: [...new Set(transports)].sort(byLocale),
+    transports: [...transports].sort(byLocale),
     connectionTypes,
   };
 }

--- a/src/confluent/config-telemetry.ts
+++ b/src/confluent/config-telemetry.ts
@@ -1,0 +1,55 @@
+import type { CLIOptions } from "@src/cli.js";
+import type { MCPServerConfiguration } from "@src/config/models.js";
+import type { TransportType } from "@src/mcp/transports/types.js";
+
+/**
+ * Wire shape of the connection-type label on telemetry events. The internal
+ * schema discriminator uses `"direct"` and `"oauth"`; the telemetry label
+ * remaps the latter to `"ccloud-oauth"` because today's OAuth arm is
+ * specifically Confluent Cloud OAuth (PKCE against CCloud Auth0). If a
+ * non-CCloud OAuth arm ever lands, {@link buildConfigTelemetry}'s mapping
+ * needs to grow.
+ */
+export type ConnectionTelemetryType = "direct" | "ccloud-oauth";
+
+/**
+ * Result of {@link buildConfigTelemetry}. Three orthogonal dimensions captured
+ * once at server start and emitted as the payload of `SERVER_START`. They are
+ * boot-time invariants, so they don't ride TOOL_CALL events — warehouse joins
+ * on `serverSessionId` recover the link when slicing is needed. See #264.
+ */
+export interface ConfigTelemetry {
+  /** Which branch of `main()` built the `MCPServerConfiguration`. */
+  configSource: "yaml" | "env-vars";
+  /** Sorted, deduplicated list of active MCP serving listeners. */
+  transports: TransportType[];
+  /**
+   * Sorted list of each declared connection's wire type. Length equals the
+   * connection count; duplicates reflect multiple connections of the same
+   * type (relevant once multi-connection lands — today always length 1).
+   */
+  connectionTypes: ConnectionTelemetryType[];
+}
+
+/**
+ * Derive the {@link ConfigTelemetry} bundle from the inputs already in scope
+ * at the end of `main()`'s bootstrap (resolved CLI options, validated
+ * `MCPServerConfiguration`, and the resolved list of active transports).
+ */
+export function buildConfigTelemetry(
+  cliOptions: CLIOptions,
+  mcpConfig: MCPServerConfiguration,
+  transports: readonly TransportType[],
+): ConfigTelemetry {
+  const byLocale = (a: string, b: string): number => a.localeCompare(b);
+  const connectionTypes = Object.values(mcpConfig.connections)
+    .map<ConnectionTelemetryType>((conn) =>
+      conn.type === "oauth" ? "ccloud-oauth" : "direct",
+    )
+    .sort(byLocale);
+  return {
+    configSource: cliOptions.config ? "yaml" : "env-vars",
+    transports: [...new Set(transports)].sort(byLocale),
+    connectionTypes,
+  };
+}

--- a/src/confluent/telemetry.ts
+++ b/src/confluent/telemetry.ts
@@ -3,6 +3,11 @@ import { logger } from "@src/logger.js";
 import { randomUUID } from "node:crypto";
 
 export enum TelemetryEvent {
+  /**
+   * Emitted once after successful startup so we can count boots independently
+   * of tool calls.
+   */
+  SERVER_START = "Server Start",
   TOOL_CALL = "Tool Call",
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   loadConfigFromYaml,
   MCPServerConfiguration,
 } from "@src/config/index.js";
+import { buildConfigTelemetry } from "@src/confluent/config-telemetry.js";
 import { buildConfig, fs, path } from "@src/confluent/node-deps.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
@@ -320,6 +321,7 @@ async function main() {
       doNotTrack: mcpConfig.server.do_not_track || env.DO_NOT_TRACK,
       writeKey: resolveTelemetryWriteKey(mcpConfig),
     });
+    const telemetry = TelemetryService.getInstance();
 
     logger.info(
       `${mcpConfig.getConnectionNames().length} connections loaded successfully`,
@@ -329,10 +331,7 @@ async function main() {
 
     const serverVersion = getPackageVersion();
 
-    TelemetryService.getInstance().setCommonProperties({
-      serverVersion,
-      transportType: transports.join(","),
-    });
+    telemetry.setCommonProperties({ serverVersion });
 
     const toolHandlers = getToolHandlersToRegister(filteredToolNames, runtime);
 
@@ -360,7 +359,7 @@ async function main() {
       toolHandlers,
       runtime,
       track: (props) =>
-        TelemetryService.getInstance().track(TelemetryEvent.TOOL_CALL, {
+        telemetry.track(TelemetryEvent.TOOL_CALL, {
           ...props,
         }),
     };
@@ -379,10 +378,19 @@ async function main() {
       },
     });
 
+    // Boot-time invariants (config source, active transports, connection
+    // types) ride this one-shot event rather than every TOOL_CALL — they
+    // don't change after startup, so duplicating them per tool call buys
+    // nothing. Warehouse queries join SERVER_START to TOOL_CALL on
+    // `serverSessionId` (a common property) when slicing is needed.
+    telemetry.track(TelemetryEvent.SERVER_START, {
+      ...buildConfigTelemetry(cliOptions, mcpConfig, transports),
+    });
+
     // Set up cleanup handlers
     const performCleanup = async () => {
       logger.info("Shutting down...");
-      await TelemetryService.getInstance().shutdown();
+      await telemetry.shutdown();
       await transportManager.stop();
       // shutdown() is race-safe with an in-flight bootstrap.
       runtime.oauthHolder?.shutdown();


### PR DESCRIPTION
## Changes

- New `SERVER_START` telemetry event, emitted once after `transportManager.start()` succeeds. Carries the three new dimensions as its payload:
    - `configSource` (`yaml` / `env-vars`),
    - `transports` (sorted active listeners),
    - `connectionTypes` (sorted list of each connection's wire type — `direct` or `ccloud-oauth`) --- will just be a single value for the time being, since only one single connection is allowed at this phase. But storing as an array then future-proofs it.
- `TOOL_CALL` common properties trimmed to just `serverVersion` (operator-relevant slicer). Boot-time invariants no longer ride every event — warehouse joins on `serverSessionId` recover the link when slicing is needed. Future plan: Some time before multi-connection lands, TOOL_CALL will gain a per-call `connectionType` reflecting which connection type that specific tool ran against.
- Derivation extracted into `src/confluent/config-telemetry.ts` (`buildConfigTelemetry()`) with 5 focused unit tests covering both `configSource` branches, the `oauth → ccloud-oauth` rename, and transport sort.
- Old `transportType` comma-string property removed (replaced by the structured `transports` array on `SERVER_START`).

We have no current dashboard, so no backwards compatibility needed.

## Relationships

Closes #264.
Being the final child, closes parent issue #151  🎉 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
