### PR TITLE
Fix VSCode+Copilot installation instructions 

### DIFF
--- a/docs/configuring-vs-code.md
+++ b/docs/configuring-vs-code.md
@@ -4,17 +4,15 @@ Add the MCP server to your VS Code user settings (`settings.json`) or workspace 
 
 ```json
 {
-  "mcp": {
-    "servers": {
-      "confluent": {
-        "command": "npx",
-        "args": [
-          "-y",
-          "@confluentinc/mcp-confluent",
-          "--config",
-          "/path/to/config.yaml"
-        ]
-      }
+  "servers": {
+    "confluent": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@confluentinc/mcp-confluent",
+        "--config",
+        "/path/to/config.yaml"
+      ]
     }
   }
 }


### PR DESCRIPTION
VSCode MCP server config now lives at toplevel 'servers' key, no longer within 'mcp'.

See https://code.visualstudio.com/docs/copilot/customization/mcp-servers

