### PR TITLE
Tests: New `mockKafkaConstructor` helper

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -76,9 +76,11 @@ vi.spyOn(nodeDeps.fs, "readFileSync").mockReturnValue("content");
 vi.spyOn(nodeDeps.segment, "Analytics").mockImplementation(
   class FakeAnalytics {
     constructor() {
-      return { track: trackStub } as unknown as Analytics;
+      return {
+        track: trackStub,
+      } as unknown as InstanceType<typeof nodeDeps.segment.Analytics>;
     }
-  } as unknown as typeof Analytics,
+  } as unknown as typeof nodeDeps.segment.Analytics,
 );
 ```
 

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -73,9 +73,13 @@ new segment.Analytics({ key }); // third-party constructors
 // test file
 import * as nodeDeps from "@src/confluent/node-deps.js";
 vi.spyOn(nodeDeps.fs, "readFileSync").mockReturnValue("content");
-vi.spyOn(nodeDeps.segment, "Analytics").mockImplementation(function () {
-  return { track: trackStub };
-} as any);
+vi.spyOn(nodeDeps.segment, "Analytics").mockImplementation(
+  class FakeAnalytics {
+    constructor() {
+      return { track: trackStub } as unknown as Analytics;
+    }
+  } as unknown as typeof Analytics,
+);
 ```
 
 The env proxy is intentionally **not** wrapped in `node-deps.ts`. Production code receives an
@@ -83,9 +87,26 @@ already-validated `Environment` as an explicit parameter from the bootstrap; it 
 into a global. Tests therefore don't need to stub the env — if a code path under test reads
 process state, that state should be a parameter you pass in.
 
-**Constructor note**: `vi.spyOn` on a `new`-called function requires `mockImplementation` with a
-**regular function** (not arrow — arrows can't be constructors). Return the instance from inside
-the function.
+**Constructor note**: `vi.spyOn` on a `new`-called function rejects `mockReturnValue` outright —
+Vitest throws at construction time with `Cannot use \`mockReturnValue\` when called with \`new\`.
+Use \`mockImplementation\` with a \`class\` keyword instead.` Follow that guidance:
+
+```typescript
+vi.spyOn(nodeDeps.someNs, "Ctor").mockImplementation(
+  class FakeCtor {
+    constructor() {
+      return fake as unknown as RealCtor;
+    }
+  } as unknown as typeof RealCtor,
+);
+```
+
+Arrow-function implementations can't be constructed at all. A regular `function () { ... }` body
+also works but requires an outer `as any` cast plus an `eslint-disable` for the explicit-any
+rule. The class-keyword form needs only an outer `as unknown as typeof RealCtor` — a _typed_
+cast rather than `any`. When the same construct-spy pattern recurs across tests, wrap it in a
+helper next to `getMockedAdmin()` / `getMockedProducer()`; `mockKafkaConstructor` in
+`tests/stubs/clients.ts` is the worked example.
 
 Add new deps to `node-deps.ts` as needed. For shared mutable objects like `logger`, spy methods
 directly on the object without a wrapper.

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -102,11 +102,14 @@ vi.spyOn(nodeDeps.someNs, "Ctor").mockImplementation(
 ```
 
 Arrow-function implementations can't be constructed at all. A regular `function () { ... }` body
-also works but requires an outer `as any` cast plus an `eslint-disable` for the explicit-any
-rule. The class-keyword form needs only an outer `as unknown as typeof RealCtor` — a _typed_
-cast rather than `any`. When the same construct-spy pattern recurs across tests, wrap it in a
-helper next to `getMockedAdmin()` / `getMockedProducer()`; `mockKafkaConstructor` in
-`tests/stubs/clients.ts` is the worked example.
+also works and can avoid `as any` entirely when its signature satisfies the constructor type —
+declaring `this: unknown` as the first parameter is usually enough (see
+`function MockAnalytics(this: unknown) { ... }` in `src/confluent/telemetry.test.ts`). Without
+that escape hatch the function shape collides with the constructor shape and you'll need an
+outer `as any` cast plus an `eslint-disable` for the explicit-any rule; the class-keyword form
+sidesteps the question and reads cleaner for multi-method fakes. When the same construct-spy
+pattern recurs across tests, wrap it in a helper next to `getMockedAdmin()` /
+`getMockedProducer()`; `mockKafkaConstructor` in `tests/stubs/clients.ts` is the worked example.
 
 Add new deps to `node-deps.ts` as needed. For shared mutable objects like `logger`, spy methods
 directly on the object without a wrapper.

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -3,6 +3,9 @@ import * as resolvers from "@src/confluent/oauth-resource-resolvers.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import {
   createMockInstance,
+  getMockedAdmin,
+  getMockedConsumer,
+  getMockedProducer,
   mockKafkaConstructor,
 } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
@@ -41,13 +44,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeAdmin = {
-          connect: vi.fn().mockResolvedValue(undefined),
-          disconnect: vi.fn().mockResolvedValue(undefined),
-          // listTopics is invoked once per call as a metadata warmup —
-          // see comment in OAuthClientManager.getKafkaAdminClient.
-          listTopics: vi.fn().mockResolvedValue([]),
-        };
+        const fakeAdmin = getMockedAdmin();
         const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const manager = buildManager();
@@ -61,11 +58,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeAdmin = {
-          connect: vi.fn().mockResolvedValue(undefined),
-          disconnect: vi.fn().mockResolvedValue(undefined),
-          listTopics: vi.fn().mockResolvedValue([]),
-        };
+        const fakeAdmin = getMockedAdmin();
         const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const holder = createMockInstance(OAuthHolder);
@@ -87,11 +80,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeAdmin = {
-          connect: vi.fn().mockResolvedValue(undefined),
-          disconnect: vi.fn().mockResolvedValue(undefined),
-          listTopics: vi.fn().mockResolvedValue([]),
-        };
+        const fakeAdmin = getMockedAdmin();
         const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const manager = buildManager();
@@ -112,13 +101,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeAdmin = {
-          connect: vi.fn().mockResolvedValue(undefined),
-          disconnect: vi.fn().mockResolvedValue(undefined),
-          // listTopics is invoked once per call as a metadata warmup —
-          // see comment in OAuthClientManager.getKafkaAdminClient.
-          listTopics: vi.fn().mockResolvedValue([]),
-        };
+        const fakeAdmin = getMockedAdmin();
         const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const manager = buildManager();
@@ -160,10 +143,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeProducer = {
-          connect: vi.fn().mockResolvedValue(undefined),
-          disconnect: vi.fn().mockResolvedValue(undefined),
-        };
+        const fakeProducer = getMockedProducer();
         mockKafkaConstructor({ producer: () => fakeProducer });
 
         const manager = buildManager();
@@ -197,7 +177,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeConsumer = { connect: vi.fn(), disconnect: vi.fn() };
+        const fakeConsumer = getMockedConsumer();
         const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
         mockKafkaConstructor({ consumer: consumerFn });
 
@@ -216,7 +196,7 @@ describe("oauth-client-manager.ts", () => {
         vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
           "broker:9092",
         );
-        const fakeConsumer = { connect: vi.fn(), disconnect: vi.fn() };
+        const fakeConsumer = getMockedConsumer();
         const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
         mockKafkaConstructor({ consumer: consumerFn });
 

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -1,4 +1,3 @@
-import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import * as resolvers from "@src/confluent/oauth-resource-resolvers.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
@@ -200,9 +199,7 @@ describe("oauth-client-manager.ts", () => {
         );
         const fakeConsumer = { connect: vi.fn(), disconnect: vi.fn() };
         const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
-        mockKafkaConstructor({
-          consumer: consumerFn as unknown as KafkaJS.Kafka["consumer"],
-        });
+        mockKafkaConstructor({ consumer: consumerFn });
 
         const manager = buildManager();
         await manager.buildKafkaConsumer("lkc-1", "env-1");
@@ -221,9 +218,7 @@ describe("oauth-client-manager.ts", () => {
         );
         const fakeConsumer = { connect: vi.fn(), disconnect: vi.fn() };
         const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
-        mockKafkaConstructor({
-          consumer: consumerFn as unknown as KafkaJS.Kafka["consumer"],
-        });
+        mockKafkaConstructor({ consumer: consumerFn });
 
         const manager = buildManager();
         await manager.buildKafkaConsumer("lkc-1", "env-1", "session-42");

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -1,9 +1,11 @@
 import type { KafkaJS } from "@confluentinc/kafka-javascript";
-import * as nodeDeps from "@src/confluent/node-deps.js";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import * as resolvers from "@src/confluent/oauth-resource-resolvers.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
-import { createMockInstance } from "@tests/stubs/index.js";
+import {
+  createMockInstance,
+  mockKafkaConstructor,
+} from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 
 describe("oauth-client-manager.ts", () => {
@@ -47,13 +49,7 @@ describe("oauth-client-manager.ts", () => {
           // see comment in OAuthClientManager.getKafkaAdminClient.
           listTopics: vi.fn().mockResolvedValue([]),
         };
-        const fakeKafka = { admin: () => fakeAdmin };
-        const kafkaSpy = vi
-          .spyOn(nodeDeps.kafkaDeps, "Kafka")
-          .mockImplementation(function () {
-            return fakeKafka as unknown as KafkaJS.Kafka;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any);
+        const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const manager = buildManager();
         await manager.getKafkaAdminClient("lkc-1", "env-1");
@@ -71,14 +67,7 @@ describe("oauth-client-manager.ts", () => {
           disconnect: vi.fn().mockResolvedValue(undefined),
           listTopics: vi.fn().mockResolvedValue([]),
         };
-        let capturedConfig: Record<string, unknown> | undefined;
-        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function (
-          config: Record<string, unknown>,
-        ) {
-          capturedConfig = config;
-          return { admin: () => fakeAdmin } as unknown as KafkaJS.Kafka;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
+        const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const holder = createMockInstance(OAuthHolder);
         holder.getDataPlaneToken.mockReturnValue("dpat");
@@ -89,8 +78,10 @@ describe("oauth-client-manager.ts", () => {
         );
         await manager.getKafkaAdminClient("lkc-1", "env-1");
 
-        expect(capturedConfig).toBeDefined();
-        expect(capturedConfig!["debug"]).toBe("security,broker,protocol");
+        expect(kafkaSpy).toHaveBeenCalledOnce();
+        expect(kafkaSpy.mock.calls[0]![0]).toMatchObject({
+          debug: "security,broker,protocol",
+        });
       });
 
       it("should omit `debug` from the rdkafka config when kafka_debug is undefined", async () => {
@@ -102,22 +93,15 @@ describe("oauth-client-manager.ts", () => {
           disconnect: vi.fn().mockResolvedValue(undefined),
           listTopics: vi.fn().mockResolvedValue([]),
         };
-        let capturedConfig: Record<string, unknown> | undefined;
-        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function (
-          config: Record<string, unknown>,
-        ) {
-          capturedConfig = config;
-          return { admin: () => fakeAdmin } as unknown as KafkaJS.Kafka;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
+        const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const manager = buildManager();
         await manager.getKafkaAdminClient("lkc-1", "env-1");
 
-        expect(capturedConfig).toBeDefined();
+        expect(kafkaSpy).toHaveBeenCalledOnce();
         // The key must be absent — not present-but-undefined — so the
         // rdkafka client never receives a stray `debug` property.
-        expect(Object.hasOwn(capturedConfig!, "debug")).toBe(false);
+        expect(Object.hasOwn(kafkaSpy.mock.calls[0]![0], "debug")).toBe(false);
       });
 
       it("should configure KafkaJS.Kafka with librdkafka-native SASL keys, not the kafkaJS-compat async provider", async () => {
@@ -136,26 +120,18 @@ describe("oauth-client-manager.ts", () => {
           // see comment in OAuthClientManager.getKafkaAdminClient.
           listTopics: vi.fn().mockResolvedValue([]),
         };
-        let capturedConfig: Record<string, unknown> | undefined;
-        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function (
-          config: Record<string, unknown>,
-        ) {
-          capturedConfig = config;
-          return { admin: () => fakeAdmin } as unknown as KafkaJS.Kafka;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
+        const kafkaSpy = mockKafkaConstructor({ admin: () => fakeAdmin });
 
         const manager = buildManager();
         await manager.getKafkaAdminClient("lkc-1", "env-1");
 
-        expect(capturedConfig).toBeDefined();
-        expect(capturedConfig!["security.protocol"]).toBe("sasl_ssl");
-        expect(capturedConfig!["sasl.mechanisms"]).toBe("OAUTHBEARER");
-        expect(typeof capturedConfig!["oauthbearer_token_refresh_cb"]).toBe(
-          "function",
-        );
+        expect(kafkaSpy).toHaveBeenCalledOnce();
+        const config = kafkaSpy.mock.calls[0]![0];
+        expect(config["security.protocol"]).toBe("sasl_ssl");
+        expect(config["sasl.mechanisms"]).toBe("OAUTHBEARER");
+        expect(typeof config["oauthbearer_token_refresh_cb"]).toBe("function");
         // The kafkaJS-compat async provider must NOT be present.
-        const kafkaJsBlock = capturedConfig!["kafkaJS"] as
+        const kafkaJsBlock = config["kafkaJS"] as
           | Record<string, unknown>
           | undefined;
         expect(kafkaJsBlock?.["sasl"]).toBeUndefined();
@@ -189,11 +165,7 @@ describe("oauth-client-manager.ts", () => {
           connect: vi.fn().mockResolvedValue(undefined),
           disconnect: vi.fn().mockResolvedValue(undefined),
         };
-        const fakeKafka = { producer: () => fakeProducer };
-        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function () {
-          return fakeKafka as unknown as KafkaJS.Kafka;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
+        mockKafkaConstructor({ producer: () => fakeProducer });
 
         const manager = buildManager();
         const producer = await manager.getKafkaProducer("lkc-1", "env-1");
@@ -227,30 +199,16 @@ describe("oauth-client-manager.ts", () => {
           "broker:9092",
         );
         const fakeConsumer = { connect: vi.fn(), disconnect: vi.fn() };
-        let consumerOpts:
-          | {
-              kafkaJS?: {
-                groupId?: string;
-                autoCommit?: boolean;
-                fromBeginning?: boolean;
-              };
-            }
-          | undefined;
-        const fakeKafka = {
-          consumer: (opts: typeof consumerOpts) => {
-            consumerOpts = opts;
-            return fakeConsumer;
-          },
-        };
-        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function () {
-          return fakeKafka as unknown as KafkaJS.Kafka;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({
+          consumer: consumerFn as unknown as KafkaJS.Kafka["consumer"],
+        });
 
         const manager = buildManager();
         await manager.buildKafkaConsumer("lkc-1", "env-1");
 
-        expect(consumerOpts?.kafkaJS).toMatchObject({
+        expect(consumerFn).toHaveBeenCalledOnce();
+        expect(consumerFn.mock.calls[0]![0]?.kafkaJS).toMatchObject({
           groupId: "mcp-confluent",
           autoCommit: false,
           fromBeginning: true,
@@ -262,22 +220,18 @@ describe("oauth-client-manager.ts", () => {
           "broker:9092",
         );
         const fakeConsumer = { connect: vi.fn(), disconnect: vi.fn() };
-        let consumerOpts: { kafkaJS?: { groupId?: string } } | undefined;
-        const fakeKafka = {
-          consumer: (opts: typeof consumerOpts) => {
-            consumerOpts = opts;
-            return fakeConsumer;
-          },
-        };
-        vi.spyOn(nodeDeps.kafkaDeps, "Kafka").mockImplementation(function () {
-          return fakeKafka as unknown as KafkaJS.Kafka;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({
+          consumer: consumerFn as unknown as KafkaJS.Kafka["consumer"],
+        });
 
         const manager = buildManager();
         await manager.buildKafkaConsumer("lkc-1", "env-1", "session-42");
 
-        expect(consumerOpts?.kafkaJS?.groupId).toBe("session-42");
+        expect(consumerFn).toHaveBeenCalledOnce();
+        expect(consumerFn.mock.calls[0]![0]?.kafkaJS?.groupId).toBe(
+          "session-42",
+        );
       });
     });
 

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -103,6 +103,13 @@ export function getMockedSchemaRegistry(): Mocked<SchemaRegistryClient> {
  * require each present method to return the complete `Admin`/`Producer`/
  * `Consumer` interface. Real tests only mock the methods they exercise.
  *
+ * Each slot is typed as `(...args: unknown[]) => unknown` — broad enough that
+ * both shapes call sites actually use land without casts: a thunk that returns
+ * a hand-rolled partial (`{ admin: () => fakeAdmin }`) and a `vi.fn()` whose
+ * captured args the test wants to read back (`{ consumer: vi.fn() }`). A
+ * narrower `KafkaJS.Kafka["consumer"]` would force every test to satisfy the
+ * real `Consumer` return type just to stub two methods.
+ *
  * The returned spy declares its constructor signature as `(config:
  * Record<string, unknown>) => Kafka` (required config, not `Partial<...> |
  * undefined` from the real signature) so `mock.calls[0]![0]` reads back as
@@ -113,13 +120,14 @@ export function getMockedSchemaRegistry(): Mocked<SchemaRegistryClient> {
  * Vitest rejects `mockReturnValue` on a `new`-called spy (it throws when the
  * spied prop is actually invoked with `new`), and an arrow-function
  * implementation can't be constructed at all. A regular `function () { ... }`
- * body also works but requires an outer `as any` cast and an `eslint-disable`
- * for the explicit-any rule — the class form needs only a typed cast.
+ * body works too if the signature can satisfy the constructor type (e.g.
+ * declaring `this: unknown`, as in `telemetry.test.ts`); the class-keyword
+ * form is just clearer for this multi-method fake.
  */
 export function mockKafkaConstructor(fake: {
-  admin?: (...args: never[]) => unknown;
-  producer?: (...args: never[]) => unknown;
-  consumer?: (...args: never[]) => unknown;
+  admin?: (...args: unknown[]) => unknown;
+  producer?: (...args: unknown[]) => unknown;
+  consumer?: (...args: unknown[]) => unknown;
 }): MockInstance<(config: Record<string, unknown>) => KafkaJS.Kafka> {
   return vi.spyOn(kafkaDeps, "Kafka").mockImplementation(
     class FakeKafka {

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -1,9 +1,10 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
+import { kafkaDeps } from "@src/confluent/node-deps.js";
 import { paths } from "@src/confluent/openapi-schema.js";
 import type { Client } from "openapi-fetch";
-import { type Mock, type Mocked, vi } from "vitest";
+import { type Mock, type MockInstance, type Mocked, vi } from "vitest";
 import { createMockInstance } from "./mock-instance.js";
 
 // shared shape for the six openapi-fetch REST seams (they differ only in `paths`).
@@ -86,6 +87,49 @@ export function getMockedConsumer(): Mocked<KafkaJS.Consumer> {
  *  (a real runtime class, so its methods come from prototype-walking). */
 export function getMockedSchemaRegistry(): Mocked<SchemaRegistryClient> {
   return createMockInstance(SchemaRegistryClient);
+}
+
+/**
+ * Mocks `new Kafka(config)` (via {@linkcode kafkaDeps.Kafka}) to return `fake`.
+ * Use when the unit under test is the code that constructs `Kafka` and the
+ * assertion is about what config got passed — read it back from
+ * `spy.mock.calls[0]![0]` rather than maintaining a closure variable. (The
+ * `!` is needed because `noUncheckedIndexedAccess` makes the outer array
+ * index possibly-undefined; the inner element type is narrowed by the helper's
+ * return type — see below.)
+ *
+ * `fake` is structurally typed (just the factory methods tests actually mock),
+ * not `Partial<KafkaJS.Kafka>`, because partial-of-the-full-class would still
+ * require each present method to return the complete `Admin`/`Producer`/
+ * `Consumer` interface. Real tests only mock the methods they exercise.
+ *
+ * The returned spy declares its constructor signature as `(config:
+ * Record<string, unknown>) => Kafka` (required config, not `Partial<...> |
+ * undefined` from the real signature) so `mock.calls[0]![0]` reads back as
+ * `Record<string, unknown>` rather than `CommonConstructorConfig | undefined`.
+ * Production never calls `new Kafka()` without a config, so this isn't a lie.
+ *
+ * Implemented via `mockImplementation(class { constructor() { return fake; } })`:
+ * Vitest rejects `mockReturnValue` on a `new`-called spy (it throws when the
+ * spied prop is actually invoked with `new`), and an arrow-function
+ * implementation can't be constructed at all. A regular `function () { ... }`
+ * body also works but requires an outer `as any` cast and an `eslint-disable`
+ * for the explicit-any rule — the class form needs only a typed cast.
+ */
+export function mockKafkaConstructor(fake: {
+  admin?: (...args: never[]) => unknown;
+  producer?: (...args: never[]) => unknown;
+  consumer?: (...args: never[]) => unknown;
+}): MockInstance<(config: Record<string, unknown>) => KafkaJS.Kafka> {
+  return vi.spyOn(kafkaDeps, "Kafka").mockImplementation(
+    class FakeKafka {
+      constructor() {
+        return fake as unknown as KafkaJS.Kafka;
+      }
+    } as unknown as typeof KafkaJS.Kafka,
+  ) as unknown as MockInstance<
+    (config: Record<string, unknown>) => KafkaJS.Kafka
+  >;
 }
 
 /**

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -6,6 +6,7 @@ export {
   getMockedProducer,
   getMockedRestClient,
   getMockedSchemaRegistry,
+  mockKafkaConstructor,
   type MockedClientManager,
   type MockedRestClient,
 } from "./clients.js";


### PR DESCRIPTION
## Summary of Changes

- New `mockKafkaConstructor()` in `tests/stubs/clients.ts` wraps the only
  `vi.spyOn(nodeDeps.kafkaDeps, "Kafka")` site (seven stubs in
  `src/confluent/oauth-client-manager.test.ts`). Each call site drops from a 5–8 line
  `function () { return ... as unknown as KafkaJS.Kafka } as any` block (plus an
  `eslint-disable`) to `mockKafkaConstructor({ admin: () => fakeAdmin })`.
- `mock<X>` matches the side-effectful-installer verb used by `mockFetch` / `mockDotenv` in
  `tests/stubs/node-deps.ts`, distinct from the `getMocked<X>` pure factories in the same file.
- Tests that read back the constructor config now use `kafkaSpy.mock.calls[0]![0]` instead of a
  `let capturedConfig` closure. The two `buildKafkaConsumer()` tests drop their `consumerOpts`
  closures the same way.

## Rules-file sharpening

- `.claude/rules/unit-tests.md` previously claimed `vi.spyOn` on a `new`-called function
  "requires `mockImplementation` with a regular function". Actual Vitest behavior: a plain
  `mockReturnValue` on a construct-called spy throws (`Cannot use \`mockReturnValue\` when
  called with \`new\`. Use \`mockImplementation\` with a \`class\` keyword instead.`).
- The class-keyword form needs only a typed outer cast, not `as any` + an `eslint-disable`.
  The note now documents this as the preferred form and points at `mockKafkaConstructor` as
  the worked example.

## Relationships

Closes #430.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
