### PR TITLE
Improve the output format from the list-connectors tool

### DIFF
--- a/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
@@ -20,11 +20,13 @@ describe("list-connectors-handler.ts", () => {
       const cases: ConnectHandleCase[] = [
         {
           label:
-            "fall back to conn kafka env_id and cluster_id when args are absent",
+            "render connector names as a newline-separated list when the API returns a non-empty array",
           connectionConfig: CONNECT_CONN,
           args: {},
           mockResponse: { data: ["connector-a", "connector-b"] },
-          outcome: { resolves: "Active Connectors" },
+          outcome: {
+            resolves: "Active Connectors:\nconnector-a\nconnector-b",
+          },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
         },
@@ -34,9 +36,18 @@ describe("list-connectors-handler.ts", () => {
           connectionConfig: CONNECT_CONN,
           args: { environmentId: "env-from-arg", clusterId: "lkc-from-arg" },
           mockResponse: { data: ["connector-a"] },
-          outcome: { resolves: "Active Connectors" },
+          outcome: { resolves: "Active Connectors:\nconnector-a" },
           expectedEnvId: "env-from-arg",
           expectedClusterId: "lkc-from-arg",
+        },
+        {
+          label: "render '(none)' when the API returns an empty array",
+          connectionConfig: CONNECT_CONN,
+          args: {},
+          mockResponse: { data: [] },
+          outcome: { resolves: "Active Connectors: (none)" },
+          expectedEnvId: "env-from-config",
+          expectedClusterId: "lkc-from-config",
         },
         {
           label: "throw when environment_id is absent from both arg and config",

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.ts
@@ -54,8 +54,11 @@ export class ListConnectorsHandler extends ConnectToolHandler {
         true,
       );
     }
+    const names = response ?? [];
     return this.createResponse(
-      `Active Connectors: ${JSON.stringify(response?.join(","))}`,
+      names.length > 0
+        ? `Active Connectors:\n${names.join("\n")}`
+        : "Active Connectors: (none)",
     );
   }
 


### PR DESCRIPTION
## Bug fix

- **Stop double-encoding the connector list.** `ListConnectorsHandler.handle()` was rendering its response as `` `Active Connectors: ${JSON.stringify(response?.join(","))}` ``. The CCloud `/connect/v1/.../connectors` route returns a bare `string[]`, so the handler was joining that array into a comma-separated string and then JSON-stringifying _the string itself_, shipping the AI a quoted comma-string like `Active Connectors: "ConnectorA,ConnectorB"` (or `Active Connectors: ""` for the empty case). Replaced with a newline-separated list and an explicit `(none)` rendering for the empty case.

  Newlines were preferred over comma-joining (the issue's Option A) because connector names can legally contain commas and a newline list is unambiguous; over a JSON-array rendering (Option B) because it stays human-skimmable in MCP clients. The `?? []` collapses the openapi-fetch nullable to the empty-array branch.

## Test tightening

- **The existing unit tests were passing for the wrong reason.** Both positive cases asserted `outcome: { resolves: "Active Connectors" }`, and `assertHandleCase`'s `resolves` is a substring match — so the buggy text `Active Connectors: "connector-a,connector-b"` happily contained the expected prefix. The cases couldn't have caught this bug. Tightened both to pin the full rendered text (`"Active Connectors:\nconnector-a\nconnector-b"` and `"Active Connectors:\nconnector-a"`), and added a missing empty-list case asserting `Active Connectors: (none)`. Verified the tightened tests turn red against the unfixed handler before applying the fix.

## Integration

- The colocated integration test asserts only `^Active Connectors:` (prefix match). Both fix branches preserve that anchor, so no change needed there.

## Relationships

- Closes #342

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
