### PR TITLE
Kafka consume: per-topic `partition` + `start` controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ All notable changes to this MCP server will be documented in this file.
   - As `_meta.category` on every `tools/list` advertisement, so MCP clients (Claude, the inspector, etc.) can group or filter the catalog by functional area.
   - In the `--list-tools` CLI output, which now buckets tools under one section header per category instead of printing them in registry-declaration order.
   - On the `explain-disabled-tools` tool, which gains an optional `group_by: "reason" | "category"` argument (default `"reason"`). Pass `group_by: "category"` to regroup the same diagnostic data by functional area when the operator's question is "what's offline in my Flink setup?" rather than "what config piece is missing?".
+- **`consume-messages` per-topic partition + starting-position controls.** Each `topics[]` entry on the consume tool now accepts an optional `partition` (restrict consumption to a single 0-indexed partition; the other assigned partitions are paused after the first poll so the consumer only delivers records from the requested one) and an optional `start` tagged-union field for picking where to begin: `"earliest"` (partition low watermark), `"latest"` (high watermark, only newly-produced messages), `{offset: "N"}` (absolute partition offset as a digit-only string so int64 values past JS's 2^53 safe-integer range stay precise; requires `partition`), or `{timestamp: ...}` (ISO 8601 string or ms-since-epoch number, broker-resolved per-partition via `admin.fetchTopicOffsetsByTimestamp`). Examples:
+  - `{name: "orders", partition: 0, start: {offset: "42"}}` — read partition 0 starting at offset 42.
+  - `{name: "orders", start: {timestamp: "2026-05-14T17:00:00Z"}}` — every partition seeks to the broker-resolved offset for that timestamp.
+  - `{name: "A", start: "earliest"}, {name: "B", start: "latest"}` — mixed-direction call: topic A replays its history while topic B parks at its high watermark.
+
+### Changed
+
+- **`consume-messages` tool: breaking shape changes alongside the new controls above.**
+  - **Top-level `offsetReset` field removed.** Position control is consolidated into the per-topic `start` tagged union (see Added); the consumer-level `auto.offset.reset` is derived from the call. The consolidation enables mixed-direction calls the prior consumer-wide `offsetReset` couldn't express ("topic A from earliest, topic B from latest" in one call now works). The starting-position default stays at `"earliest"` (no behavior change for bare-name calls); pass `start: "latest"` on the topic entries that should read only newly-produced messages.
+  - **`value` / `key` deserialization options renamed to `valueFormat` / `keyFormat`.** The old names read as data peers to `topics` (especially `value`, which looks like "the value to produce"); the new names describe what the fields do — the format/encoding of the bytes. Both are also now omit-by-default (defaulting to `{useSchemaRegistry: false}`), so the simple raw-bytes consume no longer needs `value: {}` filler.
+  - **`topicNames: string[]` removed in favor of the richer `topics[]` shape.** The single required field is now `topics`, an array of per-topic option objects. The minimal call is `{topics: [{name: "orders"}]}`; the same array carries optional `partition` and `start` controls on the entries that need them.
 
 ## 1.3.0
 

--- a/src/confluent/base-client-manager.ts
+++ b/src/confluent/base-client-manager.ts
@@ -316,10 +316,11 @@ export interface ConsumerBuildOptions {
    */
   groupId?: string;
   /**
-   * Reset policy for the consumer. Defaults to `"earliest"` for backward
-   * compatibility with the pre-#459 behavior; handlers that want a
-   * different default (e.g. consume-messages picks `"latest"`) supply it
-   * explicitly. Maps straight to librdkafka `auto.offset.reset`.
+   * Reset policy for the consumer. Defaults to `"earliest"` when the
+   * caller omits it. Handlers that derive the value from per-call inputs
+   * (e.g. `consume-messages`, which inspects each topic entry's `start`
+   * field) pass it explicitly. Maps straight to librdkafka
+   * `auto.offset.reset`.
    */
   offsetReset?: "earliest" | "latest";
 }

--- a/src/confluent/base-client-manager.ts
+++ b/src/confluent/base-client-manager.ts
@@ -285,10 +285,65 @@ export abstract class BaseClientManager
    * call `connect()` and `disconnect()` (typically in a `try/finally`).
    */
   abstract buildKafkaConsumer(
-    clusterId?: string,
-    envId?: string,
-    groupId?: string,
+    opts?: ConsumerBuildOptions,
   ): Promise<KafkaJS.Consumer>;
 
   abstract disconnect(): Promise<void>;
+}
+
+/**
+ * Per-call options for {@link BaseClientManager.buildKafkaConsumer}. All
+ * fields are optional; each concrete manager validates only what its auth
+ * model requires (e.g. OAuth needs `clusterId` + `envId`, direct ignores
+ * both).
+ */
+export interface ConsumerBuildOptions {
+  /**
+   * Confluent Cloud logical Kafka cluster id (`lkc-...`). Required for
+   * OAuth (used to resolve the SASL/OAUTHBEARER bootstrap endpoint);
+   * ignored on direct (the bootstrap comes from connection config).
+   */
+  clusterId?: string;
+  /**
+   * Confluent Cloud environment id (`env-...`) that owns the cluster.
+   * Required for OAuth; ignored on direct.
+   */
+  envId?: string;
+  /**
+   * Consumer group identifier. On direct, appended as a suffix to the
+   * configured base group.id so concurrent MCP sessions don't share a
+   * group. On OAuth, used as the literal group id.
+   */
+  groupId?: string;
+  /**
+   * Tool-facing reset policy for the consumer. Defaults to `"earliest"`
+   * for backward compatibility with the pre-#459 behavior; handlers that
+   * want a different default (e.g. consume-messages picks `"latest"`)
+   * supply it explicitly.
+   *
+   * - `"earliest"` — start from the partition low watermark when no
+   *   committed offset exists. Maps to librdkafka `auto.offset.reset=earliest`.
+   * - `"latest"` — start from the partition high watermark (only newly
+   *   produced messages). Maps to librdkafka `auto.offset.reset=latest`.
+   * - `"none"` — fail rather than auto-pick when no committed offset
+   *   exists. With the fresh disposable group.id we mint per call, this
+   *   always fails unless the caller also issues a `consumer.seek(...)`
+   *   to a specific offset before the first poll. Maps to librdkafka
+   *   `auto.offset.reset=error` (librdkafka has no "none" — "error" is
+   *   the same semantics under a different name).
+   */
+  offsetReset?: "earliest" | "latest" | "none";
+}
+
+/**
+ * Translate the tool-facing {@link ConsumerBuildOptions.offsetReset} value
+ * to the librdkafka `auto.offset.reset` string that the broker config
+ * accepts. The user-facing "none" alias has no direct librdkafka spelling;
+ * "error" is the semantically equivalent value (fail rather than
+ * auto-pick).
+ */
+export function toLibrdkafkaOffsetReset(
+  reset: NonNullable<ConsumerBuildOptions["offsetReset"]>,
+): "earliest" | "latest" | "error" {
+  return reset === "none" ? "error" : reset;
 }

--- a/src/confluent/base-client-manager.ts
+++ b/src/confluent/base-client-manager.ts
@@ -316,34 +316,10 @@ export interface ConsumerBuildOptions {
    */
   groupId?: string;
   /**
-   * Tool-facing reset policy for the consumer. Defaults to `"earliest"`
-   * for backward compatibility with the pre-#459 behavior; handlers that
-   * want a different default (e.g. consume-messages picks `"latest"`)
-   * supply it explicitly.
-   *
-   * - `"earliest"` — start from the partition low watermark when no
-   *   committed offset exists. Maps to librdkafka `auto.offset.reset=earliest`.
-   * - `"latest"` — start from the partition high watermark (only newly
-   *   produced messages). Maps to librdkafka `auto.offset.reset=latest`.
-   * - `"none"` — fail rather than auto-pick when no committed offset
-   *   exists. With the fresh disposable group.id we mint per call, this
-   *   always fails unless the caller also issues a `consumer.seek(...)`
-   *   to a specific offset before the first poll. Maps to librdkafka
-   *   `auto.offset.reset=error` (librdkafka has no "none" — "error" is
-   *   the same semantics under a different name).
+   * Reset policy for the consumer. Defaults to `"earliest"` for backward
+   * compatibility with the pre-#459 behavior; handlers that want a
+   * different default (e.g. consume-messages picks `"latest"`) supply it
+   * explicitly. Maps straight to librdkafka `auto.offset.reset`.
    */
-  offsetReset?: "earliest" | "latest" | "none";
-}
-
-/**
- * Translate the tool-facing {@link ConsumerBuildOptions.offsetReset} value
- * to the librdkafka `auto.offset.reset` string that the broker config
- * accepts. The user-facing "none" alias has no direct librdkafka spelling;
- * "error" is the semantically equivalent value (fail rather than
- * auto-pick).
- */
-export function toLibrdkafkaOffsetReset(
-  reset: NonNullable<ConsumerBuildOptions["offsetReset"]>,
-): "earliest" | "latest" | "error" {
-  return reset === "none" ? "error" : reset;
+  offsetReset?: "earliest" | "latest";
 }

--- a/src/confluent/direct-client-manager.test.ts
+++ b/src/confluent/direct-client-manager.test.ts
@@ -6,7 +6,8 @@ import type {
   ConfluentAuth,
   ConfluentEndpoints,
 } from "@src/confluent/middleware.js";
-import { describe, expect, it } from "vitest";
+import { getMockedConsumer, mockKafkaConstructor } from "@tests/stubs/index.js";
+import { describe, expect, it, vi } from "vitest";
 
 const apiKeyAuth: ConfluentAuth = { apiKey: "k", apiSecret: "s" };
 
@@ -38,6 +39,59 @@ describe("direct-client-manager.ts", () => {
       it("should resolve without error on a fresh instance", async () => {
         const cm = new DirectClientManager(buildConfig());
         await expect(cm.disconnect()).resolves.toBeUndefined();
+      });
+    });
+
+    describe("buildKafkaConsumer()", () => {
+      it("should default auto.offset.reset to 'earliest' when offsetReset is omitted", async () => {
+        const fakeConsumer = getMockedConsumer();
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({ consumer: consumerFn });
+
+        const cm = new DirectClientManager(buildConfig());
+        await cm.buildKafkaConsumer();
+
+        expect(consumerFn).toHaveBeenCalledOnce();
+        expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+          "auto.offset.reset": "earliest",
+        });
+      });
+
+      it.each([
+        ["earliest", "earliest"],
+        ["latest", "latest"],
+        // "none" is the tool-facing alias; librdkafka has no "none" — its
+        // fail-rather-than-auto-pick value is "error".
+        ["none", "error"],
+      ] as const)(
+        "should propagate offsetReset=%s as native auto.offset.reset=%s",
+        async (offsetReset, expectedReset) => {
+          const fakeConsumer = getMockedConsumer();
+          const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+          mockKafkaConstructor({ consumer: consumerFn });
+
+          const cm = new DirectClientManager(buildConfig());
+          await cm.buildKafkaConsumer({ offsetReset });
+
+          expect(consumerFn).toHaveBeenCalledOnce();
+          expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+            "auto.offset.reset": expectedReset,
+          });
+        },
+      );
+
+      it("should append opts.groupId as a suffix to the configured base group.id (preserving sessionId behavior)", async () => {
+        const fakeConsumer = getMockedConsumer();
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({ consumer: consumerFn });
+
+        const cm = new DirectClientManager(buildConfig());
+        await cm.buildKafkaConsumer({ groupId: "session-42" });
+
+        expect(consumerFn).toHaveBeenCalledOnce();
+        expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+          "group.id": "mcp-confluent-session-42",
+        });
       });
     });
   });

--- a/src/confluent/direct-client-manager.test.ts
+++ b/src/confluent/direct-client-manager.test.ts
@@ -57,15 +57,9 @@ describe("direct-client-manager.ts", () => {
         });
       });
 
-      it.each([
-        ["earliest", "earliest"],
-        ["latest", "latest"],
-        // "none" is the tool-facing alias; librdkafka has no "none" — its
-        // fail-rather-than-auto-pick value is "error".
-        ["none", "error"],
-      ] as const)(
-        "should propagate offsetReset=%s as native auto.offset.reset=%s",
-        async (offsetReset, expectedReset) => {
+      it.each(["earliest", "latest"] as const)(
+        "should propagate offsetReset=%s to auto.offset.reset",
+        async (offsetReset) => {
           const fakeConsumer = getMockedConsumer();
           const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
           mockKafkaConstructor({ consumer: consumerFn });
@@ -75,7 +69,7 @@ describe("direct-client-manager.ts", () => {
 
           expect(consumerFn).toHaveBeenCalledOnce();
           expect(consumerFn.mock.calls[0]![0]).toMatchObject({
-            "auto.offset.reset": expectedReset,
+            "auto.offset.reset": offsetReset,
           });
         },
       );

--- a/src/confluent/direct-client-manager.ts
+++ b/src/confluent/direct-client-manager.ts
@@ -10,7 +10,6 @@ import {
 } from "@src/config/models.js";
 import {
   BaseClientManager,
-  toLibrdkafkaOffsetReset,
   type BaseClientManagerConfig,
   type ConsumerBuildOptions,
 } from "@src/confluent/base-client-manager.js";
@@ -115,21 +114,17 @@ export class DirectClientManager
     const groupId = opts?.groupId
       ? `${baseGroupId}-${opts.groupId}`
       : baseGroupId;
-    // opts.offsetReset is the tool-facing alias ("none" included); the
-    // user's YAML kafkaConfig already speaks native librdkafka, so don't
-    // run that through the translator.
-    const offsetReset = opts?.offsetReset
-      ? toLibrdkafkaOffsetReset(opts.offsetReset)
-      : (this.kafkaConfig["auto.offset.reset"] ?? "earliest");
+    const offsetReset =
+      opts?.offsetReset ?? this.kafkaConfig["auto.offset.reset"] ?? "earliest";
     const consumerConfig = {
-      // Spread all user-provided config
       ...this.kafkaConfig,
-      // Override with our logic
       "group.id": groupId,
       "auto.offset.reset": offsetReset,
-      "allow.auto.create.topics":
-        this.kafkaConfig["allow.auto.create.topics"] || false,
-      "enable.auto.commit": this.kafkaConfig["enable.auto.commit"] || false,
+      // This tool is a snapshot read, not a stream resumption. Committing
+      // offsets back would silently shift the start position for the next
+      // call — not part of the tool contract — so hardcode it off rather
+      // than honoring user kafkaConfig for this key.
+      "enable.auto.commit": false,
     };
     return this.kafkaClient.get().consumer(consumerConfig);
   }

--- a/src/confluent/direct-client-manager.ts
+++ b/src/confluent/direct-client-manager.ts
@@ -120,10 +120,15 @@ export class DirectClientManager
       ...this.kafkaConfig,
       "group.id": groupId,
       "auto.offset.reset": offsetReset,
-      // This tool is a snapshot read, not a stream resumption. Committing
-      // offsets back would silently shift the start position for the next
-      // call — not part of the tool contract — so hardcode it off rather
-      // than honoring user kafkaConfig for this key.
+      // The consume-messages tool is a read-only snapshot; never a topic
+      // creator. Hardcode auto-create off so a typo'd topic name can't
+      // silently bring a topic into existence via librdkafka's
+      // default-`true` for this setting.
+      "allow.auto.create.topics": false,
+      // Same hardcode-rather-than-honor logic: this tool is a snapshot
+      // read, not a stream resumption. Committing offsets back would
+      // silently shift the start position for the next call — not part
+      // of the tool contract.
       "enable.auto.commit": false,
     };
     return this.kafkaClient.get().consumer(consumerConfig);

--- a/src/confluent/direct-client-manager.ts
+++ b/src/confluent/direct-client-manager.ts
@@ -10,9 +10,12 @@ import {
 } from "@src/config/models.js";
 import {
   BaseClientManager,
+  toLibrdkafkaOffsetReset,
   type BaseClientManagerConfig,
+  type ConsumerBuildOptions,
 } from "@src/confluent/base-client-manager.js";
 import { type ClientManager } from "@src/confluent/client-manager.js";
+import { kafkaDeps } from "@src/confluent/node-deps.js";
 import { AsyncLazy, Lazy } from "@src/lazy.js";
 import { kafkaLogger, logger } from "@src/logger.js";
 
@@ -38,7 +41,7 @@ export class DirectClientManager
     this.kafkaConfig = config.kafka;
     this.kafkaClient = new Lazy(
       () =>
-        new KafkaJS.Kafka({
+        new kafkaDeps.Kafka({
           ...this.kafkaConfig,
           kafkaJS: {
             logger: kafkaLogger,
@@ -69,21 +72,7 @@ export class DirectClientManager
 
   /** @inheritdoc */
   async getConsumer(sessionId?: string): Promise<KafkaJS.Consumer> {
-    // Build the config inline, merging with defaults
-    const baseGroupId =
-      (this.kafkaConfig["group.id"] as string) || "mcp-confluent";
-    const groupId = sessionId ? `${baseGroupId}-${sessionId}` : baseGroupId;
-    const consumerConfig = {
-      // Spread all user-provided config
-      ...this.kafkaConfig,
-      // Override with our logic
-      "group.id": groupId,
-      "auto.offset.reset": this.kafkaConfig["auto.offset.reset"] || "earliest",
-      "allow.auto.create.topics":
-        this.kafkaConfig["allow.auto.create.topics"] || false,
-      "enable.auto.commit": this.kafkaConfig["enable.auto.commit"] || false,
-    };
-    return this.kafkaClient.get().consumer(consumerConfig);
+    return this.buildKafkaConsumer({ groupId: sessionId });
   }
 
   /** @inheritdoc */
@@ -119,11 +108,30 @@ export class DirectClientManager
 
   /** @inheritdoc */
   async buildKafkaConsumer(
-    _clusterId?: string,
-    _envId?: string,
-    groupId?: string,
+    opts?: ConsumerBuildOptions,
   ): Promise<KafkaJS.Consumer> {
-    return this.getConsumer(groupId);
+    const baseGroupId =
+      (this.kafkaConfig["group.id"] as string) || "mcp-confluent";
+    const groupId = opts?.groupId
+      ? `${baseGroupId}-${opts.groupId}`
+      : baseGroupId;
+    // opts.offsetReset is the tool-facing alias ("none" included); the
+    // user's YAML kafkaConfig already speaks native librdkafka, so don't
+    // run that through the translator.
+    const offsetReset = opts?.offsetReset
+      ? toLibrdkafkaOffsetReset(opts.offsetReset)
+      : (this.kafkaConfig["auto.offset.reset"] ?? "earliest");
+    const consumerConfig = {
+      // Spread all user-provided config
+      ...this.kafkaConfig,
+      // Override with our logic
+      "group.id": groupId,
+      "auto.offset.reset": offsetReset,
+      "allow.auto.create.topics":
+        this.kafkaConfig["allow.auto.create.topics"] || false,
+      "enable.auto.commit": this.kafkaConfig["enable.auto.commit"] || false,
+    };
+    return this.kafkaClient.get().consumer(consumerConfig);
   }
 
   /** @inheritdoc */

--- a/src/confluent/node-deps.ts
+++ b/src/confluent/node-deps.ts
@@ -6,7 +6,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { Analytics } from "@segment/analytics-node";
 import { TELEMETRY_WRITE_KEY } from "@src/build-config.js";
 import * as dotenv from "dotenv";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
@@ -36,6 +36,7 @@ export const nodeFetch = { fetch: globalThis.fetch };
 // `randomBytes`. The codebase only uses the sync form.
 export const nodeCrypto = {
   randomBytes: (size: number): Buffer => randomBytes(size),
+  randomUUID: (): string => randomUUID(),
 };
 export const nodeHttp = { createServer: httpCreateServer };
 // `open` is loaded lazily so non-OAuth runs don't pay the import cost (it

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -235,15 +235,9 @@ describe("oauth-client-manager.ts", () => {
         });
       });
 
-      it.each([
-        ["earliest", "earliest"],
-        ["latest", "latest"],
-        // "none" is the tool-facing alias; librdkafka has no "none" — its
-        // fail-rather-than-auto-pick value is "error".
-        ["none", "error"],
-      ] as const)(
-        "should propagate offsetReset=%s as native auto.offset.reset=%s",
-        async (offsetReset, expectedReset) => {
+      it.each(["earliest", "latest"] as const)(
+        "should propagate offsetReset=%s to auto.offset.reset",
+        async (offsetReset) => {
           vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
             "broker:9092",
           );
@@ -260,7 +254,7 @@ describe("oauth-client-manager.ts", () => {
 
           expect(consumerFn).toHaveBeenCalledOnce();
           expect(consumerFn.mock.calls[0]![0]).toMatchObject({
-            "auto.offset.reset": expectedReset,
+            "auto.offset.reset": offsetReset,
           });
         },
       );

--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -158,7 +158,7 @@ describe("oauth-client-manager.ts", () => {
       it("should throw when cluster_id is omitted under OAuth", async () => {
         const manager = buildManager();
         await expect(
-          manager.buildKafkaConsumer(undefined, "env-1"),
+          manager.buildKafkaConsumer({ envId: "env-1" }),
         ).rejects.toThrow(
           "OAuth client construction requires a cluster id and environment id",
         );
@@ -167,7 +167,7 @@ describe("oauth-client-manager.ts", () => {
       it("should throw when environment_id is omitted under OAuth", async () => {
         const manager = buildManager();
         await expect(
-          manager.buildKafkaConsumer("lkc-1", undefined),
+          manager.buildKafkaConsumer({ clusterId: "lkc-1" }),
         ).rejects.toThrow(
           "OAuth client construction requires a cluster id and environment id",
         );
@@ -182,13 +182,15 @@ describe("oauth-client-manager.ts", () => {
         mockKafkaConstructor({ consumer: consumerFn });
 
         const manager = buildManager();
-        await manager.buildKafkaConsumer("lkc-1", "env-1");
+        await manager.buildKafkaConsumer({
+          clusterId: "lkc-1",
+          envId: "env-1",
+        });
 
         expect(consumerFn).toHaveBeenCalledOnce();
         expect(consumerFn.mock.calls[0]![0]?.kafkaJS).toMatchObject({
           groupId: "mcp-confluent",
           autoCommit: false,
-          fromBeginning: true,
         });
       });
 
@@ -201,13 +203,67 @@ describe("oauth-client-manager.ts", () => {
         mockKafkaConstructor({ consumer: consumerFn });
 
         const manager = buildManager();
-        await manager.buildKafkaConsumer("lkc-1", "env-1", "session-42");
+        await manager.buildKafkaConsumer({
+          clusterId: "lkc-1",
+          envId: "env-1",
+          groupId: "session-42",
+        });
 
         expect(consumerFn).toHaveBeenCalledOnce();
         expect(consumerFn.mock.calls[0]![0]?.kafkaJS?.groupId).toBe(
           "session-42",
         );
       });
+
+      it("should default auto.offset.reset to 'earliest' when offsetReset is omitted (preserving prior fromBeginning:true behavior)", async () => {
+        vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
+          "broker:9092",
+        );
+        const fakeConsumer = getMockedConsumer();
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({ consumer: consumerFn });
+
+        const manager = buildManager();
+        await manager.buildKafkaConsumer({
+          clusterId: "lkc-1",
+          envId: "env-1",
+        });
+
+        expect(consumerFn).toHaveBeenCalledOnce();
+        expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+          "auto.offset.reset": "earliest",
+        });
+      });
+
+      it.each([
+        ["earliest", "earliest"],
+        ["latest", "latest"],
+        // "none" is the tool-facing alias; librdkafka has no "none" — its
+        // fail-rather-than-auto-pick value is "error".
+        ["none", "error"],
+      ] as const)(
+        "should propagate offsetReset=%s as native auto.offset.reset=%s",
+        async (offsetReset, expectedReset) => {
+          vi.spyOn(resolvers, "resolveKafkaBootstrap").mockResolvedValue(
+            "broker:9092",
+          );
+          const fakeConsumer = getMockedConsumer();
+          const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+          mockKafkaConstructor({ consumer: consumerFn });
+
+          const manager = buildManager();
+          await manager.buildKafkaConsumer({
+            clusterId: "lkc-1",
+            envId: "env-1",
+            offsetReset,
+          });
+
+          expect(consumerFn).toHaveBeenCalledOnce();
+          expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+            "auto.offset.reset": expectedReset,
+          });
+        },
+      );
     });
 
     describe("getSchemaRegistrySdkClient()", () => {

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -21,11 +21,15 @@
 
 import type { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
-import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import {
+  BaseClientManager,
+  toLibrdkafkaOffsetReset,
+  type ConsumerBuildOptions,
+} from "@src/confluent/base-client-manager.js";
 import type { ConfluentRestClient } from "@src/confluent/client-manager.js";
 import {
-  type ConfluentAuth,
   createAuthMiddleware,
+  type ConfluentAuth,
 } from "@src/confluent/middleware.js";
 import { kafkaDeps } from "@src/confluent/node-deps.js";
 import {
@@ -231,18 +235,24 @@ export class OAuthClientManager extends BaseClientManager {
 
   /** @inheritdoc */
   async buildKafkaConsumer(
-    clusterId?: string,
-    envId?: string,
-    groupId?: string,
+    opts?: ConsumerBuildOptions,
   ): Promise<KafkaJS.Consumer> {
-    this.requireClusterArgs(clusterId, envId);
-    const kafka = await this.buildOAuthKafkaClient(clusterId!, envId!);
+    this.requireClusterArgs(opts?.clusterId, opts?.envId);
+    const kafka = await this.buildOAuthKafkaClient(
+      opts!.clusterId!,
+      opts!.envId!,
+    );
     return kafka.consumer({
       kafkaJS: {
-        groupId: groupId ?? "mcp-confluent",
+        groupId: opts?.groupId ?? "mcp-confluent",
         autoCommit: false,
-        fromBeginning: true,
       },
+      // Native librdkafka key (not kafkaJS.fromBeginning) so we can express
+      // "none" alongside "earliest"/"latest". kafkaJS.fromBeginning is a
+      // boolean and can't represent the no-default-seek case.
+      "auto.offset.reset": toLibrdkafkaOffsetReset(
+        opts?.offsetReset ?? "earliest",
+      ),
     });
   }
 

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -23,7 +23,6 @@ import type { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import {
   BaseClientManager,
-  toLibrdkafkaOffsetReset,
   type ConsumerBuildOptions,
 } from "@src/confluent/base-client-manager.js";
 import type { ConfluentRestClient } from "@src/confluent/client-manager.js";
@@ -247,12 +246,7 @@ export class OAuthClientManager extends BaseClientManager {
         groupId: opts?.groupId ?? "mcp-confluent",
         autoCommit: false,
       },
-      // Native librdkafka key (not kafkaJS.fromBeginning) so we can express
-      // "none" alongside "earliest"/"latest". kafkaJS.fromBeginning is a
-      // boolean and can't represent the no-default-seek case.
-      "auto.offset.reset": toLibrdkafkaOffsetReset(
-        opts?.offsetReset ?? "earliest",
-      ),
+      "auto.offset.reset": opts?.offsetReset ?? "earliest",
     });
   }
 

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -31,7 +31,7 @@ export const environmentSchema = z.object({
     updated_at: z.string(),
     deleted_at: z.string().optional(),
     resource_name: z.string(),
-    self: z.string().url(),
+    self: z.url(),
   }),
   display_name: z.string(),
   stream_governance_config: z
@@ -46,10 +46,10 @@ export const environmentListSchema = z.object({
   kind: z.literal("EnvironmentList"),
   metadata: z
     .object({
-      first: z.string().url().optional(),
-      last: z.string().url().optional(),
-      prev: z.string().url().optional(),
-      next: z.string().url().optional(),
+      first: z.url().optional(),
+      last: z.url().optional(),
+      prev: z.url().optional(),
+      next: z.url().optional(),
       total_size: z.number().optional(),
     })
     .optional(),

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -68,10 +68,10 @@ describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
       const result = await server.client.callTool({
         name: ToolName.CONSUME_MESSAGES,
         arguments: {
-          topicNames: [topic],
+          topics: [{ name: topic }],
           maxMessages: seededValues.length,
           timeoutMs: 15_000,
-          value: { useSchemaRegistry: false },
+          valueFormat: { useSchemaRegistry: false },
         },
       });
 
@@ -79,6 +79,239 @@ describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
       expect(text).toMatch(/^Consumed \d+ messages/);
       for (const value of seededValues) {
         expect(text).toContain(value);
+      }
+    });
+
+    it("should restrict consumption to one partition when `partition` is set on the topic entry", async () => {
+      // Seed a 3-partition topic with one distinct value per partition,
+      // then ask for partition 0 only. Asserts: partition 0's value
+      // appears AND the other two do not — proving the pause step
+      // suppressed the non-keep partitions end-to-end against
+      // librdkafka, not just against mocks.
+      const multiTopic = uniqueName("consume-part");
+      await admin.createTopics({
+        topics: [{ topic: multiTopic, numPartitions: 3 }],
+      });
+      try {
+        await producer.send({
+          topic: multiTopic,
+          messages: [
+            { partition: 0, value: "p0-msg" },
+            { partition: 1, value: "p1-msg" },
+            { partition: 2, value: "p2-msg" },
+          ],
+        });
+
+        const result = await server.client.callTool({
+          name: ToolName.CONSUME_MESSAGES,
+          arguments: {
+            topics: [{ name: multiTopic, partition: 0, start: "earliest" }],
+            // Allow headroom; we'll assert exactly one record landed
+            // via the negative-presence checks rather than by count.
+            maxMessages: 10,
+            timeoutMs: 15_000,
+            valueFormat: { useSchemaRegistry: false },
+          },
+        });
+
+        const text = textContent(result);
+        expect(text).toContain("p0-msg");
+        expect(text).not.toContain("p1-msg");
+        expect(text).not.toContain("p2-msg");
+      } finally {
+        await admin.deleteTopics({ topics: [multiTopic] }).catch(() => {
+          // teardown-only; a cleanup failure shouldn't fail an
+          // already-asserted test
+        });
+      }
+    });
+
+    it("should seek to an absolute partition offset when `start: {offset}` is set", async () => {
+      // Seed a single-partition topic with 5 records; their offsets
+      // within the partition are 0..4 (sequential, one batch). Seek
+      // to offset 3 and assert: the two later values appear AND the
+      // three earlier ones do not. maxMessages = 2 (the count we
+      // expect post-seek) so the call returns quickly on success
+      // and surfaces a seek failure immediately via the
+      // negative-presence assertions on offsets 0..2 if the consumer
+      // accidentally landed at the low watermark.
+      const offsetTopic = uniqueName("consume-off");
+      await admin.createTopics({
+        topics: [{ topic: offsetTopic, numPartitions: 1 }],
+      });
+      try {
+        await producer.send({
+          topic: offsetTopic,
+          messages: [
+            { value: "off-0" },
+            { value: "off-1" },
+            { value: "off-2" },
+            { value: "off-3" },
+            { value: "off-4" },
+          ],
+        });
+
+        const result = await server.client.callTool({
+          name: ToolName.CONSUME_MESSAGES,
+          arguments: {
+            topics: [
+              {
+                name: offsetTopic,
+                partition: 0,
+                start: { offset: "3" },
+              },
+            ],
+            maxMessages: 2,
+            timeoutMs: 15_000,
+            valueFormat: { useSchemaRegistry: false },
+          },
+        });
+
+        const text = textContent(result);
+        // Pin to the JSON `"value": "..."` shape rather than bare
+        // substring matching — `uniqueName("consume-off")` produces a
+        // topic name like `int-consume-off-1779...` which contains the
+        // substring `off-1`, so a loose `toContain("off-1")` would
+        // false-positive against the topic name in the response prose.
+        expect(text).toContain('"value": "off-3"');
+        expect(text).toContain('"value": "off-4"');
+        expect(text).not.toContain('"value": "off-0"');
+        expect(text).not.toContain('"value": "off-1"');
+        expect(text).not.toContain('"value": "off-2"');
+      } finally {
+        await admin.deleteTopics({ topics: [offsetTopic] }).catch(() => {
+          // teardown-only; a cleanup failure shouldn't fail an
+          // already-asserted test
+        });
+      }
+    });
+
+    it("should seek to the broker-resolved offset for a midpoint timestamp, returning only records produced past it", async () => {
+      // Produce batch A, sleep, produce batch B. The wall-clock gap
+      // between the two batches gives us a midpoint timestamp that
+      // sits after every A record's broker-assigned timestamp and
+      // before every B record's, so the broker's timestamp index
+      // should resolve our seek target to the first B offset.
+      // Exercises the live `admin.fetchTopicOffsetsByTimestamp` path
+      // and the silent-substitution defense — neither is reachable
+      // through the unit-test mocks.
+      const tsTopic = uniqueName("consume-ts");
+      await admin.createTopics({
+        topics: [{ topic: tsTopic, numPartitions: 1 }],
+      });
+      try {
+        await producer.send({
+          topic: tsTopic,
+          messages: [{ value: "a-0" }, { value: "a-1" }, { value: "a-2" }],
+        });
+        const afterA = Date.now();
+
+        // ~2s gap — long enough that round-trip timestamp jitter
+        // (producer assigns at send time; broker may add a few ms) can't
+        // muddle the midpoint window.
+        await new Promise<void>((r) => setTimeout(r, 2000));
+
+        const beforeB = Date.now();
+        await producer.send({
+          topic: tsTopic,
+          messages: [{ value: "b-0" }, { value: "b-1" }, { value: "b-2" }],
+        });
+
+        const midpointMs = Math.floor((afterA + beforeB) / 2);
+
+        const result = await server.client.callTool({
+          name: ToolName.CONSUME_MESSAGES,
+          arguments: {
+            topics: [{ name: tsTopic, start: { timestamp: midpointMs } }],
+            maxMessages: 3,
+            timeoutMs: 15_000,
+            valueFormat: { useSchemaRegistry: false },
+          },
+        });
+
+        const text = textContent(result);
+        // Only batch B should be present; the seek must have skipped
+        // past every A record.
+        expect(text).toContain('"value": "b-0"');
+        expect(text).toContain('"value": "b-1"');
+        expect(text).toContain('"value": "b-2"');
+        expect(text).not.toContain('"value": "a-0"');
+        expect(text).not.toContain('"value": "a-1"');
+        expect(text).not.toContain('"value": "a-2"');
+      } finally {
+        await admin.deleteTopics({ topics: [tsTopic] }).catch(() => {
+          // teardown-only; a cleanup failure shouldn't fail an
+          // already-asserted test
+        });
+      }
+    });
+
+    it("should honor a mixed-direction call: replay history on a topic asking for `start: 'earliest'` while parking at the high watermark on a peer topic asking for `start: 'latest'`", async () => {
+      // Two topics, both seeded with history before the consume call.
+      // Topic A asks for "earliest" → the orchestrator's mixed-direction
+      // path issues an explicit low-watermark seek for A while leaving
+      // the consumer-wide `auto.offset.reset` at "latest" for B.
+      // Result: A's history replays, B contributes nothing because
+      // nothing is produced to it during the consume window.
+      const topicA = uniqueName("consume-mix-a");
+      const topicB = uniqueName("consume-mix-b");
+      await admin.createTopics({
+        topics: [
+          { topic: topicA, numPartitions: 1 },
+          { topic: topicB, numPartitions: 1 },
+        ],
+      });
+      try {
+        await producer.send({
+          topic: topicA,
+          messages: [
+            { value: "alpha-0" },
+            { value: "alpha-1" },
+            { value: "alpha-2" },
+          ],
+        });
+        await producer.send({
+          topic: topicB,
+          messages: [
+            { value: "beta-0" },
+            { value: "beta-1" },
+            { value: "beta-2" },
+          ],
+        });
+
+        const result = await server.client.callTool({
+          name: ToolName.CONSUME_MESSAGES,
+          arguments: {
+            topics: [
+              { name: topicA, start: "earliest" },
+              { name: topicB, start: "latest" },
+            ],
+            // Exactly the count of A's seeded history. On success the
+            // call resolves as soon as those 3 land; B's "latest"
+            // arm contributes nothing because no producer is writing
+            // to it during the window.
+            maxMessages: 3,
+            timeoutMs: 15_000,
+            valueFormat: { useSchemaRegistry: false },
+          },
+        });
+
+        const text = textContent(result);
+        // Topic A's history must replay end-to-end.
+        expect(text).toContain('"value": "alpha-0"');
+        expect(text).toContain('"value": "alpha-1"');
+        expect(text).toContain('"value": "alpha-2"');
+        // Topic B's history must NOT appear — `start: "latest"` parks
+        // the consumer at B's high watermark, and nothing is produced
+        // post-call.
+        expect(text).not.toContain('"value": "beta-0"');
+        expect(text).not.toContain('"value": "beta-1"');
+        expect(text).not.toContain('"value": "beta-2"');
+      } finally {
+        await admin.deleteTopics({ topics: [topicA, topicB] }).catch(() => {
+          // teardown-only; a cleanup failure shouldn't fail an
+          // already-asserted test
+        });
       }
     });
   });

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -1,7 +1,19 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type {
+  EachMessagePayload,
+  KafkaMessage,
+} from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
+import * as schemaRegistryHelper from "@src/confluent/schema-registry-helper.js";
 import {
-  ConsumeKafkaMessagesHandler,
+  applyPostAssignmentHook,
   consumeKafkaMessagesArgs,
+  ConsumeKafkaMessagesHandler,
+  createEachMessageHandler,
+  formatMessageTimestamp,
+  normalizeStart,
+  waitForAssignment,
+  type ProcessedMessage,
 } from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
@@ -10,8 +22,9 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  getMockedConsumer,
 } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * Build a fake `admin.fetchTopicMetadata` result that mirrors what the
@@ -42,141 +55,139 @@ function fakeFetchTopicMetadataResult(
   >;
 }
 
+/**
+ * Build a synthetic `RecordBatchEntry`-shaped `KafkaMessage` for tests.
+ * The cast to `KafkaMessage` hides the fields the handler doesn't read
+ * (`attributes`, `size`, `leaderEpoch`) so each test focuses on what's
+ * load-bearing for the branch under test. Uses `in` checks so an
+ * explicit `key: null` (a legitimate `KafkaMessage` shape) stays null
+ * instead of falling through `??` to the default Buffer — the latter
+ * would mask the null-key branch.
+ */
+function fakeMessage(
+  overrides: {
+    key?: Buffer | null;
+    value?: Buffer | null;
+    timestamp?: string;
+    offset?: string;
+    headers?: KafkaMessage["headers"];
+  } = {},
+): KafkaMessage {
+  return {
+    key: "key" in overrides ? overrides.key : Buffer.from("k"),
+    value: "value" in overrides ? overrides.value : Buffer.from("v"),
+    timestamp: overrides.timestamp ?? "1747234567000",
+    offset: overrides.offset ?? "42",
+    headers: overrides.headers,
+  } as unknown as KafkaMessage;
+}
+
 describe("consume-kafka-messages-handler.ts", () => {
-  describe("consumeKafkaMessagesArgs (schema)", () => {
-    it("should default offsetReset to 'latest' when omitted", () => {
-      // The behavior change from #459: prior to this work, the handler
-      // forced "earliest" via fromBeginning:true (OAuth) or
-      // auto.offset.reset:"earliest" (direct). Natural-language asks
-      // ("show me the latest X") expect "latest" by default.
+  describe("consumeKafkaMessagesArgs (schema, per-topic `start` default)", () => {
+    it("should default each entry's `start` to 'earliest' when omitted", () => {
+      // The default lives on the per-topic entry now (was on a
+      // top-level `offsetReset` knob before #459). It defaults to
+      // "earliest" to preserve the pre-#459 read-everything behavior
+      // for bare-name calls: a caller asking for "the latest messages"
+      // is expected to pass `start: "latest"` explicitly on the topic
+      // entry that needs it.
       const parsed = consumeKafkaMessagesArgs.parse({
-        topicNames: ["t"],
-        value: {},
+        topics: [{ name: "t" }],
+        valueFormat: {},
       });
-      expect(parsed.offsetReset).toBe("latest");
+      expect(parsed.topics).toEqual([{ name: "t", start: "earliest" }]);
     });
 
     it.each(["earliest", "latest"] as const)(
-      "should accept offsetReset='%s'",
-      (offsetReset) => {
+      "should accept the literal `start: '%s'` direction value",
+      (start) => {
         const parsed = consumeKafkaMessagesArgs.parse({
-          topicNames: ["t"],
-          value: {},
-          offsetReset,
+          topics: [{ name: "t", start }],
+          valueFormat: {},
         });
-        expect(parsed.offsetReset).toBe(offsetReset);
+        expect(parsed.topics).toEqual([{ name: "t", start }]);
       },
     );
 
-    it("should reject an unknown offsetReset value with a Zod enum error citing the field", () => {
+    it("should reject an unknown `start` direction literal as a union miss on the `start` path", () => {
+      // The path lands on the union field itself; a future rename of the
+      // field (e.g. start → position) would shift the path and fail this
+      // test rather than passing under a generic /validation failed/.
       const result = consumeKafkaMessagesArgs.safeParse({
-        topicNames: ["t"],
-        value: {},
-        offsetReset: "from-the-middle",
+        topics: [{ name: "t", start: "from-the-middle" }],
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
-      // Pin both the path and the error code so a future schema rename
-      // (e.g. offsetReset → resetPolicy) doesn't pass with a generic
-      // /validation failed/ regex match.
       expect(result.error.issues).toEqual([
-        expect.objectContaining({
-          path: ["offsetReset"],
-          code: "invalid_value",
-        }),
+        expect.objectContaining({ path: ["topics", 0, "start"] }),
       ]);
     });
   });
 
-  describe("consumeKafkaMessagesArgs (schema, topics[] xor topicNames)", () => {
-    it("should accept just `topics`", () => {
+  describe("consumeKafkaMessagesArgs (schema, topics[] presence + emptiness)", () => {
+    it("should accept a `topics` array with one minimal entry", () => {
       const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t" }],
-        value: {},
+        topics: [{ name: "t" }],
+        valueFormat: {},
       });
-      expect(parsed.topics).toEqual([{ topicName: "t" }]);
-      expect(parsed.topicNames).toBeUndefined();
+      // The defaulted `start: "earliest"` lands on the parsed shape
+      // even when the caller omits it on input — pin both fields here
+      // so a future default flip is caught.
+      expect(parsed.topics).toEqual([{ name: "t", start: "earliest" }]);
     });
 
-    it("should reject when both `topicNames` and `topics` are present", () => {
-      const result = consumeKafkaMessagesArgs.safeParse({
-        topicNames: ["t"],
-        topics: [{ topicName: "t" }],
-        value: {},
-      });
+    it("should reject when `topics` is absent", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({ valueFormat: {} });
       expect(result.success).toBe(false);
       if (result.success) return;
+      // Required-field error from Zod cites the missing path.
       expect(result.error.issues).toEqual([
-        expect.objectContaining({
-          // The xor check is a top-level superRefine, so the issue path
-          // is empty (the whole object is the problem, not one field).
-          path: [],
-          // "exactly one of" + "not both" together pin the both-present
-          // branch and resist message rewording without losing
-          // specificity. "either" lives in the both-absent branch only.
-          message: expect.stringContaining("not both"),
-        }),
+        expect.objectContaining({ path: ["topics"] }),
       ]);
     });
 
-    it("should reject when both `topicNames` and `topics` are absent", () => {
-      const result = consumeKafkaMessagesArgs.safeParse({ value: {} });
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      expect(result.error.issues).toEqual([
-        expect.objectContaining({
-          path: [],
-          message: expect.stringContaining("either"),
-        }),
-      ]);
-    });
-
-    it("should reject an empty topicNames array", () => {
-      const result = consumeKafkaMessagesArgs.safeParse({
-        topicNames: [],
-        value: {},
-      });
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      // Either the inner nonempty-array check fires, or the xor superRefine
-      // does (since an empty array is "absent" semantically). Pin the
-      // observable behavior: at least one issue exists naming the empty
-      // input.
-      expect(result.error.issues.length).toBeGreaterThan(0);
-    });
-
-    it("should reject an empty topics array", () => {
+    it("should reject an empty `topics` array", () => {
       const result = consumeKafkaMessagesArgs.safeParse({
         topics: [],
-        value: {},
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
-      expect(result.error.issues.length).toBeGreaterThan(0);
+      // The nonempty-array check fires on the `topics` path.
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({ path: ["topics"] }),
+      ]);
     });
   });
 
   describe("consumeKafkaMessagesArgs (schema, per-topic entry)", () => {
-    it("should accept an entry with only `topicName`", () => {
+    it("should accept an entry with only `name`", () => {
       const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t" }],
-        value: {},
+        topics: [{ name: "t" }],
+        valueFormat: {},
       });
-      expect(parsed.topics).toEqual([{ topicName: "t" }]);
+      // `start` is filled in by the schema default — the input entry is
+      // bare-name but the parsed shape carries the defaulted direction.
+      expect(parsed.topics).toEqual([{ name: "t", start: "earliest" }]);
     });
 
-    it("should accept an entry with topicName + partition=0 (lowest valid partition index)", () => {
+    it("should accept an entry with name + partition=0 (lowest valid partition index)", () => {
       const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t", partition: 0 }],
-        value: {},
+        topics: [{ name: "t", partition: 0 }],
+        valueFormat: {},
       });
-      expect(parsed.topics?.[0]?.partition).toBe(0);
+      expect(parsed.topics[0]).toEqual({
+        name: "t",
+        partition: 0,
+        start: "earliest",
+      });
     });
 
     it("should reject a negative partition with a path naming the entry", () => {
       const result = consumeKafkaMessagesArgs.safeParse({
-        topics: [{ topicName: "t", partition: -1 }],
-        value: {},
+        topics: [{ name: "t", partition: -1 }],
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
@@ -189,8 +200,8 @@ describe("consume-kafka-messages-handler.ts", () => {
 
     it("should reject a non-integer partition", () => {
       const result = consumeKafkaMessagesArgs.safeParse({
-        topics: [{ topicName: "t", partition: 1.5 }],
-        value: {},
+        topics: [{ name: "t", partition: 1.5 }],
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
@@ -201,52 +212,68 @@ describe("consume-kafka-messages-handler.ts", () => {
       ]);
     });
 
-    it("should accept a digit-only `offset` string", () => {
+    it("should accept a digit-only `start: {offset}` string", () => {
       const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t", offset: "12345" }],
-        value: {},
+        topics: [{ name: "t", start: { offset: "12345" } }],
+        valueFormat: {},
       });
-      expect(parsed.topics?.[0]?.offset).toBe("12345");
+      expect(parsed.topics[0]).toEqual({
+        name: "t",
+        start: { offset: "12345" },
+      });
     });
 
-    it("should accept an int64-shaped `offset` string beyond JS safe-integer range (2^53)", () => {
+    it("should accept an int64-shaped `start: {offset}` string beyond JS safe-integer range (2^53)", () => {
       // Kafka offsets are int64; the schema accepts strings precisely so
       // values past 2^53 don't lose precision via JS number coercion.
       const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t", offset: "9999999999999999999" }],
-        value: {},
+        topics: [{ name: "t", start: { offset: "9999999999999999999" } }],
+        valueFormat: {},
       });
-      expect(parsed.topics?.[0]?.offset).toBe("9999999999999999999");
+      expect(parsed.topics[0]).toEqual({
+        name: "t",
+        start: { offset: "9999999999999999999" },
+      });
     });
 
-    it("should reject a non-digit `offset` string", () => {
+    it("should reject a non-digit `start: {offset}` string with the path drilling into `start.offset`", () => {
+      // Zod 4 reports the granular inner path when only one union arm
+      // matches structurally — here the `offset` arm wins on shape but
+      // the regex inner-validation fails, so the path is
+      // ["topics", 0, "start", "offset"] rather than a generic union
+      // miss at ["topics", 0, "start"].
       const result = consumeKafkaMessagesArgs.safeParse({
-        topics: [{ topicName: "t", offset: "ten" }],
-        value: {},
+        topics: [{ name: "t", start: { offset: "ten" } }],
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
       expect(result.error.issues).toEqual([
         expect.objectContaining({
-          path: ["topics", 0, "offset"],
+          path: ["topics", 0, "start", "offset"],
         }),
       ]);
     });
 
-    it("should reject an entry that supplies both `offset` and `timestamp`", () => {
+    it("should reject a `start` object that supplies both `offset` and `timestamp` (strictObject rejects the extra key)", () => {
+      // Each object arm of the union is strict, so `{offset, timestamp}`
+      // matches neither arm and falls through as a union miss. This is
+      // the structural replacement for the old `offset` ⊻ `timestamp`
+      // superRefine — Zod refuses the value rather than silently picking
+      // an arm.
       const result = consumeKafkaMessagesArgs.safeParse({
         topics: [
-          { topicName: "t", offset: "10", timestamp: "2026-05-14T17:00:00Z" },
+          {
+            name: "t",
+            start: { offset: "10", timestamp: "2026-05-14T17:00:00Z" },
+          },
         ],
-        value: {},
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
       expect(result.error.issues).toEqual([
-        expect.objectContaining({
-          path: ["topics", 0],
-          message: expect.stringMatching(/only one of .offset. or .timestamp./),
-        }),
+        expect.objectContaining({ path: ["topics", 0, "start"] }),
       ]);
     });
 
@@ -254,46 +281,57 @@ describe("consume-kafka-messages-handler.ts", () => {
       "2026-05-14T17:00:00Z",
       "2026-05-14T13:00:00-04:00",
       "2026-05-14T20:00:00.500+00:00",
-    ] as const)("should accept ISO 8601 timestamp '%s'", (timestamp) => {
+    ] as const)(
+      "should accept ISO 8601 `start: {timestamp: '%s'}`",
+      (timestamp) => {
+        const parsed = consumeKafkaMessagesArgs.parse({
+          topics: [{ name: "t", start: { timestamp } }],
+          valueFormat: {},
+        });
+        expect(parsed.topics[0]).toEqual({
+          name: "t",
+          start: { timestamp },
+        });
+      },
+    );
+
+    it("should accept a positive integer ms-since-epoch `start: {timestamp}`", () => {
       const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t", timestamp }],
-        value: {},
+        topics: [{ name: "t", start: { timestamp: 1747234567000 } }],
+        valueFormat: {},
       });
-      expect(parsed.topics?.[0]?.timestamp).toBe(timestamp);
+      expect(parsed.topics[0]).toEqual({
+        name: "t",
+        start: { timestamp: 1747234567000 },
+      });
     });
 
-    it("should accept a positive integer ms-since-epoch timestamp", () => {
-      const parsed = consumeKafkaMessagesArgs.parse({
-        topics: [{ topicName: "t", timestamp: 1747234567000 }],
-        value: {},
-      });
-      expect(parsed.topics?.[0]?.timestamp).toBe(1747234567000);
-    });
-
-    it("should reject a malformed timestamp string", () => {
+    it("should reject a malformed `start: {timestamp}` string with the path drilling into `start.timestamp`", () => {
+      // Same Zod-4 granular-path behavior as the offset case: the
+      // timestamp arm matches structurally; the inner validation fails.
       const result = consumeKafkaMessagesArgs.safeParse({
-        topics: [{ topicName: "t", timestamp: "not-a-date" }],
-        value: {},
+        topics: [{ name: "t", start: { timestamp: "not-a-date" } }],
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
       expect(result.error.issues).toEqual([
         expect.objectContaining({
-          path: ["topics", 0, "timestamp"],
+          path: ["topics", 0, "start", "timestamp"],
         }),
       ]);
     });
 
-    it("should reject a non-positive timestamp number", () => {
+    it("should reject a non-positive `start: {timestamp}` number with the path drilling into `start.timestamp`", () => {
       const result = consumeKafkaMessagesArgs.safeParse({
-        topics: [{ topicName: "t", timestamp: -1 }],
-        value: {},
+        topics: [{ name: "t", start: { timestamp: -1 } }],
+        valueFormat: {},
       });
       expect(result.success).toBe(false);
       if (result.success) return;
       expect(result.error.issues).toEqual([
         expect.objectContaining({
-          path: ["topics", 0, "timestamp"],
+          path: ["topics", 0, "start", "timestamp"],
         }),
       ]);
     });
@@ -303,11 +341,12 @@ describe("consume-kafka-messages-handler.ts", () => {
     const handler = new ConsumeKafkaMessagesHandler();
 
     describe("handle()", () => {
-      it("should pass the parsed offsetReset through to buildKafkaConsumer", async () => {
-        // Pin the chunk-2 wiring: whatever Zod resolves for offsetReset
-        // (default "latest" or an explicit value) is what the manager
-        // sees. Consumer.run resolves immediately so we don't process
-        // any messages; the assertion is the buildKafkaConsumer call.
+      it("should pass derived offsetReset='earliest' to buildKafkaConsumer when every entry agrees on `start: 'earliest'`", async () => {
+        // The consumer's `auto.offset.reset` is no longer a peer top-level
+        // input; the handler derives it from the per-topic `start` values.
+        // When every direction-only entry asks for 'earliest', that
+        // becomes the consumer-wide reset and no explicit watermark seeks
+        // are needed (the simple-call fast path is preserved).
         const clientManager = getMockedClientManager();
         const consumer = await clientManager.getConsumer();
         consumer.connect.mockResolvedValue(undefined);
@@ -323,11 +362,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topicNames: ["smoke"],
+            topics: [{ name: "smoke", start: "earliest" }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
-            offsetReset: "earliest",
+            valueFormat: {},
           },
           outcome: { resolves: "Consumed 0 messages from topics smoke" },
           clientManager,
@@ -341,7 +379,7 @@ describe("consume-kafka-messages-handler.ts", () => {
         });
       });
 
-      it("should propagate the default offsetReset ('latest') to buildKafkaConsumer when caller omits it", async () => {
+      it("should propagate the default offsetReset ('earliest') to buildKafkaConsumer when every entry omits `start`", async () => {
         const clientManager = getMockedClientManager();
         const consumer = await clientManager.getConsumer();
         consumer.connect.mockResolvedValue(undefined);
@@ -357,10 +395,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topicNames: ["smoke"],
+            topics: [{ name: "smoke" }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: { resolves: "Consumed 0 messages from topics smoke" },
           clientManager,
@@ -370,7 +408,7 @@ describe("consume-kafka-messages-handler.ts", () => {
           clusterId: undefined,
           envId: undefined,
           groupId: undefined,
-          offsetReset: "latest",
+          offsetReset: "earliest",
         });
       });
 
@@ -393,10 +431,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topicNames: ["smoke"],
+            topics: [{ name: "smoke" }],
             maxMessages: 1,
             timeoutMs: 1000,
-            value: {},
+            valueFormat: {},
           },
           outcome: {
             resolves: "Failed to consume messages: group rebalance failed",
@@ -430,10 +468,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topicNames: ["smoke"],
+            topics: [{ name: "smoke" }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: { resolves: "Consumed 0 messages from topics smoke" },
           clientManager,
@@ -466,10 +504,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topicNames: ["smoke"],
+            topics: [{ name: "smoke" }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: { useSchemaRegistry: true },
+            valueFormat: { useSchemaRegistry: true },
           },
           outcome: { resolves: "Consumed 0 messages from topics smoke" },
           clientManager,
@@ -480,7 +518,7 @@ describe("consume-kafka-messages-handler.ts", () => {
         );
       });
 
-      it("should reject `offset` without `partition` as a tool error citing the partition-scoped semantics", async () => {
+      it("should reject `start: {offset}` without `partition` as a tool error citing the partition-scoped semantics", async () => {
         // Absolute offsets are partition-scoped: offset 10 on partition 0 is
         // a different message than offset 10 on partition 1. The handler
         // rejects ambiguity at pre-flight, before any broker call beyond
@@ -498,10 +536,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [{ topicName: "smoke", offset: "10" }],
+            topics: [{ name: "smoke", start: { offset: "10" } }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: {
             resolves: "Absolute offsets are partition-scoped",
@@ -525,10 +563,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [{ topicName: "smoke", partition: 7 }],
+            topics: [{ name: "smoke", partition: 7 }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: {
             resolves: "requested partition 7 is out of range",
@@ -555,10 +593,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [{ topicName: "smoke", partition: 0, offset: "50" }],
+            topics: [{ name: "smoke", partition: 0, start: { offset: "50" } }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: {
             resolves: "offset 50 is out of range [low=100, high=200)",
@@ -585,10 +623,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [{ topicName: "smoke", partition: 0, offset: "200" }],
+            topics: [{ name: "smoke", partition: 0, start: { offset: "200" } }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: {
             resolves: "offset 200 is out of range [low=100, high=200)",
@@ -612,13 +650,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [
-              { topicName: "smoke", partition: 0 },
-              { topicName: "smoke" },
-            ],
+            topics: [{ name: "smoke", partition: 0 }, { name: "smoke" }],
             maxMessages: 1,
             timeoutMs: 50,
-            value: {},
+            valueFormat: {},
           },
           outcome: {
             resolves:
@@ -663,10 +698,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [{ topicName: "smoke", partition: 0, offset: "42" }],
+            topics: [{ name: "smoke", partition: 0, start: { offset: "42" } }],
             maxMessages: 1,
             timeoutMs: 500,
-            value: {},
+            valueFormat: {},
           },
           outcome: { resolves: "Consumed 0 messages from topics smoke" },
           clientManager,
@@ -696,6 +731,13 @@ describe("consume-kafka-messages-handler.ts", () => {
           { partition: 0, offset: "12" },
           { partition: 1, offset: "34" },
         ]);
+        // The timestamp branch cross-checks watermarks to detect the
+        // binding's silent high-watermark substitution. Both resolved
+        // offsets are well below `high` here, so neither is filtered.
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "0", high: "100", offset: "100" },
+          { partition: 1, low: "0", high: "100", offset: "100" },
+        ]);
 
         const consumer = await clientManager.getConsumer();
         consumer.connect.mockResolvedValue(undefined);
@@ -720,10 +762,10 @@ describe("consume-kafka-messages-handler.ts", () => {
             clientManager,
           ),
           args: {
-            topics: [{ topicName: "smoke", timestamp: isoTimestamp }],
+            topics: [{ name: "smoke", start: { timestamp: isoTimestamp } }],
             maxMessages: 1,
             timeoutMs: 500,
-            value: {},
+            valueFormat: {},
           },
           outcome: { resolves: "Consumed 0 messages from topics smoke" },
           clientManager,
@@ -748,6 +790,1029 @@ describe("consume-kafka-messages-handler.ts", () => {
           offset: "34",
         });
       });
+
+      it("should skip the seek for a partition whose timestamp resolution equals the high watermark (silent-substitution case), and still seek the active partition", async () => {
+        // `@confluentinc/kafka-javascript`'s fetchTopicOffsetsByTimestamp
+        // silently substitutes the high watermark when a partition has no
+        // message at or after the requested timestamp. The handler
+        // cross-checks against fetchTopicOffsets and filters those partitions
+        // out of the seek list (seeking to high == OFFSET_END would silently
+        // park the consumer waiting for new messages with no diagnostic).
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+        // Partition 0: resolved offset 42 well below high 200 → active.
+        // Partition 1: resolved offset 100 equal to high 100 → silent
+        //              substitution fired, skip the seek.
+        admin.fetchTopicOffsetsByTimestamp.mockResolvedValue([
+          { partition: 0, offset: "42" },
+          { partition: 1, offset: "100" },
+        ]);
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "0", high: "200", offset: "200" },
+          { partition: 1, low: "0", high: "100", offset: "100" },
+        ]);
+
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+        consumer.assignment.mockReturnValue([
+          { topic: "smoke", partition: 0 },
+          { topic: "smoke", partition: 1 },
+        ]);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { name: "smoke", start: { timestamp: "2026-05-14T17:00:00Z" } },
+            ],
+            maxMessages: 1,
+            timeoutMs: 500,
+            valueFormat: {},
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        // Active partition seeks; silent partition does not.
+        expect(consumer.seek).toHaveBeenCalledWith({
+          topic: "smoke",
+          partition: 0,
+          offset: "42",
+        });
+        expect(consumer.seek).not.toHaveBeenCalledWith({
+          topic: "smoke",
+          partition: 1,
+          offset: "100",
+        });
+        expect(consumer.seek).toHaveBeenCalledTimes(1);
+      });
+
+      it("should throw a tool-error response naming the timestamp when every partition's data ends before it (binding silent-substitution case)", async () => {
+        // All partitions return offset == high watermark → all silent.
+        // The handler must reject loudly rather than silently seeking
+        // every partition to OFFSET_END (which would idle the consumer
+        // until timeout and return 0 with no clue why).
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+        admin.fetchTopicOffsetsByTimestamp.mockResolvedValue([
+          { partition: 0, offset: "200" },
+          { partition: 1, offset: "100" },
+        ]);
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "0", high: "200", offset: "200" },
+          { partition: 1, low: "0", high: "100", offset: "100" },
+        ]);
+
+        const consumer = await clientManager.getConsumer();
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { name: "smoke", start: { timestamp: "2026-05-14T17:00:00Z" } },
+            ],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+          },
+          // Pin both the ISO timestamp (the literal user input echoed back)
+          // and the "every partition" phrasing so future message rewording
+          // doesn't pass a vacuous /failed/ match. The handler converts the
+          // ISO input to ms then back to an ISO string for the message; the
+          // round-trip lands on the same UTC instant.
+          outcome: {
+            resolves:
+              'Topic "smoke" has no messages at or after timestamp 2026-05-14T17:00:00.000Z (every partition has no record produced past that point)',
+          },
+          clientManager,
+        });
+      });
+
+      it("should pick offsetReset='latest' on mixed-direction calls and explicit-seek the 'earliest' minority to its partition low watermarks", async () => {
+        // Two topics, opposite directions: A wants earliest, B wants
+        // latest. The consumer can only have one auto.offset.reset, so
+        // the handler picks "latest" — librdkafka's own default and the
+        // option that keeps the explicit-seek work localized to the
+        // "earliest" minority. The handler issues explicit low-watermark
+        // seeks for A so it actually replays its history; B inherits the
+        // consumer-wide "latest" and needs no explicit seek.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([
+            { name: "topic-a", numPartitions: 2 },
+            { name: "topic-b", numPartitions: 1 },
+          ]),
+        );
+        // Only topic-a is fetched — topic-b's direction matches the
+        // consumer default so the handler doesn't need its watermarks.
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "10", high: "100", offset: "100" },
+          { partition: 1, low: "20", high: "100", offset: "100" },
+        ]);
+
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+        consumer.assignment.mockReturnValue([
+          { topic: "topic-a", partition: 0 },
+          { topic: "topic-a", partition: 1 },
+          { topic: "topic-b", partition: 0 },
+        ]);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { name: "topic-a", start: "earliest" },
+              { name: "topic-b", start: "latest" },
+            ],
+            maxMessages: 1,
+            timeoutMs: 500,
+            valueFormat: {},
+          },
+          outcome: {
+            resolves: "Consumed 0 messages from topics topic-a, topic-b",
+          },
+          clientManager,
+        });
+
+        // Consumer-wide reset goes "latest" because not every
+        // direction-only entry agrees on "earliest".
+        expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
+          clusterId: undefined,
+          envId: undefined,
+          groupId: undefined,
+          offsetReset: "latest",
+        });
+        // topic-a's partitions seek to their per-partition low watermarks
+        // (10 and 20). topic-b stays at the consumer default.
+        expect(consumer.seek).toHaveBeenCalledWith({
+          topic: "topic-a",
+          partition: 0,
+          offset: "10",
+        });
+        expect(consumer.seek).toHaveBeenCalledWith({
+          topic: "topic-a",
+          partition: 1,
+          offset: "20",
+        });
+        expect(consumer.seek).toHaveBeenCalledTimes(2);
+      });
+
+      it("should skip preflight entirely when every entry's `start` agrees on 'earliest' (no admin client call)", async () => {
+        // Both entries direction-only and both pick "earliest" → the
+        // consumer's auto.offset.reset is set to "earliest" and no per-
+        // partition seek is needed. The handler should skip the admin
+        // round-trip entirely — bare-direction-uniform is a fast path.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { name: "topic-a", start: "earliest" },
+              { name: "topic-b", start: "earliest" },
+            ],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+          },
+          outcome: {
+            resolves: "Consumed 0 messages from topics topic-a, topic-b",
+          },
+          clientManager,
+        });
+
+        expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
+          clusterId: undefined,
+          envId: undefined,
+          groupId: undefined,
+          offsetReset: "earliest",
+        });
+        // The fast path means no admin probing and no per-partition
+        // seeks — only consumer.subscribe + the librdkafka-honored
+        // consumer reset.
+        expect(admin.fetchTopicMetadata).not.toHaveBeenCalled();
+        expect(admin.fetchTopicOffsets).not.toHaveBeenCalled();
+        expect(consumer.seek).not.toHaveBeenCalled();
+        expect(consumer.pause).not.toHaveBeenCalled();
+      });
+
+      it("should resolve with 0 messages when applyPostAssignmentHook's waitForAssignment exhausts its deadline without an assignment (orchestrator's onAssignmentTimedOut callback)", async () => {
+        // needsPreflight=true (because of `partition: 0`) so the
+        // preflightHook arm of the race is active. consumer.assignment
+        // always returns [] — waitForAssignment polls until its
+        // deadlineMs catches up, then returns null and triggers the
+        // orchestrator's `onAssignmentTimedOut` arrow (the body of
+        // `accepting = false; timedOut.resolve()`).
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 1 }]),
+        );
+
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+        consumer.assignment.mockReturnValue([]);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ name: "smoke", partition: 0 }],
+            maxMessages: 1,
+            timeoutMs: 100,
+            valueFormat: {},
+            keyFormat: {},
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        // No assignment ever landed, so the post-assignment pause step
+        // is never reached.
+        expect(consumer.pause).not.toHaveBeenCalled();
+      });
+
+      it("should log via the disconnect-catch path when consumer.disconnect throws during cleanup", async () => {
+        // Disconnect failures are caught inside the outer finally so
+        // the surface response stays the success-shaped "Consumed N
+        // messages..." text rather than getting replaced by a teardown
+        // error. The orchestrator's only response is a logger.error;
+        // the test verifies the response shape is preserved AND the
+        // logger.error catch arm of the disconnect path was reached.
+        const clientManager = getMockedClientManager();
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockRejectedValue(new Error("disconnect kaboom"));
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ name: "smoke" }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+            keyFormat: {},
+          },
+          // Disconnect failure during teardown does NOT corrupt the
+          // success-shaped response — only the user-facing path is
+          // pinned here, the log line itself is intentionally not
+          // asserted (per the project's "do not test logging" rule).
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        expect(consumer.disconnect).toHaveBeenCalledOnce();
+      });
+
+      it("should resolve with exactly maxMessages records when consumer.run delivers more than that via the captured eachMessage (orchestrator's maxReached race arm)", async () => {
+        // Capture the eachMessage callback from consumer.run and drive
+        // it from the test. consumer.run's promise never resolves — the
+        // race only finishes via maxReached.resolve() from onMaxReached.
+        // Drives the post-refactor `Promise.race([maxReached.promise,
+        // timedOut.promise, rejectOnly(runPromise), rejectOnly(preflightHook)])`
+        // via its first arm.
+        const clientManager = getMockedClientManager();
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        let captured:
+          | ((payload: EachMessagePayload) => Promise<void>)
+          | undefined;
+        consumer.run.mockImplementation(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ((opts: any) => {
+            captured = opts.eachMessage;
+            // Engine "still running" — never settles so it doesn't end the
+            // race on its own.
+            return new Promise<void>(() => {});
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+        );
+
+        // Pre-parse so the args object satisfies the handler's
+        // z.infer<>-typed `toolArguments` parameter (post-default
+        // shape) — mirrors what the MCP framework hands the handler
+        // in production, where the SDK has already validated and
+        // defaulted the inputs.
+        const handlePromise = handler.handle(
+          runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          consumeKafkaMessagesArgs.parse({
+            topics: [{ name: "smoke" }],
+            maxMessages: 2,
+            timeoutMs: 5000,
+            valueFormat: {},
+            keyFormat: {},
+          }),
+        );
+
+        // Yield so consumer.run's mockImplementation runs and `captured`
+        // is set before we attempt to invoke it.
+        await new Promise<void>((r) => setImmediate(r));
+        expect(captured).toBeDefined();
+
+        // Drive three deliveries; the third should be suppressed by the
+        // orchestrator's `accepting = false` flip inside `onMaxReached`,
+        // so consumedMessages caps at 2.
+        await captured!({
+          topic: "smoke",
+          partition: 0,
+          message: fakeMessage({ value: Buffer.from("v1") }),
+        } as unknown as EachMessagePayload);
+        await captured!({
+          topic: "smoke",
+          partition: 0,
+          message: fakeMessage({ value: Buffer.from("v2") }),
+        } as unknown as EachMessagePayload);
+        await captured!({
+          topic: "smoke",
+          partition: 0,
+          message: fakeMessage({ value: Buffer.from("v3") }),
+        } as unknown as EachMessagePayload);
+
+        const result = await handlePromise;
+        const text = result.content
+          .map((c) => ("text" in c ? c.text : ""))
+          .join("");
+
+        // Exactly two messages — proves the maxReached signal fired AND
+        // the post-resolution `accepting` gate suppressed the third
+        // delivery from being pushed.
+        expect(text).toContain("Consumed 2 messages from topics smoke");
+        // Disconnect runs from the outer finally even when the race
+        // exits via the maxReached signal (not via an error).
+        expect(consumer.disconnect).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("processMessage()", () => {
+      it("should return raw key/value strings + ISO-formatted timestamp when neither side uses schema registry", async () => {
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage(),
+          undefined,
+          { useSchemaRegistry: false },
+          { useSchemaRegistry: false },
+        );
+        // Literal-equal the whole shape so every field is pinned — drift
+        // in any branch (key conversion, value conversion, timestamp
+        // formatting, headers default, topic/partition passthrough) fails
+        // here with a precise diff.
+        expect(result).toEqual({
+          key: "k",
+          value: "v",
+          timestamp: "2025-05-14T14:56:07.000Z",
+          offset: "42",
+          headers: undefined,
+          topic: "topic-x",
+          partition: 0,
+        });
+      });
+
+      it("should leave the key undefined when the Kafka message has a null key", async () => {
+        // `message.key` arrives as `null` (Buffer | null per the kafkajs
+        // type), and the handler's `message.key?.toString()` initialization
+        // plus the `if (message.key)` guard means the processed key stays
+        // at its initial value of `undefined`.
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage({ key: null }),
+          undefined,
+          { useSchemaRegistry: false },
+          { useSchemaRegistry: false },
+        );
+        expect(result.key).toBeUndefined();
+      });
+
+      it("should convert defined headers to a record of stringified values (Buffer → string, undefined → empty string)", async () => {
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage({
+            headers: {
+              "x-trace": Buffer.from("abc"),
+              "x-empty": undefined,
+            },
+          }),
+          undefined,
+          { useSchemaRegistry: false },
+          { useSchemaRegistry: false },
+        );
+        expect(result.headers).toEqual({
+          "x-trace": "abc",
+          "x-empty": "",
+        });
+      });
+
+      it("should pass message.timestamp through formatMessageTimestamp (integration with the '-1' sentinel)", async () => {
+        // Cross-check that processMessage actually wires through
+        // formatMessageTimestamp — the unit-test for that helper above
+        // pins the four branches; this one pins the *integration*.
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage({ timestamp: "-1" }),
+          undefined,
+          { useSchemaRegistry: false },
+          { useSchemaRegistry: false },
+        );
+        expect(result.timestamp).toBe("(no timestamp)");
+      });
+
+      describe("with schema registry", () => {
+        // The handler imports `getLatestSchemaIfExists` and
+        // `deserializeMessage` via a namespace alias precisely so these
+        // tests can spy on them via property lookup (ESM live bindings
+        // refuse direct named-import interception). The fake registry is
+        // an empty object cast — the spies short-circuit before the real
+        // SDK is touched, so its surface doesn't matter.
+        const fakeRegistry = {} as SchemaRegistryClient;
+
+        it("should deserialize the value via schema registry when useSchemaRegistry is true and a schema exists", async () => {
+          const getLatestSpy = vi
+            .spyOn(schemaRegistryHelper, "getLatestSchemaIfExists")
+            .mockResolvedValue({ schema: "{}", schemaType: "AVRO" });
+          const deserializeSpy = vi
+            .spyOn(schemaRegistryHelper, "deserializeMessage")
+            .mockResolvedValue({ field: 42 });
+
+          const result = await handler.processMessage(
+            "topic-x",
+            0,
+            fakeMessage(),
+            fakeRegistry,
+            { useSchemaRegistry: true },
+            { useSchemaRegistry: false },
+          );
+
+          // Value travels through the SR helpers; key stays raw.
+          expect(result.value).toEqual({ field: 42 });
+          expect(result.key).toBe("k");
+          // Pin the default subject derivation: "<topic>-value" /
+          // "<topic>-key" when options.subject is omitted.
+          expect(getLatestSpy).toHaveBeenCalledWith(
+            fakeRegistry,
+            "topic-x-value",
+          );
+          expect(deserializeSpy).toHaveBeenCalledWith(
+            "topic-x",
+            Buffer.from("v"),
+            "AVRO",
+            fakeRegistry,
+            SerdeType.VALUE,
+          );
+        });
+
+        it("should honor a caller-supplied subject instead of the default `${topic}-value`", async () => {
+          const getLatestSpy = vi
+            .spyOn(schemaRegistryHelper, "getLatestSchemaIfExists")
+            .mockResolvedValue({ schema: "{}", schemaType: "AVRO" });
+          vi.spyOn(
+            schemaRegistryHelper,
+            "deserializeMessage",
+          ).mockResolvedValue("ok");
+
+          await handler.processMessage(
+            "topic-x",
+            0,
+            fakeMessage(),
+            fakeRegistry,
+            { useSchemaRegistry: true, subject: "custom-subject-v1" },
+            { useSchemaRegistry: false },
+          );
+
+          expect(getLatestSpy).toHaveBeenCalledWith(
+            fakeRegistry,
+            "custom-subject-v1",
+          );
+        });
+
+        it("should fall back to the raw string when getLatestSchemaIfExists returns null (no schema registered)", async () => {
+          vi.spyOn(
+            schemaRegistryHelper,
+            "getLatestSchemaIfExists",
+          ).mockResolvedValue(null);
+          const deserializeSpy = vi.spyOn(
+            schemaRegistryHelper,
+            "deserializeMessage",
+          );
+
+          const result = await handler.processMessage(
+            "topic-x",
+            0,
+            fakeMessage(),
+            fakeRegistry,
+            { useSchemaRegistry: true },
+            { useSchemaRegistry: false },
+          );
+
+          expect(result.value).toBe("v");
+          // No deserialization attempt at all — the null short-circuits
+          // before the deserializer is consulted.
+          expect(deserializeSpy).not.toHaveBeenCalled();
+        });
+
+        it("should fall back to the raw string when deserializeMessage throws (corrupt payload or schema mismatch)", async () => {
+          vi.spyOn(
+            schemaRegistryHelper,
+            "getLatestSchemaIfExists",
+          ).mockResolvedValue({ schema: "{}", schemaType: "AVRO" });
+          vi.spyOn(
+            schemaRegistryHelper,
+            "deserializeMessage",
+          ).mockRejectedValue(new Error("payload corrupt"));
+
+          const result = await handler.processMessage(
+            "topic-x",
+            0,
+            fakeMessage(),
+            fakeRegistry,
+            { useSchemaRegistry: true },
+            { useSchemaRegistry: false },
+          );
+
+          // The catch arm logs and returns the raw string — the consumer
+          // gets *something* rather than a propagated error that kills
+          // the run.
+          expect(result.value).toBe("v");
+        });
+
+        it("should deserialize the key with SerdeType.KEY when keyOptions.useSchemaRegistry is true and the message has a key", async () => {
+          const getLatestSpy = vi
+            .spyOn(schemaRegistryHelper, "getLatestSchemaIfExists")
+            .mockResolvedValue({ schema: "{}", schemaType: "AVRO" });
+          const deserializeSpy = vi
+            .spyOn(schemaRegistryHelper, "deserializeMessage")
+            .mockResolvedValue("key-deserialized");
+
+          const result = await handler.processMessage(
+            "topic-x",
+            0,
+            fakeMessage(),
+            fakeRegistry,
+            { useSchemaRegistry: false },
+            { useSchemaRegistry: true },
+          );
+
+          expect(result.key).toBe("key-deserialized");
+          expect(result.value).toBe("v");
+          // Default key subject is "<topic>-key" and SerdeType.KEY drives
+          // the deserializer selection.
+          expect(getLatestSpy).toHaveBeenCalledWith(
+            fakeRegistry,
+            "topic-x-key",
+          );
+          expect(deserializeSpy).toHaveBeenCalledWith(
+            "topic-x",
+            Buffer.from("k"),
+            "AVRO",
+            fakeRegistry,
+            SerdeType.KEY,
+          );
+        });
+
+        it("should skip key deserialization entirely when message.key is null (the SR branch never fires for an absent key)", async () => {
+          const getLatestSpy = vi.spyOn(
+            schemaRegistryHelper,
+            "getLatestSchemaIfExists",
+          );
+          const deserializeSpy = vi.spyOn(
+            schemaRegistryHelper,
+            "deserializeMessage",
+          );
+
+          const result = await handler.processMessage(
+            "topic-x",
+            0,
+            fakeMessage({ key: null }),
+            fakeRegistry,
+            { useSchemaRegistry: false },
+            { useSchemaRegistry: true },
+          );
+
+          expect(result.key).toBeUndefined();
+          // The `if (message.key)` guard prevents any SR plumbing from
+          // running on the key side.
+          expect(getLatestSpy).not.toHaveBeenCalled();
+          expect(deserializeSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("formatMessageTimestamp()", () => {
+    it.each([
+      // [input, expected, why]
+      [
+        undefined,
+        "(no timestamp)",
+        "absent timestamps (pre-0.10.0 message format)",
+      ],
+      ["-1", "(no timestamp)", "Kafka sentinel for 'producer left it unset'"],
+      [
+        "1747234567000",
+        "2025-05-14T14:56:07.000Z",
+        "valid ms-since-epoch string → ISO 8601 UTC",
+      ],
+      [
+        "banana",
+        "banana",
+        "non-numeric garbage → pass through verbatim (Number() returns NaN)",
+      ],
+      [
+        "",
+        "1970-01-01T00:00:00.000Z",
+        "empty string → Number('') is 0 (finite) → epoch ISO (defensive edge case)",
+      ],
+    ] as const)("should map %j to %j (%s)", (input, expected, _why) => {
+      expect(formatMessageTimestamp(input)).toBe(expected);
+    });
+  });
+
+  describe("normalizeStart()", () => {
+    // The literal-equal target is the same ISO instant in both timestamp
+    // rows below; the difference is whether the input arrived as a string
+    // (Date.parse path) or as a number (passthrough path). Pinning both
+    // proves the two arms produce identical downstream targets — which
+    // is precisely what callers need when they don't want to think about
+    // which form the LLM picked.
+    const sharedMs = 1747234567000;
+
+    it.each([
+      // [input, expected, why]
+      ["earliest" as const, { kind: "earliest" }, "literal `earliest` arm"],
+      ["latest" as const, { kind: "latest" }, "literal `latest` arm"],
+      [
+        { offset: "42" } as const,
+        { kind: "offset", value: "42" },
+        "object arm with absolute partition offset",
+      ],
+      [
+        { timestamp: "2025-05-14T14:56:07.000Z" } as const,
+        { kind: "timestamp", ms: sharedMs },
+        "object arm with ISO 8601 string → Date.parse path",
+      ],
+      [
+        { timestamp: sharedMs } as const,
+        { kind: "timestamp", ms: sharedMs },
+        "object arm with ms-since-epoch number → passthrough path",
+      ],
+    ])("should collapse %j to %j (%s)", (input, expected, _why) => {
+      expect(normalizeStart(input)).toEqual(expected);
+    });
+  });
+
+  describe("waitForAssignment()", () => {
+    // Fake timers because the function's loop body awaits a 50ms
+    // setTimeout between polls. Real wall-clock waits would make tests
+    // either flaky or slow; fake timers let us pump iterations
+    // deterministically. `restoreMocks: true` only restores vi.spyOn
+    // installs, not fake-timer state, so the afterEach reverter is
+    // load-bearing.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should return the assignment immediately when consumer.assignment() is already populated on the first poll", async () => {
+      const populated = [{ topic: "x", partition: 0 }];
+      const consumer = getMockedConsumer();
+      consumer.assignment.mockReturnValue(populated);
+
+      const result = await waitForAssignment(consumer, Date.now() + 5000);
+
+      expect(result).toEqual(populated);
+      // Single poll, no sleep entered.
+      expect(consumer.assignment).toHaveBeenCalledOnce();
+    });
+
+    it("should return null when the deadline is already in the past and the assignment is still empty", async () => {
+      const consumer = getMockedConsumer();
+      consumer.assignment.mockReturnValue([]);
+
+      // `Date.now() >= deadline` fires on the first iteration's
+      // post-empty check, so the function returns null without entering
+      // the setTimeout sleep.
+      const result = await waitForAssignment(consumer, Date.now());
+
+      expect(result).toBeNull();
+      expect(consumer.assignment).toHaveBeenCalledOnce();
+    });
+
+    it("should poll, sleep, and return the assignment once a later iteration sees it populated", async () => {
+      const populated = [{ topic: "x", partition: 0 }];
+      const consumer = getMockedConsumer();
+      consumer.assignment
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([])
+        .mockReturnValue(populated);
+
+      const pending = waitForAssignment(consumer, Date.now() + 5000);
+      // Each iteration awaits a 50ms sleep. Advance fake time so the
+      // first two sleeps resolve and the third poll runs against the
+      // populated mock.
+      await vi.advanceTimersByTimeAsync(50);
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(await pending).toEqual(populated);
+      // Iter 1 empty → sleep, iter 2 empty → sleep, iter 3 populated →
+      // return. Exactly three polls.
+      expect(consumer.assignment).toHaveBeenCalledTimes(3);
+    });
+
+    it("should return null after polling past the deadline without the assignment populating", async () => {
+      const consumer = getMockedConsumer();
+      consumer.assignment.mockReturnValue([]);
+
+      // deadline = now + 150ms; with 50ms sleeps the loop ticks at
+      // t=0, 50, 100, 150 and the t=150 iteration's deadline check
+      // (`>=`) fires.
+      const pending = waitForAssignment(consumer, Date.now() + 150);
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(await pending).toBeNull();
+      // At least three polls before the deadline trips on iter 4.
+      expect(consumer.assignment.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("createEachMessageHandler()", () => {
+    // Default processed-shape stand-in; tests that don't care about
+    // contents reuse this so the assertions stay focused on
+    // gating/signalling behavior.
+    function makeProcessed(): ProcessedMessage {
+      return {
+        key: "k",
+        value: "v",
+        timestamp: "2025-05-14T14:56:07.000Z",
+        offset: "42",
+        headers: undefined,
+        topic: "topic-x",
+        partition: 0,
+      };
+    }
+
+    function buildHandler(
+      stateOverrides: {
+        isAccepting?: () => boolean;
+        isPreflightApplied?: () => boolean;
+        maxMessages?: number;
+      } = {},
+    ) {
+      const consumedMessages: ProcessedMessage[] = [];
+      const onMaxReached = vi.fn();
+      const processMessage = vi.fn().mockResolvedValue(makeProcessed());
+      const handler = createEachMessageHandler({
+        state: {
+          consumedMessages,
+          isAccepting: stateOverrides.isAccepting ?? (() => true),
+          isPreflightApplied: stateOverrides.isPreflightApplied ?? (() => true),
+        },
+        maxMessages: stateOverrides.maxMessages ?? 10,
+        onMaxReached,
+        processMessage,
+      });
+      return { handler, consumedMessages, onMaxReached, processMessage };
+    }
+
+    function payload(): EachMessagePayload {
+      return {
+        topic: "topic-x",
+        partition: 0,
+        message: fakeMessage(),
+      } as unknown as EachMessagePayload;
+    }
+
+    it("should call processMessage with (topic, partition, message) and push the result to consumedMessages on the happy path", async () => {
+      const { handler, processMessage, consumedMessages, onMaxReached } =
+        buildHandler({ maxMessages: 10 });
+      const inst = payload();
+
+      await handler(inst);
+
+      expect(processMessage).toHaveBeenCalledWith("topic-x", 0, inst.message);
+      expect(consumedMessages).toEqual([makeProcessed()]);
+      // Far below maxMessages → the signal must not fire.
+      expect(onMaxReached).not.toHaveBeenCalled();
+    });
+
+    it("should drop the message without calling processMessage when isAccepting() returns false (post-resolution gate)", async () => {
+      const { handler, processMessage, consumedMessages, onMaxReached } =
+        buildHandler({ isAccepting: () => false });
+
+      await handler(payload());
+
+      expect(processMessage).not.toHaveBeenCalled();
+      expect(consumedMessages).toHaveLength(0);
+      expect(onMaxReached).not.toHaveBeenCalled();
+    });
+
+    it("should drop the message without calling processMessage when isPreflightApplied() returns false (pre-pause gate)", async () => {
+      // Pre-pause messages arrive from librdkafka's fetch buffer for
+      // partitions we intend to pause. The synchronous gate drops them
+      // on arrival rather than letting them sneak into consumedMessages.
+      const { handler, processMessage, consumedMessages, onMaxReached } =
+        buildHandler({ isPreflightApplied: () => false });
+
+      await handler(payload());
+
+      expect(processMessage).not.toHaveBeenCalled();
+      expect(consumedMessages).toHaveLength(0);
+      expect(onMaxReached).not.toHaveBeenCalled();
+    });
+
+    it("should fire onMaxReached exactly once when the count reaches maxMessages", async () => {
+      const { handler, consumedMessages, onMaxReached } = buildHandler({
+        maxMessages: 2,
+      });
+
+      await handler(payload());
+      expect(onMaxReached).not.toHaveBeenCalled();
+      expect(consumedMessages).toHaveLength(1);
+
+      await handler(payload());
+      expect(onMaxReached).toHaveBeenCalledOnce();
+      expect(consumedMessages).toHaveLength(2);
+    });
+
+    it("should keep firing onMaxReached on subsequent calls once the count is at-or-above maxMessages (the orchestrator's `accepting` gate is what stops the bleed; the factory itself stays branch-simple)", async () => {
+      // Pin the actual contract: the factory always re-fires onMaxReached
+      // once length >= maxMessages. Suppression of follow-up calls is
+      // the orchestrator's job (via its accepting=false flip in the
+      // onMaxReached handler). This test exists so a future "smart" gate
+      // inside the factory fails loudly rather than silently changing
+      // the orchestrator's responsibility.
+      const { handler, consumedMessages, onMaxReached } = buildHandler({
+        maxMessages: 1,
+        // Stay accepting throughout so we exercise the inner branch.
+        isAccepting: () => true,
+      });
+
+      await handler(payload());
+      await handler(payload());
+      await handler(payload());
+
+      expect(consumedMessages).toHaveLength(3);
+      expect(onMaxReached).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("applyPostAssignmentHook()", () => {
+    // Fake timers because the timeout branch drives waitForAssignment's
+    // 50ms polling loop without burning wall-clock seconds.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should resolve onApplied (and not onAssignmentTimedOut) when the assignment populates and the pause step completes", async () => {
+      const consumer = getMockedConsumer();
+      // Assigned to partition 1; the plan asks us to keep only partition 0,
+      // so applyPauseAfterAssignment should pause partition 1.
+      consumer.assignment.mockReturnValue([{ topic: "topic-x", partition: 1 }]);
+      consumer.pause.mockReturnValue(undefined);
+      const onApplied = vi.fn();
+      const onAssignmentTimedOut = vi.fn();
+
+      await applyPostAssignmentHook({
+        consumer,
+        plan: {
+          topicNames: ["topic-x"],
+          keepPartitions: new Map([["topic-x", new Set([0])]]),
+          seeks: [],
+        },
+        deadlineMs: Date.now() + 5000,
+        onApplied,
+        onAssignmentTimedOut,
+      });
+
+      expect(consumer.pause).toHaveBeenCalledWith([
+        { topic: "topic-x", partitions: [1] },
+      ]);
+      expect(onApplied).toHaveBeenCalledOnce();
+      expect(onAssignmentTimedOut).not.toHaveBeenCalled();
+    });
+
+    it("should fire onAssignmentTimedOut (and not onApplied or consumer.pause) when waitForAssignment exhausts the deadline without an assignment", async () => {
+      const consumer = getMockedConsumer();
+      consumer.assignment.mockReturnValue([]);
+      const onApplied = vi.fn();
+      const onAssignmentTimedOut = vi.fn();
+
+      // Deadline already in the past — waitForAssignment returns null on
+      // its first poll, so we never reach the pause step.
+      await applyPostAssignmentHook({
+        consumer,
+        plan: {
+          topicNames: ["topic-x"],
+          keepPartitions: new Map([["topic-x", new Set([0])]]),
+          seeks: [],
+        },
+        deadlineMs: Date.now(),
+        onApplied,
+        onAssignmentTimedOut,
+      });
+
+      expect(consumer.pause).not.toHaveBeenCalled();
+      expect(onApplied).not.toHaveBeenCalled();
+      expect(onAssignmentTimedOut).toHaveBeenCalledOnce();
+    });
+
+    it("should reject when consumer.pause throws during the post-assignment pause step", async () => {
+      const consumer = getMockedConsumer();
+      consumer.assignment.mockReturnValue([{ topic: "topic-x", partition: 1 }]);
+      consumer.pause.mockImplementation(() => {
+        throw new Error("pause kaboom");
+      });
+      const onApplied = vi.fn();
+      const onAssignmentTimedOut = vi.fn();
+
+      await expect(
+        applyPostAssignmentHook({
+          consumer,
+          plan: {
+            topicNames: ["topic-x"],
+            // Keep only partition 0 → partition 1 must be paused → throws.
+            keepPartitions: new Map([["topic-x", new Set([0])]]),
+            seeks: [],
+          },
+          deadlineMs: Date.now() + 5000,
+          onApplied,
+          onAssignmentTimedOut,
+        }),
+      ).rejects.toThrow("pause kaboom");
+
+      // Neither completion callback fires on failure — the rejection
+      // is the only signal so the orchestrator's `rejectOnly` wrapper
+      // can surface it as the race-losing error.
+      expect(onApplied).not.toHaveBeenCalled();
+      expect(onAssignmentTimedOut).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -13,7 +13,6 @@ import {
   createEachMessageHandler,
   formatMessageTimestamp,
   normalizeStart,
-  partitionScope,
   waitForAssignment,
   type ProcessedMessage,
 } from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
@@ -1042,6 +1041,56 @@ describe("consume-kafka-messages-handler.ts", () => {
         });
       });
 
+      it("should name the restricted partition in the no-messages error when the caller targets a single partition that has no record at or after the timestamp", async () => {
+        // Sibling of the prior test, but with `partition: 1` on the topic
+        // entry so the filter narrows to one partition before the
+        // silent-substitution check. Pins the "partition N has no record"
+        // phrasing — the restricted-scope branch of the error message
+        // that the every-partition test above doesn't cover.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+        admin.fetchTopicOffsetsByTimestamp.mockResolvedValue([
+          { partition: 0, offset: "50" },
+          { partition: 1, offset: "100" },
+        ]);
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "0", high: "200", offset: "200" },
+          { partition: 1, low: "0", high: "100", offset: "100" },
+        ]);
+
+        const consumer = await clientManager.getConsumer();
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              {
+                name: "smoke",
+                partition: 1,
+                start: { timestamp: "2026-05-14T17:00:00Z" },
+              },
+            ],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+          },
+          outcome: {
+            resolves:
+              'Topic "smoke" has no messages at or after timestamp 2026-05-14T17:00:00.000Z (partition 1 has no record produced past that point)',
+          },
+          clientManager,
+        });
+      });
+
       it("should pick offsetReset='latest' on mixed-direction calls and explicit-seek the 'earliest' minority to its partition low watermarks", async () => {
         // Two topics, opposite directions: A wants earliest, B wants
         // latest. The consumer can only have one auto.offset.reset, so
@@ -1735,49 +1784,6 @@ describe("consume-kafka-messages-handler.ts", () => {
       expect(await pending).toBeNull();
       // At least three polls before the deadline trips on iter 4.
       expect(consumer.assignment.mock.calls.length).toBeGreaterThanOrEqual(3);
-    });
-  });
-
-  describe("partitionScope()", () => {
-    // Pin both branches of both methods so a future reshuffle of the
-    // "unrestricted vs restricted" framing can't silently land a bug
-    // — every caller routes through this helper, so any drift here
-    // ripples through the seek resolvers.
-    const items: { partition: number; tag: string }[] = [
-      { partition: 0, tag: "a" },
-      { partition: 1, tag: "b" },
-      { partition: 2, tag: "c" },
-    ];
-
-    describe(".filter(items)", () => {
-      it("should pass items through unchanged when no partition restriction", () => {
-        const scope = partitionScope(undefined);
-        expect(scope.filter(items)).toEqual(items);
-      });
-
-      it("should return only items matching the restricted partition when one is set", () => {
-        const scope = partitionScope(1);
-        expect(scope.filter(items)).toEqual([{ partition: 1, tag: "b" }]);
-      });
-
-      it("should return an empty array when the restricted partition has no matching items", () => {
-        // Defensive — the upstream validators normally guarantee the
-        // requested partition exists, but the helper itself must stay
-        // total: no matches means an empty array, not a throw.
-        const scope = partitionScope(99);
-        expect(scope.filter(items)).toEqual([]);
-      });
-    });
-
-    describe(".phrase()", () => {
-      it("should describe an unrestricted scope as 'every partition'", () => {
-        expect(partitionScope(undefined).phrase()).toBe("every partition");
-      });
-
-      it("should describe a restricted scope as 'partition N' with the partition index inlined", () => {
-        expect(partitionScope(0).phrase()).toBe("partition 0");
-        expect(partitionScope(7).phrase()).toBe("partition 7");
-      });
     });
   });
 

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -1,4 +1,8 @@
-import { ConsumeKafkaMessagesHandler } from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
+import { KafkaJS } from "@confluentinc/kafka-javascript";
+import {
+  ConsumeKafkaMessagesHandler,
+  consumeKafkaMessagesArgs,
+} from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
@@ -9,11 +13,367 @@ import {
 } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
+/**
+ * Build a fake `admin.fetchTopicMetadata` result that mirrors what the
+ * library actually returns at runtime (a bare `Array<ITopicMetadata>`).
+ * The published `.d.ts` declares `Promise<{ topics: Array<ITopicMetadata> }>`
+ * but the implementation hands back the array directly — see the matching
+ * note in {@link consume-kafka-messages-handler.ts}. The cast hides the
+ * declared-shape lie from the call site so tests stay readable.
+ */
+function fakeFetchTopicMetadataResult(
+  topics: Array<{ name: string; numPartitions: number }>,
+): Awaited<ReturnType<KafkaJS.Admin["fetchTopicMetadata"]>> {
+  const arr = topics.map((t) => ({
+    name: t.name,
+    partitions: Array.from({ length: t.numPartitions }, (_, i) => ({
+      partitionId: i,
+      partitionErrorCode: 0,
+      leader: 1,
+      leaderNode: null,
+      replicas: [1],
+      replicaNodes: [],
+      isr: [1],
+      isrNodes: [],
+    })),
+  }));
+  return arr as unknown as Awaited<
+    ReturnType<KafkaJS.Admin["fetchTopicMetadata"]>
+  >;
+}
+
 describe("consume-kafka-messages-handler.ts", () => {
+  describe("consumeKafkaMessagesArgs (schema)", () => {
+    it("should default offsetReset to 'latest' when omitted", () => {
+      // The behavior change from #459: prior to this work, the handler
+      // forced "earliest" via fromBeginning:true (OAuth) or
+      // auto.offset.reset:"earliest" (direct). Natural-language asks
+      // ("show me the latest X") expect "latest" by default.
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topicNames: ["t"],
+        value: {},
+      });
+      expect(parsed.offsetReset).toBe("latest");
+    });
+
+    it.each(["earliest", "latest", "none"] as const)(
+      "should accept offsetReset='%s'",
+      (offsetReset) => {
+        const parsed = consumeKafkaMessagesArgs.parse({
+          topicNames: ["t"],
+          value: {},
+          offsetReset,
+        });
+        expect(parsed.offsetReset).toBe(offsetReset);
+      },
+    );
+
+    it("should reject an unknown offsetReset value with a Zod enum error citing the field", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topicNames: ["t"],
+        value: {},
+        offsetReset: "from-the-middle",
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      // Pin both the path and the error code so a future schema rename
+      // (e.g. offsetReset → resetPolicy) doesn't pass with a generic
+      // /validation failed/ regex match.
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["offsetReset"],
+          code: "invalid_value",
+        }),
+      ]);
+    });
+  });
+
+  describe("consumeKafkaMessagesArgs (schema, topics[] xor topicNames)", () => {
+    it("should accept just `topics`", () => {
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t" }],
+        value: {},
+      });
+      expect(parsed.topics).toEqual([{ topicName: "t" }]);
+      expect(parsed.topicNames).toBeUndefined();
+    });
+
+    it("should reject when both `topicNames` and `topics` are present", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topicNames: ["t"],
+        topics: [{ topicName: "t" }],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          // The xor check is a top-level superRefine, so the issue path
+          // is empty (the whole object is the problem, not one field).
+          path: [],
+          // "exactly one of" + "not both" together pin the both-present
+          // branch and resist message rewording without losing
+          // specificity. "either" lives in the both-absent branch only.
+          message: expect.stringContaining("not both"),
+        }),
+      ]);
+    });
+
+    it("should reject when both `topicNames` and `topics` are absent", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({ value: {} });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: [],
+          message: expect.stringContaining("either"),
+        }),
+      ]);
+    });
+
+    it("should reject an empty topicNames array", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topicNames: [],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      // Either the inner nonempty-array check fires, or the xor superRefine
+      // does (since an empty array is "absent" semantically). Pin the
+      // observable behavior: at least one issue exists naming the empty
+      // input.
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    });
+
+    it("should reject an empty topics array", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("consumeKafkaMessagesArgs (schema, per-topic entry)", () => {
+    it("should accept an entry with only `topicName`", () => {
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t" }],
+        value: {},
+      });
+      expect(parsed.topics).toEqual([{ topicName: "t" }]);
+    });
+
+    it("should accept an entry with topicName + partition=0 (lowest valid partition index)", () => {
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t", partition: 0 }],
+        value: {},
+      });
+      expect(parsed.topics?.[0]?.partition).toBe(0);
+    });
+
+    it("should reject a negative partition with a path naming the entry", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [{ topicName: "t", partition: -1 }],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["topics", 0, "partition"],
+        }),
+      ]);
+    });
+
+    it("should reject a non-integer partition", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [{ topicName: "t", partition: 1.5 }],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["topics", 0, "partition"],
+        }),
+      ]);
+    });
+
+    it("should accept a digit-only `offset` string", () => {
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t", offset: "12345" }],
+        value: {},
+      });
+      expect(parsed.topics?.[0]?.offset).toBe("12345");
+    });
+
+    it("should accept an int64-shaped `offset` string beyond JS safe-integer range (2^53)", () => {
+      // Kafka offsets are int64; the schema accepts strings precisely so
+      // values past 2^53 don't lose precision via JS number coercion.
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t", offset: "9999999999999999999" }],
+        value: {},
+      });
+      expect(parsed.topics?.[0]?.offset).toBe("9999999999999999999");
+    });
+
+    it("should reject a non-digit `offset` string", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [{ topicName: "t", offset: "ten" }],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["topics", 0, "offset"],
+        }),
+      ]);
+    });
+
+    it("should reject an entry that supplies both `offset` and `timestamp`", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [
+          { topicName: "t", offset: "10", timestamp: "2026-05-14T17:00:00Z" },
+        ],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["topics", 0],
+          message: expect.stringMatching(/only one of .offset. or .timestamp./),
+        }),
+      ]);
+    });
+
+    it.each([
+      "2026-05-14T17:00:00Z",
+      "2026-05-14T13:00:00-04:00",
+      "2026-05-14T20:00:00.500+00:00",
+    ] as const)("should accept ISO 8601 timestamp '%s'", (timestamp) => {
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t", timestamp }],
+        value: {},
+      });
+      expect(parsed.topics?.[0]?.timestamp).toBe(timestamp);
+    });
+
+    it("should accept a positive integer ms-since-epoch timestamp", () => {
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ topicName: "t", timestamp: 1747234567000 }],
+        value: {},
+      });
+      expect(parsed.topics?.[0]?.timestamp).toBe(1747234567000);
+    });
+
+    it("should reject a malformed timestamp string", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [{ topicName: "t", timestamp: "not-a-date" }],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["topics", 0, "timestamp"],
+        }),
+      ]);
+    });
+
+    it("should reject a non-positive timestamp number", () => {
+      const result = consumeKafkaMessagesArgs.safeParse({
+        topics: [{ topicName: "t", timestamp: -1 }],
+        value: {},
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["topics", 0, "timestamp"],
+        }),
+      ]);
+    });
+  });
+
   describe("ConsumeKafkaMessagesHandler", () => {
     const handler = new ConsumeKafkaMessagesHandler();
 
     describe("handle()", () => {
+      it("should pass the parsed offsetReset through to buildKafkaConsumer", async () => {
+        // Pin the chunk-2 wiring: whatever Zod resolves for offsetReset
+        // (default "latest" or an explicit value) is what the manager
+        // sees. Consumer.run resolves immediately so we don't process
+        // any messages; the assertion is the buildKafkaConsumer call.
+        const clientManager = getMockedClientManager();
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topicNames: ["smoke"],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+            offsetReset: "earliest",
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
+          clusterId: undefined,
+          envId: undefined,
+          groupId: undefined,
+          offsetReset: "earliest",
+        });
+      });
+
+      it("should propagate the default offsetReset ('latest') to buildKafkaConsumer when caller omits it", async () => {
+        const clientManager = getMockedClientManager();
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topicNames: ["smoke"],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
+          clusterId: undefined,
+          envId: undefined,
+          groupId: undefined,
+          offsetReset: "latest",
+        });
+      });
+
       it("should return an isError response when consumer.run rejects", async () => {
         // The outer `catch (error)` in the consume handler catches errors
         // from connect/subscribe/run and renders them via formatKafkaError.
@@ -118,6 +478,275 @@ describe("consume-kafka-messages-handler.ts", () => {
         expect(clientManager.getSchemaRegistrySdkClient).toHaveBeenCalledWith(
           undefined,
         );
+      });
+
+      it("should reject `offset` without `partition` as a tool error citing the partition-scoped semantics", async () => {
+        // Absolute offsets are partition-scoped: offset 10 on partition 0 is
+        // a different message than offset 10 on partition 1. The handler
+        // rejects ambiguity at pre-flight, before any broker call beyond
+        // the admin probe (and in fact before that — the guard is the
+        // first thing buildPreflightPlan does).
+        const clientManager = getMockedClientManager();
+        const consumer = await clientManager.getConsumer();
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ topicName: "smoke", offset: "10" }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+          },
+          outcome: {
+            resolves: "Absolute offsets are partition-scoped",
+          },
+          clientManager,
+        });
+      });
+
+      it("should reject a partition index >= numPartitions returned by fetchTopicMetadata", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ topicName: "smoke", partition: 7 }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+          },
+          outcome: {
+            resolves: "requested partition 7 is out of range",
+          },
+          clientManager,
+        });
+      });
+
+      it("should reject an `offset` below the partition's low watermark", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 1 }]),
+        );
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "100", high: "200", offset: "200" },
+        ]);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ topicName: "smoke", partition: 0, offset: "50" }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+          },
+          outcome: {
+            resolves: "offset 50 is out of range [low=100, high=200)",
+          },
+          clientManager,
+        });
+      });
+
+      it("should reject an `offset` >= the partition's high watermark", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 1 }]),
+        );
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "100", high: "200", offset: "200" },
+        ]);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ topicName: "smoke", partition: 0, offset: "200" }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+          },
+          outcome: {
+            resolves: "offset 200 is out of range [low=100, high=200)",
+          },
+          clientManager,
+        });
+      });
+
+      it("should reject a topic that mixes partition-specific entries with unrestricted entries", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { topicName: "smoke", partition: 0 },
+              { topicName: "smoke" },
+            ],
+            maxMessages: 1,
+            timeoutMs: 50,
+            value: {},
+          },
+          outcome: {
+            resolves:
+              'Topic "smoke" mixes entries with explicit partitions and entries without one',
+          },
+          clientManager,
+        });
+      });
+
+      it("should pause unassigned-to-target partitions and seek to the explicit offset for the requested partition", async () => {
+        // Happy path of the seek/pause dance: caller restricts to
+        // partition 0 with an explicit offset. The broker assigns three
+        // partitions (0, 1, 2); we expect pause on partitions 1 and 2,
+        // and seek on partition 0 to the requested offset.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 3 }]),
+        );
+        admin.fetchTopicOffsets.mockResolvedValue([
+          { partition: 0, low: "0", high: "100", offset: "100" },
+          { partition: 1, low: "0", high: "100", offset: "100" },
+          { partition: 2, low: "0", high: "100", offset: "100" },
+        ]);
+
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+        consumer.assignment.mockReturnValue([
+          { topic: "smoke", partition: 0 },
+          { topic: "smoke", partition: 1 },
+          { topic: "smoke", partition: 2 },
+        ]);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ topicName: "smoke", partition: 0, offset: "42" }],
+            maxMessages: 1,
+            timeoutMs: 500,
+            value: {},
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        expect(consumer.pause).toHaveBeenCalledWith([
+          { topic: "smoke", partitions: [1, 2] },
+        ]);
+        expect(consumer.seek).toHaveBeenCalledWith({
+          topic: "smoke",
+          partition: 0,
+          offset: "42",
+        });
+      });
+
+      it("should resolve a timestamp to per-partition offsets via fetchTopicOffsetsByTimestamp and seek each one", async () => {
+        // With `timestamp` and no `partition`, the spec says: resolve
+        // server-side to a per-partition offset map and seek each
+        // partition independently. ISO 8601 inputs are normalized to ms
+        // before the admin call.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+        admin.fetchTopicOffsetsByTimestamp.mockResolvedValue([
+          { partition: 0, offset: "12" },
+          { partition: 1, offset: "34" },
+        ]);
+
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+        consumer.assignment.mockReturnValue([
+          { topic: "smoke", partition: 0 },
+          { topic: "smoke", partition: 1 },
+        ]);
+
+        // ISO 8601 string; the handler must convert to ms-since-epoch via
+        // Date.parse before calling fetchTopicOffsetsByTimestamp.
+        const isoTimestamp = "2026-05-14T17:00:00Z";
+        const expectedMs = Date.parse(isoTimestamp);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ topicName: "smoke", timestamp: isoTimestamp }],
+            maxMessages: 1,
+            timeoutMs: 500,
+            value: {},
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        expect(admin.fetchTopicOffsetsByTimestamp).toHaveBeenCalledWith(
+          "smoke",
+          expectedMs,
+        );
+        // No partition restriction → keepPartitions is empty for "smoke" →
+        // no pause calls.
+        expect(consumer.pause).not.toHaveBeenCalled();
+        // Both partitions seek to their resolved offsets.
+        expect(consumer.seek).toHaveBeenCalledWith({
+          topic: "smoke",
+          partition: 0,
+          offset: "12",
+        });
+        expect(consumer.seek).toHaveBeenCalledWith({
+          topic: "smoke",
+          partition: 1,
+          offset: "34",
+        });
       });
     });
   });

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -1620,6 +1620,10 @@ describe("consume-kafka-messages-handler.ts", () => {
       stateOverrides: {
         isAccepting?: () => boolean;
         isPreflightApplied?: () => boolean;
+        shouldKeepDuringPrePause?: (
+          topic: string,
+          partition: number,
+        ) => boolean;
         maxMessages?: number;
       } = {},
     ) {
@@ -1631,6 +1635,8 @@ describe("consume-kafka-messages-handler.ts", () => {
           consumedMessages,
           isAccepting: stateOverrides.isAccepting ?? (() => true),
           isPreflightApplied: stateOverrides.isPreflightApplied ?? (() => true),
+          shouldKeepDuringPrePause:
+            stateOverrides.shouldKeepDuringPrePause ?? (() => true),
         },
         maxMessages: stateOverrides.maxMessages ?? 10,
         onMaxReached,
@@ -1671,18 +1677,86 @@ describe("consume-kafka-messages-handler.ts", () => {
       expect(onMaxReached).not.toHaveBeenCalled();
     });
 
-    it("should drop the message without calling processMessage when isPreflightApplied() returns false (pre-pause gate)", async () => {
-      // Pre-pause messages arrive from librdkafka's fetch buffer for
-      // partitions we intend to pause. The synchronous gate drops them
-      // on arrival rather than letting them sneak into consumedMessages.
+    it("should drop the message without calling processMessage when isPreflightApplied() is false AND the partition is outside the keep-set (pre-pause gate, partition-aware)", async () => {
+      // Pre-pause: a delivery from a partition we intend to pause
+      // arrives via librdkafka's fetch buffer between assignment-landing
+      // and pause-being-applied. The gate must drop it; if it sneaked
+      // through it'd corrupt consumedMessages with an off-target record.
       const { handler, processMessage, consumedMessages, onMaxReached } =
-        buildHandler({ isPreflightApplied: () => false });
+        buildHandler({
+          isPreflightApplied: () => false,
+          shouldKeepDuringPrePause: () => false,
+        });
 
       await handler(payload());
 
       expect(processMessage).not.toHaveBeenCalled();
       expect(consumedMessages).toHaveLength(0);
       expect(onMaxReached).not.toHaveBeenCalled();
+    });
+
+    it("should let a keep-set partition through during the pre-pause window when isPreflightApplied() is still false (no silent data loss on the partitions the caller asked for)", async () => {
+      // The bug Copilot caught: a partition-restricted consume can have
+      // librdkafka deliver records for the keep-set partition as soon
+      // as the rebalance assigns it (the pre-run-stashed seek is already
+      // baked in), well before the post-assignment hook flips
+      // preflightApplied. The earlier unconditional drop swallowed those
+      // records silently. The partition-aware gate must let them through.
+      const { handler, processMessage, consumedMessages } = buildHandler({
+        isPreflightApplied: () => false,
+        shouldKeepDuringPrePause: () => true,
+      });
+
+      const inst = payload();
+      await handler(inst);
+
+      expect(processMessage).toHaveBeenCalledWith("topic-x", 0, inst.message);
+      expect(consumedMessages).toEqual([makeProcessed()]);
+    });
+
+    it("should consult shouldKeepDuringPrePause with the actual (topic, partition) of the delivery so the keep-set check is per-message, not per-call", async () => {
+      // Pin the call shape: the gate must hand the real topic/partition
+      // of each delivery to the predicate. A bug where the gate dropped
+      // (or kept) every message regardless of partition would slip past
+      // the tests above; this one calls the same handler twice with
+      // different partitions and asserts both invocations land in the
+      // predicate as their own observable call.
+      const consumedMessages: ProcessedMessage[] = [];
+      const onMaxReached = vi.fn();
+      const processMessage = vi.fn().mockResolvedValue(makeProcessed());
+      const shouldKeepDuringPrePause = vi
+        .fn<(topic: string, partition: number) => boolean>()
+        .mockImplementation((_topic, partition) => partition === 0);
+      const handler = createEachMessageHandler({
+        state: {
+          consumedMessages,
+          isAccepting: () => true,
+          isPreflightApplied: () => false,
+          shouldKeepDuringPrePause,
+        },
+        maxMessages: 10,
+        onMaxReached,
+        processMessage,
+      });
+
+      await handler({
+        topic: "topic-x",
+        partition: 0,
+        message: fakeMessage(),
+      } as unknown as EachMessagePayload);
+      await handler({
+        topic: "topic-x",
+        partition: 1,
+        message: fakeMessage(),
+      } as unknown as EachMessagePayload);
+
+      // The predicate was consulted twice with the matching args.
+      expect(shouldKeepDuringPrePause).toHaveBeenCalledTimes(2);
+      expect(shouldKeepDuringPrePause).toHaveBeenNthCalledWith(1, "topic-x", 0);
+      expect(shouldKeepDuringPrePause).toHaveBeenNthCalledWith(2, "topic-x", 1);
+      // Only the partition-0 message landed; partition-1 was dropped.
+      expect(processMessage).toHaveBeenCalledOnce();
+      expect(consumedMessages).toHaveLength(1);
     });
 
     it("should fire onMaxReached exactly once when the count reaches maxMessages", async () => {

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -56,7 +56,7 @@ describe("consume-kafka-messages-handler.ts", () => {
       expect(parsed.offsetReset).toBe("latest");
     });
 
-    it.each(["earliest", "latest", "none"] as const)(
+    it.each(["earliest", "latest"] as const)(
       "should accept offsetReset='%s'",
       (offsetReset) => {
         const parsed = consumeKafkaMessagesArgs.parse({

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -4,6 +4,7 @@ import type {
   KafkaMessage,
 } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
+import * as nodeDeps from "@src/confluent/node-deps.js";
 import * as schemaRegistryHelper from "@src/confluent/schema-registry-helper.js";
 import {
   applyPostAssignmentHook,
@@ -12,6 +13,7 @@ import {
   createEachMessageHandler,
   formatMessageTimestamp,
   normalizeStart,
+  partitionScope,
   waitForAssignment,
   type ProcessedMessage,
 } from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
@@ -306,6 +308,20 @@ describe("consume-kafka-messages-handler.ts", () => {
       });
     });
 
+    it("should accept `start: {timestamp: 0}` (Unix epoch) — symmetry with the ISO arm, which accepts '1970-01-01T00:00:00Z'", () => {
+      // The numeric arm uses `.nonnegative()` so it stays in lockstep
+      // with the ISO arm; rejecting 0 here while accepting the same
+      // instant in ISO form would be a schema asymmetry.
+      const parsed = consumeKafkaMessagesArgs.parse({
+        topics: [{ name: "t", start: { timestamp: 0 } }],
+        valueFormat: {},
+      });
+      expect(parsed.topics[0]).toEqual({
+        name: "t",
+        start: { timestamp: 0 },
+      });
+    });
+
     it("should reject a malformed `start: {timestamp}` string with the path drilling into `start.timestamp`", () => {
       // Same Zod-4 granular-path behavior as the offset case: the
       // timestamp arm matches structurally; the inner validation fails.
@@ -322,7 +338,9 @@ describe("consume-kafka-messages-handler.ts", () => {
       ]);
     });
 
-    it("should reject a non-positive `start: {timestamp}` number with the path drilling into `start.timestamp`", () => {
+    it("should reject a negative `start: {timestamp}` number with the path drilling into `start.timestamp`", () => {
+      // The numeric arm uses `.nonnegative()` — negative values are
+      // still rejected; only zero and positive integers pass.
       const result = consumeKafkaMessagesArgs.safeParse({
         topics: [{ name: "t", start: { timestamp: -1 } }],
         valueFormat: {},
@@ -374,7 +392,10 @@ describe("consume-kafka-messages-handler.ts", () => {
         expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
           clusterId: undefined,
           envId: undefined,
-          groupId: undefined,
+          // Per-invocation UUID — loose matcher per the unit-tests
+          // rule's explicit allowance for generated UUIDs. A focused
+          // test below pins the exact derivation contract.
+          groupId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
           offsetReset: "earliest",
         });
       });
@@ -407,7 +428,52 @@ describe("consume-kafka-messages-handler.ts", () => {
         expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
           clusterId: undefined,
           envId: undefined,
-          groupId: undefined,
+          // Per-invocation UUID — loose matcher per the unit-tests
+          // rule's explicit allowance for generated UUIDs. A focused
+          // test below pins the exact derivation contract.
+          groupId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
+          offsetReset: "earliest",
+        });
+      });
+
+      it("should pass a fresh `nodeCrypto.randomUUID()` as groupId so each consume call is the sole member of its own Kafka consumer group (no concurrent-call partition contention)", async () => {
+        // Pin the exact derivation: groupId is whatever
+        // `nodeCrypto.randomUUID()` returned. Two concurrent calls
+        // can't race for the same partition assignment because each
+        // joins a different group of size 1.
+        const stubbedUuid = "deadbeef-cafe-1234-5678-abcdef012345";
+        vi.spyOn(nodeDeps.nodeCrypto, "randomUUID").mockReturnValue(
+          stubbedUuid,
+        );
+
+        const clientManager = getMockedClientManager();
+        const consumer = await clientManager.getConsumer();
+        consumer.connect.mockResolvedValue(undefined);
+        consumer.subscribe.mockResolvedValue(undefined);
+        consumer.run.mockResolvedValue(undefined);
+        consumer.disconnect.mockResolvedValue(undefined);
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [{ name: "smoke" }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+        });
+
+        expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
+          clusterId: undefined,
+          envId: undefined,
+          groupId: stubbedUuid,
           offsetReset: "earliest",
         });
       });
@@ -1037,7 +1103,10 @@ describe("consume-kafka-messages-handler.ts", () => {
         expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
           clusterId: undefined,
           envId: undefined,
-          groupId: undefined,
+          // Per-invocation UUID — loose matcher per the unit-tests
+          // rule's explicit allowance for generated UUIDs. A focused
+          // test below pins the exact derivation contract.
+          groupId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
           offsetReset: "latest",
         });
         // topic-a's partitions seek to their per-partition low watermarks
@@ -1093,7 +1162,10 @@ describe("consume-kafka-messages-handler.ts", () => {
         expect(clientManager.buildKafkaConsumer).toHaveBeenCalledWith({
           clusterId: undefined,
           envId: undefined,
-          groupId: undefined,
+          // Per-invocation UUID — loose matcher per the unit-tests
+          // rule's explicit allowance for generated UUIDs. A focused
+          // test below pins the exact derivation contract.
+          groupId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
           offsetReset: "earliest",
         });
         // The fast path means no admin probing and no per-partition
@@ -1663,6 +1735,49 @@ describe("consume-kafka-messages-handler.ts", () => {
       expect(await pending).toBeNull();
       // At least three polls before the deadline trips on iter 4.
       expect(consumer.assignment.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("partitionScope()", () => {
+    // Pin both branches of both methods so a future reshuffle of the
+    // "unrestricted vs restricted" framing can't silently land a bug
+    // — every caller routes through this helper, so any drift here
+    // ripples through the seek resolvers.
+    const items: { partition: number; tag: string }[] = [
+      { partition: 0, tag: "a" },
+      { partition: 1, tag: "b" },
+      { partition: 2, tag: "c" },
+    ];
+
+    describe(".filter(items)", () => {
+      it("should pass items through unchanged when no partition restriction", () => {
+        const scope = partitionScope(undefined);
+        expect(scope.filter(items)).toEqual(items);
+      });
+
+      it("should return only items matching the restricted partition when one is set", () => {
+        const scope = partitionScope(1);
+        expect(scope.filter(items)).toEqual([{ partition: 1, tag: "b" }]);
+      });
+
+      it("should return an empty array when the restricted partition has no matching items", () => {
+        // Defensive — the upstream validators normally guarantee the
+        // requested partition exists, but the helper itself must stay
+        // total: no matches means an empty array, not a throw.
+        const scope = partitionScope(99);
+        expect(scope.filter(items)).toEqual([]);
+      });
+    });
+
+    describe(".phrase()", () => {
+      it("should describe an unrestricted scope as 'every partition'", () => {
+        expect(partitionScope(undefined).phrase()).toBe("every partition");
+      });
+
+      it("should describe a restricted scope as 'partition N' with the partition index inlined", () => {
+        expect(partitionScope(0).phrase()).toBe("partition 0");
+        expect(partitionScope(7).phrase()).toBe("partition 7");
+      });
     });
   });
 

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -663,6 +663,74 @@ describe("consume-kafka-messages-handler.ts", () => {
         });
       });
 
+      it("should reject multiple unrestricted entries on the same topic (ambiguous: only one starting position per partition is honorable)", async () => {
+        // Two entries for "smoke" both at the topic level, with
+        // conflicting `start` directions. The schema/handler can't honor
+        // both — exactly one start wins the race silently. Reject loudly
+        // at preflight with a message naming the topic and the count.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { name: "smoke", start: "earliest" },
+              { name: "smoke", start: "latest" },
+            ],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+          },
+          outcome: {
+            resolves:
+              'Topic "smoke" has 2 entries without partition restrictions',
+          },
+          clientManager,
+        });
+      });
+
+      it("should reject duplicate `(topic, partition)` pairs (ambiguous: each subscribed partition has one starting position)", async () => {
+        // Two entries for the same partition with different `start`
+        // offsets — librdkafka would honor the seek that wins the
+        // pre-run-stash race, silently dropping the other.
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.fetchTopicMetadata.mockResolvedValue(
+          fakeFetchTopicMetadataResult([{ name: "smoke", numPartitions: 2 }]),
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWith(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topics: [
+              { name: "smoke", partition: 0, start: { offset: "10" } },
+              { name: "smoke", partition: 0, start: { offset: "20" } },
+            ],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+          },
+          outcome: {
+            resolves: 'Topic "smoke" has multiple entries for partition 0',
+          },
+          clientManager,
+        });
+      });
+
       it("should pause unassigned-to-target partitions and seek to the explicit offset for the requested partition", async () => {
         // Happy path of the seek/pause dance: caller restricts to
         // partition 0 with an explicit offset. The broker assigns three
@@ -1135,16 +1203,14 @@ describe("consume-kafka-messages-handler.ts", () => {
         let captured:
           | ((payload: EachMessagePayload) => Promise<void>)
           | undefined;
-        consumer.run.mockImplementation(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ((opts: any) => {
-            captured = opts.eachMessage;
-            // Engine "still running" — never settles so it doesn't end the
-            // race on its own.
-            return new Promise<void>(() => {});
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          }) as any,
-        );
+        consumer.run.mockImplementation((opts) => {
+          // `opts` infers as `ConsumerRunConfig | undefined` from the
+          // mocked `consumer.run` signature; no `any` needed.
+          captured = opts?.eachMessage;
+          // Engine "still running" — never settles so it doesn't end
+          // the race on its own.
+          return new Promise<void>(() => {});
+        });
 
         // Pre-parse so the args object satisfies the handler's
         // z.infer<>-typed `toolArguments` parameter (post-default

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -744,34 +744,10 @@ export async function waitForAssignment(
 }
 
 /**
- * Stash per-partition seeks on the consumer *before* `consumer.run()` is
- * invoked. The kafkajs-compat library queues these as "pending seeks" via
- * its `#addPendingOperation` → `#seekInternal` path; when the first
- * rebalance fires inside `run()`, the assignment handler calls
- * `#assignAsPerSeekedOffsets` and modifies the assignment to include the
- * seeked offsets *before* calling `assignmentFn`, so the partition is
- * assigned at the seek target atomically.
- *
- * This avoids the `ERR__STATE` race that the post-assignment seek path
- * trips: even after `consumer.assignment()` returns the partition, the
- * native librdkafka client can briefly reject seeks because its internal
- * state hasn't fully transitioned from "rebalancing" to "ready." The
- * pre-run path bypasses native seek calls entirely.
- */
-function stashSeeksBeforeRun(
-  consumer: KafkaJS.Consumer,
-  plan: PreflightPlan,
-): void {
-  for (const s of plan.seeks) {
-    consumer.seek({ topic: s.topic, partition: s.partition, offset: s.offset });
-  }
-}
-
-/**
  * After the consumer assignment lands, pause any assigned partition that
- * isn't in the keep-set. Seeks happen pre-run via {@link stashSeeksBeforeRun}
- * so the per-partition seek targets are already baked into the assignment
- * by the time this runs.
+ * isn't in the keep-set. Seeks were stashed before `consumer.run()` (see
+ * the inline comment in the orchestrator) so the per-partition seek
+ * targets are already baked into the assignment by the time this runs.
  */
 async function applyPauseAfterAssignment(
   consumer: KafkaJS.Consumer,
@@ -1098,14 +1074,27 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       await consumer.connect();
       await consumer.subscribe({ topics: plan.topicNames });
 
-      // Stash per-partition seeks BEFORE `consumer.run()`. The kafkajs-compat
-      // library queues these as pending seeks and applies them atomically
-      // during the first rebalance via `#assignAsPerSeekedOffsets`, so the
-      // partition is assigned at the seek target directly. Calling
-      // `consumer.seek()` after the rebalance trips an `ERR__STATE` race
-      // because the native librdkafka client can briefly reject seeks even
-      // after `consumer.assignment()` reports the partition as assigned.
-      stashSeeksBeforeRun(consumer, plan);
+      // Stash per-partition seeks on the consumer BEFORE `consumer.run()`
+      // is invoked. The kafkajs-compat library queues these as "pending
+      // seeks" via its `#addPendingOperation` → `#seekInternal` path; when
+      // the first rebalance fires inside `run()`, the assignment handler
+      // calls `#assignAsPerSeekedOffsets` and modifies the assignment to
+      // include the seeked offsets BEFORE calling `assignmentFn`, so the
+      // partition is assigned at the seek target atomically.
+      //
+      // This avoids the `ERR__STATE` race that the post-assignment seek
+      // path trips: even after `consumer.assignment()` returns the
+      // partition, the native librdkafka client can briefly reject seeks
+      // because its internal state hasn't fully transitioned from
+      // "rebalancing" to "ready." The pre-run path bypasses native seek
+      // calls entirely.
+      for (const s of plan.seeks) {
+        consumer.seek({
+          topic: s.topic,
+          partition: s.partition,
+          offset: s.offset,
+        });
+      }
 
       // Named exit conditions. Each Deferred resolves only its own
       // promise — the prior shared `timeoutReached` boolean was written

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -79,22 +79,16 @@ const topicConsumeOptions = z
       )
       .optional()
       .describe(
-        "Absolute starting offset within the partition. Kafka offsets " +
-          "are int64; pass as a string to preserve precision beyond JS's " +
-          "2^53 safe-integer range. Mutually exclusive with `timestamp`.",
+        "Absolute starting offset within the partition, as a digit-only " +
+          "string. Mutually exclusive with `timestamp`.",
       ),
     timestamp: z
-      .union([
-        z.string().datetime({ offset: true }),
-        z.number().int().positive(),
-      ])
+      .union([z.iso.datetime({ offset: true }), z.number().int().positive()])
       .optional()
       .describe(
         "Start consuming from this point in time. ISO 8601 preferred " +
           '(e.g. "2026-05-14T17:00:00Z" or "2026-05-14T13:00:00-04:00"); ' +
-          "ms-since-epoch accepted as an escape hatch for programmatic " +
-          "callers. Resolved to a partition offset server-side via " +
-          "fetchTopicOffsetsByTimestamp. Mutually exclusive with `offset`.",
+          "ms-since-epoch also accepted. Mutually exclusive with `offset`.",
       ),
   })
   .superRefine((data, ctx) => {
@@ -145,16 +139,14 @@ export const consumeKafkaMessagesArgs = z
         "Maximum time in milliseconds to wait for messages before stopping.",
       ),
     offsetReset: z
-      .enum(["earliest", "latest", "none"])
+      .enum(["earliest", "latest"])
       .optional()
       .default("latest")
       .describe(
         "Starting position when no committed offset exists: 'latest' " +
           "(default) reads only newly-produced messages from the partition " +
           "high watermark; 'earliest' reads from the partition low watermark " +
-          "(the entire retained history); 'none' fails rather than auto-pick, " +
-          "useful when the caller plans to seek to a specific offset and " +
-          "wants a loud error if that seek doesn't take effect.",
+          "(the entire retained history).",
       ),
     value: valueOptions,
     key: keyOptions.optional(),

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -154,8 +154,18 @@ export const consumeKafkaMessagesArgs = z.object({
     .describe(
       "Maximum time in milliseconds to wait for messages before stopping.",
     ),
-  valueFormat: schemaRegistryOptions,
-  keyFormat: schemaRegistryOptions,
+  valueFormat: schemaRegistryOptions.describe(
+    "How to interpret each message's VALUE bytes. Default: returned as a " +
+      "raw UTF-8 string. Set `useSchemaRegistry: true` (optionally with a " +
+      "`subject` override) to deserialize via the registered AVRO / JSON / " +
+      "PROTOBUF schema in Schema Registry.",
+  ),
+  keyFormat: schemaRegistryOptions.describe(
+    "How to interpret each message's KEY bytes. Default: returned as a " +
+      "raw UTF-8 string. Set `useSchemaRegistry: true` (optionally with a " +
+      "`subject` override) to deserialize via the registered AVRO / JSON / " +
+      "PROTOBUF schema in Schema Registry.",
+  ),
   cluster_id: z
     .string()
     .optional()
@@ -417,6 +427,53 @@ function validateRequestedPartitions(
 }
 
 /**
+ * Reject entries that target the same effective partition set more than
+ * once — those are ambiguous (each subscribed partition can have only
+ * one starting position; whichever seek/reset wins the race silently
+ * decides the behavior, and the caller never learns their request was
+ * over-specified). Two shapes of duplicate are rejected:
+ *
+ *  - **Unrestricted-mode topic** (no entry on this topic carries
+ *    `partition`): only one entry per topic is allowed. Two entries
+ *    targeting "every partition" with different `start` directions
+ *    (one `earliest`, one `latest`) is the canonical ambiguous case
+ *    and is what this branch catches.
+ *  - **Partition-mode topic** (every entry on this topic carries
+ *    `partition`): each `partition` index may appear at most once.
+ *    Two entries for the same `(topic, partition)` with different
+ *    `start` offsets/timestamps is the second ambiguous case.
+ *
+ * Assumes the caller has already invoked `buildKeepPartitions` (or its
+ * equivalent all-or-nothing check), so every topic group is consistently
+ * either fully unrestricted or fully partition-restricted.
+ */
+function validateNoDuplicateTargets(
+  byTopic: Map<string, NormalizedTopicTarget[]>,
+): void {
+  for (const [topic, list] of byTopic) {
+    if (list.length === 1) continue;
+    const partitioned = list[0]?.partition !== undefined;
+    if (!partitioned) {
+      throw new Error(
+        `Topic "${topic}" has ${list.length} entries without partition restrictions; ` +
+          `specify each topic at most once at the unrestricted level (or restrict each entry to a distinct partition).`,
+      );
+    }
+    const seen = new Set<number>();
+    for (const t of list) {
+      const p = t.partition!;
+      if (seen.has(p)) {
+        throw new Error(
+          `Topic "${topic}" has multiple entries for partition ${p}; ` +
+            `specify each (topic, partition) pair at most once.`,
+        );
+      }
+      seen.add(p);
+    }
+  }
+}
+
+/**
  * Derive the per-topic keep-set for partition pause/skip filtering.
  * Per-topic mode is all-or-nothing: every entry for a given topic
  * must specify `partition`, or none of them may. Mixing the two is
@@ -596,8 +653,8 @@ async function resolveTimestampSeeks(
       `Topic "${topic}" has no messages at or after timestamp ` +
         `${new Date(timestampMs).toISOString()} ` +
         `(${partitionPhrase} no record produced past that point). ` +
-        `Try a more recent timestamp, or omit \`timestamp\` to consume ` +
-        `from the live position.`,
+        `Try an earlier timestamp, or use \`start: "latest"\` to consume ` +
+        `from the live position instead.`,
     );
   }
   if (silent.length > 0) {
@@ -647,6 +704,7 @@ async function buildPreflightPlan(
   const numPartitionsByTopic = await fetchPartitionCounts(admin, topicNames);
   validateRequestedPartitions(targets, numPartitionsByTopic);
   const keepPartitions = buildKeepPartitions(byTopic);
+  validateNoDuplicateTargets(byTopic);
 
   const getWatermarks = createWatermarkCache(admin);
   const seeks: PreflightPlan["seeks"] = [];
@@ -998,7 +1056,16 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
 
     let registry: SchemaRegistryClient | undefined;
     if (needsRegistry) {
-      registry = await clientManager.getSchemaRegistrySdkClient(resolved.envId);
+      try {
+        registry = await clientManager.getSchemaRegistrySdkClient(
+          resolved.envId,
+        );
+      } catch (error: unknown) {
+        return this.createResponse(
+          `Failed to consume messages: ${formatKafkaError(error)}`,
+          true,
+        );
+      }
     }
 
     const targets = normalizeTopicTargets(parsed);
@@ -1007,11 +1074,17 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
 
     let plan: PreflightPlan;
     if (needsPreflight) {
-      const admin = await clientManager.getKafkaAdminClient(
-        resolved.clusterId,
-        resolved.envId,
-      );
+      // `admin` is acquired INSIDE the try so a failed
+      // getKafkaAdminClient() (auth/network) becomes a tool-error
+      // response rather than propagating up unhandled. The finally
+      // guards against running disposeIfOAuth on an undefined admin
+      // (which would happen if the acquisition itself threw).
+      let admin: KafkaJS.Admin | undefined;
       try {
+        admin = await clientManager.getKafkaAdminClient(
+          resolved.clusterId,
+          resolved.envId,
+        );
         plan = await buildPreflightPlan(admin, targets, offsetReset);
       } catch (error: unknown) {
         return this.createResponse(
@@ -1019,7 +1092,9 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
           true,
         );
       } finally {
-        await disposeIfOAuth(runtime, connId, admin);
+        if (admin !== undefined) {
+          await disposeIfOAuth(runtime, connId, admin);
+        }
       }
     } else {
       plan = {

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1,5 +1,8 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
-import { KafkaMessage } from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import type {
+  ITopicMetadata,
+  KafkaMessage,
+} from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
 import {
   deserializeMessage,
@@ -13,6 +16,7 @@ import {
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
+  disposeIfOAuth,
   formatKafkaError,
   resolveKafkaClusterArgs,
 } from "@src/confluent/tools/cluster-arg-resolvers.js";
@@ -44,42 +48,149 @@ const keyOptions = z.object({}).extend(messageOptions.shape);
 type ValueOptions = z.infer<typeof valueOptions>;
 type KeyOptions = z.infer<typeof keyOptions>;
 
-export const consumeKafkaMessagesArgs = z.object({
-  topicNames: z
-    .array(z.string())
-    .nonempty()
-    .describe("Names of the Kafka topics to consume from."),
-  maxMessages: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .default(10)
-    .describe("Maximum number of messages to consume before stopping."),
-  timeoutMs: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .default(10000)
-    .describe(
-      "Maximum time in milliseconds to wait for messages before stopping.",
-    ),
-  value: valueOptions,
-  key: keyOptions.optional(),
-  cluster_id: z
-    .string()
-    .optional()
-    .describe(
-      "Confluent Cloud logical Kafka cluster ID (lkc-...). Discover via list-clusters.",
-    ),
-  environment_id: z
-    .string()
-    .optional()
-    .describe(
-      "Confluent Cloud environment ID (env-...) that owns the cluster. Discover via list-environments.",
-    ),
-});
+/**
+ * Per-topic consume options. Lets callers restrict consumption to a
+ * specific partition and/or seek to a specific starting position within
+ * that partition. Use the parent {@link consumeKafkaMessagesArgs}'s
+ * `topics` array; pass a bare {@link consumeKafkaMessagesArgs.topicNames}
+ * list when no per-topic overrides are needed.
+ */
+const topicConsumeOptions = z
+  .object({
+    topicName: z
+      .string()
+      .min(1)
+      .describe("Name of the Kafka topic to consume from."),
+    partition: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Restrict consumption to this partition (0-indexed). Other " +
+          "partitions in the topic are paused after assignment. Omit " +
+          "to consume all partitions of the topic.",
+      ),
+    offset: z
+      .string()
+      .regex(
+        /^\d+$/,
+        "offset must be a non-negative integer (digit-only string)",
+      )
+      .optional()
+      .describe(
+        "Absolute starting offset within the partition. Kafka offsets " +
+          "are int64; pass as a string to preserve precision beyond JS's " +
+          "2^53 safe-integer range. Mutually exclusive with `timestamp`.",
+      ),
+    timestamp: z
+      .union([
+        z.string().datetime({ offset: true }),
+        z.number().int().positive(),
+      ])
+      .optional()
+      .describe(
+        "Start consuming from this point in time. ISO 8601 preferred " +
+          '(e.g. "2026-05-14T17:00:00Z" or "2026-05-14T13:00:00-04:00"); ' +
+          "ms-since-epoch accepted as an escape hatch for programmatic " +
+          "callers. Resolved to a partition offset server-side via " +
+          "fetchTopicOffsetsByTimestamp. Mutually exclusive with `offset`.",
+      ),
+  })
+  .superRefine((data, ctx) => {
+    if (data.offset !== undefined && data.timestamp !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Specify only one of `offset` or `timestamp` per topic entry, not both.",
+        path: [],
+      });
+    }
+  });
+
+export const consumeKafkaMessagesArgs = z
+  .object({
+    topicNames: z
+      .array(z.string())
+      .nonempty()
+      .optional()
+      .describe(
+        "Simple list of Kafka topic names. Use when no per-topic " +
+          "partition/offset/timestamp overrides are needed. Mutually " +
+          "exclusive with `topics`.",
+      ),
+    topics: z
+      .array(topicConsumeOptions)
+      .nonempty()
+      .optional()
+      .describe(
+        "Per-topic consume options. Use when restricting partitions " +
+          "or seeking by offset/timestamp on individual topics. " +
+          "Mutually exclusive with `topicNames`.",
+      ),
+    maxMessages: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(10)
+      .describe("Maximum number of messages to consume before stopping."),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(10000)
+      .describe(
+        "Maximum time in milliseconds to wait for messages before stopping.",
+      ),
+    offsetReset: z
+      .enum(["earliest", "latest", "none"])
+      .optional()
+      .default("latest")
+      .describe(
+        "Starting position when no committed offset exists: 'latest' " +
+          "(default) reads only newly-produced messages from the partition " +
+          "high watermark; 'earliest' reads from the partition low watermark " +
+          "(the entire retained history); 'none' fails rather than auto-pick, " +
+          "useful when the caller plans to seek to a specific offset and " +
+          "wants a loud error if that seek doesn't take effect.",
+      ),
+    value: valueOptions,
+    key: keyOptions.optional(),
+    cluster_id: z
+      .string()
+      .optional()
+      .describe(
+        "Confluent Cloud logical Kafka cluster ID (lkc-...). Discover via list-clusters.",
+      ),
+    environment_id: z
+      .string()
+      .optional()
+      .describe(
+        "Confluent Cloud environment ID (env-...) that owns the cluster. Discover via list-environments.",
+      ),
+  })
+  .superRefine((data, ctx) => {
+    const hasTopicNames =
+      data.topicNames !== undefined && data.topicNames.length > 0;
+    const hasTopics = data.topics !== undefined && data.topics.length > 0;
+    if (hasTopicNames && hasTopics) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Specify exactly one of `topicNames` (simple list) or `topics` (per-topic overrides), not both.",
+        path: [],
+      });
+    } else if (!hasTopicNames && !hasTopics) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Specify either `topicNames` (simple list of topics) or `topics` (per-topic partition/offset/timestamp overrides).",
+        path: [],
+      });
+    }
+  });
 
 interface ProcessedMessage {
   key: unknown;
@@ -89,6 +200,271 @@ interface ProcessedMessage {
   headers?: Record<string, string>;
   topic: string;
   partition: number;
+}
+
+/**
+ * Internal normalized form for the per-topic consume options, used by the
+ * pre-flight and seek/pause helpers. Either branch of the tool's input
+ * (`topicNames` or `topics`) collapses into a list of these.
+ */
+interface NormalizedTopicTarget {
+  topicName: string;
+  partition?: number;
+  /** Digit-only string, already validated by Zod. */
+  offset?: string;
+  /** ms-since-epoch; ISO 8601 inputs are normalized at the boundary. */
+  timestampMs?: number;
+}
+
+/**
+ * Result of {@link buildPreflightPlan}: the canonical list of topics to
+ * subscribe to plus the partition-keep set and per-partition seek targets
+ * that {@link applySeekAndPause} will apply after the consumer assignment
+ * lands.
+ */
+interface PreflightPlan {
+  /** Unique topic names to subscribe to (deduplicated across entries). */
+  topicNames: string[];
+  /**
+   * If a topic appears here, only the listed partitions are kept active;
+   * any other partition the broker assigns is paused. Absent topic means
+   * "keep every assigned partition for that topic."
+   */
+  keepPartitions: Map<string, Set<number>>;
+  /** Per-(topic, partition) seek targets. */
+  seeks: { topic: string; partition: number; offset: string }[];
+}
+
+/**
+ * Normalize the parsed tool args into a uniform list of per-topic targets.
+ * `topicNames` callers get bare entries (no partition/offset/timestamp);
+ * `topics` callers get their entries through with ISO 8601 timestamps
+ * converted to ms-since-epoch so downstream code only sees numbers.
+ */
+function normalizeTopicTargets(
+  parsed: z.infer<typeof consumeKafkaMessagesArgs>,
+): NormalizedTopicTarget[] {
+  if (parsed.topicNames !== undefined) {
+    return parsed.topicNames.map((topicName) => ({ topicName }));
+  }
+  // Zod's xor refinement guarantees `topics` is populated here.
+  return parsed.topics!.map((entry) => ({
+    topicName: entry.topicName,
+    partition: entry.partition,
+    offset: entry.offset,
+    timestampMs:
+      entry.timestamp === undefined
+        ? undefined
+        : typeof entry.timestamp === "number"
+          ? entry.timestamp
+          : Date.parse(entry.timestamp),
+  }));
+}
+
+/**
+ * Returns true when any target carries a partition restriction or seek
+ * target — i.e. when the handler needs to build an admin client and run
+ * pre-flight + post-assignment seek/pause. Plain `topicNames` calls skip
+ * the whole dance.
+ */
+function planNeedsPreflight(targets: NormalizedTopicTarget[]): boolean {
+  return targets.some(
+    (t) =>
+      t.partition !== undefined ||
+      t.offset !== undefined ||
+      t.timestampMs !== undefined,
+  );
+}
+
+/**
+ * Validates the requested targets against broker metadata and watermarks,
+ * resolves any timestamp-based seeks to concrete partition offsets, and
+ * produces the canonical {@link PreflightPlan}. Thrown errors are caught
+ * one frame up and rendered as a tool-error response.
+ *
+ * Validation rules (handler-side; the Zod schema covers field-level shape):
+ * - `offset` requires `partition` — absolute offsets are partition-scoped;
+ *   different partitions have different offset spaces.
+ * - All-or-nothing partition mode per topic: every entry for a given
+ *   topic must specify `partition`, or none of them may. Mixing is
+ *   ambiguous (does the bare entry override the partitioned one or
+ *   coexist with it?) and rejected loudly.
+ * - Requested partitions must exist (cross-check with
+ *   `admin.fetchTopicMetadata`).
+ * - Absolute offsets must lie in `[low, high)` for their partition
+ *   (cross-check with `admin.fetchTopicOffsets`).
+ */
+async function buildPreflightPlan(
+  admin: KafkaJS.Admin,
+  targets: NormalizedTopicTarget[],
+): Promise<PreflightPlan> {
+  for (const t of targets) {
+    if (t.offset !== undefined && t.partition === undefined) {
+      throw new Error(
+        `Topic "${t.topicName}" has an explicit offset (${t.offset}) but no partition. ` +
+          `Absolute offsets are partition-scoped — different partitions have different offset spaces. ` +
+          `Either also supply a partition for this entry, or use timestamp (which resolves per-partition).`,
+      );
+    }
+  }
+
+  const byTopic = new Map<string, NormalizedTopicTarget[]>();
+  for (const t of targets) {
+    let list = byTopic.get(t.topicName);
+    if (!list) {
+      list = [];
+      byTopic.set(t.topicName, list);
+    }
+    list.push(t);
+  }
+  const topicNames = [...byTopic.keys()];
+
+  const metadataRaw = await admin.fetchTopicMetadata({ topics: topicNames });
+  // The @confluentinc/kafka-javascript .d.ts declares this call as
+  // `Promise<{ topics: Array<ITopicMetadata> }>` but the runtime
+  // implementation returns the bare `Array<ITopicMetadata>` — long-standing
+  // mismatch tracked at confluentinc/confluent-kafka-javascript#367.
+  // Normalize defensively so either shape works if the library ever fixes
+  // its type declaration.
+  const topicMetadata: ITopicMetadata[] = Array.isArray(metadataRaw)
+    ? (metadataRaw as unknown as ITopicMetadata[])
+    : metadataRaw.topics;
+  const numPartitionsByTopic = new Map<string, number>();
+  for (const t of topicMetadata) {
+    numPartitionsByTopic.set(t.name, t.partitions.length);
+  }
+  for (const name of topicNames) {
+    if (!numPartitionsByTopic.has(name)) {
+      throw new Error(
+        `Topic "${name}" returned no partition metadata (does it exist on this cluster?).`,
+      );
+    }
+  }
+
+  for (const t of targets) {
+    if (t.partition !== undefined) {
+      const numParts = numPartitionsByTopic.get(t.topicName)!;
+      if (t.partition >= numParts) {
+        throw new Error(
+          `Topic "${t.topicName}" has ${numParts} partition(s) (0..${numParts - 1}); ` +
+            `requested partition ${t.partition} is out of range.`,
+        );
+      }
+    }
+  }
+
+  const keepPartitions = new Map<string, Set<number>>();
+  for (const [topic, list] of byTopic) {
+    const explicit = list
+      .map((t) => t.partition)
+      .filter((p): p is number => p !== undefined);
+    if (explicit.length === list.length) {
+      keepPartitions.set(topic, new Set(explicit));
+    } else if (explicit.length > 0) {
+      throw new Error(
+        `Topic "${topic}" mixes entries with explicit partitions and entries without one. ` +
+          `Pick one mode per topic: either every entry restricts to a partition, or none do.`,
+      );
+    }
+    // explicit.length === 0 → no restriction; keepPartitions omits the topic.
+  }
+
+  const seeks: PreflightPlan["seeks"] = [];
+  for (const t of targets) {
+    if (t.offset !== undefined && t.partition !== undefined) {
+      const offsets = await admin.fetchTopicOffsets(t.topicName);
+      const partOffsets = offsets.find((o) => o.partition === t.partition);
+      if (!partOffsets) {
+        throw new Error(
+          `Topic "${t.topicName}" partition ${t.partition} returned no offset metadata.`,
+        );
+      }
+      const low = BigInt(partOffsets.low);
+      const high = BigInt(partOffsets.high);
+      const target = BigInt(t.offset);
+      if (target < low || target >= high) {
+        throw new Error(
+          `Topic "${t.topicName}" partition ${t.partition} offset ${t.offset} is out of range ` +
+            `[low=${partOffsets.low}, high=${partOffsets.high}). ` +
+            `An empty partition has low === high; pick an offset already on the partition.`,
+        );
+      }
+      seeks.push({
+        topic: t.topicName,
+        partition: t.partition,
+        offset: t.offset,
+      });
+    } else if (t.timestampMs !== undefined) {
+      const resolved = await admin.fetchTopicOffsetsByTimestamp(
+        t.topicName,
+        t.timestampMs,
+      );
+      const candidates =
+        t.partition !== undefined
+          ? resolved.filter((r) => r.partition === t.partition)
+          : resolved;
+      for (const r of candidates) {
+        seeks.push({
+          topic: t.topicName,
+          partition: r.partition,
+          offset: r.offset,
+        });
+      }
+    }
+  }
+
+  return { topicNames, keepPartitions, seeks };
+}
+
+/**
+ * Poll `consumer.assignment()` until it returns a non-empty array or the
+ * supplied deadline passes. Returns the assignment, or `null` if the
+ * deadline was hit first. The kafkajs-compat consumer only populates its
+ * assignment after `consumer.run()` triggers the first poll, so this is
+ * the well-defined seam to wait on before issuing per-partition seeks.
+ */
+async function waitForAssignment(
+  consumer: KafkaJS.Consumer,
+  deadline: number,
+): Promise<{ topic: string; partition: number }[] | null> {
+  for (;;) {
+    const assignment = consumer.assignment();
+    if (assignment.length > 0) {
+      return assignment;
+    }
+    if (Date.now() >= deadline) {
+      return null;
+    }
+    await new Promise<void>((r) => setTimeout(r, 50));
+  }
+}
+
+/**
+ * After the consumer assignment lands, pause any assigned partition that
+ * isn't in the keep-set and seek each per-partition target to its
+ * resolved offset.
+ */
+async function applySeekAndPause(
+  consumer: KafkaJS.Consumer,
+  plan: PreflightPlan,
+  assignment: { topic: string; partition: number }[],
+): Promise<void> {
+  const toPause: { topic: string; partitions: number[] }[] = [];
+  for (const [topic, keepSet] of plan.keepPartitions) {
+    const pauseForTopic = assignment
+      .filter((a) => a.topic === topic && !keepSet.has(a.partition))
+      .map((a) => a.partition);
+    if (pauseForTopic.length > 0) {
+      toPause.push({ topic, partitions: pauseForTopic });
+    }
+  }
+  if (toPause.length > 0) {
+    consumer.pause(toPause);
+  }
+
+  for (const s of plan.seeks) {
+    consumer.seek({ topic: s.topic, partition: s.partition, offset: s.offset });
+  }
 }
 
 /**
@@ -194,7 +570,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     sessionId?: string,
   ): Promise<CallToolResult> {
     const parsed = consumeKafkaMessagesArgs.parse(toolArguments);
-    const { topicNames, maxMessages, timeoutMs, value, key } = parsed;
+    const { maxMessages, timeoutMs, value, key, offsetReset } = parsed;
 
     const { connId, clientManager } = this.resolveSoleConnection(runtime);
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
@@ -207,18 +583,51 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       registry = await clientManager.getSchemaRegistrySdkClient(resolved.envId);
     }
 
+    const targets = normalizeTopicTargets(parsed);
+    const needsPreflight = planNeedsPreflight(targets);
+
+    let plan: PreflightPlan;
+    if (needsPreflight) {
+      const admin = await clientManager.getKafkaAdminClient(
+        resolved.clusterId,
+        resolved.envId,
+      );
+      try {
+        plan = await buildPreflightPlan(admin, targets);
+      } catch (error: unknown) {
+        return this.createResponse(
+          `Failed to consume messages: ${formatKafkaError(error)}`,
+          true,
+        );
+      } finally {
+        await disposeIfOAuth(runtime, connId, admin);
+      }
+    } else {
+      plan = {
+        topicNames: [...new Set(targets.map((t) => t.topicName))],
+        keepPartitions: new Map(),
+        seeks: [],
+      };
+    }
+
     const consumedMessages: ProcessedMessage[] = [];
     let timeoutReached = false;
+    // When the plan has no seeks/pauses, every message coming in via
+    // eachMessage is "post-seek" by definition — start counting immediately.
+    let seekApplied = !needsPreflight;
     let consumer: KafkaJS.Consumer | undefined;
 
     try {
-      consumer = await clientManager.buildKafkaConsumer(
-        resolved.clusterId,
-        resolved.envId,
-        sessionId,
-      );
+      consumer = await clientManager.buildKafkaConsumer({
+        clusterId: resolved.clusterId,
+        envId: resolved.envId,
+        groupId: sessionId,
+        offsetReset,
+      });
       await consumer.connect();
-      await consumer.subscribe({ topics: topicNames });
+      await consumer.subscribe({ topics: plan.topicNames });
+
+      const deadline = Date.now() + timeoutMs;
 
       const consumePromise = new Promise<void>((resolve, reject) => {
         if (!consumer) {
@@ -229,6 +638,10 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
           .run({
             eachMessage: async ({ topic, partition, message }) => {
               if (timeoutReached) return;
+              // Drop messages that arrive before the seek/pause dance has
+              // run; they're from the consumer's pre-seek fetch buffer and
+              // don't reflect the requested starting position.
+              if (!seekApplied) return;
               const processed = await this.processMessage(
                 topic,
                 partition,
@@ -251,12 +664,30 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
           timeoutReached = true;
           resolve();
         }, timeoutMs);
+
+        if (needsPreflight) {
+          (async () => {
+            const assignment = await waitForAssignment(consumer!, deadline);
+            if (!assignment) {
+              // timeoutMs elapsed before the consumer received any
+              // partition assignment — we'll return 0 messages with the
+              // normal timeout path. The setTimeout above will also fire.
+              timeoutReached = true;
+              resolve();
+              return;
+            }
+            await applySeekAndPause(consumer!, plan, assignment);
+            seekApplied = true;
+          })().catch((error) => {
+            reject(error);
+          });
+        }
       });
 
       await consumePromise;
 
       return this.createResponse(
-        `Consumed ${consumedMessages.length} messages from topics ${topicNames.join(", ")}.\nConsumed messages: ${JSON.stringify(consumedMessages, null, 2)}`,
+        `Consumed ${consumedMessages.length} messages from topics ${plan.topicNames.join(", ")}.\nConsumed messages: ${JSON.stringify(consumedMessages, null, 2)}`,
         false,
       );
     } catch (error: unknown) {

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -23,7 +23,7 @@ import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
-const messageOptions = z
+const schemaRegistryOptions = z
   .object({
     useSchemaRegistry: z
       .boolean()
@@ -47,12 +47,12 @@ const messageOptions = z
   .default({ useSchemaRegistry: false });
 
 // `ValueOptions` and `KeyOptions` are structurally identical to
-// `messageOptions` — they exist as named types only to make the
+// `schemaRegistryOptions` — they exist as named types only to make the
 // value-side vs key-side distinction explicit at `processMessage`'s
-// signature. The schema fields below use `messageOptions` directly;
+// signature. The schema fields below use `schemaRegistryOptions` directly;
 // no separate runtime schema is needed for each side.
-type ValueOptions = z.infer<typeof messageOptions>;
-type KeyOptions = z.infer<typeof messageOptions>;
+type ValueOptions = z.infer<typeof schemaRegistryOptions>;
+type KeyOptions = z.infer<typeof schemaRegistryOptions>;
 
 /**
  * Per-entry "where to start consuming" tagged union. Collapses the prior
@@ -154,8 +154,8 @@ export const consumeKafkaMessagesArgs = z.object({
     .describe(
       "Maximum time in milliseconds to wait for messages before stopping.",
     ),
-  valueFormat: messageOptions,
-  keyFormat: messageOptions,
+  valueFormat: schemaRegistryOptions,
+  keyFormat: schemaRegistryOptions,
   cluster_id: z
     .string()
     .optional()

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1246,7 +1246,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     return {
       name: ToolName.CONSUME_MESSAGES,
       description:
-        "Consumes messages from one or more Kafka topics. Supports automatic deserialization of Schema Registry encoded messages (AVRO, JSON, PROTOBUF).",
+        "Consume messages from Kafka topics. Optionally restrict to a partition, start from an offset, timestamp, or 'earliest'/'latest'. Auto-deserializes Schema Registry messages (AVRO/JSON/PROTOBUF).",
       inputSchema: consumeKafkaMessagesArgs.shape,
       annotations: READ_ONLY,
     };

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -472,6 +472,28 @@ function createWatermarkCache(admin: KafkaJS.Admin): WatermarkCache {
 }
 
 /**
+ * Encapsulate the "is consumption restricted to one partition, or
+ * unrestricted across the whole topic?" decision behind two operations:
+ * `filter(items)` (subset to the restricted partition, or pass through
+ * unchanged) and `phrase()` (a human-readable description for use in
+ * error messages and logs). Centralizes the `restrictToPartition ===
+ * undefined` check in one place so the seek resolvers don't each
+ * re-derive it.
+ */
+function partitionScope(restrictToPartition: number | undefined) {
+  return {
+    filter: <T extends { partition: number }>(items: T[]): T[] =>
+      restrictToPartition === undefined
+        ? items
+        : items.filter((i) => i.partition === restrictToPartition),
+    phrase: (): string =>
+      restrictToPartition === undefined
+        ? "every partition"
+        : `partition ${restrictToPartition}`,
+  };
+}
+
+/**
  * Validate an explicit `start: {offset}` against the partition's
  * `[low, high)` watermarks and return the seek target. Throws if the
  * partition has no offset metadata or the requested offset is out of
@@ -533,10 +555,8 @@ async function resolveTimestampSeeks(
     watermarkByPartition.set(w.partition, { low: w.low, high: w.high });
   }
 
-  const candidates =
-    restrictToPartition !== undefined
-      ? resolved.filter((r) => r.partition === restrictToPartition)
-      : resolved;
+  const scope = partitionScope(restrictToPartition);
+  const candidates = scope.filter(resolved);
 
   const active: typeof candidates = [];
   const silent: number[] = [];
@@ -571,10 +591,7 @@ async function resolveTimestampSeeks(
   }
 
   if (active.length === 0) {
-    const partitionPhrase =
-      restrictToPartition !== undefined
-        ? `partition ${restrictToPartition} has`
-        : `every partition has`;
+    const partitionPhrase = `${scope.phrase()} has`;
     throw new Error(
       `Topic "${topic}" has no messages at or after timestamp ` +
         `${new Date(timestampMs).toISOString()} ` +
@@ -611,10 +628,7 @@ async function resolveEarliestMinoritySeeks(
   getWatermarks: WatermarkCache,
 ): Promise<PreflightPlan["seeks"]> {
   const offsets = await getWatermarks(topic);
-  const partitionsToSeek =
-    restrictToPartition !== undefined
-      ? offsets.filter((o) => o.partition === restrictToPartition)
-      : offsets;
+  const partitionsToSeek = partitionScope(restrictToPartition).filter(offsets);
   return partitionsToSeek.map((p) => ({
     topic,
     partition: p.partition,

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -371,18 +371,6 @@ function guardOffsetRequiresPartition(targets: NormalizedTopicTarget[]): void {
  * for both the all-or-nothing partition-mode check and the keep-set
  * derivation; computing it once means subsequent iterations stay O(N).
  */
-function groupByTopic(
-  targets: NormalizedTopicTarget[],
-): Map<string, NormalizedTopicTarget[]> {
-  const byTopic = new Map<string, NormalizedTopicTarget[]>();
-  for (const t of targets) {
-    const list = byTopic.get(t.name);
-    if (list) list.push(t);
-    else byTopic.set(t.name, [t]);
-  }
-  return byTopic;
-}
-
 /**
  * Fetch partition counts for the supplied topics via
  * `admin.fetchTopicMetadata`. Throws if any requested topic returned no
@@ -524,28 +512,6 @@ function createWatermarkCache(admin: KafkaJS.Admin): WatermarkCache {
 }
 
 /**
- * Encapsulate the "is consumption restricted to one partition, or
- * unrestricted across the whole topic?" decision behind two operations:
- * `filter(items)` (subset to the restricted partition, or pass through
- * unchanged) and `phrase()` (a human-readable description for use in
- * error messages and logs). Centralizes the `restrictToPartition ===
- * undefined` check in one place so the seek resolvers don't each
- * re-derive it.
- */
-export function partitionScope(restrictToPartition: number | undefined) {
-  return {
-    filter: <T extends { partition: number }>(items: T[]): T[] =>
-      restrictToPartition === undefined
-        ? items
-        : items.filter((i) => i.partition === restrictToPartition),
-    phrase: (): string =>
-      restrictToPartition === undefined
-        ? "every partition"
-        : `partition ${restrictToPartition}`,
-  };
-}
-
-/**
  * Validate an explicit `start: {offset}` against the partition's
  * `[low, high)` watermarks and return the seek target. Throws if the
  * partition has no offset metadata or the requested offset is out of
@@ -607,8 +573,10 @@ async function resolveTimestampSeeks(
     watermarkByPartition.set(w.partition, { low: w.low, high: w.high });
   }
 
-  const scope = partitionScope(restrictToPartition);
-  const candidates = scope.filter(resolved);
+  const candidates =
+    restrictToPartition === undefined
+      ? resolved
+      : resolved.filter((r) => r.partition === restrictToPartition);
 
   const active: typeof candidates = [];
   const silent: number[] = [];
@@ -643,11 +611,14 @@ async function resolveTimestampSeeks(
   }
 
   if (active.length === 0) {
-    const partitionPhrase = `${scope.phrase()} has`;
+    const scopePhrase =
+      restrictToPartition === undefined
+        ? "every partition"
+        : `partition ${restrictToPartition}`;
     throw new Error(
       `Topic "${topic}" has no messages at or after timestamp ` +
         `${new Date(timestampMs).toISOString()} ` +
-        `(${partitionPhrase} no record produced past that point). ` +
+        `(${scopePhrase} has no record produced past that point). ` +
         `Try an earlier timestamp, or use \`start: "latest"\` to consume ` +
         `from the live position instead.`,
     );
@@ -680,7 +651,10 @@ async function resolveEarliestMinoritySeeks(
   getWatermarks: WatermarkCache,
 ): Promise<PreflightPlan["seeks"]> {
   const offsets = await getWatermarks(topic);
-  const partitionsToSeek = partitionScope(restrictToPartition).filter(offsets);
+  const partitionsToSeek =
+    restrictToPartition === undefined
+      ? offsets
+      : offsets.filter((o) => o.partition === restrictToPartition);
   return partitionsToSeek.map((p) => ({
     topic,
     partition: p.partition,
@@ -694,7 +668,12 @@ async function buildPreflightPlan(
   consumerOffsetReset: "earliest" | "latest",
 ): Promise<PreflightPlan> {
   guardOffsetRequiresPartition(targets);
-  const byTopic = groupByTopic(targets);
+  const byTopic = new Map<string, NormalizedTopicTarget[]>();
+  for (const t of targets) {
+    const list = byTopic.get(t.name);
+    if (list) list.push(t);
+    else byTopic.set(t.name, [t]);
+  }
   const topicNames = [...byTopic.keys()];
   const numPartitionsByTopic = await fetchPartitionCounts(admin, topicNames);
   validateRequestedPartitions(targets, numPartitionsByTopic);

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -440,41 +440,51 @@ function validateRequestedPartitions(
 }
 
 /**
- * Reject entries that target the same effective partition set more than
- * once — those are ambiguous (each subscribed partition can have only
- * one starting position; whichever seek/reset wins the race silently
- * decides the behavior, and the caller never learns their request was
- * over-specified). Two shapes of duplicate are rejected:
+ * Validate per-topic consistency and derive the keep-partitions map in
+ * a single pass over `byTopic`. Three rejections fire here, each a
+ * shape of "starting position is ambiguous" the consumer can't honor:
  *
- *  - **Unrestricted-mode topic** (no entry on this topic carries
- *    `partition`): only one entry per topic is allowed. Two entries
- *    targeting "every partition" with different `start` directions
- *    (one `earliest`, one `latest`) is the canonical ambiguous case
- *    and is what this branch catches.
- *  - **Partition-mode topic** (every entry on this topic carries
- *    `partition`): each `partition` index may appear at most once.
- *    Two entries for the same `(topic, partition)` with different
- *    `start` offsets/timestamps is the second ambiguous case.
+ *  - **Mixed mode**: a topic with some entries restricting to a partition
+ *    and others not — does the bare entry coexist with or override the
+ *    partitioned one? Reject loudly.
+ *  - **Duplicate unrestricted**: a topic with multiple entries that all
+ *    omit `partition`. Two "every partition" entries with conflicting
+ *    `start` directions silently let one win the seek/reset race; reject.
+ *  - **Duplicate (topic, partition)**: the same partition index referenced
+ *    twice within one topic — same ambiguity at finer granularity.
  *
- * Assumes the caller has already invoked `buildKeepPartitions` (or its
- * equivalent all-or-nothing check), so every topic group is consistently
- * either fully unrestricted or fully partition-restricted.
+ * Topics whose entries are all unrestricted are omitted from the
+ * returned map (downstream: "keep every assigned partition for that
+ * topic"). For topics that restrict, the keep-set is exactly the
+ * requested partition indices.
  */
-function validateNoDuplicateTargets(
+function validateAndBuildKeepPartitions(
   byTopic: Map<string, NormalizedTopicTarget[]>,
-): void {
+): Map<string, Set<number>> {
+  const keepPartitions = new Map<string, Set<number>>();
   for (const [topic, list] of byTopic) {
-    if (list.length === 1) continue;
-    const partitioned = list[0]?.partition !== undefined;
-    if (!partitioned) {
+    const explicit = list
+      .map((t) => t.partition)
+      .filter((p): p is number => p !== undefined);
+    const allPartitioned = explicit.length === list.length;
+    const nonePartitioned = explicit.length === 0;
+    if (!allPartitioned && !nonePartitioned) {
       throw new Error(
-        `Topic "${topic}" has ${list.length} entries without partition restrictions; ` +
-          `specify each topic at most once at the unrestricted level (or restrict each entry to a distinct partition).`,
+        `Topic "${topic}" mixes entries with explicit partitions and entries without one. ` +
+          `Pick one mode per topic: either every entry restricts to a partition, or none do.`,
       );
     }
+    if (nonePartitioned) {
+      if (list.length > 1) {
+        throw new Error(
+          `Topic "${topic}" has ${list.length} entries without partition restrictions; ` +
+            `specify each topic at most once at the unrestricted level (or restrict each entry to a distinct partition).`,
+        );
+      }
+      continue;
+    }
     const seen = new Set<number>();
-    for (const t of list) {
-      const p = t.partition!;
+    for (const p of explicit) {
       if (seen.has(p)) {
         throw new Error(
           `Topic "${topic}" has multiple entries for partition ${p}; ` +
@@ -483,35 +493,7 @@ function validateNoDuplicateTargets(
       }
       seen.add(p);
     }
-  }
-}
-
-/**
- * Derive the per-topic keep-set for partition pause/skip filtering.
- * Per-topic mode is all-or-nothing: every entry for a given topic
- * must specify `partition`, or none of them may. Mixing the two is
- * ambiguous (does the bare entry override the partitioned one or
- * coexist with it?) and rejected loudly. Topics whose entries never
- * specify a partition are omitted from the map (downstream: "keep
- * every assigned partition for that topic").
- */
-function buildKeepPartitions(
-  byTopic: Map<string, NormalizedTopicTarget[]>,
-): Map<string, Set<number>> {
-  const keepPartitions = new Map<string, Set<number>>();
-  for (const [topic, list] of byTopic) {
-    const explicit = list
-      .map((t) => t.partition)
-      .filter((p): p is number => p !== undefined);
-    if (explicit.length === list.length) {
-      keepPartitions.set(topic, new Set(explicit));
-    } else if (explicit.length > 0) {
-      throw new Error(
-        `Topic "${topic}" mixes entries with explicit partitions and entries without one. ` +
-          `Pick one mode per topic: either every entry restricts to a partition, or none do.`,
-      );
-    }
-    // explicit.length === 0 → no restriction; keepPartitions omits the topic.
+    keepPartitions.set(topic, seen);
   }
   return keepPartitions;
 }
@@ -716,8 +698,7 @@ async function buildPreflightPlan(
   const topicNames = [...byTopic.keys()];
   const numPartitionsByTopic = await fetchPartitionCounts(admin, topicNames);
   validateRequestedPartitions(targets, numPartitionsByTopic);
-  const keepPartitions = buildKeepPartitions(byTopic);
-  validateNoDuplicateTargets(byTopic);
+  const keepPartitions = validateAndBuildKeepPartitions(byTopic);
 
   const getWatermarks = createWatermarkCache(admin);
   const seeks: PreflightPlan["seeks"] = [];

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -4,10 +4,7 @@ import type {
   KafkaMessage,
 } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
-import {
-  deserializeMessage,
-  getLatestSchemaIfExists,
-} from "@src/confluent/schema-registry-helper.js";
+import * as schemaRegistryHelper from "@src/confluent/schema-registry-helper.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -38,7 +35,7 @@ const messageOptions = z.object({
     .string()
     .optional()
     .describe(
-      "Schema registry subject. Defaults to 'topicName-value' or 'topicName-key'.",
+      "Schema registry subject. Defaults to '<topic>-value' or '<topic>-key'.",
     ),
 });
 
@@ -49,144 +46,132 @@ type ValueOptions = z.infer<typeof valueOptions>;
 type KeyOptions = z.infer<typeof keyOptions>;
 
 /**
- * Per-topic consume options. Lets callers restrict consumption to a
- * specific partition and/or seek to a specific starting position within
- * that partition. Use the parent {@link consumeKafkaMessagesArgs}'s
- * `topics` array; pass a bare {@link consumeKafkaMessagesArgs.topicNames}
- * list when no per-topic overrides are needed.
+ * Per-entry "where to start consuming" tagged union. Collapses the prior
+ * `offset` and `timestamp` peer fields plus the top-level `offsetReset`
+ * knob into a single per-topic position control with four arms:
+ *
+ *   - `"earliest"` — begin at the partition low watermark (entire retained
+ *     history).
+ *   - `"latest"` — begin at the partition high watermark (only
+ *     newly-produced messages). This is the default when `start` is
+ *     omitted.
+ *   - `{ offset: "..." }` — begin at an absolute partition offset
+ *     (digit-only string; requires `partition`).
+ *   - `{ timestamp: ... }` — begin at the broker-resolved offset for the
+ *     supplied time (ISO 8601 preferred; ms-since-epoch also accepted).
+ *
+ * The object arms are `strictObject` so `{offset, timestamp}` together is
+ * a union miss rather than a silent strip of one key.
  */
-const topicConsumeOptions = z
-  .object({
-    topicName: z
-      .string()
-      .min(1)
-      .describe("Name of the Kafka topic to consume from."),
-    partition: z
-      .number()
-      .int()
-      .nonnegative()
-      .optional()
-      .describe(
-        "Restrict consumption to this partition (0-indexed). Other " +
-          "partitions in the topic are paused after assignment. Omit " +
-          "to consume all partitions of the topic.",
-      ),
-    offset: z
-      .string()
-      .regex(
-        /^\d+$/,
-        "offset must be a non-negative integer (digit-only string)",
-      )
-      .optional()
-      .describe(
-        "Absolute starting offset within the partition, as a digit-only " +
-          "string. Mutually exclusive with `timestamp`.",
-      ),
-    timestamp: z
-      .union([z.iso.datetime({ offset: true }), z.number().int().positive()])
-      .optional()
-      .describe(
-        "Start consuming from this point in time. ISO 8601 preferred " +
-          '(e.g. "2026-05-14T17:00:00Z" or "2026-05-14T13:00:00-04:00"); ' +
-          "ms-since-epoch also accepted. Mutually exclusive with `offset`.",
-      ),
-  })
-  .superRefine((data, ctx) => {
-    if (data.offset !== undefined && data.timestamp !== undefined) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Specify only one of `offset` or `timestamp` per topic entry, not both.",
-        path: [],
-      });
-    }
-  });
+const startOption = z
+  .union([
+    z.literal("earliest"),
+    z.literal("latest"),
+    z.strictObject({
+      offset: z
+        .string()
+        .regex(
+          /^\d+$/,
+          "offset must be a non-negative integer (digit-only string)",
+        )
+        .describe(
+          "Absolute starting offset within the partition, as a digit-only string.",
+        ),
+    }),
+    z.strictObject({
+      timestamp: z
+        .union([z.iso.datetime({ offset: true }), z.number().int().positive()])
+        .describe(
+          'ISO 8601 timestamp (e.g. "2026-05-14T17:00:00Z" or ' +
+            '"2026-05-14T13:00:00-04:00") or ms-since-epoch number. The ' +
+            "broker resolves this to a per-partition offset.",
+        ),
+    }),
+  ])
+  .describe(
+    "Where to begin consuming this topic. Use 'earliest' for the entire " +
+      "retained history; 'latest' for " +
+      "newly-produced messages only; {offset: 'N'} for an absolute " +
+      "partition offset (requires `partition`); or {timestamp: '...'} " +
+      "to seek to the broker-resolved offset for a point in time.",
+  );
 
-export const consumeKafkaMessagesArgs = z
-  .object({
-    topicNames: z
-      .array(z.string())
-      .nonempty()
-      .optional()
-      .describe(
-        "Simple list of Kafka topic names. Use when no per-topic " +
-          "partition/offset/timestamp overrides are needed. Mutually " +
-          "exclusive with `topics`.",
-      ),
-    topics: z
-      .array(topicConsumeOptions)
-      .nonempty()
-      .optional()
-      .describe(
-        "Per-topic consume options. Use when restricting partitions " +
-          "or seeking by offset/timestamp on individual topics. " +
-          "Mutually exclusive with `topicNames`.",
-      ),
-    maxMessages: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .default(10)
-      .describe("Maximum number of messages to consume before stopping."),
-    timeoutMs: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .default(10000)
-      .describe(
-        "Maximum time in milliseconds to wait for messages before stopping.",
-      ),
-    offsetReset: z
-      .enum(["earliest", "latest"])
-      .optional()
-      .default("latest")
-      .describe(
-        "Starting position when no committed offset exists: 'latest' " +
-          "(default) reads only newly-produced messages from the partition " +
-          "high watermark; 'earliest' reads from the partition low watermark " +
-          "(the entire retained history).",
-      ),
-    value: valueOptions,
-    key: keyOptions.optional(),
-    cluster_id: z
-      .string()
-      .optional()
-      .describe(
-        "Confluent Cloud logical Kafka cluster ID (lkc-...). Discover via list-clusters.",
-      ),
-    environment_id: z
-      .string()
-      .optional()
-      .describe(
-        "Confluent Cloud environment ID (env-...) that owns the cluster. Discover via list-environments.",
-      ),
-  })
-  .superRefine((data, ctx) => {
-    const hasTopicNames =
-      data.topicNames !== undefined && data.topicNames.length > 0;
-    const hasTopics = data.topics !== undefined && data.topics.length > 0;
-    if (hasTopicNames && hasTopics) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Specify exactly one of `topicNames` (simple list) or `topics` (per-topic overrides), not both.",
-        path: [],
-      });
-    } else if (!hasTopicNames && !hasTopics) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Specify either `topicNames` (simple list of topics) or `topics` (per-topic partition/offset/timestamp overrides).",
-        path: [],
-      });
-    }
-  });
+/**
+ * Per-topic consume options. `name` is the only required field. `partition`
+ * optionally restricts to one partition; `start` optionally picks the
+ * starting position. Both are independent — `partition` answers WHICH
+ * partition(s), `start` answers WHERE in them to begin.
+ */
+const topicConsumeOptions = z.object({
+  name: z.string().min(1).describe("Kafka topic name to consume from."),
+  partition: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      "Optional. Restrict consumption to this partition (0-indexed). " +
+        "Other partitions in the topic are paused after assignment. " +
+        "Omit to consume all partitions of the topic.",
+    ),
+  start: startOption.optional().default("earliest"),
+});
 
-interface ProcessedMessage {
+export const consumeKafkaMessagesArgs = z.object({
+  topics: z
+    .array(topicConsumeOptions)
+    .nonempty()
+    .describe(
+      "Topics to consume from. Each entry is an object with at least " +
+        "`name` (the Kafka topic name). Example simple call: " +
+        '[{name: "orders"}]. The `partition` and `start` fields let ' +
+        "callers restrict to a specific partition and/or pick where in " +
+        "the topic to begin consuming (e.g. " +
+        '[{name: "orders", partition: 0, start: {offset: "42"}}] or ' +
+        '[{name: "orders", start: {timestamp: "2026-05-14T17:00:00Z"}}]).',
+    ),
+  maxMessages: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(10)
+    .describe("Maximum number of messages to consume before stopping."),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(10000)
+    .describe(
+      "Maximum time in milliseconds to wait for messages before stopping.",
+    ),
+  valueFormat: valueOptions.optional().default({ useSchemaRegistry: false }),
+  keyFormat: keyOptions.optional().default({ useSchemaRegistry: false }),
+  cluster_id: z
+    .string()
+    .optional()
+    .describe(
+      "Confluent Cloud logical Kafka cluster ID (lkc-...). Discover via list-clusters.",
+    ),
+  environment_id: z
+    .string()
+    .optional()
+    .describe(
+      "Confluent Cloud environment ID (env-...) that owns the cluster. Discover via list-environments.",
+    ),
+});
+
+export interface ProcessedMessage {
   key: unknown;
   value: unknown;
+  /**
+   * Message timestamp as an ISO 8601 UTC string (e.g.
+   * `"2026-03-01T17:00:00.000Z"`). Surfaced in this format so an LLM
+   * consumer can immediately spot mismatches between a requested
+   * `timestamp` filter and the actual delivered records — ms-since-epoch
+   * makes such drift invisible without arithmetic.
+   */
   timestamp: string;
   offset: string;
   headers?: Record<string, string>;
@@ -195,24 +180,42 @@ interface ProcessedMessage {
 }
 
 /**
- * Internal normalized form for the per-topic consume options, used by the
- * pre-flight and seek/pause helpers. Either branch of the tool's input
- * (`topicNames` or `topics`) collapses into a list of these.
+ * Format a Kafka message's `message.timestamp` (a string of ms-since-epoch
+ * per kafkajs) into an ISO 8601 UTC string. Returns `"(no timestamp)"` for
+ * undefined or Kafka's `-1` sentinel (message format pre-0.10.0 or
+ * timestamp unset by the producer). Exported for direct unit-test coverage
+ * of the four branches plus the empty-string edge case (`Number("")` is
+ * `0`, which is finite, so an empty timestamp string formats as epoch).
  */
+export function formatMessageTimestamp(ts: string | undefined): string {
+  if (ts === undefined || ts === "-1") return "(no timestamp)";
+  const ms = Number(ts);
+  if (!Number.isFinite(ms)) return ts;
+  return new Date(ms).toISOString();
+}
+
+/**
+ * Internal normalized form for the per-topic consume options. Each parsed
+ * `topics` entry's `start` union collapses into one of these tagged
+ * variants so downstream code switches on `start.kind` instead of probing
+ * for which optional field happens to be set.
+ */
+type NormalizedStart =
+  | { kind: "earliest" }
+  | { kind: "latest" }
+  | { kind: "offset"; value: string }
+  | { kind: "timestamp"; ms: number };
+
 interface NormalizedTopicTarget {
-  topicName: string;
+  name: string;
   partition?: number;
-  /** Digit-only string, already validated by Zod. */
-  offset?: string;
-  /** ms-since-epoch; ISO 8601 inputs are normalized at the boundary. */
-  timestampMs?: number;
+  start: NormalizedStart;
 }
 
 /**
  * Result of {@link buildPreflightPlan}: the canonical list of topics to
  * subscribe to plus the partition-keep set and per-partition seek targets
- * that {@link applySeekAndPause} will apply after the consumer assignment
- * lands.
+ * that the post-assignment dance will apply.
  */
 interface PreflightPlan {
   /** Unique topic names to subscribe to (deduplicated across entries). */
@@ -228,55 +231,102 @@ interface PreflightPlan {
 }
 
 /**
+ * Collapse the parsed `start` union into the internal tagged form.
+ * ISO 8601 timestamps normalize to ms-since-epoch at this boundary so
+ * downstream code only sees numbers. Exported so the timestamp-arm's
+ * string-vs-number branch can be unit-tested directly (the handler-level
+ * tests only exercise the string path).
+ */
+export function normalizeStart(
+  start: z.infer<typeof topicConsumeOptions>["start"],
+): NormalizedStart {
+  if (start === "earliest") return { kind: "earliest" };
+  if (start === "latest") return { kind: "latest" };
+  if ("offset" in start) return { kind: "offset", value: start.offset };
+  return {
+    kind: "timestamp",
+    ms:
+      typeof start.timestamp === "number"
+        ? start.timestamp
+        : Date.parse(start.timestamp),
+  };
+}
+
+/**
  * Normalize the parsed tool args into a uniform list of per-topic targets.
- * `topicNames` callers get bare entries (no partition/offset/timestamp);
- * `topics` callers get their entries through with ISO 8601 timestamps
- * converted to ms-since-epoch so downstream code only sees numbers.
  */
 function normalizeTopicTargets(
   parsed: z.infer<typeof consumeKafkaMessagesArgs>,
 ): NormalizedTopicTarget[] {
-  if (parsed.topicNames !== undefined) {
-    return parsed.topicNames.map((topicName) => ({ topicName }));
-  }
-  // Zod's xor refinement guarantees `topics` is populated here.
-  return parsed.topics!.map((entry) => ({
-    topicName: entry.topicName,
+  return parsed.topics.map((entry) => ({
+    name: entry.name,
     partition: entry.partition,
-    offset: entry.offset,
-    timestampMs:
-      entry.timestamp === undefined
-        ? undefined
-        : typeof entry.timestamp === "number"
-          ? entry.timestamp
-          : Date.parse(entry.timestamp),
+    start: normalizeStart(entry.start),
   }));
 }
 
 /**
- * Returns true when any target carries a partition restriction or seek
- * target — i.e. when the handler needs to build an admin client and run
- * pre-flight + post-assignment seek/pause. Plain `topicNames` calls skip
- * the whole dance.
+ * Pick the consumer's `auto.offset.reset` value from the call. The
+ * consumer-wide setting governs any partition that doesn't get an
+ * explicit seek — so we want to align it with the call's intent and
+ * avoid emitting watermark seeks unnecessarily.
+ *
+ * Rule: if every direction-only entry (`start: "earliest"` or
+ * `start: "latest"`) agrees on `"earliest"`, use `"earliest"`; otherwise
+ * use `"latest"`. The choice of `"latest"` as the mixed-direction
+ * tiebreaker matches librdkafka's own `auto.offset.reset` default and
+ * keeps the explicit-seek work localized to the `"earliest"` minority
+ * (which gets per-partition low-watermark seeks during preflight); the
+ * `"latest"` majority inherits the consumer-wide default and needs no
+ * extra admin round-trips.
  */
-function planNeedsPreflight(targets: NormalizedTopicTarget[]): boolean {
+function deriveConsumerOffsetReset(
+  targets: NormalizedTopicTarget[],
+): "earliest" | "latest" {
+  const directions = targets
+    .map((t) =>
+      t.start.kind === "earliest" || t.start.kind === "latest"
+        ? t.start.kind
+        : null,
+    )
+    .filter((d): d is "earliest" | "latest" => d !== null);
+  if (directions.length > 0 && directions.every((d) => d === "earliest")) {
+    return "earliest";
+  }
+  return "latest";
+}
+
+/**
+ * Returns true when any target requires the admin pre-flight + seek/pause
+ * dance. Bare-name-only calls (no partition restrictions, no explicit
+ * offset/timestamp seeks, and a `start` whose direction matches the
+ * consumer's chosen reset) skip the whole dance — the consumer's
+ * `auto.offset.reset` handles them naturally.
+ */
+function planNeedsPreflight(
+  targets: NormalizedTopicTarget[],
+  consumerOffsetReset: "earliest" | "latest",
+): boolean {
   return targets.some(
     (t) =>
       t.partition !== undefined ||
-      t.offset !== undefined ||
-      t.timestampMs !== undefined,
+      t.start.kind === "offset" ||
+      t.start.kind === "timestamp" ||
+      (t.start.kind === "earliest" && consumerOffsetReset === "latest"),
   );
 }
 
 /**
  * Validates the requested targets against broker metadata and watermarks,
- * resolves any timestamp-based seeks to concrete partition offsets, and
- * produces the canonical {@link PreflightPlan}. Thrown errors are caught
- * one frame up and rendered as a tool-error response.
+ * resolves any timestamp-based seeks to concrete partition offsets, issues
+ * explicit watermark seeks for direction-only entries that don't match the
+ * consumer's chosen `auto.offset.reset`, and produces the canonical
+ * {@link PreflightPlan}. Thrown errors are caught one frame up and rendered
+ * as a tool-error response.
  *
  * Validation rules (handler-side; the Zod schema covers field-level shape):
- * - `offset` requires `partition` — absolute offsets are partition-scoped;
- *   different partitions have different offset spaces.
+ * - `start: {offset}` requires `partition` — absolute offsets are
+ *   partition-scoped; different partitions have different offset spaces.
  * - All-or-nothing partition mode per topic: every entry for a given
  *   topic must specify `partition`, or none of them may. Mixing is
  *   ambiguous (does the bare entry override the partitioned one or
@@ -286,65 +336,110 @@ function planNeedsPreflight(targets: NormalizedTopicTarget[]): boolean {
  * - Absolute offsets must lie in `[low, high)` for their partition
  *   (cross-check with `admin.fetchTopicOffsets`).
  */
-async function buildPreflightPlan(
-  admin: KafkaJS.Admin,
-  targets: NormalizedTopicTarget[],
-): Promise<PreflightPlan> {
+/**
+ * Reject any target that supplies `start: {offset}` without a
+ * `partition` — absolute offsets are partition-scoped (offset 10 on
+ * partition 0 is a different message than offset 10 on partition 1),
+ * so picking a default is footgun-prone; rejecting at the boundary is
+ * louder.
+ */
+function guardOffsetRequiresPartition(targets: NormalizedTopicTarget[]): void {
   for (const t of targets) {
-    if (t.offset !== undefined && t.partition === undefined) {
+    if (t.start.kind === "offset" && t.partition === undefined) {
       throw new Error(
-        `Topic "${t.topicName}" has an explicit offset (${t.offset}) but no partition. ` +
+        `Topic "${t.name}" has an explicit offset (${t.start.value}) but no partition. ` +
           `Absolute offsets are partition-scoped — different partitions have different offset spaces. ` +
-          `Either also supply a partition for this entry, or use timestamp (which resolves per-partition).`,
+          `Either also supply a partition for this entry, or use a timestamp (which resolves per-partition).`,
       );
     }
   }
+}
 
+/**
+ * Group targets by topic name preserving entry order. Used downstream
+ * for both the all-or-nothing partition-mode check and the keep-set
+ * derivation; computing it once means subsequent iterations stay O(N).
+ */
+function groupByTopic(
+  targets: NormalizedTopicTarget[],
+): Map<string, NormalizedTopicTarget[]> {
   const byTopic = new Map<string, NormalizedTopicTarget[]>();
   for (const t of targets) {
-    let list = byTopic.get(t.topicName);
-    if (!list) {
-      list = [];
-      byTopic.set(t.topicName, list);
-    }
-    list.push(t);
+    const list = byTopic.get(t.name);
+    if (list) list.push(t);
+    else byTopic.set(t.name, [t]);
   }
-  const topicNames = [...byTopic.keys()];
+  return byTopic;
+}
 
+/**
+ * Fetch partition counts for the supplied topics via
+ * `admin.fetchTopicMetadata`. Throws if any requested topic returned no
+ * metadata (typically: the topic doesn't exist on this cluster).
+ *
+ * Defensive shape normalization: the `@confluentinc/kafka-javascript`
+ * `.d.ts` declares this call as `Promise<{ topics: Array<ITopicMetadata> }>`
+ * but the runtime implementation returns the bare `Array<ITopicMetadata>`
+ * — long-standing mismatch tracked at
+ * confluentinc/confluent-kafka-javascript#367. Handle either shape so a
+ * future library fix doesn't require code change here.
+ */
+async function fetchPartitionCounts(
+  admin: KafkaJS.Admin,
+  topicNames: string[],
+): Promise<Map<string, number>> {
   const metadataRaw = await admin.fetchTopicMetadata({ topics: topicNames });
-  // The @confluentinc/kafka-javascript .d.ts declares this call as
-  // `Promise<{ topics: Array<ITopicMetadata> }>` but the runtime
-  // implementation returns the bare `Array<ITopicMetadata>` — long-standing
-  // mismatch tracked at confluentinc/confluent-kafka-javascript#367.
-  // Normalize defensively so either shape works if the library ever fixes
-  // its type declaration.
   const topicMetadata: ITopicMetadata[] = Array.isArray(metadataRaw)
     ? (metadataRaw as unknown as ITopicMetadata[])
     : metadataRaw.topics;
-  const numPartitionsByTopic = new Map<string, number>();
+  const counts = new Map<string, number>();
   for (const t of topicMetadata) {
-    numPartitionsByTopic.set(t.name, t.partitions.length);
+    counts.set(t.name, t.partitions.length);
   }
   for (const name of topicNames) {
-    if (!numPartitionsByTopic.has(name)) {
+    if (!counts.has(name)) {
       throw new Error(
         `Topic "${name}" returned no partition metadata (does it exist on this cluster?).`,
       );
     }
   }
+  return counts;
+}
 
+/**
+ * Reject any target whose `partition` index is out of range for its
+ * topic. The error message cites the actual partition count so the
+ * caller can correct without guessing.
+ */
+function validateRequestedPartitions(
+  targets: NormalizedTopicTarget[],
+  numPartitionsByTopic: Map<string, number>,
+): void {
   for (const t of targets) {
     if (t.partition !== undefined) {
-      const numParts = numPartitionsByTopic.get(t.topicName)!;
+      const numParts = numPartitionsByTopic.get(t.name)!;
       if (t.partition >= numParts) {
         throw new Error(
-          `Topic "${t.topicName}" has ${numParts} partition(s) (0..${numParts - 1}); ` +
+          `Topic "${t.name}" has ${numParts} partition(s) (0..${numParts - 1}); ` +
             `requested partition ${t.partition} is out of range.`,
         );
       }
     }
   }
+}
 
+/**
+ * Derive the per-topic keep-set for partition pause/skip filtering.
+ * Per-topic mode is all-or-nothing: every entry for a given topic
+ * must specify `partition`, or none of them may. Mixing the two is
+ * ambiguous (does the bare entry override the partitioned one or
+ * coexist with it?) and rejected loudly. Topics whose entries never
+ * specify a partition are omitted from the map (downstream: "keep
+ * every assigned partition for that topic").
+ */
+function buildKeepPartitions(
+  byTopic: Map<string, NormalizedTopicTarget[]>,
+): Map<string, Set<number>> {
   const keepPartitions = new Map<string, Set<number>>();
   for (const [topic, list] of byTopic) {
     const explicit = list
@@ -360,48 +455,230 @@ async function buildPreflightPlan(
     }
     // explicit.length === 0 → no restriction; keepPartitions omits the topic.
   }
+  return keepPartitions;
+}
 
+/**
+ * Per-topic memoization wrapper around `admin.fetchTopicOffsets` so
+ * three resolution paths (explicit-offset bounds check, timestamp's
+ * silent-substitution cross-check, earliest-minority low-watermark
+ * seek) share one admin round-trip per topic per call.
+ */
+type WatermarkCache = (
+  topic: string,
+) => Promise<Awaited<ReturnType<KafkaJS.Admin["fetchTopicOffsets"]>>>;
+
+function createWatermarkCache(admin: KafkaJS.Admin): WatermarkCache {
+  const cache = new Map<
+    string,
+    Awaited<ReturnType<KafkaJS.Admin["fetchTopicOffsets"]>>
+  >();
+  return async (topic) => {
+    let wm = cache.get(topic);
+    if (!wm) {
+      wm = await admin.fetchTopicOffsets(topic);
+      cache.set(topic, wm);
+    }
+    return wm;
+  };
+}
+
+/**
+ * Validate an explicit `start: {offset}` against the partition's
+ * `[low, high)` watermarks and return the seek target. Throws if the
+ * partition has no offset metadata or the requested offset is out of
+ * range.
+ */
+async function resolveExplicitOffsetSeek(
+  topic: string,
+  partition: number,
+  offset: string,
+  getWatermarks: WatermarkCache,
+): Promise<PreflightPlan["seeks"][number]> {
+  const offsets = await getWatermarks(topic);
+  const partOffsets = offsets.find((o) => o.partition === partition);
+  if (!partOffsets) {
+    throw new Error(
+      `Topic "${topic}" partition ${partition} returned no offset metadata.`,
+    );
+  }
+  const low = BigInt(partOffsets.low);
+  const high = BigInt(partOffsets.high);
+  const target = BigInt(offset);
+  if (target < low || target >= high) {
+    throw new Error(
+      `Topic "${topic}" partition ${partition} offset ${offset} is out of range ` +
+        `[low=${partOffsets.low}, high=${partOffsets.high}). ` +
+        `An empty partition has low === high; pick an offset already on the partition.`,
+    );
+  }
+  return { topic, partition, offset };
+}
+
+/**
+ * Resolve a `start: {timestamp}` to per-partition offsets via
+ * `admin.fetchTopicOffsetsByTimestamp` AND filter out the binding's
+ * silent high-watermark substitutions.
+ *
+ * `@confluentinc/kafka-javascript`'s `fetchTopicOffsetsByTimestamp`
+ * silently substitutes the partition's high watermark when no message
+ * exists at or after the requested timestamp (see the method's
+ * docstring in node_modules/.../kafkajs/_admin.js). Seeking to a
+ * position == high watermark parks the consumer at OFFSET_END and we'd
+ * time out with zero messages with no signal as to why. The defense:
+ * cross-check each resolved offset against the partition's actual
+ * watermarks, skip silent partitions, and emit a diagnostic log so
+ * operators can distinguish the three resolution modes (silent /
+ * broker-low-fallback / real-index-hit).
+ */
+async function resolveTimestampSeeks(
+  admin: KafkaJS.Admin,
+  topic: string,
+  restrictToPartition: number | undefined,
+  timestampMs: number,
+  getWatermarks: WatermarkCache,
+): Promise<PreflightPlan["seeks"]> {
+  const resolved = await admin.fetchTopicOffsetsByTimestamp(topic, timestampMs);
+  const watermarks = await getWatermarks(topic);
+  const watermarkByPartition = new Map<number, { low: string; high: string }>();
+  for (const w of watermarks) {
+    watermarkByPartition.set(w.partition, { low: w.low, high: w.high });
+  }
+
+  const candidates =
+    restrictToPartition !== undefined
+      ? resolved.filter((r) => r.partition === restrictToPartition)
+      : resolved;
+
+  const active: typeof candidates = [];
+  const silent: number[] = [];
+  for (const r of candidates) {
+    const wm = watermarkByPartition.get(r.partition);
+    // Diagnostic log so debugging timestamp-to-offset resolution
+    // doesn't require adding instrumentation later. Lets a reader
+    // distinguish three failure modes from one log inspection:
+    //   - resolvedOffset == high → binding's silent substitution
+    //     (already filtered below; the warn-level log fires too).
+    //   - resolvedOffset == low → broker fell back to the earliest
+    //     offset (e.g. requested timestamp is older than every
+    //     indexed message, or tiered-storage index quirk).
+    //   - resolvedOffset in (low, high) → real timestamp resolution.
+    logger.info(
+      {
+        topic,
+        partition: r.partition,
+        resolvedOffset: r.offset,
+        low: wm?.low,
+        high: wm?.high,
+        requestedMs: timestampMs,
+        requestedIso: new Date(timestampMs).toISOString(),
+      },
+      `Timestamp → offset resolution for ${topic} partition ${r.partition}`,
+    );
+    if (wm !== undefined && BigInt(r.offset) >= BigInt(wm.high)) {
+      silent.push(r.partition);
+    } else {
+      active.push(r);
+    }
+  }
+
+  if (active.length === 0) {
+    const partitionPhrase =
+      restrictToPartition !== undefined
+        ? `partition ${restrictToPartition} has`
+        : `every partition has`;
+    throw new Error(
+      `Topic "${topic}" has no messages at or after timestamp ` +
+        `${new Date(timestampMs).toISOString()} ` +
+        `(${partitionPhrase} no record produced past that point). ` +
+        `Try a more recent timestamp, or omit \`timestamp\` to consume ` +
+        `from the live position.`,
+    );
+  }
+  if (silent.length > 0) {
+    logger.warn(
+      { topic, timestampMs, silentPartitions: silent },
+      `Skipping seek for partitions of "${topic}" with no record at or after the requested timestamp; they will idle at OFFSET_END.`,
+    );
+  }
+
+  return active.map((r) => ({
+    topic,
+    partition: r.partition,
+    offset: r.offset,
+  }));
+}
+
+/**
+ * Resolve a `start: "earliest"` entry that lost the direction-derivation
+ * race — i.e. another entry pushed the consumer-wide
+ * `auto.offset.reset` to `"latest"`. Returns explicit low-watermark
+ * seeks for every partition (or the single restricted partition) so
+ * this topic replays its history instead of inheriting the
+ * consumer-wide "latest" default.
+ */
+async function resolveEarliestMinoritySeeks(
+  topic: string,
+  restrictToPartition: number | undefined,
+  getWatermarks: WatermarkCache,
+): Promise<PreflightPlan["seeks"]> {
+  const offsets = await getWatermarks(topic);
+  const partitionsToSeek =
+    restrictToPartition !== undefined
+      ? offsets.filter((o) => o.partition === restrictToPartition)
+      : offsets;
+  return partitionsToSeek.map((p) => ({
+    topic,
+    partition: p.partition,
+    offset: p.low,
+  }));
+}
+
+async function buildPreflightPlan(
+  admin: KafkaJS.Admin,
+  targets: NormalizedTopicTarget[],
+  consumerOffsetReset: "earliest" | "latest",
+): Promise<PreflightPlan> {
+  guardOffsetRequiresPartition(targets);
+  const byTopic = groupByTopic(targets);
+  const topicNames = [...byTopic.keys()];
+  const numPartitionsByTopic = await fetchPartitionCounts(admin, topicNames);
+  validateRequestedPartitions(targets, numPartitionsByTopic);
+  const keepPartitions = buildKeepPartitions(byTopic);
+
+  const getWatermarks = createWatermarkCache(admin);
   const seeks: PreflightPlan["seeks"] = [];
   for (const t of targets) {
-    if (t.offset !== undefined && t.partition !== undefined) {
-      const offsets = await admin.fetchTopicOffsets(t.topicName);
-      const partOffsets = offsets.find((o) => o.partition === t.partition);
-      if (!partOffsets) {
-        throw new Error(
-          `Topic "${t.topicName}" partition ${t.partition} returned no offset metadata.`,
-        );
-      }
-      const low = BigInt(partOffsets.low);
-      const high = BigInt(partOffsets.high);
-      const target = BigInt(t.offset);
-      if (target < low || target >= high) {
-        throw new Error(
-          `Topic "${t.topicName}" partition ${t.partition} offset ${t.offset} is out of range ` +
-            `[low=${partOffsets.low}, high=${partOffsets.high}). ` +
-            `An empty partition has low === high; pick an offset already on the partition.`,
-        );
-      }
-      seeks.push({
-        topic: t.topicName,
-        partition: t.partition,
-        offset: t.offset,
-      });
-    } else if (t.timestampMs !== undefined) {
-      const resolved = await admin.fetchTopicOffsetsByTimestamp(
-        t.topicName,
-        t.timestampMs,
+    if (t.start.kind === "offset" && t.partition !== undefined) {
+      seeks.push(
+        await resolveExplicitOffsetSeek(
+          t.name,
+          t.partition,
+          t.start.value,
+          getWatermarks,
+        ),
       );
-      const candidates =
-        t.partition !== undefined
-          ? resolved.filter((r) => r.partition === t.partition)
-          : resolved;
-      for (const r of candidates) {
-        seeks.push({
-          topic: t.topicName,
-          partition: r.partition,
-          offset: r.offset,
-        });
-      }
+    } else if (t.start.kind === "timestamp") {
+      seeks.push(
+        ...(await resolveTimestampSeeks(
+          admin,
+          t.name,
+          t.partition,
+          t.start.ms,
+          getWatermarks,
+        )),
+      );
+    } else if (
+      t.start.kind === "earliest" &&
+      consumerOffsetReset === "latest"
+    ) {
+      seeks.push(
+        ...(await resolveEarliestMinoritySeeks(
+          t.name,
+          t.partition,
+          getWatermarks,
+        )),
+      );
     }
   }
 
@@ -414,8 +691,10 @@ async function buildPreflightPlan(
  * deadline was hit first. The kafkajs-compat consumer only populates its
  * assignment after `consumer.run()` triggers the first poll, so this is
  * the well-defined seam to wait on before issuing per-partition seeks.
+ * Exported so the three branches (immediate-return, polled-populate,
+ * polled-timeout) can be exercised directly under fake timers.
  */
-async function waitForAssignment(
+export async function waitForAssignment(
   consumer: KafkaJS.Consumer,
   deadline: number,
 ): Promise<{ topic: string; partition: number }[] | null> {
@@ -432,11 +711,36 @@ async function waitForAssignment(
 }
 
 /**
- * After the consumer assignment lands, pause any assigned partition that
- * isn't in the keep-set and seek each per-partition target to its
- * resolved offset.
+ * Stash per-partition seeks on the consumer *before* `consumer.run()` is
+ * invoked. The kafkajs-compat library queues these as "pending seeks" via
+ * its `#addPendingOperation` → `#seekInternal` path; when the first
+ * rebalance fires inside `run()`, the assignment handler calls
+ * `#assignAsPerSeekedOffsets` and modifies the assignment to include the
+ * seeked offsets *before* calling `assignmentFn`, so the partition is
+ * assigned at the seek target atomically.
+ *
+ * This avoids the `ERR__STATE` race that the post-assignment seek path
+ * trips: even after `consumer.assignment()` returns the partition, the
+ * native librdkafka client can briefly reject seeks because its internal
+ * state hasn't fully transitioned from "rebalancing" to "ready." The
+ * pre-run path bypasses native seek calls entirely.
  */
-async function applySeekAndPause(
+function stashSeeksBeforeRun(
+  consumer: KafkaJS.Consumer,
+  plan: PreflightPlan,
+): void {
+  for (const s of plan.seeks) {
+    consumer.seek({ topic: s.topic, partition: s.partition, offset: s.offset });
+  }
+}
+
+/**
+ * After the consumer assignment lands, pause any assigned partition that
+ * isn't in the keep-set. Seeks happen pre-run via {@link stashSeeksBeforeRun}
+ * so the per-partition seek targets are already baked into the assignment
+ * by the time this runs.
+ */
+async function applyPauseAfterAssignment(
   consumer: KafkaJS.Consumer,
   plan: PreflightPlan,
   assignment: { topic: string; partition: number }[],
@@ -453,10 +757,82 @@ async function applySeekAndPause(
   if (toPause.length > 0) {
     consumer.pause(toPause);
   }
+}
 
-  for (const s of plan.seeks) {
-    consumer.seek({ topic: s.topic, partition: s.partition, offset: s.offset });
+/**
+ * Wrap a promise so its successful resolution is ignored (never settles
+ * downstream) while its rejection still propagates. Used in the
+ * orchestrator's `Promise.race` to let "engine still running" branches
+ * (`consumer.run`, `applyPostAssignmentHook`) participate only on
+ * failure — successful completion of those promises shouldn't end the
+ * consume loop, but their errors must surface as the race's rejection.
+ */
+function rejectOnly<T>(p: Promise<T>): Promise<never> {
+  return p.then(() => new Promise<never>(() => {}));
+}
+
+/**
+ * Drive the post-`consumer.run()` pause step: poll for an assignment up
+ * to `deadlineMs`, then pause partitions outside the keep-set. Signals
+ * completion via callbacks rather than its return value because the
+ * orchestrator's `Promise.race` only cares about success (`onApplied`)
+ * vs. assignment-deadline-elapsed (`onAssignmentTimedOut`); internal
+ * pause failures propagate as a rejection so the race can surface them
+ * via `rejectOnly`.
+ */
+export async function applyPostAssignmentHook(opts: {
+  consumer: KafkaJS.Consumer;
+  plan: PreflightPlan;
+  deadlineMs: number;
+  onApplied: () => void;
+  onAssignmentTimedOut: () => void;
+}): Promise<void> {
+  const assignment = await waitForAssignment(opts.consumer, opts.deadlineMs);
+  if (!assignment) {
+    opts.onAssignmentTimedOut();
+    return;
   }
+  await applyPauseAfterAssignment(opts.consumer, opts.plan, assignment);
+  opts.onApplied();
+}
+
+/**
+ * Build the `eachMessage` callback `consumer.run` invokes per record.
+ * Pulled out of the orchestrator so the synchronous gates and the
+ * "did we hit `maxMessages`?" signal are individually testable.
+ *
+ * The synchronous boolean getters (`isAccepting`, `isPreflightApplied`)
+ * intentionally stay synchronous — `await`ing a Deferred in their place
+ * would change behavior, because pre-pause deliveries from librdkafka's
+ * fetch buffer must be dropped on arrival rather than queued through.
+ */
+export function createEachMessageHandler(opts: {
+  state: {
+    consumedMessages: ProcessedMessage[];
+    isAccepting: () => boolean;
+    isPreflightApplied: () => boolean;
+  };
+  maxMessages: number;
+  onMaxReached: () => void;
+  processMessage: (
+    topic: string,
+    partition: number,
+    message: KafkaMessage,
+  ) => Promise<ProcessedMessage>;
+}): (payload: {
+  topic: string;
+  partition: number;
+  message: KafkaMessage;
+}) => Promise<void> {
+  return async ({ topic, partition, message }) => {
+    if (!opts.state.isAccepting()) return;
+    if (!opts.state.isPreflightApplied()) return;
+    const processed = await opts.processMessage(topic, partition, message);
+    opts.state.consumedMessages.push(processed);
+    if (opts.state.consumedMessages.length >= opts.maxMessages) {
+      opts.onMaxReached();
+    }
+  };
 }
 
 /**
@@ -471,8 +847,8 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
    * @param partition - The partition the message was consumed from
    * @param message - The raw Kafka message
    * @param registry - Optional Schema Registry client for deserialization
-   * @param valueOptions - Options for value deserialization
-   * @param keyOptions - Optional options for key deserialization
+   * @param valueOptions - Options for value-side deserialization
+   * @param keyOptions - Options for key-side deserialization
    * @returns A processed message with deserialized key and value
    */
   async processMessage(
@@ -481,7 +857,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     message: KafkaMessage,
     registry: SchemaRegistryClient | undefined,
     valueOptions: ValueOptions,
-    keyOptions?: KeyOptions,
+    keyOptions: KeyOptions,
   ): Promise<ProcessedMessage> {
     let processedKey: unknown = message.key?.toString();
     let processedValue: unknown = message.value?.toString();
@@ -497,12 +873,15 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       const subject =
         options.subject ||
         `${topic}-${serdeType === SerdeType.KEY ? "key" : "value"}`;
-      const schema = await getLatestSchemaIfExists(registry, subject);
+      const schema = await schemaRegistryHelper.getLatestSchemaIfExists(
+        registry,
+        subject,
+      );
       if (!schema || !schema.schemaType) {
         return buffer?.toString();
       }
       try {
-        return await deserializeMessage(
+        return await schemaRegistryHelper.deserializeMessage(
           topic,
           buffer as Buffer,
           schema.schemaType,
@@ -523,7 +902,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       valueOptions,
       SerdeType.VALUE,
     );
-    if (message.key && keyOptions) {
+    if (message.key) {
       processedKey = await deserializeWithOptions(
         message.key as Buffer,
         keyOptions,
@@ -534,7 +913,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     return {
       key: processedKey,
       value: processedValue,
-      timestamp: message.timestamp,
+      timestamp: formatMessageTimestamp(message.timestamp),
       offset: message.offset,
       headers: message.headers
         ? Object.fromEntries(
@@ -550,11 +929,31 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
   }
 
   /**
-   * Main handler for consuming messages from Kafka topics.
-   * @param clientManager - The client manager for Kafka and registry clients
-   * @param toolArguments - The arguments for the tool, including topics, message limits, and deserialization options
-   * @param sessionId - Optional session ID for Kafka consumer
-   * @returns A CallToolResult containing the consumed messages or error information
+   * Consume messages from one or more Kafka topics, honoring per-topic
+   * `partition` and `start` controls. Resolves when one of four exit
+   * conditions wins a `Promise.race`: `maxMessages` records have been
+   * collected, the `timeoutMs` budget elapses, `consumer.run()` rejects,
+   * or the post-assignment hook rejects. On the timeout path the
+   * partial set collected so far is returned (success-shaped response,
+   * not an error).
+   *
+   * @param runtime - The {@link ServerRuntime} (config + active client
+   *   manager + OAuth holder). Supplied by the MCP server dispatcher;
+   *   the handler resolves cluster/env/registry clients off of it.
+   * @param toolArguments - Parsed args matching `consumeKafkaMessagesArgs`.
+   *   The handler re-parses internally to apply defaults at the
+   *   boundary.
+   * @param sessionId - Per-transport session identifier the MCP server
+   *   dispatcher hands in from `context?.sessionId`. Becomes the
+   *   consumer's `group.id` suffix (direct) or literal value (OAuth) so
+   *   concurrent MCP sessions don't share consumer-group state. NOT
+   *   part of the tool's input schema — the LLM cannot supply or
+   *   influence this value; it's sourced from the underlying HTTP/SSE
+   *   transport and is `undefined` for stdio.
+   * @returns A {@link CallToolResult}. Success path emits a text block
+   *   summarizing the consumed messages; failures (build/preflight/run
+   *   errors) surface via `createResponse(text, true)` with the
+   *   formatted Kafka error.
    */
   async handle(
     runtime: ServerRuntime,
@@ -562,13 +961,13 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     sessionId?: string,
   ): Promise<CallToolResult> {
     const parsed = consumeKafkaMessagesArgs.parse(toolArguments);
-    const { maxMessages, timeoutMs, value, key, offsetReset } = parsed;
+    const { maxMessages, timeoutMs, valueFormat, keyFormat } = parsed;
 
     const { connId, clientManager } = this.resolveSoleConnection(runtime);
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
 
     const needsRegistry =
-      (value && value.useSchemaRegistry) || (key && key.useSchemaRegistry);
+      valueFormat.useSchemaRegistry || keyFormat.useSchemaRegistry;
 
     let registry: SchemaRegistryClient | undefined;
     if (needsRegistry) {
@@ -576,7 +975,8 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
     }
 
     const targets = normalizeTopicTargets(parsed);
-    const needsPreflight = planNeedsPreflight(targets);
+    const offsetReset = deriveConsumerOffsetReset(targets);
+    const needsPreflight = planNeedsPreflight(targets, offsetReset);
 
     let plan: PreflightPlan;
     if (needsPreflight) {
@@ -585,7 +985,7 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
         resolved.envId,
       );
       try {
-        plan = await buildPreflightPlan(admin, targets);
+        plan = await buildPreflightPlan(admin, targets, offsetReset);
       } catch (error: unknown) {
         return this.createResponse(
           `Failed to consume messages: ${formatKafkaError(error)}`,
@@ -596,17 +996,21 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       }
     } else {
       plan = {
-        topicNames: [...new Set(targets.map((t) => t.topicName))],
+        topicNames: [...new Set(targets.map((t) => t.name))],
         keepPartitions: new Map(),
         seeks: [],
       };
     }
 
     const consumedMessages: ProcessedMessage[] = [];
-    let timeoutReached = false;
-    // When the plan has no seeks/pauses, every message coming in via
-    // eachMessage is "post-seek" by definition — start counting immediately.
-    let seekApplied = !needsPreflight;
+    // `accepting` is the synchronous gate that suppresses further
+    // processing once any terminal condition fires. `preflightApplied`
+    // is the synchronous gate that drops pre-pause fetch-buffer
+    // deliveries. Both stay booleans because eachMessage needs to check
+    // them on arrival — a `Promise` would require `await`, which would
+    // queue rather than drop the message.
+    let accepting = true;
+    let preflightApplied = !needsPreflight;
     let consumer: KafkaJS.Consumer | undefined;
 
     try {
@@ -619,64 +1023,80 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       await consumer.connect();
       await consumer.subscribe({ topics: plan.topicNames });
 
-      const deadline = Date.now() + timeoutMs;
+      // Stash per-partition seeks BEFORE `consumer.run()`. The kafkajs-compat
+      // library queues these as pending seeks and applies them atomically
+      // during the first rebalance via `#assignAsPerSeekedOffsets`, so the
+      // partition is assigned at the seek target directly. Calling
+      // `consumer.seek()` after the rebalance trips an `ERR__STATE` race
+      // because the native librdkafka client can briefly reject seeks even
+      // after `consumer.assignment()` reports the partition as assigned.
+      stashSeeksBeforeRun(consumer, plan);
 
-      const consumePromise = new Promise<void>((resolve, reject) => {
-        if (!consumer) {
-          reject(new Error("Consumer was unexpectedly undefined"));
-          return;
-        }
-        consumer
-          .run({
-            eachMessage: async ({ topic, partition, message }) => {
-              if (timeoutReached) return;
-              // Drop messages that arrive before the seek/pause dance has
-              // run; they're from the consumer's pre-seek fetch buffer and
-              // don't reflect the requested starting position.
-              if (!seekApplied) return;
-              const processed = await this.processMessage(
-                topic,
-                partition,
-                message,
-                registry,
-                value,
-                key,
-              );
-              consumedMessages.push(processed);
-              if (consumedMessages.length >= maxMessages) {
-                timeoutReached = true;
-                resolve();
-              }
-            },
-          })
-          .catch((error) => {
-            reject(error);
-          });
-        setTimeout(() => {
-          timeoutReached = true;
-          resolve();
-        }, timeoutMs);
+      // Named exit conditions. Each Deferred resolves only its own
+      // promise — the prior shared `timeoutReached` boolean was written
+      // by three sites with overlapping semantics; this splits them into
+      // independent signals the race observes.
+      const maxReached = Promise.withResolvers<void>();
+      const timedOut = Promise.withResolvers<void>();
+      const consumerActive = consumer;
 
-        if (needsPreflight) {
-          (async () => {
-            const assignment = await waitForAssignment(consumer!, deadline);
-            if (!assignment) {
-              // timeoutMs elapsed before the consumer received any
-              // partition assignment — we'll return 0 messages with the
-              // normal timeout path. The setTimeout above will also fire.
-              timeoutReached = true;
-              resolve();
-              return;
-            }
-            await applySeekAndPause(consumer!, plan, assignment);
-            seekApplied = true;
-          })().catch((error) => {
-            reject(error);
-          });
-        }
+      const eachMessage = createEachMessageHandler({
+        state: {
+          consumedMessages,
+          isAccepting: () => accepting,
+          isPreflightApplied: () => preflightApplied,
+        },
+        maxMessages,
+        onMaxReached: () => {
+          accepting = false;
+          maxReached.resolve();
+        },
+        processMessage: (topic, partition, message) =>
+          this.processMessage(
+            topic,
+            partition,
+            message,
+            registry,
+            valueFormat,
+            keyFormat,
+          ),
       });
 
-      await consumePromise;
+      const timer = setTimeout(() => {
+        accepting = false;
+        timedOut.resolve();
+      }, timeoutMs);
+
+      const preflightHook = needsPreflight
+        ? applyPostAssignmentHook({
+            consumer: consumerActive,
+            plan,
+            deadlineMs: Date.now() + timeoutMs,
+            onApplied: () => {
+              preflightApplied = true;
+            },
+            onAssignmentTimedOut: () => {
+              accepting = false;
+              timedOut.resolve();
+            },
+          })
+        : Promise.resolve();
+
+      const runPromise = consumerActive.run({ eachMessage });
+
+      try {
+        await Promise.race([
+          maxReached.promise,
+          timedOut.promise,
+          // Success of either branch means "engine still running" — only
+          // their rejection is a terminal condition for the race.
+          rejectOnly(runPromise),
+          rejectOnly(preflightHook),
+        ]);
+      } finally {
+        clearTimeout(timer);
+        accepting = false;
+      }
 
       return this.createResponse(
         `Consumed ${consumedMessages.length} messages from topics ${plan.topicNames.join(", ")}.\nConsumed messages: ${JSON.stringify(consumedMessages, null, 2)}`,

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1127,8 +1127,11 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
         // Per-invocation unique group id: each consume call becomes
         // the sole member of its own Kafka consumer group, so two
         // concurrent calls can't race for the same partition
-        // assignment via rebalance. The base manager will prefix
-        // this with its `mcp-confluent` namespace.
+        // assignment via rebalance. (How the value reaches `group.id`
+        // depends on the manager: `DirectClientManager` appends it as
+        // a suffix to its base `mcp-confluent` group; `OAuthClientManager`
+        // uses it as the literal group id. Both yield a unique-per-call
+        // group, which is what the no-contention contract requires.)
         groupId: nodeCrypto.randomUUID(),
         offsetReset,
       });

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -4,6 +4,7 @@ import type {
   KafkaMessage,
 } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
+import { nodeCrypto } from "@src/confluent/node-deps.js";
 import * as schemaRegistryHelper from "@src/confluent/schema-registry-helper.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -88,7 +89,10 @@ const startOption = z
     }),
     z.strictObject({
       timestamp: z
-        .union([z.iso.datetime({ offset: true }), z.number().int().positive()])
+        .union([
+          z.iso.datetime({ offset: true }),
+          z.number().int().nonnegative(),
+        ])
         .describe(
           'ISO 8601 timestamp (e.g. "2026-05-14T17:00:00Z" or ' +
             '"2026-05-14T13:00:00-04:00") or ms-since-epoch number. The ' +
@@ -184,11 +188,20 @@ export interface ProcessedMessage {
   key: unknown;
   value: unknown;
   /**
-   * Message timestamp as an ISO 8601 UTC string (e.g.
-   * `"2026-03-01T17:00:00.000Z"`). Surfaced in this format so an LLM
-   * consumer can immediately spot mismatches between a requested
-   * `timestamp` filter and the actual delivered records — ms-since-epoch
-   * makes such drift invisible without arithmetic.
+   * Message timestamp, normalized by {@link formatMessageTimestamp}.
+   * Usual case: an ISO 8601 UTC string like `"2026-03-01T17:00:00.000Z"`
+   * — surfaced in this format so an LLM consumer can immediately spot
+   * mismatches between a requested `start: {timestamp}` filter and the
+   * delivered records (ms-since-epoch makes such drift invisible
+   * without arithmetic). Two non-ISO outcomes are possible:
+   *
+   * - The literal sentinel `"(no timestamp)"` when the underlying
+   *   Kafka message has no timestamp (Kafka's `-1` sentinel for
+   *   pre-0.10.0 message formats, or any record whose producer didn't
+   *   set one).
+   * - The raw input string passed through unchanged when
+   *   `Number(input)` is non-finite — a defensive escape hatch for
+   *   degenerate library inputs.
    */
   timestamp: string;
   offset: string;
@@ -537,7 +550,7 @@ function createWatermarkCache(admin: KafkaJS.Admin): WatermarkCache {
  * undefined` check in one place so the seek resolvers don't each
  * re-derive it.
  */
-function partitionScope(restrictToPartition: number | undefined) {
+export function partitionScope(restrictToPartition: number | undefined) {
   return {
     filter: <T extends { partition: number }>(items: T[]): T[] =>
       restrictToPartition === undefined
@@ -1028,13 +1041,6 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
    * @param toolArguments - Parsed args matching `consumeKafkaMessagesArgs`.
    *   The handler re-parses internally to apply defaults at the
    *   boundary.
-   * @param sessionId - Per-transport session identifier the MCP server
-   *   dispatcher hands in from `context?.sessionId`. Becomes the
-   *   consumer's `group.id` suffix (direct) or literal value (OAuth) so
-   *   concurrent MCP sessions don't share consumer-group state. NOT
-   *   part of the tool's input schema — the LLM cannot supply or
-   *   influence this value; it's sourced from the underlying HTTP/SSE
-   *   transport and is `undefined` for stdio.
    * @returns A {@link CallToolResult}. Success path emits a text block
    *   summarizing the consumed messages; failures (build/preflight/run
    *   errors) surface via `createResponse(text, true)` with the
@@ -1043,7 +1049,6 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
   async handle(
     runtime: ServerRuntime,
     toolArguments: z.infer<typeof consumeKafkaMessagesArgs>,
-    sessionId?: string,
   ): Promise<CallToolResult> {
     const parsed = consumeKafkaMessagesArgs.parse(toolArguments);
     const { maxMessages, timeoutMs, valueFormat, keyFormat } = parsed;
@@ -1119,7 +1124,12 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
       consumer = await clientManager.buildKafkaConsumer({
         clusterId: resolved.clusterId,
         envId: resolved.envId,
-        groupId: sessionId,
+        // Per-invocation unique group id: each consume call becomes
+        // the sole member of its own Kafka consumer group, so two
+        // concurrent calls can't race for the same partition
+        // assignment via rebalance. The base manager will prefix
+        // this with its `mcp-confluent` namespace.
+        groupId: nodeCrypto.randomUUID(),
         offsetReset,
       });
       await consumer.connect();

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -23,27 +23,36 @@ import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
-const messageOptions = z.object({
-  useSchemaRegistry: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe(
-      "Whether to use schema registry for deserialization. If false, messages will be returned as raw.",
-    ),
-  subject: z
-    .string()
-    .optional()
-    .describe(
-      "Schema registry subject. Defaults to '<topic>-value' or '<topic>-key'.",
-    ),
-});
+const messageOptions = z
+  .object({
+    useSchemaRegistry: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Whether to use schema registry for deserialization. If false, messages will be returned as raw.",
+      ),
+    subject: z
+      .string()
+      .optional()
+      .describe(
+        "Schema registry subject. Defaults to '<topic>-value' or '<topic>-key'.",
+      ),
+  })
+  // The optional() + default() wrapping lives here on the shared
+  // schema so `valueFormat` and `keyFormat` declarations downstream
+  // are bare references — one place to change if the omit-by-default
+  // contract ever evolves.
+  .optional()
+  .default({ useSchemaRegistry: false });
 
-const valueOptions = z.object({}).extend(messageOptions.shape);
-const keyOptions = z.object({}).extend(messageOptions.shape);
-
-type ValueOptions = z.infer<typeof valueOptions>;
-type KeyOptions = z.infer<typeof keyOptions>;
+// `ValueOptions` and `KeyOptions` are structurally identical to
+// `messageOptions` — they exist as named types only to make the
+// value-side vs key-side distinction explicit at `processMessage`'s
+// signature. The schema fields below use `messageOptions` directly;
+// no separate runtime schema is needed for each side.
+type ValueOptions = z.infer<typeof messageOptions>;
+type KeyOptions = z.infer<typeof messageOptions>;
 
 /**
  * Per-entry "where to start consuming" tagged union. Collapses the prior
@@ -51,10 +60,9 @@ type KeyOptions = z.infer<typeof keyOptions>;
  * knob into a single per-topic position control with four arms:
  *
  *   - `"earliest"` — begin at the partition low watermark (entire retained
- *     history).
+ *     history). This is the default when `start` is omitted.
  *   - `"latest"` — begin at the partition high watermark (only
- *     newly-produced messages). This is the default when `start` is
- *     omitted.
+ *     newly-produced messages).
  *   - `{ offset: "..." }` — begin at an absolute partition offset
  *     (digit-only string; requires `partition`).
  *   - `{ timestamp: ... }` — begin at the broker-resolved offset for the
@@ -146,8 +154,8 @@ export const consumeKafkaMessagesArgs = z.object({
     .describe(
       "Maximum time in milliseconds to wait for messages before stopping.",
     ),
-  valueFormat: valueOptions.optional().default({ useSchemaRegistry: false }),
-  keyFormat: keyOptions.optional().default({ useSchemaRegistry: false }),
+  valueFormat: messageOptions,
+  keyFormat: messageOptions,
   cluster_id: z
     .string()
     .optional()
@@ -316,26 +324,6 @@ function planNeedsPreflight(
   );
 }
 
-/**
- * Validates the requested targets against broker metadata and watermarks,
- * resolves any timestamp-based seeks to concrete partition offsets, issues
- * explicit watermark seeks for direction-only entries that don't match the
- * consumer's chosen `auto.offset.reset`, and produces the canonical
- * {@link PreflightPlan}. Thrown errors are caught one frame up and rendered
- * as a tool-error response.
- *
- * Validation rules (handler-side; the Zod schema covers field-level shape):
- * - `start: {offset}` requires `partition` — absolute offsets are
- *   partition-scoped; different partitions have different offset spaces.
- * - All-or-nothing partition mode per topic: every entry for a given
- *   topic must specify `partition`, or none of them may. Mixing is
- *   ambiguous (does the bare entry override the partitioned one or
- *   coexist with it?) and rejected loudly.
- * - Requested partitions must exist (cross-check with
- *   `admin.fetchTopicMetadata`).
- * - Absolute offsets must lie in `[low, high)` for their partition
- *   (cross-check with `admin.fetchTopicOffsets`).
- */
 /**
  * Reject any target that supplies `start: {offset}` without a
  * `partition` — absolute offsets are partition-scoped (offset 10 on
@@ -801,16 +789,36 @@ export async function applyPostAssignmentHook(opts: {
  * Pulled out of the orchestrator so the synchronous gates and the
  * "did we hit `maxMessages`?" signal are individually testable.
  *
- * The synchronous boolean getters (`isAccepting`, `isPreflightApplied`)
- * intentionally stay synchronous — `await`ing a Deferred in their place
- * would change behavior, because pre-pause deliveries from librdkafka's
- * fetch buffer must be dropped on arrival rather than queued through.
+ * The synchronous boolean/predicate getters (`isAccepting`,
+ * `isPreflightApplied`, `shouldKeepDuringPrePause`) intentionally stay
+ * synchronous — `await`ing a Deferred in their place would change
+ * behavior, because pre-pause deliveries from librdkafka's fetch buffer
+ * must be filtered on arrival rather than queued through.
+ *
+ * Pre-pause gate semantics: before the post-assignment pause step has
+ * run, drop a delivery **only** when its `(topic, partition)` is one
+ * we'd pause anyway (i.e. outside the topic's keep-set). Keep-set
+ * deliveries arriving during the brief window between assignment-landing
+ * and pause-being-applied are real records the caller asked for; the
+ * pre-run-stashed seeks have already positioned the consumer, so
+ * librdkafka can hand them to `eachMessage` immediately. Dropping them
+ * would be silent data loss. After `preflightApplied` flips, the gate
+ * doesn't fire (pause has already kept the unwanted partitions silent).
  */
 export function createEachMessageHandler(opts: {
   state: {
     consumedMessages: ProcessedMessage[];
     isAccepting: () => boolean;
     isPreflightApplied: () => boolean;
+    /**
+     * Returns `true` if this `(topic, partition)` is in the topic's
+     * keep-set (or the topic has no partition restriction at all). Used
+     * by the pre-pause gate to let legitimate caller-requested records
+     * through immediately while still dropping the about-to-be-paused
+     * partitions that librdkafka may deliver in the assignment-to-pause
+     * window.
+     */
+    shouldKeepDuringPrePause: (topic: string, partition: number) => boolean;
   };
   maxMessages: number;
   onMaxReached: () => void;
@@ -826,7 +834,12 @@ export function createEachMessageHandler(opts: {
 }) => Promise<void> {
   return async ({ topic, partition, message }) => {
     if (!opts.state.isAccepting()) return;
-    if (!opts.state.isPreflightApplied()) return;
+    if (
+      !opts.state.isPreflightApplied() &&
+      !opts.state.shouldKeepDuringPrePause(topic, partition)
+    ) {
+      return;
+    }
     const processed = await opts.processMessage(topic, partition, message);
     opts.state.consumedMessages.push(processed);
     if (opts.state.consumedMessages.length >= opts.maxMessages) {
@@ -1045,6 +1058,15 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
           consumedMessages,
           isAccepting: () => accepting,
           isPreflightApplied: () => preflightApplied,
+          // Pre-pause gate predicate: a (topic, partition) is "keep" if
+          // the topic has no partition restriction (keepPartitions omits
+          // it) or the partition is in the topic's keep-set. The
+          // orchestrator's `plan.keepPartitions` is built so absence of
+          // an entry means "no restriction"; we honor that contract here.
+          shouldKeepDuringPrePause: (topic, partition) => {
+            const keepSet = plan.keepPartitions.get(topic);
+            return keepSet === undefined || keepSet.has(partition);
+          },
         },
         maxMessages,
         onMaxReached: () => {

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -1,5 +1,6 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { ConsumerBuildOptions } from "@src/confluent/base-client-manager.js";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import { kafkaDeps } from "@src/confluent/node-deps.js";
 import { paths } from "@src/confluent/openapi-schema.js";
@@ -172,11 +173,7 @@ export interface MockedClientManager extends Mocked<DirectClientManager> {
     (clusterId?: string, envId?: string) => Promise<Mocked<KafkaJS.Producer>>
   >;
   buildKafkaConsumer: Mock<
-    (
-      clusterId?: string,
-      envId?: string,
-      groupId?: string,
-    ) => Promise<Mocked<KafkaJS.Consumer>>
+    (opts?: ConsumerBuildOptions) => Promise<Mocked<KafkaJS.Consumer>>
   >;
   getConfluentCloudFlinkRestClient: Mock<() => MockedRestClient>;
   getConfluentCloudRestClient: Mock<() => MockedRestClient>;
@@ -249,8 +246,8 @@ export function getMockedClientManager(): MockedClientManager {
   // canonical configuration point so existing test setup keeps working.
   cm.getKafkaAdminClient.mockImplementation(() => cm.getAdminClient());
   cm.getKafkaProducer.mockImplementation(() => cm.getProducer());
-  cm.buildKafkaConsumer.mockImplementation((_cluster, _env, groupId) =>
-    cm.getConsumer(groupId),
+  cm.buildKafkaConsumer.mockImplementation((opts) =>
+    cm.getConsumer(opts?.groupId),
   );
 
   cm.getSchemaRegistryClient.mockReturnValue(getMockedSchemaRegistry());


### PR DESCRIPTION
 TL;DR

- **NEW: partition restriction** — consume from a single specific partition; the other broker-assigned partitions get paused so they're never read.
  Example: `{topics: [{name: "X", partition: 0}]}`.
- **NEW: absolute-offset seek** — start at a specific offset within a partition (digit-only string preserves int64 precision past JS's 2^53 ceiling).
  Example: `{topics: [{name: "X", partition: 0, start: {offset: "42"}}]}`.
- **NEW: timestamp seek** — start at the broker-resolved offset for a specific point in time, ISO 8601 string or ms-since-epoch number.
  Example: `{topics: [{name: "X", start: {timestamp: "2026-05-14T17:00:00Z"}}]}`.
- **Renamed for clarity**: the per-message Schema Registry deserialization options `value` / `key` → `valueFormat` / `keyFormat` (and now omit-by-default).
  The old names competed for cognitive space with `topics` data — `value` especially read like input data ("the value to produce / filter by") rather than a per-call deserialization knob; the new names describe what the fields actually do (the format/encoding of the bytes).
- **Migration**: top-level `offsetReset` removed (rolled into per-topic `start`); `topicNames: string[]` replaced by `topics[]` object array.
  The starting-position default stays at `"earliest"` (no behavior change for bare-name calls); pass `start: "latest"` on the topic entries that should read only newly-produced messages.
- **New**: Each consume invocation becomes a unique Kafka consumer `groupId`. No more possible reuse based on `sessionId`.

## Per-topic `partition` + `start` shape

The single required field is `topics`, an array of per-topic option objects.
The minimal call collapses to `{topics: [{name: "orders"}]}`; the same array carries optional `partition` and `start` controls on the entries that need them, e.g. `topics: [{name: "orders"}, {name: "shipments", partition: 0, start: {offset: "42"}}]`.
At the Zod boundary `topics` is the only no-default no-optional field: `maxMessages` / `timeoutMs` / `valueFormat` / `keyFormat` all carry defaults (the parser fills them in if omitted), and `cluster_id` / `environment_id` are bare `.optional()`.
The LLM-facing JSON Schema, however, currently lists every defaulted field in `required` alongside `topics` — the same Zod 4 output-mode-emission quirk discussed below in the context of `start` (and tracked at #482).
The runtime accepts the omitted fields and applies their defaults correctly; the schema just doesn't tell the LLM that.

`partition` and `start` are independent — `partition` answers WHICH partition(s) to read, `start` answers WHERE in them to begin:

- `partition` — restrict consumption to one partition (0-indexed).
  Other partitions the broker assigns get paused after the consumer's first poll, so they're never read.
- `start` — a tagged-union "where to begin" control with four arms:
  - `"earliest"` — begin at the partition low watermark (entire retained history).
    This is the default when `start` is omitted.
  - `"latest"` — begin at the partition high watermark (only newly-produced messages).
  - `{offset: "..."}` — begin at an absolute partition offset, passed as a digit-only string so int64 values past JS's 2^53 safe-integer range stay precise.
    Requires `partition` to also be set (absolute offsets are partition-scoped).
  - `{timestamp: ...}` — begin at the broker-resolved offset for the supplied time.
    Accepts ISO 8601 strings (`"2026-05-14T17:00:00Z"`, `"2026-05-14T13:00:00-04:00"`) or ms-since-epoch numbers.
    ISO 8601 is preferred — LLMs are fluent in it and don't trip over seconds-vs-milliseconds or timezone arithmetic; the handler normalizes server-side via `Date.parse` before calling `admin.fetchTopicOffsetsByTimestamp`.
    Resolves per-partition when no `partition` is given.

## `valueFormat` and `keyFormat`: rename + optional

The pre-existing `value` and `key` top-level fields (which control deserialization options for the value-side and key-side bytes of each Kafka message) read as out-of-place data peers to `topics` — `value` especially looks like input data ("the value to produce / filter by") until the LLM steps into the inner `useSchemaRegistry` field.
They're renamed to `valueFormat` / `keyFormat` so the names describe what the fields do (the format/encoding of the bytes), parse cleanly as peers to `topics`, and don't compete for cognitive space.
Both are also marked `.optional().default({useSchemaRegistry: false})`, so the LLM's input schema treats them as omit-by-default — the simple raw-bytes consume no longer needs `value: {}` filler.
The handler-side parse always sees both fields as defined (with the default applied at the boundary), so the downstream call sites and `processMessage` signature got slightly tighter: the previously-optional `keyOptions?` parameter and its inner `message.key && keyOptions` guard collapse to a single `message.key` guard.

## While here

`list-environments-handler.ts`'s response schema had four `z.string().url()` calls Zod 4 deprecates in favor of the top-level `z.url()` format schema.
Same validator, same params; swept while we were touching another Zod schema in this branch.
After the sweep there are zero `z.string().<format>()` deprecations left in /src.

## Relationships

- Closes #459.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
