### PR TITLE
chore: edit claude rules

### DIFF
--- a/.claude/rules/tool-handlers.md
+++ b/.claude/rules/tool-handlers.md
@@ -28,6 +28,7 @@ Every tool handler follows this pattern:
    - Otherwise extend `BaseToolHandler` from `@src/confluent/tools/base-tools.js` directly. If a domain has more than one tool with the same predicate, introduce a domain subclass first and extend that.
 2. **Implement these members:**
    - `getToolConfig()` → returns `{ name: ToolName, description: string, inputSchema: zodSchema.shape, annotations: ToolAnnotations }`. Use one of the shared annotation constants exported from `base-tools.ts`: `READ_ONLY`, `CREATE_UPDATE`, or `DESTRUCTIVE` (don't construct ad-hoc instances).
+     Test-side: assert by identity (`expect(config.annotations).toBe(READ_ONLY)`); see `.claude/rules/unit-tests.md` Handler Tests.
    - `handle(runtime, toolArguments, sessionId?)` → returns `Promise<CallToolResult>`.
    - `readonly predicate` (skip if you inherited it from a domain subclass) → a `ConnectionPredicate` from `connection-predicates.ts` that gates tool enablement. Declared as a one-liner property, never as a method:
      ```typescript

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -233,8 +233,6 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   as default for success cases). Pass `"DISCOVER"` as the `outcome` sentinel to run the
   handler and get a copy-paste suggestion for the correct expectation; replace before
   committing.
-  `assertHandleCase` is geared toward outcome-shaped throws/resolves; when a handler test asserts _formatted text content_ and `_meta` aggregation (rather than just resolve/throw outcome), a bespoke per-test shape is acceptable.
-  Reach for `assertHandleCase` first and only fall back when the outcome model doesn't fit the assertions.
 
 - **Schema-validation tests: prefer `it.each` or scope the name.**
   When a Zod schema rejects multiple field shapes (e.g. malformed dates, page-size bounds, missing required keys), either cover each rejection case with `it.each` _or_ scope the single test's name to what it actually checks (`"should reject malformed startDate"` rather than `"should surface ZodError"`).

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -62,6 +62,16 @@ compute — timestamps, generated UUIDs, opaque tokens minted by the unit under 
 fields whose value the test deliberately doesn't pin (e.g. a free-port-allocated URL).
 "I don't want to spell out the full object" is not non-determinism.
 
+#### `toMatchObject` is not literal
+
+`toMatchObject` is the loose-matcher trap inside an otherwise literal-looking assertion: it matches a subset, accepts extra keys, and does not pin key order.
+When the test is asserting the _full_ shape, use `toEqual` instead; when explicitly checking absence, use `not.toHaveProperty("…")` rather than `toMatchObject({ key: undefined })`.
+`toMatchObject({ key: undefined })` works in vitest but reads ambiguously to the next reader — is the key absent, or present-with-undefined? — and obscures intent in diffs.
+
+If ordering is part of the contract being tested, assert it explicitly with `Object.keys(obj)` against an expected array.
+`toMatchObject` and `toEqual` on a plain object do not pin insertion order.
+If ordering is only asserted in a rendered text section, the structured `_meta` assertion can stay loose — but scope the test name to say so, so a future reader doesn't widen the contract by accident.
+
 **Cautionary tale.** Issue #129 (`ListTableFlowRegions sends cloud=undefined`) was a path
 key built via template literal — the colocated test used `expect.any(String)` for that
 path and `expect.objectContaining({ params: { path: { cloud: "AWS" } } })` for the
@@ -209,6 +219,8 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
 ## Handler Tests
 
 - Test `getToolConfig()` (name, description, input schema, annotations).
+  Assert annotations by identity against the shared constant: `expect(config.annotations).toBe(READ_ONLY)` — not field-by-field (`config.annotations?.readOnlyHint === true`).
+  Identity catches drift if the constant changes (e.g. a new annotation field is added) where the field probe would silently still pass.
 - Test `enabledConnectionIds(runtime)` against representative `ServerRuntime` fixtures: a runtime
   whose connection has the relevant service block (expect the connection id) and a bare runtime
   without that block (expect `[]`). Helper factories live in `tests/factories/runtime.ts`
@@ -221,6 +233,13 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   as default for success cases). Pass `"DISCOVER"` as the `outcome` sentinel to run the
   handler and get a copy-paste suggestion for the correct expectation; replace before
   committing.
+  `assertHandleCase` is geared toward outcome-shaped throws/resolves; when a handler test asserts _formatted text content_ and `_meta` aggregation (rather than just resolve/throw outcome), a bespoke per-test shape is acceptable.
+  Reach for `assertHandleCase` first and only fall back when the outcome model doesn't fit the assertions.
+
+- **Schema-validation tests: prefer `it.each` or scope the name.**
+  When a Zod schema rejects multiple field shapes (e.g. malformed dates, page-size bounds, missing required keys), either cover each rejection case with `it.each` _or_ scope the single test's name to what it actually checks (`"should reject malformed startDate"` rather than `"should surface ZodError"`).
+  A single-case test under a broad name hides coverage gaps from later readers.
+  For per-handler `_meta.error instanceof ZodError` tests, one well-chosen failing fixture is sufficient (typical pick: the discriminator/`kind` literal, since it fails fastest); if the schema also validates line-item shape (`data[*]`), add one more case for that — it's a different validation path.
 
   `getMockedClientManager()` returns a `MockedClientManager` (a
   `Mocked<DirectClientManager>` whose client-getters are narrowed to return


### PR DESCRIPTION
 ## Summary

Background: for [510](https://github.com/confluentinc/mcp-confluent/pull/510), when I was increasing unit test coverage, as part of self-review, I asked Claude to go back and read historical test PR comments and apply them to my PR. I figured if Claude messed up twice it's worth editing the rules. 

  ## Edits and supporting review history

### 1. `unit-tests.md` Handler Tests — assert annotations by identity
Tightens the "Test `getToolConfig()`" bullet to require `expect(config.annotations).toBe(READ_ONLY)` over a field probe like `config.annotations?.readOnlyHint === true`, since [we've got 146](https://github.com/confluentinc/mcp-confluent/pull/146) but Claude blythely ignored in my recent iteration. 
 
### 2. `unit-tests.md` — `toMatchObject` subsection under "Literal arguments over loose matchers"
  - Supporting comment: [PR #441 review by Copilot on object-literal key
  order](https://github.com/confluentinc/mcp-confluent/pull/441#discussion_r3226820202). As @jlrobins notes, this prevents robot bickering. 

  ### 3. `unit-tests.md` Handler Tests — schema-validation tests: `it.each` or scope the name
  
  Adds a bullet on Zod parse-failure tests: when a schema rejects multiple field shapes, either cover each case with `it.each` or scope the single test's name to what it checks. This is spurred by a [PR #420 review by @shouples](https://github.com/confluentinc/mcp-confluent/pull/420#discussion_r3211552099)

  ### 5. `tool-handlers.md` line 30 — test-side cross-link
  
  Appends a half-sentence to the existing annotation-constants line directing readers to the test-side identity rule in `unit-tests.md`