### PR TITLE
chore: set next version under development to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this MCP server will be documented in this file.
 
 ## Unreleased
 
+## 1.3.0
+
 ### Added
 
 - **OAuth (PKCE) authentication for Confluent Cloud.** A `connections.<id>.type: oauth` connection signs the user in via the Confluent Cloud login page on the first tool call that needs Cloud access, then reuses the session — no static API keys to provision.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@confluentinc/mcp-confluent",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@confluentinc/mcp-confluent",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@confluentinc/mcp-confluent",
   "description": "Confluent MCP Server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Confluent Inc.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The other half of https://github.com/confluentinc/mcp-confluent/pull/465; `main` moves forward, [`v1.3.x`](https://github.com/confluentinc/mcp-confluent/tree/v1.3.x) iterates on any `1.3.#` changes.