### PR TITLE
Remove consumer-group handler-level enabledConnectionIds() tests because the central method is tested centrally as of PR-400

### DIFF
--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
@@ -12,11 +12,7 @@ import {
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
-import {
-  bareRuntime,
-  DEFAULT_CONNECTION_ID,
-  kafkaRuntime,
-} from "@tests/factories/runtime.js";
+import { kafkaRuntime } from "@tests/factories/runtime.js";
 import { getMockedClientManager } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
@@ -145,20 +141,6 @@ describe("describe-consumer-group-handler.ts", () => {
       const description = handler.getToolConfig().description;
       expect(description).not.toMatch(/TopicPartition\[\]/);
       expect(description).toMatch(/\{ ?topic, ?partition ?\}/);
-    });
-  });
-
-  describe("enabledConnectionIds()", () => {
-    const handler = new DescribeConsumerGroupHandler();
-
-    it("should enable on a kafka runtime", () => {
-      expect(handler.enabledConnectionIds(kafkaRuntime())).toEqual([
-        DEFAULT_CONNECTION_ID,
-      ]);
-    });
-
-    it("should disable on a bare runtime", () => {
-      expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
     });
   });
 

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
@@ -13,11 +13,7 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
-import {
-  bareRuntime,
-  DEFAULT_CONNECTION_ID,
-  kafkaRuntime,
-} from "@tests/factories/runtime.js";
+import { kafkaRuntime } from "@tests/factories/runtime.js";
 import { getMockedClientManager } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
@@ -200,20 +196,6 @@ describe("get-consumer-group-lag-handler.ts", () => {
         "groupId",
         "topics",
       ]);
-    });
-  });
-
-  describe("enabledConnectionIds()", () => {
-    const handler = new GetConsumerGroupLagHandler();
-
-    it("should enable on a kafka runtime", () => {
-      expect(handler.enabledConnectionIds(kafkaRuntime())).toEqual([
-        DEFAULT_CONNECTION_ID,
-      ]);
-    });
-
-    it("should disable on a bare runtime", () => {
-      expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
     });
   });
 

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
@@ -2,11 +2,7 @@ import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { GetPartitionOffsetsHandler } from "@src/confluent/tools/handlers/kafka/get-partition-offsets-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
-import {
-  bareRuntime,
-  DEFAULT_CONNECTION_ID,
-  kafkaRuntime,
-} from "@tests/factories/runtime.js";
+import { kafkaRuntime } from "@tests/factories/runtime.js";
 import { getMockedClientManager } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
@@ -24,20 +20,6 @@ describe("get-partition-offsets-handler.ts", () => {
         "partition",
         "topicName",
       ]);
-    });
-  });
-
-  describe("enabledConnectionIds()", () => {
-    const handler = new GetPartitionOffsetsHandler();
-
-    it("should enable on a kafka runtime", () => {
-      expect(handler.enabledConnectionIds(kafkaRuntime())).toEqual([
-        DEFAULT_CONNECTION_ID,
-      ]);
-    });
-
-    it("should disable on a bare runtime", () => {
-      expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
     });
   });
 

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
@@ -7,11 +7,7 @@ import {
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
-import {
-  bareRuntime,
-  DEFAULT_CONNECTION_ID,
-  kafkaRuntime,
-} from "@tests/factories/runtime.js";
+import { kafkaRuntime } from "@tests/factories/runtime.js";
 import { getMockedClientManager } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
@@ -87,20 +83,6 @@ describe("list-consumer-groups-handler.ts", () => {
         "matchStates",
         "matchType",
       ]);
-    });
-  });
-
-  describe("enabledConnectionIds()", () => {
-    const handler = new ListConsumerGroupsHandler();
-
-    it("should enable on a kafka runtime", () => {
-      expect(handler.enabledConnectionIds(kafkaRuntime())).toEqual([
-        DEFAULT_CONNECTION_ID,
-      ]);
-    });
-
-    it("should disable on a bare runtime", () => {
-      expect(handler.enabledConnectionIds(bareRuntime())).toEqual([]);
     });
   });
 


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Remove recently added `enabledConnectionIds()` unit tests.
- Redundant because of #400.
