### PR TITLE
hotfix(CI): skip tests when only running with INTEGRATION_TEST_TRANSPORT=stdio

### DIFF
--- a/src/mcp/transports/multi-client.integration.test.ts
+++ b/src/mcp/transports/multi-client.integration.test.ts
@@ -26,6 +26,11 @@ describe("multi-client", { tags: [Tag.SMOKE] }, () => {
     return;
   }
 
+  if (multiClientTransports.length === 0) {
+    it.skip("multi-client coverage applies only to HTTP/SSE transports", () => {});
+    return;
+  }
+
   describe.each(multiClientTransports)("via %s transport", (transport) => {
     let server: StartedServer;
     let secondClient: Client | undefined;


### PR DESCRIPTION
https://github.com/confluentinc/mcp-confluent/pull/412 accidentally broke tests in CI (which filter blocks by `INTEGRATION_TEST_TRANSPORT`), so `stdio` tests wouldn't actually run any multi-client tests (and then would fail):
<img width="390" height="708" alt="image" src="https://github.com/user-attachments/assets/8a67115b-b401-43c1-a665-89587d1356fd" />
<img width="873" height="218" alt="image" src="https://github.com/user-attachments/assets/a29c89a5-c884-4864-8d91-f321ddde043a" />

Now [back](https://semaphore.ci.confluent.io/workflows/cf83dd37-123c-481d-8255-fe240f872fab?pipeline_id=ab03a447-575e-428b-ae7f-13cfaa764e87) to happy tests:
<img width="870" height="719" alt="image" src="https://github.com/user-attachments/assets/c1e158a8-a2fc-428c-a11b-2e5bf721e0ea" />

