### PR TITLE
Minor: add Bob instructions to README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ npx @confluentinc/mcp-confluent --init-config
 6. **Interact with your resources through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud or local resources.
    The client will send requests to this MCP server, which will then interact with the available connections on your behalf.
 
-> Note: if you are installing in [IBM Bob](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
+> Note: if you are installing in [IBM Bob](https://bob.ibm.com/), you will need to set this in your `/Users/{user_name}/.bob/settings/mcp_settings.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -159,24 +159,6 @@ npx @confluentinc/mcp-confluent --init-config
 6. **Interact with your resources through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud or local resources.
    The client will send requests to this MCP server, which will then interact with the available connections on your behalf.
 
-> Note: if you are installing in [IBM Bob](https://bob.ibm.com/), you will need to set this in your `/Users/{user_name}/.bob/settings/mcp_settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "confluent": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@confluentinc/mcp-confluent",
-        "-c",
-        "/Users/username/path-to-config/myconfig.yaml"
-      ]
-    }
-  }
-}
-```
-
 ## Configuration
 
 The full configuration reference — YAML schema, every service block, env-var interpolation, OAuth and HTTP/SSE auth setup, the (deprecated) legacy env-var table, and tool-to-block mapping — lives in [CONFIGURATION.md](CONFIGURATION.md).
@@ -380,6 +362,7 @@ Please refer to the following guides for step-by-step instructions on setting up
 - [Cursor](docs/configuring-cursor.md)
 - [Gemini CLI](docs/configuring-gemini-cli.md)
 - [Goose CLI](docs/configuring-goose-cli.md)
+- [IBM Bob](docs/configuring-ibm-bob.md)
 - [VS Code](docs/configuring-vs-code.md)
 - [Windsurf](docs/configuring-windsurf.md)
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ See [CONFIGURATION.md → Authentication modes](CONFIGURATION.md#authentication-
 
 The ¹-marked categories in [Available Tools for Confluent Cloud](#available-tools-for-confluent-cloud) work under OAuth today; everything else still needs a `direct` connection with static API keys.
 
-[Note: if you are installing in \[IBM Bob](https://bob.ibm.com/)](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
+Note: if you are installing in \[IBM Bob](https://bob.ibm.com/)](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -159,6 +159,24 @@ npx @confluentinc/mcp-confluent --init-config
 6. **Interact with your resources through the Client:** Once the client is connected and configured, you can use the client's interface to interact with Confluent Cloud or local resources.
    The client will send requests to this MCP server, which will then interact with the available connections on your behalf.
 
+> Note: if you are installing in [IBM Bob](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "confluent": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@confluentinc/mcp-confluent",
+        "-c",
+        "/Users/username/path-to-config/myconfig.yaml"
+      ]
+    }
+  }
+}
+```
+
 ## Configuration
 
 The full configuration reference — YAML schema, every service block, env-var interpolation, OAuth and HTTP/SSE auth setup, the (deprecated) legacy env-var table, and tool-to-block mapping — lives in [CONFIGURATION.md](CONFIGURATION.md).
@@ -202,24 +220,6 @@ connections:
 See [CONFIGURATION.md → Authentication modes](CONFIGURATION.md#authentication-modes) for the full schema and ergonomics.
 
 The ¹-marked categories in [Available Tools for Confluent Cloud](#available-tools-for-confluent-cloud) work under OAuth today; everything else still needs a `direct` connection with static API keys.
-
-Note: if you are installing in [IBM Bob](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "confluent": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@confluentinc/mcp-confluent",
-        "-c",
-        "/Users/username/path-to-config/myconfig.yaml"
-      ]
-    }
-  }
-}
-```
 
 ## CLI Usage
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ npx @confluentinc/mcp-confluent --init-config
 
 3. **Start the Server:** You can run the MCP server in one of two ways:
    - **From source:** Follow the instructions in the [Contributing Guide](CONTRIBUTING.md) to build and run the server from source.
-        This typically involves:
+     This typically involves:
      - Installing dependencies (`npm install`)
      - Building the project (`npm run build` or `npm run dev`)
    - **With npx:** You can start the server directly using npx, no build required:
@@ -202,6 +202,24 @@ connections:
 See [CONFIGURATION.md → Authentication modes](CONFIGURATION.md#authentication-modes) for the full schema and ergonomics.
 
 The ¹-marked categories in [Available Tools for Confluent Cloud](#available-tools-for-confluent-cloud) work under OAuth today; everything else still needs a `direct` connection with static API keys.
+
+[Note: if you are installing in \[IBM Bob](https://bob.ibm.com/)](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "confluent": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@confluentinc/mcp-confluent",
+        "-c",
+        "/Users/username/path-to-config/myconfig.yaml"
+      ]
+    }
+  }
+}
+```
 
 ## CLI Usage
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ See [CONFIGURATION.md → Authentication modes](CONFIGURATION.md#authentication-
 
 The ¹-marked categories in [Available Tools for Confluent Cloud](#available-tools-for-confluent-cloud) work under OAuth today; everything else still needs a `direct` connection with static API keys.
 
-Note: if you are installing in \[IBM Bob](https://bob.ibm.com/)](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
+Note: if you are installing in [IBM Bob](https://bob.ibm.com/), you will need to set this in your `Users/{user_name}/.bob/settings/mcp_settings.json`:
 
 ```json
 {

--- a/docs/configuring-ibm-bob.md
+++ b/docs/configuring-ibm-bob.md
@@ -1,0 +1,22 @@
+# Configuring IBM Bob
+
+[IBM Bob](https://bob.ibm.com/) supports MCP servers via `mcp_settings.json`.
+Add the server to `/Users/{user_name}/.bob/settings/mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "confluent": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@confluentinc/mcp-confluent",
+        "-c",
+        "/Users/username/path-to-config/myconfig.yaml"
+      ]
+    }
+  }
+}
+```
+
+See [CONFIGURATION.md](../CONFIGURATION.md) for what to put in `config.yaml`. Legacy env-var configuration (`-e /path/to/config.env`) still works during the deprecation window.


### PR DESCRIPTION
## Summary of Changes

Bob needs a `mcp_settings.json` file to work. This addition to the README and /docs helps the user figure this out. Also on save there's a small space that gets formatted, left it in for now. 