### PR TITLE
Enable OAuth support for list-schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,16 +282,17 @@ exclusive — pick the template that matches the auth mode you want.
 
 ### Supported tools under OAuth
 
-| Category                                   | Tools                                                                                  | Notes                                                                                                                                   |
-| ------------------------------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| **Kafka (native)**                         | `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages` | Requires arguments `cluster_id` + `environment_id`. SR serialization (AVRO, JSONSCHEMA) on produce/consume; PROTOBUF not supported yet. |
-| **Kafka REST**                             | `get-topic-config`, `alter-topic-config`                                               | Requires arguments `clusterId` + `environmentId`.                                                                                       |
-| **Organizations, Environments & Clusters** | `list-organizations`, `list-environments`, `read-environment`, `list-clusters`         | —                                                                                                                                       |
-| **Billing**                                | `list-billing-costs`                                                                   | —                                                                                                                                       |
+| Category                                   | Tools                                                                                  | Notes                                                                                                                                        |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Kafka (native)**                         | `list-topics`, `create-topics`, `delete-topics`, `produce-message`, `consume-messages` | Requires arguments `cluster_id` + `environment_id`. SR serialization (AVRO, JSONSCHEMA) on produce/consume; PROTOBUF not supported yet.      |
+| **Kafka REST**                             | `get-topic-config`, `alter-topic-config`                                               | Requires arguments `clusterId` + `environmentId`.                                                                                            |
+| **Schema Registry**                        | `list-schemas`                                                                         | Requires argument `environment_id`. The SR cluster + endpoint are auto-resolved from it (single SR per environment is the CCloud invariant). |
+| **Organizations, Environments & Clusters** | `list-organizations`, `list-environments`, `read-environment`, `list-clusters`         | —                                                                                                                                            |
+| **Billing**                                | `list-billing-costs`                                                                   | —                                                                                                                                            |
 
 ### Limitations
 
-- **Other REST-only tool categories** (Connect, Tableflow, Flink, Schema Registry, Metrics, Catalog & Tags) are still being migrated to OAuth and currently require a `direct` connection.
+- **Other REST-only tool categories** (Connect, Tableflow, Flink, Metrics, Catalog & Tags) are still being migrated to OAuth and currently require a `direct` connection.
 
 ## CLI Usage
 

--- a/src/confluent/tools/connection-predicates.test.ts
+++ b/src/confluent/tools/connection-predicates.test.ts
@@ -16,6 +16,7 @@ import {
   hasKafkaBootstrap,
   hasKafkaRestWithAuth,
   hasSchemaRegistry,
+  hasSchemaRegistryOrOAuth,
   hasTableflow,
   hasTelemetry,
   kafkaBootstrapOrOAuth,
@@ -459,6 +460,22 @@ describe("connection-predicates.ts", () => {
 
     it("should return ENABLED for an OAuth connection (the predicate is widened)", () => {
       expect(kafkaRestWithAuthOrOAuth(OAUTH_CONN)).toEqual(ENABLED);
+    });
+  });
+
+  describe("hasSchemaRegistryOrOAuth", () => {
+    it("should return ENABLED for a direct connection with a schema_registry block", () => {
+      expect(hasSchemaRegistryOrOAuth(SCHEMA_REGISTRY_CONN)).toEqual(ENABLED);
+    });
+
+    it("should report MissingSchemaRegistryBlock for a direct connection without a schema_registry block", () => {
+      expect(hasSchemaRegistryOrOAuth(KAFKA_CONN)).toEqual(
+        disabledFor(ToolDisabledReason.MissingSchemaRegistryBlock),
+      );
+    });
+
+    it("should return ENABLED for an OAuth connection (the predicate is widened)", () => {
+      expect(hasSchemaRegistryOrOAuth(OAUTH_CONN)).toEqual(ENABLED);
     });
   });
 

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -265,6 +265,16 @@ export const kafkaRestWithAuthOrOAuth: ConnectionPredicate =
   widenForOAuth(hasKafkaRestWithAuth);
 
 /**
+ * The Schema Registry gate, widened to admit OAuth. Direct connections still
+ * need a `schema_registry` block; OAuth connections satisfy it unconditionally
+ * (the SR cluster + endpoint are auto-resolved at call time from `environment_id`
+ * via the SRCM REST API, and the bearer middleware handles auth). Use on
+ * SR-domain handlers (`list-schemas`, `delete-schema`).
+ */
+export const hasSchemaRegistryOrOAuth: ConnectionPredicate =
+  widenForOAuth(hasSchemaRegistry);
+
+/**
  * Gate for tools that create connectors against the direct Confluent Cloud
  * REST surface: requires both a `confluent_cloud` block (the `/connect/v1`
  * endpoint) and `kafka.auth` (the connector spec carries kafka API

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -267,9 +267,8 @@ export const kafkaRestWithAuthOrOAuth: ConnectionPredicate =
 /**
  * The Schema Registry gate, widened to admit OAuth. Direct connections still
  * need a `schema_registry` block; OAuth connections satisfy it unconditionally
- * (the SR cluster + endpoint are auto-resolved at call time from `environment_id`
- * via the SRCM REST API, and the bearer middleware handles auth). Use on
- * SR-domain handlers (`list-schemas`, `delete-schema`).
+ * (the SR cluster + endpoint are auto-resolved at call time from
+ * `environment_id`).
  */
 export const hasSchemaRegistryOrOAuth: ConnectionPredicate =
   widenForOAuth(hasSchemaRegistry);

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -1,3 +1,4 @@
+import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
@@ -6,8 +7,9 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, type Mocked } from "vitest";
 
 const SR_CONN = {
   schema_registry: { endpoint: "https://sr.example.com" },
@@ -18,9 +20,15 @@ describe("list-schemas-handler.ts", () => {
     const handler = new ListSchemasHandler();
 
     describe("handle()", () => {
+      let clientManager: MockedClientManager;
+      let sr: Mocked<SchemaRegistryClient>;
+
+      beforeEach(() => {
+        clientManager = getMockedClientManager();
+        sr = clientManager.getSchemaRegistryClient();
+      });
+
       it("should return a JSON map of subject -> latest schema metadata when latestOnly is true (the default)", async () => {
-        const clientManager = getMockedClientManager();
-        const sr = clientManager.getSchemaRegistryClient();
         sr.getAllSubjects.mockResolvedValue(["subject-a", "subject-b"]);
         sr.getLatestSchemaMetadata.mockImplementation(
           async (subject: string) => ({
@@ -30,7 +38,6 @@ describe("list-schemas-handler.ts", () => {
             schema: `{"name":"${subject}"}`,
           }),
         );
-        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
 
         await assertHandleCase({
           handler,
@@ -46,8 +53,6 @@ describe("list-schemas-handler.ts", () => {
       });
 
       it("should filter subjects to those matching subjectPrefix before fetching metadata", async () => {
-        const clientManager = getMockedClientManager();
-        const sr = clientManager.getSchemaRegistryClient();
         sr.getAllSubjects.mockResolvedValue([
           "order-events",
           "order-status",
@@ -59,7 +64,6 @@ describe("list-schemas-handler.ts", () => {
           schemaType: "AVRO",
           schema: "{}",
         });
-        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
 
         await assertHandleCase({
           handler,
@@ -77,10 +81,7 @@ describe("list-schemas-handler.ts", () => {
       });
 
       it("should pass environment_id through to getSchemaRegistrySdkClient (OAuth wiring)", async () => {
-        const clientManager = getMockedClientManager();
-        const sr = clientManager.getSchemaRegistryClient();
         sr.getAllSubjects.mockResolvedValue([]);
-        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
 
         await assertHandleCase({
           handler,
@@ -96,10 +97,7 @@ describe("list-schemas-handler.ts", () => {
       });
 
       it("should return an isError response when getAllSubjects rejects", async () => {
-        const clientManager = getMockedClientManager();
-        const sr = clientManager.getSchemaRegistryClient();
         sr.getAllSubjects.mockRejectedValue(new Error("registry unreachable"));
-        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
 
         await assertHandleCase({
           handler,

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -1,0 +1,116 @@
+import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  runtimeWith,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, expect, it } from "vitest";
+
+const SR_CONN = {
+  schema_registry: { endpoint: "https://sr.example.com" },
+};
+
+describe("list-schemas-handler.ts", () => {
+  describe("ListSchemasHandler", () => {
+    const handler = new ListSchemasHandler();
+
+    describe("handle()", () => {
+      it("should return a JSON map of subject -> latest schema metadata when latestOnly is true (the default)", async () => {
+        const clientManager = getMockedClientManager();
+        const sr = clientManager.getSchemaRegistryClient();
+        sr.getAllSubjects.mockResolvedValue(["subject-a", "subject-b"]);
+        sr.getLatestSchemaMetadata.mockImplementation(
+          async (subject: string) => ({
+            version: 1,
+            id: subject === "subject-a" ? 10 : 20,
+            schemaType: "AVRO",
+            schema: `{"name":"${subject}"}`,
+          }),
+        );
+        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          args: {},
+          outcome: { resolves: '"subject-a":{"version":1,"id":10' },
+          clientManager,
+        });
+
+        expect(sr.getAllSubjects).toHaveBeenCalledOnce();
+        expect(sr.getLatestSchemaMetadata).toHaveBeenCalledWith("subject-a");
+        expect(sr.getLatestSchemaMetadata).toHaveBeenCalledWith("subject-b");
+      });
+
+      it("should filter subjects to those matching subjectPrefix before fetching metadata", async () => {
+        const clientManager = getMockedClientManager();
+        const sr = clientManager.getSchemaRegistryClient();
+        sr.getAllSubjects.mockResolvedValue([
+          "order-events",
+          "order-status",
+          "user-events",
+        ]);
+        sr.getLatestSchemaMetadata.mockResolvedValue({
+          version: 1,
+          id: 1,
+          schemaType: "AVRO",
+          schema: "{}",
+        });
+        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          args: { subjectPrefix: "order-" },
+          outcome: { resolves: '"order-events"' },
+          clientManager,
+        });
+
+        expect(sr.getLatestSchemaMetadata).toHaveBeenCalledWith("order-events");
+        expect(sr.getLatestSchemaMetadata).toHaveBeenCalledWith("order-status");
+        expect(sr.getLatestSchemaMetadata).not.toHaveBeenCalledWith(
+          "user-events",
+        );
+      });
+
+      it("should pass environment_id through to getSchemaRegistrySdkClient (OAuth wiring)", async () => {
+        const clientManager = getMockedClientManager();
+        const sr = clientManager.getSchemaRegistryClient();
+        sr.getAllSubjects.mockResolvedValue([]);
+        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          args: { environment_id: "env-42" },
+          outcome: { resolves: "{}" },
+          clientManager,
+        });
+
+        expect(clientManager.getSchemaRegistrySdkClient).toHaveBeenCalledWith(
+          "env-42",
+        );
+      });
+
+      it("should return an isError response when getAllSubjects rejects", async () => {
+        const clientManager = getMockedClientManager();
+        const sr = clientManager.getSchemaRegistryClient();
+        sr.getAllSubjects.mockRejectedValue(new Error("registry unreachable"));
+        clientManager.getSchemaRegistrySdkClient.mockResolvedValue(sr);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          args: {},
+          outcome: {
+            resolves: "Failed to list schemas: registry unreachable",
+          },
+          clientManager,
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -5,7 +5,7 @@ import {
   READ_ONLY,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { hasSchemaRegistry } from "@src/confluent/tools/connection-predicates.js";
+import { hasSchemaRegistryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -26,6 +26,12 @@ const listSchemasArguments = z.object({
     .describe("List deleted schemas. (Only used if latestOnly is false)")
     .default(false)
     .optional(),
+  environment_id: z
+    .string()
+    .optional()
+    .describe(
+      "Confluent Cloud environment ID (env-...) that owns the Schema Registry. Discover via list-environments.",
+    ),
 });
 
 export class ListSchemasHandler extends BaseToolHandler {
@@ -33,8 +39,8 @@ export class ListSchemasHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
-    const { latestOnly, subjectPrefix, deleted } =
+    const { clientManager } = this.resolveSoleConnection(runtime);
+    const { latestOnly, subjectPrefix, deleted, environment_id } =
       listSchemasArguments.parse(toolArguments);
 
     logger.debug(
@@ -42,12 +48,13 @@ export class ListSchemasHandler extends BaseToolHandler {
         latestOnly,
         subjectPrefix,
         deleted,
+        environment_id,
       },
       "ListSchemasHandler.handle called with arguments",
     );
 
     const registry: SchemaRegistryClient =
-      clientManager.getSchemaRegistryClient();
+      await clientManager.getSchemaRegistrySdkClient(environment_id);
 
     try {
       let subjects: string[] = await registry.getAllSubjects();
@@ -166,5 +173,5 @@ export class ListSchemasHandler extends BaseToolHandler {
       annotations: READ_ONLY,
     };
   }
-  readonly predicate = hasSchemaRegistry;
+  readonly predicate = hasSchemaRegistryOrOAuth;
 }

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -14,6 +14,7 @@ import {
   hasConfluentCloudOrOAuth,
   hasFlink,
   hasSchemaRegistry,
+  hasSchemaRegistryOrOAuth,
   hasTableflow,
   hasTelemetry,
   kafkaBootstrapOrOAuth,
@@ -211,7 +212,7 @@ describe("tool-registry.ts", () => {
         [ToolName.LIST_BILLING_COSTS]: hasConfluentCloudOrOAuth,
         [ToolName.LIST_ORGANIZATIONS]: hasConfluentCloudOrOAuth,
         // Schema Registry
-        [ToolName.LIST_SCHEMAS]: hasSchemaRegistry,
+        [ToolName.LIST_SCHEMAS]: hasSchemaRegistryOrOAuth,
         [ToolName.DELETE_SCHEMA]: hasSchemaRegistry,
         // Tableflow
         [ToolName.CREATE_TABLEFLOW_TOPIC]: hasTableflow,
@@ -358,7 +359,9 @@ describe("tool-registry.ts", () => {
       [ToolName.LIST_SCHEMAS]: {
         outcome: { resolves: "{}" },
         setup: (cm) => {
-          cm.getSchemaRegistryClient().getAllSubjects.mockResolvedValue([]);
+          const sr = cm.getSchemaRegistryClient();
+          sr.getAllSubjects.mockResolvedValue([]);
+          cm.getSchemaRegistrySdkClient.mockResolvedValue(sr);
         },
       },
       [ToolName.DELETE_SCHEMA]: { outcome: { throws: "ZodError" } },

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -359,9 +359,7 @@ describe("tool-registry.ts", () => {
       [ToolName.LIST_SCHEMAS]: {
         outcome: { resolves: "{}" },
         setup: (cm) => {
-          const sr = cm.getSchemaRegistryClient();
-          sr.getAllSubjects.mockResolvedValue([]);
-          cm.getSchemaRegistrySdkClient.mockResolvedValue(sr);
+          cm.getSchemaRegistryClient().getAllSubjects.mockResolvedValue([]);
         },
       },
       [ToolName.DELETE_SCHEMA]: { outcome: { throws: "ZodError" } },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -248,6 +248,8 @@ describe("index.ts", () => {
         ToolName.GET_TOPIC_CONFIG,
         ToolName.LIST_CLUSTERS,
         ToolName.EXPLAIN_DISABLED_TOOLS,
+        // Schema Registry (hasSchemaRegistryOrOAuth)
+        ToolName.LIST_SCHEMAS,
       ];
 
       const EXPECTED_OAUTH_DISABLED: readonly ToolName[] = [
@@ -270,6 +272,8 @@ describe("index.ts", () => {
         ToolName.READ_CONNECTOR,
         ToolName.CREATE_CONNECTOR,
         ToolName.DELETE_CONNECTOR,
+        // Schema Registry (hasSchemaRegistry — delete-schema not yet OAuth-migrated)
+        ToolName.DELETE_SCHEMA,
         // Catalog / search (hasCCloudCatalogSupport — needs the schema_registry block)
         ToolName.SEARCH_TOPICS_BY_TAG,
         ToolName.SEARCH_TOPICS_BY_NAME,
@@ -278,9 +282,6 @@ describe("index.ts", () => {
         ToolName.REMOVE_TAG_FROM_ENTITY,
         ToolName.ADD_TAGS_TO_TOPIC,
         ToolName.LIST_TAGS,
-        // Schema Registry (hasSchemaRegistry)
-        ToolName.LIST_SCHEMAS,
-        ToolName.DELETE_SCHEMA,
         // Tableflow (hasTableflow — needs the tableflow service block)
         ToolName.CREATE_TABLEFLOW_TOPIC,
         ToolName.LIST_TABLEFLOW_REGIONS,

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -187,6 +187,9 @@ export interface MockedClientManager extends Mocked<DirectClientManager> {
   >;
   getConfluentCloudTelemetryRestClient: Mock<() => MockedRestClient>;
   getSchemaRegistryClient: Mock<() => Mocked<SchemaRegistryClient>>;
+  getSchemaRegistrySdkClient: Mock<
+    (envId?: string) => Promise<Mocked<SchemaRegistryClient>>
+  >;
 }
 
 /**
@@ -247,6 +250,9 @@ export function getMockedClientManager(): MockedClientManager {
   );
 
   cm.getSchemaRegistryClient.mockReturnValue(getMockedSchemaRegistry());
+  cm.getSchemaRegistrySdkClient.mockImplementation(async () =>
+    cm.getSchemaRegistryClient(),
+  );
 
   return cm;
 }


### PR DESCRIPTION
## Summary of Changes

- Enable `list-schemas` under OAuth.
  - The handler now uses the cluster-aware `getSchemaRegistrySdkClient(envId)` accessor (introduced by #429), passing the new optional `environment_id` tool argument through. Under direct connections the accessor still resolves to the existing Lazy-cached SR SDK singleton; under OAuth it auto-resolves the SR cluster + endpoint from `environment_id`.
- Add `hasSchemaRegistryOrOAuth` predicate, widened from `hasSchemaRegistry` via the existing `widenForOAuth` combinator.
  - Sibling to the other widened predicates (`hasConfluentCloudOrOAuth`, `kafkaBootstrapOrOAuth`, `kafkaRestWithAuthOrOAuth`). Stays a separate named export so direct-only handlers can keep using the strict form.

This is the first slice of broader Schema Registry OAuth support:
- #440 (this)
  - #437 

Part of #321 

<img width="578" height="740" alt="Screenshot 2026-05-11 at 5 54 30 PM" src="https://github.com/user-attachments/assets/c64d9eba-c6b0-48f8-9476-3c2c7db70972" />

### Click-testing instructions

1. Start the server with `--config oauth.yaml` against a Confluent Cloud env that has Schema Registry enabled.
2. Call `list-schemas` with `environment_id: env-...`. Verify the response is a JSON map of subject → schema metadata.
3. Call `list-schemas` with no `environment_id` argument. Verify the response is the existing OAuth-required error pointing at `list-environments` for discovery.
4. Call `list-schemas` with `environment_id` and a `subjectPrefix` (e.g., `"order-"`). Verify only matching subjects appear.
5. Switch to a direct-mode config (api-key SR), call `list-schemas` with no `environment_id`. Verify direct-mode behavior is unchanged — the arg is ignored, the existing Lazy SR client is reused.

### Optional: Any additional details or context that should be provided?

- Before: `list-schemas` was direct-only via the `hasSchemaRegistry` predicate (which short-circuits OAuth connections). Under OAuth the tool was hidden from the catalogue entirely.
- After: enabled under both modes. The `environment_id` argument is required at call time under OAuth (the SR cluster + endpoint are auto-resolved from it — single SR per environment is the CCloud invariant) and ignored under direct.
- No behavior change for any other handler.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
  - Yes — `list-schemas` is now available under OAuth connections with the optional `environment_id` argument; the SR cluster + endpoint are auto-resolved from it.