### PR TITLE
fix: track created flink statements in `_meta` and delete during integration test teardown

### DIFF
--- a/src/confluent/tools/handlers/flink/catalog/catalog-resolver.ts
+++ b/src/confluent/tools/handlers/flink/catalog/catalog-resolver.ts
@@ -75,6 +75,22 @@ export interface SchemaMapping {
 }
 
 /**
+ * Result of a resolver lookup. `statementName` is the name minted by the
+ * underlying {@linkcode executeFlinkSql} call, surfaced so the calling
+ * handler can emit it via `_meta.flinkStatementsCreated` for test-side
+ * cleanup.
+ */
+export interface CatalogMappingResult {
+  mappings: CatalogMapping[];
+  statementName?: string;
+}
+
+export interface SchemaMappingResult {
+  mappings: SchemaMapping[];
+  statementName?: string;
+}
+
+/**
  * Looks up catalog mappings from INFORMATION_SCHEMA.CATALOGS.
  * Returns a 1:1 mapping between environment IDs (CATALOG_ID) and friendly names (CATALOG_NAME).
  */
@@ -86,7 +102,7 @@ export async function getCatalogMapping(
     environmentId: string;
     computePoolId: string;
   },
-): Promise<CatalogMapping[]> {
+): Promise<CatalogMappingResult> {
   const sql = `SELECT \`CATALOG_ID\`, \`CATALOG_NAME\` FROM \`${catalogName}\`.\`INFORMATION_SCHEMA\`.\`CATALOGS\``;
 
   const result = await executeFlinkSql(clientManager, sql, {
@@ -96,7 +112,7 @@ export async function getCatalogMapping(
   });
 
   if (!result.success || !result.data) {
-    return [];
+    return { mappings: [], statementName: result.statementName };
   }
 
   const mappings: CatalogMapping[] = [];
@@ -108,7 +124,7 @@ export async function getCatalogMapping(
       mappings.push({ catalogId, catalogName: catalogNameValue });
     }
   }
-  return mappings;
+  return { mappings, statementName: result.statementName };
 }
 
 /**
@@ -146,7 +162,7 @@ export async function getSchemaMapping(
     environmentId: string;
     computePoolId: string;
   },
-): Promise<SchemaMapping[]> {
+): Promise<SchemaMappingResult> {
   const sql = `SELECT \`SCHEMA_ID\`, \`SCHEMA_NAME\` FROM \`${catalogName}\`.\`INFORMATION_SCHEMA\`.\`SCHEMATA\` WHERE \`SCHEMA_NAME\` <> 'INFORMATION_SCHEMA'`;
 
   const result = await executeFlinkSql(clientManager, sql, {
@@ -156,7 +172,7 @@ export async function getSchemaMapping(
   });
 
   if (!result.success || !result.data) {
-    return [];
+    return { mappings: [], statementName: result.statementName };
   }
 
   const mappings: SchemaMapping[] = [];
@@ -168,7 +184,7 @@ export async function getSchemaMapping(
       mappings.push({ schemaId, schemaName });
     }
   }
-  return mappings;
+  return { mappings, statementName: result.statementName };
 }
 
 /**

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
@@ -1,6 +1,10 @@
 import { DescribeTableHandler } from "@src/confluent/tools/handlers/flink/catalog/describe-table-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { findFriendlySchemaName } from "@tests/harness/flink.js";
+import {
+  findFriendlySchemaName,
+  trackStatementsFromMeta,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
 import {
   getTestClusterId,
   withSharedAdminClient,
@@ -39,6 +43,10 @@ describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
 
   // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
   const { admin, createdTopics } = withSharedAdminClient();
+  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated.
+  // expect.poll() retries grow the array with every attempt (all leaks land
+  // in the sweep, not just the final one).
+  const { createdStatements } = withSharedFlinkStatementCleanup();
   const tableName = uniqueName("flink-tbl");
 
   beforeAll(async () => {
@@ -74,6 +82,7 @@ describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
         name: ToolName.LIST_FLINK_DATABASES,
         arguments: {},
       });
+      trackStatementsFromMeta(dbResult, createdStatements);
       expect(
         dbResult.isError,
         `list-databases failed: ${textContent(dbResult)}`,
@@ -95,6 +104,7 @@ describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
               name: ToolName.DESCRIBE_FLINK_TABLE,
               arguments: { tableName, databaseName },
             });
+            trackStatementsFromMeta(result, createdStatements);
             if (result.isError === true) throw new Error(textContent(result));
             return textContent(result);
           },

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
@@ -76,6 +76,47 @@ describe("describe-table-handler.ts", () => {
         },
       );
 
+      it("should surface the executeFlinkSql statement name via _meta.flinkStatementsCreated on success", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).not.toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should still surface the statement name via _meta on the error path", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: {
+            ...SQL_RESPONSE,
+            status: { phase: "FAILED", detail: "synthetic failure" },
+          },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should surface BOTH statement names when an lkc-* databaseName triggers the resolver lookup", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME, databaseName: "lkc-explicit" },
+        );
+        expect(result.isError).not.toBe(true);
+        // resolver lookup + main query each mint their own statement
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
       it.each([
         {
           label: "use config environment_id when catalogName arg is absent",

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
@@ -6,7 +6,10 @@ import {
   resolveToSchemaName,
 } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
-import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
+import {
+  executeFlinkSql,
+  type FlinkStatementMeta,
+} from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -77,15 +80,20 @@ export class DescribeTableHandler extends FlinkCatalogToolHandler {
     // Database name is optional - if provided, resolve it to friendly SCHEMA_NAME
     const database_input = resolveDatabaseName(databaseName, conn);
 
-    // If a database was specified, resolve cluster ID to friendly name
-    let schema_name: string | undefined;
-    if (database_input) {
-      const mappings = await getSchemaMapping(clientManager, catalog_name, {
+    const statementsCreated: string[] = [];
+
+    // Only run getSchemaMapping for lkc-* inputs; resolveToSchemaName
+    // passes friendly names through, so the roundtrip would just leak a
+    // statement.
+    let schema_name: string | undefined = database_input;
+    if (database_input?.startsWith("lkc-")) {
+      const lookup = await getSchemaMapping(clientManager, catalog_name, {
         organizationId: organization_id,
         environmentId: environment_id,
         computePoolId: compute_pool_id,
       });
-      schema_name = resolveToSchemaName(database_input, mappings);
+      if (lookup.statementName) statementsCreated.push(lookup.statementName);
+      schema_name = resolveToSchemaName(database_input, lookup.mappings);
     }
 
     // Query INFORMATION_SCHEMA.COLUMNS for full schema details
@@ -101,11 +109,16 @@ export class DescribeTableHandler extends FlinkCatalogToolHandler {
       environmentId: environment_id,
       computePoolId: compute_pool_id,
     });
+    if (result.statementName) statementsCreated.push(result.statementName);
+    const meta: FlinkStatementMeta = {
+      flinkStatementsCreated: statementsCreated,
+    };
 
     if (!result.success) {
       return this.createResponse(
         `Failed to describe table: ${result.error}`,
         true,
+        meta,
       );
     }
 
@@ -117,12 +130,15 @@ export class DescribeTableHandler extends FlinkCatalogToolHandler {
       return this.createResponse(
         `Table ${scope} not found or has no columns.`,
         true,
+        meta,
       );
     }
 
     // Include TABLE_SCHEMA in response so user knows which database the table is in
     return this.createResponse(
       `Table '${tableName}' schema:\n${JSON.stringify(columns, null, 2)}`,
+      false,
+      meta,
     );
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
@@ -1,6 +1,10 @@
 import { GetTableInfoHandler } from "@src/confluent/tools/handlers/flink/catalog/get-table-info-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { findFriendlySchemaName } from "@tests/harness/flink.js";
+import {
+  findFriendlySchemaName,
+  trackStatementsFromMeta,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
 import {
   getTestClusterId,
   withSharedAdminClient,
@@ -39,6 +43,10 @@ describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
 
   // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
   const { admin, createdTopics } = withSharedAdminClient();
+  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated.
+  // expect.poll() retries grow the array with every attempt (all leaks land
+  // in the sweep, not just the final one).
+  const { createdStatements } = withSharedFlinkStatementCleanup();
   const tableName = uniqueName("flink-tbl");
 
   beforeAll(async () => {
@@ -74,6 +82,7 @@ describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
         name: ToolName.LIST_FLINK_DATABASES,
         arguments: {},
       });
+      trackStatementsFromMeta(dbResult, createdStatements);
       expect(
         dbResult.isError,
         `list-databases failed: ${textContent(dbResult)}`,
@@ -95,6 +104,7 @@ describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
               name: ToolName.GET_FLINK_TABLE_INFO,
               arguments: { tableName, databaseName },
             });
+            trackStatementsFromMeta(result, createdStatements);
             if (result.isError === true) throw new Error(textContent(result));
             return textContent(result);
           },

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
@@ -76,6 +76,46 @@ describe("get-table-info-handler.ts", () => {
         },
       );
 
+      it("should surface the executeFlinkSql statement name via _meta.flinkStatementsCreated on success", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).not.toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should still surface the statement name via _meta on the error path", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: {
+            ...SQL_RESPONSE,
+            status: { phase: "FAILED", detail: "synthetic failure" },
+          },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should surface BOTH statement names when an lkc-* databaseName triggers the resolver lookup", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME, databaseName: "lkc-explicit" },
+        );
+        expect(result.isError).not.toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
       it.each([
         {
           label: "use config environment_id when catalogName arg is absent",

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
@@ -6,7 +6,10 @@ import {
   resolveToSchemaName,
 } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
-import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
+import {
+  executeFlinkSql,
+  type FlinkStatementMeta,
+} from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -77,15 +80,20 @@ export class GetTableInfoHandler extends FlinkCatalogToolHandler {
     // Database name is optional - if provided, resolve it to friendly SCHEMA_NAME
     const database_input = resolveDatabaseName(databaseName, conn);
 
-    // If a database was specified, resolve cluster ID to friendly name
-    let schema_name: string | undefined;
-    if (database_input) {
-      const mappings = await getSchemaMapping(clientManager, catalog_name, {
+    const statementsCreated: string[] = [];
+
+    // Only run getSchemaMapping for lkc-* inputs; resolveToSchemaName
+    // passes friendly names through, so the roundtrip would just leak a
+    // statement.
+    let schema_name: string | undefined = database_input;
+    if (database_input?.startsWith("lkc-")) {
+      const lookup = await getSchemaMapping(clientManager, catalog_name, {
         organizationId: organization_id,
         environmentId: environment_id,
         computePoolId: compute_pool_id,
       });
-      schema_name = resolveToSchemaName(database_input, mappings);
+      if (lookup.statementName) statementsCreated.push(lookup.statementName);
+      schema_name = resolveToSchemaName(database_input, lookup.mappings);
     }
 
     // Query INFORMATION_SCHEMA.TABLES for table metadata including watermarks
@@ -101,11 +109,16 @@ export class GetTableInfoHandler extends FlinkCatalogToolHandler {
       environmentId: environment_id,
       computePoolId: compute_pool_id,
     });
+    if (result.statementName) statementsCreated.push(result.statementName);
+    const meta: FlinkStatementMeta = {
+      flinkStatementsCreated: statementsCreated,
+    };
 
     if (!result.success) {
       return this.createResponse(
         `Failed to get table info: ${result.error}`,
         true,
+        meta,
       );
     }
 
@@ -114,11 +127,13 @@ export class GetTableInfoHandler extends FlinkCatalogToolHandler {
       const scope = schema_name
         ? `'${catalog_name}.${schema_name}.${tableName}'`
         : `'${tableName}' in catalog '${catalog_name}'`;
-      return this.createResponse(`Table ${scope} not found.`, true);
+      return this.createResponse(`Table ${scope} not found.`, true, meta);
     }
 
     return this.createResponse(
       `Table info for '${tableName}':\n${JSON.stringify(tables[0], null, 2)}`,
+      false,
+      meta,
     );
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
@@ -1,5 +1,9 @@
 import { ListCatalogsHandler } from "@src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  trackStatementsFromMeta,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -18,6 +22,9 @@ describe("list-catalogs-handler", { tags: [Tag.FLINK] }, () => {
     it.skip("requires flink config", () => {});
     return;
   }
+
+  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
+  const { createdStatements } = withSharedFlinkStatementCleanup();
 
   describe.each(activeTransports)("via %s transport", (transport) => {
     let server: StartedServer;
@@ -43,6 +50,7 @@ describe("list-catalogs-handler", { tags: [Tag.FLINK] }, () => {
         name: ToolName.LIST_FLINK_CATALOGS,
         arguments: {},
       });
+      trackStatementsFromMeta(result, createdStatements);
 
       expect(textContent(result)).toMatch(/^Catalogs:/);
     });

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
@@ -68,6 +68,39 @@ describe("list-catalogs-handler.ts", () => {
         },
       );
 
+      it("should surface the executeFlinkSql statement name via _meta.flinkStatementsCreated on success", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).not.toBe(true);
+        // statement name is minted client-side by executeFlinkSql via Date.now()
+        // + Math.random(), so it's genuinely non-deterministic from the test's
+        // POV; pin only the prefix the cleanup script keys on
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should still surface the statement name via _meta on the error path", async () => {
+        // status poll returning FAILED forces executeFlinkSql into its
+        // error-with-statementName branch (statement was created, just bombed)
+        flinkRest.GET.mockResolvedValue({
+          data: {
+            ...SQL_RESPONSE,
+            status: { phase: "FAILED", detail: "synthetic failure" },
+          },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
       it("should embed config environment_id as catalog name in the POST SQL statement", async () => {
         await assertHandleCase({
           handler,

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
@@ -1,7 +1,10 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
-import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
+import {
+  executeFlinkSql,
+  type FlinkStatementMeta,
+} from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -53,21 +56,29 @@ export class ListCatalogsHandler extends FlinkCatalogToolHandler {
       environmentId: environment_id,
       computePoolId: compute_pool_id,
     });
+    const meta: FlinkStatementMeta = {
+      flinkStatementsCreated: result.statementName
+        ? [result.statementName]
+        : [],
+    };
 
     if (!result.success) {
       return this.createResponse(
         `Failed to list catalogs: ${result.error}`,
         true,
+        meta,
       );
     }
 
     const catalogs = result.data ?? [];
     if (catalogs.length === 0) {
-      return this.createResponse("No catalogs found.");
+      return this.createResponse("No catalogs found.", false, meta);
     }
 
     return this.createResponse(
       `Catalogs:\n${JSON.stringify(catalogs, null, 2)}`,
+      false,
+      meta,
     );
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
@@ -1,5 +1,9 @@
 import { ListDatabasesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-databases-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  trackStatementsFromMeta,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -18,6 +22,9 @@ describe("list-databases-handler", { tags: [Tag.FLINK] }, () => {
     it.skip("requires flink config", () => {});
     return;
   }
+
+  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
+  const { createdStatements } = withSharedFlinkStatementCleanup();
 
   describe.each(activeTransports)("via %s transport", (transport) => {
     let server: StartedServer;
@@ -43,6 +50,7 @@ describe("list-databases-handler", { tags: [Tag.FLINK] }, () => {
         name: ToolName.LIST_FLINK_DATABASES,
         arguments: {},
       });
+      trackStatementsFromMeta(result, createdStatements);
 
       // fresh test account may have no databases; either response shape is valid
       expect(textContent(result)).toMatch(/^(Databases:|No databases found)/);

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
@@ -67,6 +67,34 @@ describe("list-databases-handler.ts", () => {
         },
       );
 
+      it("should surface the executeFlinkSql statement name via _meta.flinkStatementsCreated on success", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).not.toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should still surface the statement name via _meta on the error path", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: {
+            ...SQL_RESPONSE,
+            status: { phase: "FAILED", detail: "synthetic failure" },
+          },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
       it.each([
         {
           label: "use config environment_id when catalogName arg is absent",

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
@@ -1,7 +1,10 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
-import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
+import {
+  executeFlinkSql,
+  type FlinkStatementMeta,
+} from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -60,21 +63,29 @@ export class ListDatabasesHandler extends FlinkCatalogToolHandler {
       environmentId: environment_id,
       computePoolId: compute_pool_id,
     });
+    const meta: FlinkStatementMeta = {
+      flinkStatementsCreated: result.statementName
+        ? [result.statementName]
+        : [],
+    };
 
     if (!result.success) {
       return this.createResponse(
         `Failed to list databases: ${result.error}`,
         true,
+        meta,
       );
     }
 
     const databases = result.data ?? [];
     if (databases.length === 0) {
-      return this.createResponse("No databases found.");
+      return this.createResponse("No databases found.", false, meta);
     }
 
     return this.createResponse(
       `Databases:\n${JSON.stringify(databases, null, 2)}`,
+      false,
+      meta,
     );
   }
 

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
@@ -1,5 +1,9 @@
 import { ListTablesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-tables-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import {
+  trackStatementsFromMeta,
+  withSharedFlinkStatementCleanup,
+} from "@tests/harness/flink.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -18,6 +22,9 @@ describe("list-tables-handler", { tags: [Tag.FLINK] }, () => {
     it.skip("requires flink config", () => {});
     return;
   }
+
+  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
+  const { createdStatements } = withSharedFlinkStatementCleanup();
 
   describe.each(activeTransports)("via %s transport", (transport) => {
     let server: StartedServer;
@@ -43,6 +50,7 @@ describe("list-tables-handler", { tags: [Tag.FLINK] }, () => {
         name: ToolName.LIST_FLINK_TABLES,
         arguments: {},
       });
+      trackStatementsFromMeta(result, createdStatements);
 
       // handler filters out INFORMATION_SCHEMA; a fresh env may have no user tables
       expect(textContent(result)).toMatch(

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
@@ -69,6 +69,34 @@ describe("list-tables-handler.ts", () => {
         },
       );
 
+      it("should surface the executeFlinkSql statement name via _meta.flinkStatementsCreated on success", async () => {
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).not.toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
+      it("should still surface the statement name via _meta on the error path", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: {
+            ...SQL_RESPONSE,
+            status: { phase: "FAILED", detail: "synthetic failure" },
+          },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(result._meta?.flinkStatementsCreated).toEqual([
+          expect.stringMatching(/^mcp-query-/),
+        ]);
+      });
+
       it.each([
         {
           label: "use config environment_id when catalogName arg is absent",

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
@@ -1,7 +1,10 @@
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
-import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
+import {
+  executeFlinkSql,
+  type FlinkStatementMeta,
+} from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
@@ -61,11 +64,17 @@ export class ListTablesHandler extends FlinkCatalogToolHandler {
       environmentId: environment_id,
       computePoolId: compute_pool_id,
     });
+    const meta: FlinkStatementMeta = {
+      flinkStatementsCreated: result.statementName
+        ? [result.statementName]
+        : [],
+    };
 
     if (!result.success) {
       return this.createResponse(
         `Failed to list tables: ${result.error}`,
         true,
+        meta,
       );
     }
 
@@ -73,11 +82,15 @@ export class ListTablesHandler extends FlinkCatalogToolHandler {
     if (tables.length === 0) {
       return this.createResponse(
         `No tables found in catalog '${catalog_name}'.`,
+        false,
+        meta,
       );
     }
 
     return this.createResponse(
       `Tables in catalog '${catalog_name}':\n${JSON.stringify(tables, null, 2)}`,
+      false,
+      meta,
     );
   }
 

--- a/src/confluent/tools/handlers/flink/flink-sql-helper.ts
+++ b/src/confluent/tools/handlers/flink/flink-sql-helper.ts
@@ -9,6 +9,20 @@ export interface FlinkSqlResult {
   phase?: string;
 }
 
+/**
+ * `_meta` payload emitted by catalog handlers so integration tests can sweep
+ * statements the handler created internally. {@linkcode executeFlinkSql}
+ * does not auto-delete (a streaming caller would break under that semantic).
+ *
+ * Declared as `type` rather than `interface` so the shape is assignable to
+ * {@link BaseToolHandler.createResponse}'s `_meta: Record<string, unknown>`
+ * parameter; interfaces are excluded from that target by declaration-merging
+ * rules (microsoft/TypeScript#15300).
+ */
+export type FlinkStatementMeta = {
+  flinkStatementsCreated: string[];
+};
+
 export interface FlinkSqlOptions {
   organizationId: string;
   environmentId: string;

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
@@ -53,13 +53,53 @@ describe("list-flink-statements-handler", { tags: [Tag.FLINK] }, () => {
     });
 
     it("should return a JSON payload that includes the seeded statement", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_FLINK_STATEMENTS,
-        arguments: {},
-      });
+      // Pagination guard: the test account is shared, so accumulated state (e.g. `mcp-query-*`
+      // from catalog handler leaks) can push the seed off the first page of 100. Walk pages until
+      // we find it, with a cap.
+      const MAX_PAGES = 20;
+      let pageToken: string | undefined;
+      let pagesChecked = 0;
+      let found = false;
+      let totalSeen = 0;
 
-      // handler stringifies the raw response, so just check that the statement name appears
-      expect(textContent(result)).toContain(seedName);
+      do {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_FLINK_STATEMENTS,
+          arguments: pageToken ? { pageToken } : {},
+        });
+        const text = textContent(result);
+        const body = JSON.parse(text) as {
+          data?: Array<{ name: string }>;
+          metadata?: { next?: string };
+        };
+        const names = body.data?.map((s) => s.name) ?? [];
+        totalSeen += names.length;
+        if (names.includes(seedName)) {
+          found = true;
+          break;
+        }
+        pageToken = extractPageToken(body.metadata?.next);
+        pagesChecked++;
+      } while (pageToken && pagesChecked < MAX_PAGES);
+
+      expect(
+        found,
+        `seed statement ${seedName} not found after scanning ${totalSeen} statement(s) across ${pagesChecked} page(s). Check to make sure statements are not piling up in the test environment.`,
+      ).toBe(true);
     });
   });
 });
+
+/**
+ * Extracts the `page_token` from a CCloud `metadata.next` value, falling back
+ * to a substring search since CCloud returns both full URLs and bare tokens.
+ */
+function extractPageToken(nextUrl: string | undefined): string | undefined {
+  if (!nextUrl) return undefined;
+  try {
+    return new URL(nextUrl).searchParams.get("page_token") ?? undefined;
+  } catch {
+    const idx = nextUrl.indexOf("page_token=");
+    return idx === -1 ? undefined : nextUrl.slice(idx + "page_token=".length);
+  }
+}

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -1,6 +1,8 @@
 import type { paths } from "@src/confluent/openapi-schema.js";
+import type { FlinkStatementMeta } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
 import { integrationRuntime } from "@tests/harness/runtime.js";
+import type { CallToolResponse } from "@tests/harness/tool-results.js";
 import { setTimeout as sleep } from "node:timers/promises";
 import createClient, { type Client } from "openapi-fetch";
 import { afterAll } from "vitest";
@@ -199,6 +201,21 @@ export function withSharedFlinkStatementCleanup(): {
     );
   });
   return { createdStatements };
+}
+
+/**
+ * Reads `_meta.flinkStatementsCreated` from a tool-call result and pushes names onto
+ * {@linkcode createdStatements} for sweep by {@linkcode withSharedFlinkStatementCleanup}'s `afterAll`.
+ */
+export function trackStatementsFromMeta(
+  result: CallToolResponse,
+  createdStatements: string[],
+): void {
+  const names = (result._meta as Partial<FlinkStatementMeta> | undefined)
+    ?.flinkStatementsCreated;
+  if (Array.isArray(names) && names.length > 0) {
+    createdStatements.push(...names.filter((n) => typeof n === "string"));
+  }
 }
 
 /**

--- a/tests/harness/tool-results.ts
+++ b/tests/harness/tool-results.ts
@@ -5,7 +5,7 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
  *  the discriminated union of the current `CallToolResult` shape and the
  *  legacy `CompatibilityCallToolResult` shape with `toolResult` instead of
  *  `content`. */
-type CallToolResponse = Awaited<ReturnType<Client["callTool"]>>;
+export type CallToolResponse = Awaited<ReturnType<Client["callTool"]>>;
 
 /**
  * Concatenates all text-typed content blocks from a tool call result. Empty


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

`executeFlinkSql` creates Flink statements but previously didn't expose any way of gathering up the statement names for cleanup. This caused failures in integration tests because we were accumulating so many statements that the integration tests would hit the pagination threshold and fail.

This PR sets up a basic `{ flinkStatementsCreated: string[] }` meta structure for the `flink/catalog` tool handlers' responses, and updates all associated integration tests to track created statements to make sure they're cleaned up as part of `withSharedFlinkStatementCleanup`.

> [!NOTE]
> Lots of files changed here, but they mainly boil down to three groups:
> 1) the actual `_meta` additions to the affected handlers
> 2) integration tests referencing the tracked statements from `_meta`
> 3) unit tests preventing regressions that drop statement tracking

Closes #485 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
