### PR TITLE
hotfix(tests): remove GCP assertion from the list-tableflow-regions `cloud=undefined` case

### DIFF
--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.integration.test.ts
@@ -50,11 +50,37 @@ describe("list-tableflow-regions-handler", { tags: [Tag.TABLEFLOW] }, () => {
       expect(text).toContain("us-east-2");
     });
 
-    it("should return regions across clouds when cloud is omitted", async () => {
-      // regression for #129: omitted cloud must not send `?cloud=undefined`,
-      // which CCloud rejects. With the fix, the call returns regions across
-      // all clouds — assert two distinct clouds appear so a future regression
-      // to default-cloud filtering would fail this test.
+    it("should return AZURE regions when filtered by cloud=AZURE", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_TABLEFLOW_REGIONS,
+        arguments: { cloud: "AZURE" },
+      });
+
+      const text = textContent(result);
+      expect(text).toMatch(/^Tableflow Regions:/);
+      expect(text).toContain("eastus2");
+    });
+
+    it("should return GCP regions when filtered by cloud=GCP", async (ctx) => {
+      // CCloud has no GCP tableflow regions today (call returns total_size=0). Skip rather than
+      // fail so this auto-validates when GCP lands. A real "filter ignored" regression isn't
+      // masked: total_size > 0 bypasses the skip, and the GCP cloud assertion catches it.
+      const result = await server.client.callTool({
+        name: ToolName.LIST_TABLEFLOW_REGIONS,
+        arguments: { cloud: "GCP" },
+      });
+
+      const text = textContent(result);
+      expect(text).toMatch(/^Tableflow Regions:/);
+      if (/"total_size":0\b/.test(text)) {
+        ctx.skip("CCloud has no GCP tableflow regions configured");
+      }
+      expect(text).toMatch(/"cloud":"GCP"/);
+    });
+
+    it("should succeed when cloud is omitted", async () => {
+      // regression for #129: omitted cloud must not send `?cloud=undefined`, which CCloud rejects
+      // with 400. The success-prefix match below is the regression guard.
       const result = await server.client.callTool({
         name: ToolName.LIST_TABLEFLOW_REGIONS,
         arguments: {},
@@ -63,7 +89,8 @@ describe("list-tableflow-regions-handler", { tags: [Tag.TABLEFLOW] }, () => {
       const text = textContent(result);
       expect(text).toMatch(/^Tableflow Regions:/);
       expect(text).toMatch(/"cloud":"AWS"/);
-      expect(text).toMatch(/"cloud":"GCP"/);
+      // FUTURE: update this test when CCloud returns multiple cloud providers when `cloud` isn't
+      // specified
     });
   });
 });


### PR DESCRIPTION
## Summary of Changes

Follow-up to #431 -- (that missed actually running the integration tests! 🤦) -- leaving `cloud` undefined won't return more than AWS regions, so this removes the GCP assertion while adding an assertion for passing AZURE, and a skippable test for if/when GCP is supported.

Tableflow tests all green again (with GCP skipped):
<img width="682" height="128" alt="image" src="https://github.com/user-attachments/assets/080a3b49-9ef2-4054-a74d-0f514cac510b" />

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
