### PR TITLE
overhaul integration test structures in CI

### DIFF
--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -534,20 +534,21 @@ The smoke block fires on any change under `src/` (excluding `*.test.ts`) so tran
 
 ### Scheduled / manual full (`.semaphore/integration.yml`)
 
-One block per service config (6 of them: kafka, schema-registry, confluent-cloud, flink, tableflow, telemetry).
-Each block declares a hard-coded `TOOL_GROUP` matrix of the tool groups whose handlers consume that service config; a tool group with handlers across multiple service configs appears in each matching block (e.g. `@catalog` runs under both `@requires-kafka-config` and `@requires-confluent-cloud-config`).
-The scheduled task in `service.yml` and the manual `Integration Tests: full (manual)` promotion in `semaphore.yml` both pass two parameters to this pipeline: `SERVICE_CONFIGS` (pipe-separated, controls which blocks run via each block's `skip.when` clause) and `CONNECTION_TYPE` (one of `all` / `direct` / `oauth`, forwarded as `INTEGRATION_TEST_CONNECTION_TYPE` to both the harness's `activeConnectionTypes` filter and the Makefile's tag-filter composer).
+One block per service config (6 of them: kafka, schema-registry, confluent-cloud, flink, tableflow, telemetry) plus a cross-cutting `@smoke` block that runs the transport-layer regression tests (auth middleware, multi-client wiring, OAuth round-trip).
+Each service-config block declares a hard-coded `TOOL_GROUP` matrix of the tool groups whose handlers consume that service config; a tool group with handlers across multiple service configs appears in each matching block (e.g. `@catalog` runs under both `@requires-kafka-config` and `@requires-confluent-cloud-config`).
+The smoke block has no matrix axis and no service-config filter; it just runs `make test-integration TAGS=@smoke`.
+The scheduled task in `service.yml` and the manual `Integration Tests: full (manual)` promotion in `semaphore.yml` both pass two parameters to this pipeline: `SERVICE_CONFIGS` (pipe-separated, controls which blocks run via each block's `skip.when` clause; accepts the six service-config tags plus `@smoke` as a sentinel for the cross-cutting block) and `CONNECTION_TYPE` (one of `all` / `direct` / `oauth`, forwarded as `INTEGRATION_TEST_CONNECTION_TYPE` to both the harness's `activeConnectionTypes` filter and the Makefile's tag-filter composer).
 
 ### Tuning CI speed without code changes
 
-| Want to ...                                        | Edit                                                                 | Effect                                             |
-| -------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------- |
-| Drop a service config from the scheduled run       | `SERVICE_CONFIGS` default in `service.yml`                           | Skips one whole block in the scheduled pipeline    |
-| Limit a manual run to one connection mode          | Pick `direct` or `oauth` for `CONNECTION_TYPE` in the Semaphore UI   | Halves runtime per cell                            |
-| Stop a tool group from running on PRs              | Delete the corresponding block in `.semaphore/semaphore.yml`         | One fewer block; rest stays `change_in()`-gated    |
-| Re-balance which scheduled block runs a tool group | `TOOL_GROUP` matrix `values` array in `.semaphore/integration.yml`   | Moves the cell to a different service-config block |
-| Tighten the smoke-block trigger                    | The `exclude` glob in the smoke block's `change_in()` clause         | Reduces smoke-block fire rate                      |
-| Change how the daily run is scheduled              | The `at:` cron in `service.yml`'s `scheduled-integration-tests` task | Shifts daily run time                              |
+| Want to ...                                                   | Edit                                                                                       | Effect                                             |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| Drop a block (service config or smoke) from the scheduled run | `SERVICE_CONFIGS` default in `service.yml`                                                 | Skips one whole block in the scheduled pipeline    |
+| Limit a manual run to one connection mode                     | Pick `direct` or `oauth` for `CONNECTION_TYPE` in the Semaphore UI                         | Halves runtime per cell                            |
+| Stop a tool group from running on PRs                         | Delete the corresponding block in `.semaphore/semaphore.yml`                               | One fewer block; rest stays `change_in()`-gated    |
+| Re-balance which scheduled block runs a tool group            | `TOOL_GROUP` matrix `values` array in `.semaphore/integration.yml`                         | Moves the cell to a different service-config block |
+| Tighten the per-PR smoke-block trigger                        | The `exclude` glob in the smoke block's `change_in()` clause in `.semaphore/semaphore.yml` | Reduces smoke-block fire rate on PRs               |
+| Change how the daily run is scheduled                         | The `at:` cron in `service.yml`'s `scheduled-integration-tests` task                       | Shifts daily run time                              |
 
 Anything beyond this (adding a new tag axis, renaming a tag, adding a new service-config block to `MCPServerConfiguration`) is a tag-system structural change and requires touching `tests/tags.ts`, the integration test files, and the harness alongside the YAML.
 

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -20,10 +20,11 @@ don't conflict.
   sits next to `list-topics-handler.ts` in `src/confluent/tools/handlers/kafka/`.
 - Do NOT put integration test files under `tests/` (only shared harness,
   stubs, factories, and fixtures live there).
-- Tag the outermost `describe` with the tool group via the `Tag` enum from
-  `@tests/tags.js` (e.g. `{ tags: [Tag.KAFKA] }`). `tests/tags.ts` is the
-  single source of truth; `vitest.config.ts` derives its `test.tags` list
-  from the same enum, so adding a new tool group means editing one file.
+- Tag the outermost `describe` with **two** axes via the `Tag` enum from `@tests/tags.js`: the tool-group tag (e.g. `Tag.KAFKA`) and at least one service-config tag (e.g. `Tag.REQUIRES_KAFKA_CONFIG`).
+  Tool-group tags map 1:1 to handler directories under `src/confluent/tools/handlers/` and drive per-PR `change_in()` gating in `.semaphore/semaphore.yml`.
+  Service-config tags map 1:1 to service blocks on `MCPServerConfiguration` (`kafka`, `flink`, `schema_registry`, `confluent_cloud`, `tableflow`, `telemetry`) and drive the matrix axes in `.semaphore/integration.yml`.
+  A test that needs more than one service block to be provisioned declares all of them and will run in every matching block of the scheduled / manual pipeline.
+  `tests/tags.ts` is the single source of truth; `vitest.config.ts` derives its `test.tags` list from the same enum, so adding a new tag means editing one file.
 
 ## Running Tests Locally
 
@@ -413,8 +414,11 @@ sets it per-block (see CI Matrix below).
 `activeConnectionTypes` (from `@tests/harness/connection-types.js`) mirrors `activeTransports` along a second axis: dual-mode tests use it to gate the connection shapes (direct vs OAuth) they support.
 It honors the `INTEGRATION_TEST_CONNECTION_TYPE` env var:
 
-- **unset** → both connection types active (default for local runs / full coverage)
+- **unset** or **`all`** → both connection types active (default for local runs / full coverage)
 - **`direct`** or **`oauth`** → only that connection type active
+
+`all` is an explicit sentinel because the Semaphore Tasks UI serializes an empty-string dropdown option as the literal 2-char string `""`, which would slip past a plain emptiness check.
+The Makefile mirrors this on the tag-filter side: unset or `all` appends no clause, `oauth` appends `&& @oauth` (only OAuth describes collect), `direct` appends `&& !@oauth` so the direct-only lane doesn't double-execute direct-only tests through OAuth describes.
 
 Single-mode tests (the vast majority; everything that needs only direct api-key auth) don't need to touch this; they default to direct via the `integrationRuntime()` / `startServer({ transport })` calls.
 
@@ -519,11 +523,33 @@ OAuth describes that don't seed (e.g. `list-organizations`, `list-billing-costs`
 
 ## CI Matrix
 
-`.semaphore/integration.yml` has one block per MCP transport (stdio, http,
-and sse), each skippable via the `TRANSPORTS` pipeline parameter. Within a
-block, jobs parallelize across tool groups (the `TOOL_GROUP` matrix axis).
-The matrix axis picks up new tags automatically - no block or anchor
-changes needed.
+The CI surface has two shapes; they share the harness and the Makefile but differ in what each block represents.
+
+### Per-PR (`.semaphore/semaphore.yml`)
+
+One block per tool group (12 of them) plus a smoke block, each gated by `run.when: change_in('/src/confluent/tools/handlers/<dir>/', { default_branch: 'main' })`.
+Only the blocks whose handler dirs the PR touched actually run; everything else stays gray.
+Within a block, a single job exercises both connection types sequentially via the harness's `activeConnectionTypes` default; transport (stdio/http/sse) and connection type (direct/oauth) are deliberately NOT Semaphore axes, since splitting them would multiply agent count without unique coverage.
+The smoke block fires on any change under `src/` (excluding `*.test.ts`) so transport-layer regressions (auth middleware, multi-client wiring, OAuth flow) trigger regardless of which handler dir the PR touched.
+
+### Scheduled / manual full (`.semaphore/integration.yml`)
+
+One block per service config (6 of them: kafka, schema-registry, confluent-cloud, flink, tableflow, telemetry).
+Each block declares a hard-coded `TOOL_GROUP` matrix of the tool groups whose handlers consume that service config; a tool group with handlers across multiple service configs appears in each matching block (e.g. `@catalog` runs under both `@requires-kafka-config` and `@requires-confluent-cloud-config`).
+The scheduled task in `service.yml` and the manual `Integration Tests: full (manual)` promotion in `semaphore.yml` both pass two parameters to this pipeline: `SERVICE_CONFIGS` (pipe-separated, controls which blocks run via each block's `skip.when` clause) and `CONNECTION_TYPE` (one of `all` / `direct` / `oauth`, forwarded as `INTEGRATION_TEST_CONNECTION_TYPE` to both the harness's `activeConnectionTypes` filter and the Makefile's tag-filter composer).
+
+### Tuning CI speed without code changes
+
+| Want to ...                                        | Edit                                                                 | Effect                                             |
+| -------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------- |
+| Drop a service config from the scheduled run       | `SERVICE_CONFIGS` default in `service.yml`                           | Skips one whole block in the scheduled pipeline    |
+| Limit a manual run to one connection mode          | Pick `direct` or `oauth` for `CONNECTION_TYPE` in the Semaphore UI   | Halves runtime per cell                            |
+| Stop a tool group from running on PRs              | Delete the corresponding block in `.semaphore/semaphore.yml`         | One fewer block; rest stays `change_in()`-gated    |
+| Re-balance which scheduled block runs a tool group | `TOOL_GROUP` matrix `values` array in `.semaphore/integration.yml`   | Moves the cell to a different service-config block |
+| Tighten the smoke-block trigger                    | The `exclude` glob in the smoke block's `change_in()` clause         | Reduces smoke-block fire rate                      |
+| Change how the daily run is scheduled              | The `at:` cron in `service.yml`'s `scheduled-integration-tests` task | Shifts daily run time                              |
+
+Anything beyond this (adding a new tag axis, renaming a tag, adding a new service-config block to `MCPServerConfiguration`) is a tag-system structural change and requires touching `tests/tags.ts`, the integration test files, and the harness alongside the YAML.
 
 ## Adding a New Tool Group
 
@@ -555,9 +581,10 @@ Schema Registry, Flink, Tableflow):
    `src/confluent/tools/connection-predicates.ts` for the skip gate (or
    add a new predicate there if none fit).
 
-6. **CI default** (optional): bump the `TOOL_GROUPS` default in
-   `service.yml`'s `scheduled-integration-tests` task to include the new
-   tag, or override per-run via the Semaphore UI.
+6. **CI wiring**:
+   - Add a new tool-group block to `.semaphore/semaphore.yml` (copy an existing block, swap the name, the `change_in()` handler dir, and the `TAGS=` value in the job command).
+   - Add the new tool-group tag to the `TOOL_GROUP` matrix `values` array in every `.semaphore/integration.yml` service-config block whose service config the new handler consumes.
+   - Service-config blocks in `integration.yml` and the `SERVICE_CONFIGS` default in `service.yml`'s `scheduled-integration-tests` task only need to change if the new handler also requires a new service config (i.e. a new `REQUIRES_*_CONFIG` tag).
 
 ## What NOT to Do
 

--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -36,65 +36,132 @@ global_job_config:
       commands:
         - make remove-test-env
 
+# Service-config-organized blocks. This pipeline is the scheduled-daily and
+# manual full-run shape; per-PR work lives in semaphore.yml's
+# change_in()-gated blocks, not here.
+#
+# Each block's TOOL_GROUP matrix values are hard-coded from which tool-group
+# tests carry the matching `Tag.REQUIRES_<X>_CONFIG` tag in tests/tags.ts.
+#
+# Transport (stdio / http / sse) is intentionally NOT a matrix axis:
+# `tests/harness/transports.ts` reads `INTEGRATION_TEST_TRANSPORT` and
+# returns all three when unset, so each matrix cell exercises every
+# transport sequentially within the same job. Splitting transports across
+# Semaphore jobs would 3x the agent count for the same coverage.
 blocks:
-  - name: "Integration Tests: stdio"
-    dependencies: []
-    # skip this block when the triggering parameters don't include stdio
+  - name: "Integration Tests: @requires-kafka-config"
     skip:
-      when: "'${{parameters.TRANSPORTS}}' !~ 'stdio'"
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-kafka-config'"
     task:
       env_vars:
-        - name: TRANSPORT
-          value: stdio
-        # Default `direct` keeps CI on the existing direct matrix; ops can
-        # override at promotion time. OAuth coverage in CI lands with #380's
-        # matrix restructure.
-        - name: INTEGRATION_TEST_CONNECTION_TYPE
-          value: "${{parameters.CONNECTION_TYPE}}"
-      # task-level epilogue so $TOOL_GROUP / $TRANSPORT from the matrix axis
-      # are unambiguously in scope when result-publishing runs.
-      epilogue: &transport-epilogue
+        - name: SERVICE_CONFIG
+          value: "@requires-kafka-config"
+      epilogue: &service-config-epilogue
         always:
           commands:
-            - make store-integration-test-results TAG="$TOOL_GROUP" TRANSPORT="$TRANSPORT"
-      jobs: &transport-jobs
-        # Semaphore auto-appends the matrix axis (e.g. " - TOOL_GROUP=@kafka")
-        # to the rendered job name, so we don't need to manually include here.
+            - make store-integration-test-results SERVICE_CONFIG="$SERVICE_CONFIG" TAGS="$TOOL_GROUP" CONNECTION_TYPE="$CONNECTION_TYPE"
+      jobs:
         - name: "Integration tests"
-          commands:
+          commands: &service-config-job-commands
             - npm run test:harness
-            - make test-integration TAG="$TOOL_GROUP" TRANSPORT="$TRANSPORT"
-          # matrix axis: pipe-split TOOL_GROUPS from pipeline parameters. one
-          # job per tool-group tag within this transport's block.
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration SERVICE_CONFIG="$SERVICE_CONFIG" TAGS="$TOOL_GROUP"
           matrix:
             - env_var: TOOL_GROUP
-              values: '%{{parameters.TOOL_GROUPS | splitList "|"}}'
+              values: ["@kafka", "@catalog"]
+            - &connection-type-matrix-entry
+              env_var: CONNECTION_TYPE
+              values: '%{{parameters.CONNECTION_TYPES | splitList "|"}}'
 
-  - name: "Integration Tests: http"
-    dependencies: []
+  - name: "Integration Tests: @requires-schema-registry-config"
     skip:
-      when: "'${{parameters.TRANSPORTS}}' !~ 'http'"
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-schema-registry-config'"
     task:
       env_vars:
-        - name: TRANSPORT
-          value: http
-        - name: INTEGRATION_TEST_CONNECTION_TYPE
-          value: "${{parameters.CONNECTION_TYPE}}"
-      epilogue: *transport-epilogue
-      jobs: *transport-jobs
+        - name: SERVICE_CONFIG
+          value: "@requires-schema-registry-config"
+      epilogue: *service-config-epilogue
+      jobs:
+        - name: "Integration tests"
+          commands: *service-config-job-commands
+          matrix:
+            - env_var: TOOL_GROUP
+              values: ["@schema", "@catalog"]
+            - *connection-type-matrix-entry
 
-  - name: "Integration Tests: sse"
-    dependencies: []
+  - name: "Integration Tests: @requires-confluent-cloud-config"
     skip:
-      when: "'${{parameters.TRANSPORTS}}' !~ 'sse'"
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-confluent-cloud-config'"
     task:
       env_vars:
-        - name: TRANSPORT
-          value: sse
-        - name: INTEGRATION_TEST_CONNECTION_TYPE
-          value: "${{parameters.CONNECTION_TYPE}}"
-      epilogue: *transport-epilogue
-      jobs: *transport-jobs
+        - name: SERVICE_CONFIG
+          value: "@requires-confluent-cloud-config"
+      epilogue: *service-config-epilogue
+      jobs:
+        - name: "Integration tests"
+          commands: *service-config-job-commands
+          matrix:
+            - env_var: TOOL_GROUP
+              values:
+                [
+                  "@billing",
+                  "@catalog",
+                  "@clusters",
+                  "@connect",
+                  "@docs",
+                  "@environments",
+                  "@flink",
+                  "@organizations",
+                  "@tableflow",
+                ]
+            - *connection-type-matrix-entry
+
+  - name: "Integration Tests: @requires-flink-config"
+    skip:
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-flink-config'"
+    task:
+      env_vars:
+        - name: SERVICE_CONFIG
+          value: "@requires-flink-config"
+      epilogue: *service-config-epilogue
+      jobs:
+        - name: "Integration tests"
+          commands: *service-config-job-commands
+          matrix:
+            - env_var: TOOL_GROUP
+              values: ["@flink"]
+            - *connection-type-matrix-entry
+
+  - name: "Integration Tests: @requires-tableflow-config"
+    skip:
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-tableflow-config'"
+    task:
+      env_vars:
+        - name: SERVICE_CONFIG
+          value: "@requires-tableflow-config"
+      epilogue: *service-config-epilogue
+      jobs:
+        - name: "Integration tests"
+          commands: *service-config-job-commands
+          matrix:
+            - env_var: TOOL_GROUP
+              values: ["@tableflow"]
+            - *connection-type-matrix-entry
+
+  - name: "Integration Tests: @requires-telemetry-config"
+    skip:
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-telemetry-config'"
+    task:
+      env_vars:
+        - name: SERVICE_CONFIG
+          value: "@requires-telemetry-config"
+      epilogue: *service-config-epilogue
+      jobs:
+        - name: "Integration tests"
+          commands: *service-config-job-commands
+          matrix:
+            - env_var: TOOL_GROUP
+              values: ["@metrics"]
+            - *connection-type-matrix-entry
 
 after_pipeline:
   task:

--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -50,6 +50,7 @@ global_job_config:
 # Semaphore jobs would 3x the agent count for the same coverage.
 blocks:
   - name: "Integration Tests: @requires-kafka-config"
+    dependencies: []
     skip:
       when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-kafka-config'"
     task:
@@ -73,6 +74,7 @@ blocks:
               values: '%{{parameters.CONNECTION_TYPES | splitList "|"}}'
 
   - name: "Integration Tests: @requires-schema-registry-config"
+    dependencies: []
     skip:
       when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-schema-registry-config'"
     task:
@@ -89,6 +91,7 @@ blocks:
             - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-confluent-cloud-config"
+    dependencies: []
     skip:
       when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-confluent-cloud-config'"
     task:
@@ -116,6 +119,7 @@ blocks:
             - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-flink-config"
+    dependencies: []
     skip:
       when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-flink-config'"
     task:
@@ -132,6 +136,7 @@ blocks:
             - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-tableflow-config"
+    dependencies: []
     skip:
       when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-tableflow-config'"
     task:
@@ -148,6 +153,7 @@ blocks:
             - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-telemetry-config"
+    dependencies: []
     skip:
       when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@requires-telemetry-config'"
     task:

--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -182,6 +182,31 @@ blocks:
             - env_var: TOOL_GROUP
               values: ["@metrics"]
 
+  # Smoke block: cross-cutting transport-layer regression coverage (auth
+  # middleware, multi-client wiring, OAuth flow) that doesn't belong to any
+  # service-config matrix cell because `@smoke` isn't in any TOOL_GROUP
+  # values array. Gated on `@smoke` appearing in `SERVICE_CONFIGS` rather
+  # than carrying its own parameter so the operator surface stays at two
+  # params (SERVICE_CONFIGS + CONNECTION_TYPE). The scheduled task and the
+  # manual full promotion both include `@smoke` in their defaults.
+  - name: "Integration Tests: @smoke"
+    dependencies: []
+    skip:
+      when: "'${{parameters.SERVICE_CONFIGS}}' !~ '@smoke'"
+    task:
+      env_vars:
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
+      epilogue:
+        always:
+          commands:
+            - make store-integration-test-results TAGS="@smoke"
+      jobs:
+        - name: "Integration tests"
+          commands:
+            - npm run test:harness
+            - make test-integration TAGS="@smoke"
+
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -43,6 +43,13 @@ global_job_config:
 # Each block's TOOL_GROUP matrix values are hard-coded from which tool-group
 # tests carry the matching `Tag.REQUIRES_<X>_CONFIG` tag in tests/tags.ts.
 #
+# Connection type (direct vs OAuth) is NOT a matrix axis: each cell runs
+# both modes sequentially via the harness's `activeConnectionTypes`
+# default. The manual full promotion's optional `CONNECTION_TYPE` parameter
+# (forwarded as `INTEGRATION_TEST_CONNECTION_TYPE` at task scope) lets
+# operators limit a run to one mode; scheduled and the default manual run
+# leave it empty so both modes exercise.
+#
 # Transport (stdio / http / sse) is intentionally NOT a matrix axis:
 # `tests/harness/transports.ts` reads `INTEGRATION_TEST_TRANSPORT` and
 # returns all three when unset, so each matrix cell exercises every
@@ -57,21 +64,20 @@ blocks:
       env_vars:
         - name: SERVICE_CONFIG
           value: "@requires-kafka-config"
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
       epilogue: &service-config-epilogue
         always:
           commands:
-            - make store-integration-test-results SERVICE_CONFIG="$SERVICE_CONFIG" TAGS="$TOOL_GROUP" CONNECTION_TYPE="$CONNECTION_TYPE"
+            - make store-integration-test-results SERVICE_CONFIG="$SERVICE_CONFIG" TAGS="$TOOL_GROUP"
       jobs:
         - name: "Integration tests"
           commands: &service-config-job-commands
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration SERVICE_CONFIG="$SERVICE_CONFIG" TAGS="$TOOL_GROUP"
+            - make test-integration SERVICE_CONFIG="$SERVICE_CONFIG" TAGS="$TOOL_GROUP"
           matrix:
             - env_var: TOOL_GROUP
               values: ["@kafka", "@catalog"]
-            - &connection-type-matrix-entry
-              env_var: CONNECTION_TYPE
-              values: '%{{parameters.CONNECTION_TYPES | splitList "|"}}'
 
   - name: "Integration Tests: @requires-schema-registry-config"
     dependencies: []
@@ -81,6 +87,8 @@ blocks:
       env_vars:
         - name: SERVICE_CONFIG
           value: "@requires-schema-registry-config"
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
       epilogue: *service-config-epilogue
       jobs:
         - name: "Integration tests"
@@ -88,7 +96,6 @@ blocks:
           matrix:
             - env_var: TOOL_GROUP
               values: ["@schema", "@catalog"]
-            - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-confluent-cloud-config"
     dependencies: []
@@ -98,6 +105,8 @@ blocks:
       env_vars:
         - name: SERVICE_CONFIG
           value: "@requires-confluent-cloud-config"
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
       epilogue: *service-config-epilogue
       jobs:
         - name: "Integration tests"
@@ -116,7 +125,6 @@ blocks:
                   "@organizations",
                   "@tableflow",
                 ]
-            - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-flink-config"
     dependencies: []
@@ -126,6 +134,8 @@ blocks:
       env_vars:
         - name: SERVICE_CONFIG
           value: "@requires-flink-config"
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
       epilogue: *service-config-epilogue
       jobs:
         - name: "Integration tests"
@@ -133,7 +143,6 @@ blocks:
           matrix:
             - env_var: TOOL_GROUP
               values: ["@flink"]
-            - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-tableflow-config"
     dependencies: []
@@ -143,6 +152,8 @@ blocks:
       env_vars:
         - name: SERVICE_CONFIG
           value: "@requires-tableflow-config"
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
       epilogue: *service-config-epilogue
       jobs:
         - name: "Integration tests"
@@ -150,7 +161,6 @@ blocks:
           matrix:
             - env_var: TOOL_GROUP
               values: ["@tableflow"]
-            - *connection-type-matrix-entry
 
   - name: "Integration Tests: @requires-telemetry-config"
     dependencies: []
@@ -160,6 +170,8 @@ blocks:
       env_vars:
         - name: SERVICE_CONFIG
           value: "@requires-telemetry-config"
+        - name: INTEGRATION_TEST_CONNECTION_TYPE
+          value: "${{parameters.CONNECTION_TYPE}}"
       epilogue: *service-config-epilogue
       jobs:
         - name: "Integration tests"
@@ -167,7 +179,6 @@ blocks:
           matrix:
             - env_var: TOOL_GROUP
               values: ["@metrics"]
-            - *connection-type-matrix-entry
 
 after_pipeline:
   task:

--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -45,10 +45,12 @@ global_job_config:
 #
 # Connection type (direct vs OAuth) is NOT a matrix axis: each cell runs
 # both modes sequentially via the harness's `activeConnectionTypes`
-# default. The manual full promotion's optional `CONNECTION_TYPE` parameter
-# (forwarded as `INTEGRATION_TEST_CONNECTION_TYPE` at task scope) lets
-# operators limit a run to one mode; scheduled and the default manual run
-# leave it empty so both modes exercise.
+# default. The triggering task or promotion supplies `CONNECTION_TYPE`
+# (forwarded as `INTEGRATION_TEST_CONNECTION_TYPE` at task scope): the
+# scheduled task defaults to empty (which the harness treats as "both"),
+# the manual full promotion defaults to "all" (an explicit sentinel for
+# "both"). Operators can override either to `direct` or `oauth` to limit
+# a run to a single mode.
 #
 # Transport (stdio / http / sse) is intentionally NOT a matrix axis:
 # `tests/harness/transports.ts` reads `INTEGRATION_TEST_TRANSPORT` and

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -234,8 +234,7 @@ blocks:
   # Smoke block: fires on any non-test src/ change, so transport-layer
   # regressions (auth middleware, multi-client wiring, OAuth flow) trigger
   # regardless of which handler dir the PR touched. The `exclude` glob
-  # covers both `*.test.ts` and `*.integration.test.ts` (the latter ends
-  # in `.test.ts`).
+  # covers both unit and integration test files.
   - name: "Integration Tests: smoke"
     dependencies: ["Build & Test"]
     run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -269,8 +269,8 @@ promotions:
     parameters:
       env_vars:
         - name: SERVICE_CONFIGS
-          description: "Pipe-separated service-config tags. One matrix block per service config."
-          default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
+          description: "Pipe-separated tags. One block per service-config tag, plus @smoke to include the cross-cutting transport-layer smoke tests."
+          default_value: "@smoke|@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           required: true
         - name: CONNECTION_TYPE
           description: "Connection type to exercise. 'all' (default) runs both direct and oauth sequentially in each job; 'direct' or 'oauth' limits the run to that single mode."

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,6 +45,224 @@ blocks:
             - sem-version java 17
             - emit-sonarqube-data --run_only_sonar_scan --enable_sonarqube_enterprise
 
+  # Per-tool-group integration blocks. Each gates on `change_in()` over its
+  # handler directory via `run.when`, so a PR only fires the integration
+  # blocks whose handler dirs it touched. `default_branch: 'main'` must
+  # repeat literally on every `change_in()` call: YAML anchors don't reach
+  # inside the quoted conditions-DSL string, and the DSL's default is
+  # 'master', so without the override `change_in()` evaluates as
+  # "everything changed" on feature branches and every block would fire.
+  #
+  # Every block (including smoke) fans the `CONNECTION_TYPE` matrix axis
+  # across `direct` and `oauth`, so each PR exercises both connection
+  # shapes for the touched handler dir. Tool groups without OAuth describes
+  # skip the OAuth tests gracefully via the harness's per-describe
+  # `activeConnectionTypes` filter.
+
+  - name: "Integration Tests: catalog"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/catalog/', { default_branch: 'main' })"
+    task:
+      prologue: &integration-prologue
+        commands:
+          - npm ci --prefer-offline --include=dev
+          # chromium is needed for any @oauth-tagged tests as well as the OAuth smoke test
+          - |
+            PLAYWRIGHT_VERSION=$(node -p "require('playwright-core/package.json').version")
+            cache restore "playwright-chromium-${PLAYWRIGHT_VERSION}"
+            npx playwright-core install chromium && \
+              cache store "playwright-chromium-${PLAYWRIGHT_VERSION}" ~/.cache/ms-playwright
+          - . vault-setup --version v3 --role mcp-confluent
+          - make setup-test-env
+          - npm run build
+      epilogue: &integration-epilogue
+        always:
+          commands:
+            - make remove-test-env
+            - test-results publish TEST-integration.xml --name "Integration (${SEMAPHORE_JOB_NAME})" --force || true
+      jobs:
+        - name: "@catalog"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@catalog
+          matrix: &connection-type-matrix
+            - env_var: CONNECTION_TYPE
+              values: ["direct", "oauth"]
+
+  - name: "Integration Tests: billing"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/billing/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@billing"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@billing
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: clusters"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/clusters/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@clusters"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@clusters
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: connect"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/connect/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@connect"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@connect
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: docs"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/docs/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@docs"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@docs
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: environments"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/environments/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@environments"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@environments
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: flink"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/flink/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@flink"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@flink
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: kafka"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/kafka/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@kafka"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@kafka
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: metrics"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/metrics/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@metrics"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@metrics
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: organizations"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/organizations/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@organizations"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@organizations
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: schema"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/schema/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@schema"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@schema
+          matrix: *connection-type-matrix
+
+  - name: "Integration Tests: tableflow"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/confluent/tools/handlers/tableflow/', { default_branch: 'main' })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@tableflow"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@tableflow
+          matrix: *connection-type-matrix
+
+  # Smoke block: fires on any non-test src/ change, so transport-layer
+  # regressions (auth middleware, multi-client wiring, OAuth flow) trigger
+  # regardless of which handler dir the PR touched. The `exclude` glob
+  # covers both `*.test.ts` and `*.integration.test.ts` (the latter ends
+  # in `.test.ts`).
+  - name: "Integration Tests: smoke"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in('/src/', { default_branch: 'main', exclude: ['/src/**/*.test.ts'] })"
+    task:
+      prologue: *integration-prologue
+      epilogue: *integration-epilogue
+      jobs:
+        - name: "@smoke"
+          commands:
+            - npm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@smoke
+          matrix: *connection-type-matrix
+
 after_pipeline:
   task:
     jobs:
@@ -55,19 +273,21 @@ after_pipeline:
 promotions:
   - name: Docker Image Scan
     pipeline_file: docker-image-scan.yml
-  - name: "Integration Tests"
+
+  # Manual operator escape hatch: pick an arbitrary cut of service configs
+  # and connection types from the Semaphore UI. integration.yml is the
+  # service-config-organized pipeline used here and by the scheduled
+  # daily run in service.yml; per-PR work lives in the change_in()-gated
+  # blocks above, not promotions.
+  - name: "Integration Tests: full (manual)"
     pipeline_file: integration.yml
     parameters:
       env_vars:
-        - name: TOOL_GROUPS
-          description: "Pipe-separated vitest tags to run (e.g. @kafka|@schema)"
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink|@tableflow|@billing|@docs|@catalog"
+        - name: SERVICE_CONFIGS
+          description: "Pipe-separated service-config tags. One matrix block per service config."
+          default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           required: true
-        - name: TRANSPORTS
-          description: "Pipe-separated MCP transports (stdio|http|sse)"
-          default_value: "stdio|http|sse"
-          required: true
-        - name: CONNECTION_TYPE
-          description: "Connection type to test (direct or oauth)"
-          default_value: "direct"
+        - name: CONNECTION_TYPES
+          description: "Pipe-separated connection types (direct, oauth). Each one becomes a matrix axis alongside the tool group."
+          default_value: "direct|oauth"
           required: true

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -53,11 +53,12 @@ blocks:
   # 'master', so without the override `change_in()` evaluates as
   # "everything changed" on feature branches and every block would fire.
   #
-  # Every block (including smoke) fans the `CONNECTION_TYPE` matrix axis
-  # across `direct` and `oauth`, so each PR exercises both connection
-  # shapes for the touched handler dir. Tool groups without OAuth describes
-  # skip the OAuth tests gracefully via the harness's per-describe
-  # `activeConnectionTypes` filter.
+  # Each block runs ONE job that exercises both `direct` and `oauth`
+  # connection types sequentially via the harness's `activeConnectionTypes`
+  # default (`INTEGRATION_TEST_CONNECTION_TYPE` left unset = both modes
+  # active). Splitting into a CONNECTION_TYPE matrix axis would double the
+  # agent count without adding unique test coverage; tool groups without
+  # OAuth describes skip the OAuth pass gracefully inside the job.
 
   - name: "Integration Tests: catalog"
     dependencies: ["Build & Test"]
@@ -85,10 +86,7 @@ blocks:
         - name: "@catalog"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@catalog
-          matrix: &connection-type-matrix
-            - env_var: CONNECTION_TYPE
-              values: ["direct", "oauth"]
+            - make test-integration TAGS=@catalog
 
   - name: "Integration Tests: billing"
     dependencies: ["Build & Test"]
@@ -101,8 +99,7 @@ blocks:
         - name: "@billing"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@billing
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@billing
 
   - name: "Integration Tests: clusters"
     dependencies: ["Build & Test"]
@@ -115,8 +112,7 @@ blocks:
         - name: "@clusters"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@clusters
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@clusters
 
   - name: "Integration Tests: connect"
     dependencies: ["Build & Test"]
@@ -129,8 +125,7 @@ blocks:
         - name: "@connect"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@connect
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@connect
 
   - name: "Integration Tests: docs"
     dependencies: ["Build & Test"]
@@ -143,8 +138,7 @@ blocks:
         - name: "@docs"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@docs
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@docs
 
   - name: "Integration Tests: environments"
     dependencies: ["Build & Test"]
@@ -157,8 +151,7 @@ blocks:
         - name: "@environments"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@environments
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@environments
 
   - name: "Integration Tests: flink"
     dependencies: ["Build & Test"]
@@ -171,8 +164,7 @@ blocks:
         - name: "@flink"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@flink
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@flink
 
   - name: "Integration Tests: kafka"
     dependencies: ["Build & Test"]
@@ -185,8 +177,7 @@ blocks:
         - name: "@kafka"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@kafka
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@kafka
 
   - name: "Integration Tests: metrics"
     dependencies: ["Build & Test"]
@@ -199,8 +190,7 @@ blocks:
         - name: "@metrics"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@metrics
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@metrics
 
   - name: "Integration Tests: organizations"
     dependencies: ["Build & Test"]
@@ -213,8 +203,7 @@ blocks:
         - name: "@organizations"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@organizations
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@organizations
 
   - name: "Integration Tests: schema"
     dependencies: ["Build & Test"]
@@ -227,8 +216,7 @@ blocks:
         - name: "@schema"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@schema
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@schema
 
   - name: "Integration Tests: tableflow"
     dependencies: ["Build & Test"]
@@ -241,8 +229,7 @@ blocks:
         - name: "@tableflow"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@tableflow
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@tableflow
 
   # Smoke block: fires on any non-test src/ change, so transport-layer
   # regressions (auth middleware, multi-client wiring, OAuth flow) trigger
@@ -260,8 +247,7 @@ blocks:
         - name: "@smoke"
           commands:
             - npm run test:harness
-            - INTEGRATION_TEST_CONNECTION_TYPE="$CONNECTION_TYPE" make test-integration TAGS=@smoke
-          matrix: *connection-type-matrix
+            - make test-integration TAGS=@smoke
 
 after_pipeline:
   task:
@@ -274,9 +260,9 @@ promotions:
   - name: Docker Image Scan
     pipeline_file: docker-image-scan.yml
 
-  # Manual operator escape hatch: pick an arbitrary cut of service configs
-  # and connection types from the Semaphore UI. integration.yml is the
-  # service-config-organized pipeline used here and by the scheduled
+  # Manual operator escape hatch: pick a cut of service configs (and
+  # optionally one connection type) from the Semaphore UI. integration.yml
+  # is the service-config-organized pipeline used here and by the scheduled
   # daily run in service.yml; per-PR work lives in the change_in()-gated
   # blocks above, not promotions.
   - name: "Integration Tests: full (manual)"
@@ -287,7 +273,7 @@ promotions:
           description: "Pipe-separated service-config tags. One matrix block per service config."
           default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           required: true
-        - name: CONNECTION_TYPES
-          description: "Pipe-separated connection types (direct, oauth). Each one becomes a matrix axis alongside the tool group."
-          default_value: "direct|oauth"
-          required: true
+        - name: CONNECTION_TYPE
+          description: "Optional single connection type (direct or oauth). Empty = both modes run sequentially in each job."
+          default_value: ""
+          required: false

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -280,4 +280,4 @@ promotions:
             - "all"
             - "direct"
             - "oauth"
-          required: false
+          required: true

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -274,6 +274,10 @@ promotions:
           default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           required: true
         - name: CONNECTION_TYPE
-          description: "Optional single connection type (direct or oauth). Empty = both modes run sequentially in each job."
-          default_value: ""
+          description: "Connection type to exercise. 'all' (default) runs both direct and oauth sequentially in each job; 'direct' or 'oauth' limits the run to that single mode."
+          default_value: "all"
+          options:
+            - "all"
+            - "direct"
+            - "oauth"
           required: false

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,17 @@ test-integration:
 			set -- "$$@" "src/confluent/tools/handlers/$$TAG_SUFFIX"; \
 		fi; \
 	fi; \
-	npm run build && \
+	if [ ! -f dist/index.js ]; then npm run build; fi && \
 	INTEGRATION_TEST_TRANSPORT="$$TRANSPORT_VAL" npx vitest run \
 		--project integration \
 		--outputFile.junit=TEST-integration.xml \
 		"$$@"
+# ^ `npm run build` is skipped when `dist/index.js` already exists. CI's
+# integration prologue builds before invoking `make test-integration`, so
+# this avoids the double build per matrix cell. Local devs running cold
+# (no `dist/`) still get an automatic build; for staleness control,
+# `rm -rf dist && make test-integration ...` or running `npm run dev` in a
+# watch terminal alongside.
 
 # publish JUnit results to semaphore: each test lane writes a distinct file via package.json's
 # --outputFile.junit overrides, so per-test-type publishing stays separated in the Semaphore UI

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ remove-test-env:
 # include glob. @smoke and empty TAGS fall through to a filter on just the
 # service config, since neither is directory-aligned.
 #
-# When INTEGRATION_TEST_CONNECTION_TYPE is set in the environment (CI sets
-# it per matrix cell via the CONNECTION_TYPE axis), we also append a
+# When INTEGRATION_TEST_CONNECTION_TYPE is set (manual full-promotion
+# CONNECTION_TYPE parameter forwards into this env var), we append a
 # `@oauth` / `!@oauth` clause to the tag filter:
 #  - `direct` lane excludes oauth describes (`!@oauth`), so single-mode
 #    direct-only tests don't re-run alongside dual-mode oauth describes.
@@ -157,7 +157,7 @@ store-unit-test-results:
 
 store-integration-test-results:
 	@if [ -f TEST-integration.xml ]; then \
-		test-results publish TEST-integration.xml --name "Integration ($(SERVICE_CONFIG) / $(TAGS) / $(CONNECTION_TYPE))" --force; \
+		test-results publish TEST-integration.xml --name "Integration ($(SERVICE_CONFIG) / $(TAGS) / $${INTEGRATION_TEST_CONNECTION_TYPE:-all})" --force; \
 	else \
 		echo "no TEST-integration.xml to publish"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
 # Makefile for mcp-confluent integration test lifecycle.
 #
-# Used by .semaphore/integration.yml to pull secrets from Vault, run a
-# single-tag / single-transport matrix cell, and publish results to
-# Semaphore. Also works locally: `make setup-test-env` once, then
-# `make test-integration TAG=@kafka`.
+# Used by .semaphore/semaphore.yml's per-PR tool-group blocks and
+# .semaphore/integration.yml's per-service-config blocks to pull secrets
+# from Vault, run a single matrix cell, and publish results to Semaphore.
+# Also works locally: `make setup-test-env` once, then
+# `make test-integration SERVICE_CONFIG=@requires-kafka-config TAGS=@kafka`.
 
 VAULT_SECRET_BASE ?= stag/kv/semaphore/mcpconfluent/testing
 ENV_FILE ?= .env.integration
-# TAG and TRANSPORT default to empty; when unset, `test-integration` runs the full integration
-# suite without filtering. Semaphore tasks (service.yml) can set defaults.
-TAG ?=
+# SERVICE_CONFIG filters tests by service-config tag (e.g. @requires-kafka-config) -
+# drives integration.yml's matrix axis. TAGS layers an AND-filter on top
+# (typically a tool-group tag like @kafka, or @smoke). Both default to empty;
+# unset, `test-integration` runs the full integration suite. TRANSPORT filters
+# which MCP transport each file's describe.each exercises.
+SERVICE_CONFIG ?=
+TAGS ?=
 TRANSPORT ?=
 
 # Vault paths -> fields. Each entry is `<path-suffix>:<comma-separated-fields>`,
@@ -61,30 +66,78 @@ setup-test-env:
 remove-test-env:
 	@rm -f $(ENV_FILE)
 
-# Run the integration tests. TAG filters tests by tool-group tag; TRANSPORT
-# filters which MCP transport (stdio or http) each file's describe.each
-# exercises, via the INTEGRATION_TEST_TRANSPORT env var read by
-# tests/harness/transports.ts.
+# Run the integration tests. SERVICE_CONFIG and TAGS compose into a single
+# vitest tag expression: an empty value drops that clause. When TAGS names a
+# non-smoke tool-group tag whose value matches a `handlers/<dir>/`, we also
+# pass that directory as a positional scope filter so vitest only collects
+# files under it; without the scope, --tags-filter is a runtime-skip filter
+# that still loads (and prints as skipped) every file in the project's
+# include glob. @smoke and empty TAGS fall through to a filter on just the
+# service config, since neither is directory-aligned.
 #
-# Both filters are conditionally applied: an empty or literal-env-var-name
-# value falls through to "run everything" instead of forcing a filter. The
-# `!= "TOOL_GROUP"` / `!= "TRANSPORT"` guards catch a CI misconfiguration where
-# Semaphore's matrix env-var name leaks through uninterpolated; without them,
-# vitest would silently match 0 tests (TAG) or activeTransports would throw
-# (TRANSPORT). Same idea as vscode's Makefile check on TEST_SUITE.
+# When INTEGRATION_TEST_CONNECTION_TYPE is set in the environment (CI sets
+# it per matrix cell via the CONNECTION_TYPE axis), we also append a
+# `@oauth` / `!@oauth` clause to the tag filter:
+#  - `direct` lane excludes oauth describes (`!@oauth`), so single-mode
+#    direct-only tests don't re-run alongside dual-mode oauth describes.
+#  - `oauth` lane only collects oauth describes (`@oauth`), so the cell
+#    skips every direct-only test and only exercises the PKCE-flow paths.
+# Unset (local dev) skips the clause entirely; vitest collects everything.
+#
+# The `!= "SERVICE_CONFIG"` / `!= "TOOL_GROUP"` / `!= "TRANSPORT"` guards
+# catch a Semaphore misconfiguration where a matrix env-var name leaks
+# through uninterpolated (e.g. `make test-integration TAGS=TOOL_GROUP` if
+# `$TOOL_GROUP` failed to expand in integration.yml's job command); without
+# them, vitest would silently match 0 tests.
+#
+# `set --` builds argv one word at a time so values containing `&&` (e.g.
+# `--tags-filter=@requires-kafka-config && @kafka`) stay quoted as a single
+# argument; an unquoted variable would let the shell interpret `&&` as a
+# control operator and split the npm command. Vitest is invoked directly
+# via `npx vitest run` rather than `npm run test:integration --` for the
+# same reason: npm concatenates trailing `--` args into the script string
+# verbatim, so `&&` inside a filter value would split that script too.
 test-integration:
-	@echo "running integration tests: tag=$(TAG) transport=$(TRANSPORT)"
-	@if [ -n "$(TAG)" ] && [ "$(TAG)" != "TOOL_GROUP" ]; then \
-		TAG_ARG="--tags-filter=$(TAG)"; \
-	else \
-		TAG_ARG=""; \
+	@echo "running integration tests: service_config=$(SERVICE_CONFIG) tags=$(TAGS) transport=$(TRANSPORT) connection_type=$$INTEGRATION_TEST_CONNECTION_TYPE"
+	@set --; \
+	SERVICE_CONFIG_VAL=""; [ -n "$(SERVICE_CONFIG)" ] && [ "$(SERVICE_CONFIG)" != "SERVICE_CONFIG" ] && SERVICE_CONFIG_VAL="$(SERVICE_CONFIG)"; \
+	TAGS_VAL=""; [ -n "$(TAGS)" ] && [ "$(TAGS)" != "TOOL_GROUP" ] && TAGS_VAL="$(TAGS)"; \
+	TRANSPORT_VAL=""; [ -n "$(TRANSPORT)" ] && [ "$(TRANSPORT)" != "TRANSPORT" ] && TRANSPORT_VAL="$(TRANSPORT)"; \
+	CONNECTION_FILTER=""; \
+	case "$$INTEGRATION_TEST_CONNECTION_TYPE" in \
+		direct) CONNECTION_FILTER="!@oauth";; \
+		oauth) CONNECTION_FILTER="@oauth";; \
+	esac; \
+	FILTER_PARTS=""; \
+	if [ -n "$$SERVICE_CONFIG_VAL" ]; then FILTER_PARTS="$$SERVICE_CONFIG_VAL"; fi; \
+	if [ -n "$$TAGS_VAL" ]; then \
+		if [ -n "$$FILTER_PARTS" ]; then \
+			FILTER_PARTS="$$FILTER_PARTS && $$TAGS_VAL"; \
+		else \
+			FILTER_PARTS="$$TAGS_VAL"; \
+		fi; \
 	fi; \
-	if [ -n "$(TRANSPORT)" ] && [ "$(TRANSPORT)" != "TRANSPORT" ]; then \
-		TRANSPORT_ENV="$(TRANSPORT)"; \
-	else \
-		TRANSPORT_ENV=""; \
+	if [ -n "$$CONNECTION_FILTER" ]; then \
+		if [ -n "$$FILTER_PARTS" ]; then \
+			FILTER_PARTS="$$FILTER_PARTS && $$CONNECTION_FILTER"; \
+		else \
+			FILTER_PARTS="$$CONNECTION_FILTER"; \
+		fi; \
 	fi; \
-	INTEGRATION_TEST_TRANSPORT="$$TRANSPORT_ENV" npm run test:integration -- $$TAG_ARG
+	if [ -n "$$FILTER_PARTS" ]; then \
+		set -- "$$@" "--tags-filter=$$FILTER_PARTS"; \
+	fi; \
+	if [ -n "$$TAGS_VAL" ] && [ "$$TAGS_VAL" != "@smoke" ]; then \
+		TAG_SUFFIX=$$(echo "$$TAGS_VAL" | sed 's/^@//'); \
+		if [ -d "src/confluent/tools/handlers/$$TAG_SUFFIX" ]; then \
+			set -- "$$@" "src/confluent/tools/handlers/$$TAG_SUFFIX"; \
+		fi; \
+	fi; \
+	npm run build && \
+	INTEGRATION_TEST_TRANSPORT="$$TRANSPORT_VAL" npx vitest run \
+		--project integration \
+		--outputFile.junit=TEST-integration.xml \
+		"$$@"
 
 # publish JUnit results to semaphore: each test lane writes a distinct file via package.json's
 # --outputFile.junit overrides, so per-test-type publishing stays separated in the Semaphore UI
@@ -98,7 +151,7 @@ store-unit-test-results:
 
 store-integration-test-results:
 	@if [ -f TEST-integration.xml ]; then \
-		test-results publish TEST-integration.xml --name "Integration ($(TAG) / $(TRANSPORT))" --force; \
+		test-results publish TEST-integration.xml --name "Integration ($(SERVICE_CONFIG) / $(TAGS) / $(CONNECTION_TYPE))" --force; \
 	else \
 		echo "no TEST-integration.xml to publish"; \
 	fi

--- a/service.yml
+++ b/service.yml
@@ -57,8 +57,8 @@ semaphore:
       parameters:
         - name: SERVICE_CONFIGS
           required: true
-          default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
-          description: 'Pipe-separated service-config tags. One matrix block per service config.'
+          default_value: "@smoke|@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
+          description: 'Pipe-separated tags. One block per service-config tag, plus @smoke to include the cross-cutting transport-layer smoke tests.'
         - name: CONNECTION_TYPE
           required: true
           default_value: "all"

--- a/service.yml
+++ b/service.yml
@@ -55,18 +55,14 @@ semaphore:
       scheduled: true
       at: "0 5 * * *" # Every day at 05:00 UTC
       parameters:
-        - name: TOOL_GROUPS
+        - name: SERVICE_CONFIGS
           required: true
-          default_value: "@smoke|@kafka|@schema|@environments|@clusters|@connect|@metrics|@flink|@tableflow|@billing|@docs|@catalog"
-          description: 'Pipe-separated tool-group tags to test.'
-        - name: TRANSPORTS
+          default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
+          description: 'Pipe-separated service-config tags. One matrix block per service config.'
+        - name: CONNECTION_TYPES
           required: true
-          default_value: "stdio|http|sse"
-          description: 'Pipe-separated MCP transport(s) to test.'
-        - name: CONNECTION_TYPE
-          required: true
-          default_value: "direct"
-          description: 'Connection type to test (direct or oauth).'
+          default_value: "direct|oauth"
+          description: 'Pipe-separated connection types (direct, oauth). Each becomes a matrix axis alongside the tool group within each service-config block.'
     - name: scheduled-npm-audit
       branch: main
       pipeline_file: .semaphore/npm-audit.yml

--- a/service.yml
+++ b/service.yml
@@ -59,6 +59,14 @@ semaphore:
           required: true
           default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           description: 'Pipe-separated service-config tags. One matrix block per service config.'
+        - name: CONNECTION_TYPE
+          required: false
+          default_value: ""
+          options:
+            - "direct"
+            - "oauth"
+            - ""
+          description: 'Optional single connection type (direct or oauth). Empty (default) runs both modes sequentially in each job.'
     - name: scheduled-npm-audit
       branch: main
       pipeline_file: .semaphore/npm-audit.yml

--- a/service.yml
+++ b/service.yml
@@ -63,10 +63,10 @@ semaphore:
           required: false
           default_value: ""
           options:
+            - "all"
             - "direct"
             - "oauth"
-            - ""
-          description: 'Optional single connection type (direct or oauth). Empty (default) runs both modes sequentially in each job.'
+          description: 'Connection type to exercise. all (default) runs both direct and oauth sequentially in each job; direct or oauth limits the run to that single mode.'
     - name: scheduled-npm-audit
       branch: main
       pipeline_file: .semaphore/npm-audit.yml

--- a/service.yml
+++ b/service.yml
@@ -60,8 +60,8 @@ semaphore:
           default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           description: 'Pipe-separated service-config tags. One matrix block per service config.'
         - name: CONNECTION_TYPE
-          required: false
-          default_value: ""
+          required: true
+          default_value: "all"
           options:
             - "all"
             - "direct"

--- a/service.yml
+++ b/service.yml
@@ -59,10 +59,6 @@ semaphore:
           required: true
           default_value: "@requires-kafka-config|@requires-schema-registry-config|@requires-confluent-cloud-config|@requires-flink-config|@requires-tableflow-config|@requires-telemetry-config"
           description: 'Pipe-separated service-config tags. One matrix block per service config.'
-        - name: CONNECTION_TYPES
-          required: true
-          default_value: "direct|oauth"
-          description: 'Pipe-separated connection types (direct, oauth). Each becomes a matrix axis alongside the tool group within each service-config block.'
     - name: scheduled-npm-audit
       branch: main
       pipeline_file: .semaphore/npm-audit.yml

--- a/src/confluent/oauth/ccloud-oauth.integration.test.ts
+++ b/src/confluent/oauth/ccloud-oauth.integration.test.ts
@@ -21,40 +21,44 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const runtime = integrationRuntime({ oauth: true });
 
-describe("CCloud OAuth flow", { tags: [Tag.SMOKE, Tag.OAUTH] }, () => {
-  if (Object.keys(runtime.config.connections).length === 0) {
-    it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-    return;
-  }
-  // playwright drives the prod Auth0 sign-in form with these creds; populated by
-  // `make setup-test-env` from vault path confluent-cloud-user.
-  const credentials = getOAuthCredentialsFromEnv();
-  if (!credentials) {
-    it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-    return;
-  }
+describe(
+  "CCloud OAuth flow",
+  { tags: [Tag.SMOKE, Tag.OAUTH, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (Object.keys(runtime.config.connections).length === 0) {
+      it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+      return;
+    }
+    // playwright drives the prod Auth0 sign-in form with these creds; populated by
+    // `make setup-test-env` from vault path confluent-cloud-user.
+    const credentials = getOAuthCredentialsFromEnv();
+    if (!credentials) {
+      it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+      return;
+    }
 
-  let server: StartedServer;
+    let server: StartedServer;
 
-  beforeAll(async () => {
-    server = await startOAuthServer({ transport: TransportType.STDIO });
-  }, 180_000);
+    beforeAll(async () => {
+      server = await startOAuthServer({ transport: TransportType.STDIO });
+    }, 180_000);
 
-  afterAll(async () => {
-    await stopOAuthServer(server);
-  });
+    afterAll(async () => {
+      await stopOAuthServer(server);
+    });
 
-  it(
-    "should complete the CCloud OAuth flow via playwright and invoke an OAuth-eligible tool",
-    // covers the Auth0 sign-in round-trip (form fill + consent + redirect) plus the cloud REST call
-    { timeout: 120_000 },
-    async () => {
-      const result = await callToolWithOAuthFlow(server, credentials, {
-        name: ToolName.LIST_ORGANIZATIONS,
-        arguments: {},
-      });
+    it(
+      "should complete the CCloud OAuth flow via playwright and invoke an OAuth-eligible tool",
+      // covers the Auth0 sign-in round-trip (form fill + consent + redirect) plus the cloud REST call
+      { timeout: 120_000 },
+      async () => {
+        const result = await callToolWithOAuthFlow(server, credentials, {
+          name: ToolName.LIST_ORGANIZATIONS,
+          arguments: {},
+        });
 
-      expect(textContent(result)).toMatch(/^Retrieved \d+ organizations?:/);
-    },
-  );
-});
+        expect(textContent(result)).toMatch(/^Retrieved \d+ organizations?:/);
+      },
+    );
+  },
+);

--- a/src/confluent/oauth/pkce-login.ts
+++ b/src/confluent/oauth/pkce-login.ts
@@ -54,6 +54,7 @@ export type PkceLoginFailureReason =
   | "user_aborted"
   | "port_in_use"
   | "auth0_unreachable"
+  | "callback_server_error"
   | "configuration";
 
 /** Structured error so callers can react to the cause of a failed PKCE login. */
@@ -151,19 +152,6 @@ export async function runPkceLogin(
   };
 
   const server = nodeHttp.createServer((req, res) => {
-    // TEMPORARY INSTRUMENTATION: log every request that reaches the callback server, BEFORE any
-    // path/state validation. Diagnosing the CI failure where playwright's redirect-to-127.0.0.1
-    // appears to succeed but the server never receives the GET. Optional chaining on `socket`
-    // because the unit-test stub's synthetic IncomingMessage doesn't carry one.
-    logger.info(
-      {
-        url: req.url,
-        method: req.method,
-        remoteAddress: req.socket?.remoteAddress,
-        remotePort: req.socket?.remotePort,
-      },
-      "OAuth callback server received request",
-    );
     const reqUrl = req.url ?? "";
     const parsed = new URL(reqUrl, "http://127.0.0.1");
     if (parsed.pathname === SKILLS_HINT_COPIED_PATH) {
@@ -279,17 +267,17 @@ export async function runPkceLogin(
     server.listen(OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_HOST, () => {
       bound = true;
       server.off("error", onBindError);
-      // TEMPORARY INSTRUMENTATION: confirm bind succeeded on the expected host:port. Pair with
-      // "OAuth callback server received request" log to diagnose CI runs where the redirect
-      // appears to succeed (waitForURL match) but the server never receives the GET.
-      logger.info(
-        { host: OAUTH_CALLBACK_HOST, port: OAUTH_CALLBACK_PORT },
-        "OAuth callback server listening",
-      );
-      // Replace the bind-time rejector with a log-only listener so a stray
-      // post-bind socket error doesn't escape as an uncaught 'error' event.
+      // Post-bind socket errors must reject the in-flight flow, not just warn: if the listener
+      // dies mid-callback (EMFILE, broken TLS upgrade, etc.) the user would otherwise hang on
+      // `codePromise` until `PKCE_LOGIN_TIMEOUT_MS` (minutes) instead of failing fast.
       server.on("error", (err) => {
         logger.warn({ err }, "PKCE callback server post-bind error");
+        rejectFlow(
+          new PkceLoginError(
+            "callback_server_error",
+            `PKCE callback listener errored after bind: ${err.message}`,
+          ),
+        );
       });
       resolve();
     });

--- a/src/confluent/oauth/pkce-login.ts
+++ b/src/confluent/oauth/pkce-login.ts
@@ -151,6 +151,18 @@ export async function runPkceLogin(
   };
 
   const server = nodeHttp.createServer((req, res) => {
+    // TEMPORARY INSTRUMENTATION: log every request that reaches the callback server, BEFORE any
+    // path/state validation. Diagnosing the CI failure where playwright's redirect-to-127.0.0.1
+    // appears to succeed but the server never receives the GET.
+    logger.info(
+      {
+        url: req.url,
+        method: req.method,
+        remoteAddress: req.socket.remoteAddress,
+        remotePort: req.socket.remotePort,
+      },
+      "OAuth callback server received request",
+    );
     const reqUrl = req.url ?? "";
     const parsed = new URL(reqUrl, "http://127.0.0.1");
     if (parsed.pathname === SKILLS_HINT_COPIED_PATH) {
@@ -266,6 +278,17 @@ export async function runPkceLogin(
     server.listen(OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_HOST, () => {
       bound = true;
       server.off("error", onBindError);
+      // TEMPORARY INSTRUMENTATION: confirm bind actually happened on the expected host:port,
+      // and dump what the listener says its address is (handles cases where `host` was an alias).
+      const address = server.address();
+      logger.info(
+        {
+          host: OAUTH_CALLBACK_HOST,
+          port: OAUTH_CALLBACK_PORT,
+          actualAddress: address,
+        },
+        "OAuth callback server listening",
+      );
       // Replace the bind-time rejector with a log-only listener so a stray
       // post-bind socket error doesn't escape as an uncaught 'error' event.
       server.on("error", (err) => {

--- a/src/confluent/oauth/pkce-login.ts
+++ b/src/confluent/oauth/pkce-login.ts
@@ -153,13 +153,14 @@ export async function runPkceLogin(
   const server = nodeHttp.createServer((req, res) => {
     // TEMPORARY INSTRUMENTATION: log every request that reaches the callback server, BEFORE any
     // path/state validation. Diagnosing the CI failure where playwright's redirect-to-127.0.0.1
-    // appears to succeed but the server never receives the GET.
+    // appears to succeed but the server never receives the GET. Optional chaining on `socket`
+    // because the unit-test stub's synthetic IncomingMessage doesn't carry one.
     logger.info(
       {
         url: req.url,
         method: req.method,
-        remoteAddress: req.socket.remoteAddress,
-        remotePort: req.socket.remotePort,
+        remoteAddress: req.socket?.remoteAddress,
+        remotePort: req.socket?.remotePort,
       },
       "OAuth callback server received request",
     );
@@ -278,15 +279,11 @@ export async function runPkceLogin(
     server.listen(OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_HOST, () => {
       bound = true;
       server.off("error", onBindError);
-      // TEMPORARY INSTRUMENTATION: confirm bind actually happened on the expected host:port,
-      // and dump what the listener says its address is (handles cases where `host` was an alias).
-      const address = server.address();
+      // TEMPORARY INSTRUMENTATION: confirm bind succeeded on the expected host:port. Pair with
+      // "OAuth callback server received request" log to diagnose CI runs where the redirect
+      // appears to succeed (waitForURL match) but the server never receives the GET.
       logger.info(
-        {
-          host: OAUTH_CALLBACK_HOST,
-          port: OAUTH_CALLBACK_PORT,
-          actualAddress: address,
-        },
+        { host: OAUTH_CALLBACK_HOST, port: OAUTH_CALLBACK_PORT },
         "OAuth callback server listening",
       );
       // Replace the bind-time rejector with a log-only listener so a stray

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.integration.test.ts
@@ -36,71 +36,21 @@ function utcDate(daysAgo: number): string {
 const startDate = utcDate(2);
 const endDate = utcDate(1);
 
-describe("list-billing-costs-handler", { tags: [Tag.BILLING] }, () => {
-  // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
-  // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "list-billing-costs-handler",
+  { tags: [Tag.BILLING, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
+    // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-billing-costs in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        expect(
-          tools.find((t) => t.name === ToolName.LIST_BILLING_COSTS),
-        ).toBeDefined();
-      });
-
-      it("should return billing costs for a 1-day window", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_BILLING_COSTS,
-          arguments: { startDate, endDate },
-        });
-
-        expect(result.isError).not.toBe(true);
-        // handler emits this prefix whether or not the window has line items, so an empty response
-        // still proves the tool ran end-to-end
-        expect(textContent(result)).toMatch(
-          /^Successfully retrieved billing costs:/,
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+      const directRuntime = integrationRuntime({ oauth: false });
+      if (handler.enabledConnectionIds(directRuntime).length === 0) {
+        it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
@@ -108,11 +58,11 @@ describe("list-billing-costs-handler", { tags: [Tag.BILLING] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-billing-costs in tools/list", async () => {
@@ -122,19 +72,73 @@ describe("list-billing-costs-handler", { tags: [Tag.BILLING] }, () => {
           ).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return billing costs for a 1-day window", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_BILLING_COSTS,
             arguments: { startDate, endDate },
           });
 
           expect(result.isError).not.toBe(true);
+          // handler emits this prefix whether or not the window has line items, so an empty response
+          // still proves the tool ran end-to-end
           expect(textContent(result)).toMatch(
             /^Successfully retrieved billing costs:/,
           );
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-billing-costs in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            expect(
+              tools.find((t) => t.name === ToolName.LIST_BILLING_COSTS),
+            ).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return billing costs for a 1-day window", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_BILLING_COSTS,
+              arguments: { startDate, endDate },
+            });
+
+            expect(result.isError).not.toBe(true);
+            expect(textContent(result)).toMatch(
+              /^Successfully retrieved billing costs:/,
+            );
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
@@ -25,128 +25,139 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new AddTagToTopicHandler();
 const runtime = integrationRuntime();
 
-describe("add-tags-to-topic-handler", { tags: [Tag.CATALOG] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
-    return;
-  }
-  // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
-  // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
-  const conn = runtime.config.getSoleDirectConnection();
-  if (!conn.confluent_cloud) {
-    it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
-    return;
-  }
-  if (
-    !conn.kafka?.bootstrap_servers ||
-    !conn.kafka.auth ||
-    !conn.kafka.cluster_id ||
-    !conn.kafka.env_id
-  ) {
-    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id + kafka.env_id config", () => {});
-    return;
-  }
+describe(
+  "add-tags-to-topic-handler",
+  {
+    tags: [
+      Tag.CATALOG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+      Tag.REQUIRES_KAFKA_CONFIG,
+      Tag.REQUIRES_SCHEMA_REGISTRY_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+      return;
+    }
+    // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
+    // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
+    const conn = runtime.config.getSoleDirectConnection();
+    if (!conn.confluent_cloud) {
+      it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
+      return;
+    }
+    if (
+      !conn.kafka?.bootstrap_servers ||
+      !conn.kafka.auth ||
+      !conn.kafka.cluster_id ||
+      !conn.kafka.env_id
+    ) {
+      it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id + kafka.env_id config", () => {});
+      return;
+    }
 
-  // installs beforeAll/afterAll at this describe scope: SR REST client + tag cleanup, kafka admin
-  // + topic cleanup, SR SDK + subject cleanup (registering a `<topic>-value` subject is what gets
-  // the topic indexed in catalog so tag assignment is accepted)
-  const { client, createdTags } = withSharedCatalogTagsClient();
-  const { admin, createdTopics } = withSharedAdminClient();
-  const { client: srClient, createdSubjects } = withSharedSrClient();
-  const kafkaClusterId = getTestClusterId();
-  let srClusterId: string;
-
-  beforeAll(async () => {
-    srClusterId = await getSchemaRegistryClusterId();
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs beforeAll/afterAll at this describe scope: SR REST client + tag cleanup, kafka admin
+    // + topic cleanup, SR SDK + subject cleanup (registering a `<topic>-value` subject is what gets
+    // the topic indexed in catalog so tag assignment is accepted)
+    const { client, createdTags } = withSharedCatalogTagsClient();
+    const { admin, createdTopics } = withSharedAdminClient();
+    const { client: srClient, createdSubjects } = withSharedSrClient();
+    const kafkaClusterId = getTestClusterId();
+    let srClusterId: string;
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      srClusterId = await getSchemaRegistryClusterId();
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose add-tags-to-topic in tools/list", async () => {
-      const { tools } = await server.client.listTools();
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
 
-      expect(
-        tools.find((t) => t.name === ToolName.ADD_TAGS_TO_TOPIC),
-      ).toBeDefined();
-    });
+      afterAll(async () => {
+        await server?.stop();
+      });
 
-    it(
-      "should assign a tag to a topic",
-      // 180s covers the 120s catalog-indexing poll plus topic/schema seed and the assign call
-      { timeout: 180_000 },
-      async () => {
-        // fresh tag + topic per transport so each iteration has clean targets
-        const tagName = uniqueName(`addtag-${transport}`);
-        const topic = uniqueName(`addtag-${transport}`);
-        const subject = `${topic}-value`;
-        createdTags.push(tagName);
-        createdTopics.push(topic);
-        createdSubjects.push(subject);
+      it("should expose add-tags-to-topic in tools/list", async () => {
+        const { tools } = await server.client.listTools();
 
-        const path = wrapAsPathBasedClient(client());
-        const { error: tagError } = await path[
-          "/catalog/v1/types/tagdefs"
-        ].POST({
-          body: [
-            {
-              entityTypes: ["kafka_topic"],
-              name: tagName,
-              description: "integration test add target",
-            },
-          ],
-        });
-        expect(tagError, JSON.stringify(tagError)).toBeUndefined();
-        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
-        // registering a schema for `<topic>-value` triggers stream governance to index the topic
-        // entity in catalog; without it the tag-assign POST 404s on 4040009 ("Instance kafka_topic
-        // ... does not exist"). CCloud indexing policy, not a catalog API contract - drop if/when
-        // CCloud indexes all topics regardless of schema association
-        await srClient().register(subject, { schema: TEST_AVRO_SCHEMA });
+        expect(
+          tools.find((t) => t.name === ToolName.ADD_TAGS_TO_TOPIC),
+        ).toBeDefined();
+      });
 
-        const qualifiedName = `${srClusterId}:${kafkaClusterId}:${topic}`;
-        // poll the catalog topic-entity GET until stream governance finishes indexing the new
-        // subject->topic association AND echoes the qualified name we constructed; a format drift
-        // in CCloud's qualified-name encoding fails fast with a diff here instead of timing out on
-        // the assign POST
-        await expect
-          .poll(
-            async () => {
-              const { data } = await path[
-                "/catalog/v1/entity/type/{typeName}/name/{qualifiedName}"
-              ].GET({
-                params: { path: { typeName: "kafka_topic", qualifiedName } },
-              });
-              return data?.entity?.attributes?.qualifiedName;
-            },
-            { timeout: 120_000, interval: 2_000 },
-          )
-          .toBe(qualifiedName);
+      it(
+        "should assign a tag to a topic",
+        // 180s covers the 120s catalog-indexing poll plus topic/schema seed and the assign call
+        { timeout: 180_000 },
+        async () => {
+          // fresh tag + topic per transport so each iteration has clean targets
+          const tagName = uniqueName(`addtag-${transport}`);
+          const topic = uniqueName(`addtag-${transport}`);
+          const subject = `${topic}-value`;
+          createdTags.push(tagName);
+          createdTopics.push(topic);
+          createdSubjects.push(subject);
 
-        const result = await server.client.callTool({
-          name: ToolName.ADD_TAGS_TO_TOPIC,
-          arguments: {
-            tagAssignments: [
+          const path = wrapAsPathBasedClient(client());
+          const { error: tagError } = await path[
+            "/catalog/v1/types/tagdefs"
+          ].POST({
+            body: [
               {
-                entityType: "kafka_topic",
-                entityName: qualifiedName,
-                typeName: tagName,
+                entityTypes: ["kafka_topic"],
+                name: tagName,
+                description: "integration test add target",
               },
             ],
-          },
-        });
+          });
+          expect(tagError, JSON.stringify(tagError)).toBeUndefined();
+          await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
+          // registering a schema for `<topic>-value` triggers stream governance to index the topic
+          // entity in catalog; without it the tag-assign POST 404s on 4040009 ("Instance kafka_topic
+          // ... does not exist"). CCloud indexing policy, not a catalog API contract - drop if/when
+          // CCloud indexes all topics regardless of schema association
+          await srClient().register(subject, { schema: TEST_AVRO_SCHEMA });
 
-        expect(textContent(result)).toMatch(/^Successfully assigned tag:/);
-        expect(textContent(result)).toContain(tagName);
-      },
-    );
-  });
-});
+          const qualifiedName = `${srClusterId}:${kafkaClusterId}:${topic}`;
+          // poll the catalog topic-entity GET until stream governance finishes indexing the new
+          // subject->topic association AND echoes the qualified name we constructed; a format drift
+          // in CCloud's qualified-name encoding fails fast with a diff here instead of timing out on
+          // the assign POST
+          await expect
+            .poll(
+              async () => {
+                const { data } = await path[
+                  "/catalog/v1/entity/type/{typeName}/name/{qualifiedName}"
+                ].GET({
+                  params: { path: { typeName: "kafka_topic", qualifiedName } },
+                });
+                return data?.entity?.attributes?.qualifiedName;
+              },
+              { timeout: 120_000, interval: 2_000 },
+            )
+            .toBe(qualifiedName);
+
+          const result = await server.client.callTool({
+            name: ToolName.ADD_TAGS_TO_TOPIC,
+            arguments: {
+              tagAssignments: [
+                {
+                  entityType: "kafka_topic",
+                  entityName: qualifiedName,
+                  typeName: tagName,
+                },
+              ],
+            },
+          });
+
+          expect(textContent(result)).toMatch(/^Successfully assigned tag:/);
+          expect(textContent(result)).toContain(tagName);
+        },
+      );
+    });
+  },
+);

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.integration.test.ts
@@ -15,48 +15,52 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new CreateTopicTagsHandler();
 const runtime = integrationRuntime();
 
-describe("create-topic-tags-handler", { tags: [Tag.CATALOG] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
-    return;
-  }
+describe(
+  "create-topic-tags-handler",
+  { tags: [Tag.CATALOG, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+      return;
+    }
 
-  // installs beforeAll/afterAll at this describe scope (shared SR REST client, tag cleanup)
-  const { createdTags } = withSharedCatalogTagsClient();
+    // installs beforeAll/afterAll at this describe scope (shared SR REST client, tag cleanup)
+    const { createdTags } = withSharedCatalogTagsClient();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose create-topic-tags in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.CREATE_TOPIC_TAGS),
-      ).toBeDefined();
-    });
-
-    it("should create a tag and return it in the response", async () => {
-      // fresh tag per transport so each iteration has a clean POST target
-      const tagName = uniqueName(`create-${transport}`);
-      createdTags.push(tagName);
-
-      const result = await server.client.callTool({
-        name: ToolName.CREATE_TOPIC_TAGS,
-        arguments: {
-          tags: [{ tagName, description: "integration test create" }],
-        },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toMatch(/^Successfully created tag:/);
-      expect(textContent(result)).toContain(tagName);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose create-topic-tags in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.CREATE_TOPIC_TAGS),
+        ).toBeDefined();
+      });
+
+      it("should create a tag and return it in the response", async () => {
+        // fresh tag per transport so each iteration has a clean POST target
+        const tagName = uniqueName(`create-${transport}`);
+        createdTags.push(tagName);
+
+        const result = await server.client.callTool({
+          name: ToolName.CREATE_TOPIC_TAGS,
+          arguments: {
+            tags: [{ tagName, description: "integration test create" }],
+          },
+        });
+
+        expect(textContent(result)).toMatch(/^Successfully created tag:/);
+        expect(textContent(result)).toContain(tagName);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/catalog/delete-tag.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.integration.test.ts
@@ -16,71 +16,75 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new DeleteTagHandler();
 const runtime = integrationRuntime();
 
-describe("delete-tag-handler", { tags: [Tag.CATALOG] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
-    return;
-  }
+describe(
+  "delete-tag-handler",
+  { tags: [Tag.CATALOG, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+      return;
+    }
 
-  // installs beforeAll/afterAll at this describe scope (shared SR REST client, tag cleanup)
-  const { client, createdTags } = withSharedCatalogTagsClient();
+    // installs beforeAll/afterAll at this describe scope (shared SR REST client, tag cleanup)
+    const { client, createdTags } = withSharedCatalogTagsClient();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
+
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose delete-tag in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(tools.find((t) => t.name === ToolName.DELETE_TAG)).toBeDefined();
+      });
+
+      it(
+        "should delete a pre-existing tag",
+        // CCloud's DELETE-by-name waits on the tagdef-by-name replica that trails the create
+        // write; on cold runs the request can take 3+ minutes to return 4040001 or success
+        { timeout: 300_000 },
+        async (ctx) => {
+          // seed a fresh tag per transport so each iteration has its own delete target
+          const tagName = uniqueName(`delete-${transport}`);
+          createdTags.push(tagName);
+          const path = wrapAsPathBasedClient(client());
+          const { error: seedError } = await path[
+            "/catalog/v1/types/tagdefs"
+          ].POST({
+            body: [
+              {
+                entityTypes: ["kafka_topic"],
+                name: tagName,
+                description: "integration test delete target",
+              },
+            ],
+          });
+          expect(seedError, JSON.stringify(seedError)).toBeUndefined();
+
+          const result = await server.client.callTool({
+            name: ToolName.DELETE_TAG,
+            arguments: { tagName },
+          });
+          const text = textContent(result);
+          // the DELETE handler hits the same lagged replica and 404s before tagdef create
+          // propagates; skip honestly rather than fail. afterAll cleanup re-runs DELETE later so
+          // state stays clean.
+          if (text.includes('"error_code":4040001')) {
+            ctx.skip(
+              `CCloud catalog tagdef propagation exceeded test budget for tag ${tagName} (4040001)`,
+            );
+            return;
+          }
+          expect(text).toContain(`Successfully deleted tag: ${tagName}`);
+        },
+      );
     });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose delete-tag in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(tools.find((t) => t.name === ToolName.DELETE_TAG)).toBeDefined();
-    });
-
-    it(
-      "should delete a pre-existing tag",
-      // CCloud's DELETE-by-name waits on the tagdef-by-name replica that trails the create
-      // write; on cold runs the request can take 3+ minutes to return 4040001 or success
-      { timeout: 300_000 },
-      async (ctx) => {
-        // seed a fresh tag per transport so each iteration has its own delete target
-        const tagName = uniqueName(`delete-${transport}`);
-        createdTags.push(tagName);
-        const path = wrapAsPathBasedClient(client());
-        const { error: seedError } = await path[
-          "/catalog/v1/types/tagdefs"
-        ].POST({
-          body: [
-            {
-              entityTypes: ["kafka_topic"],
-              name: tagName,
-              description: "integration test delete target",
-            },
-          ],
-        });
-        expect(seedError, JSON.stringify(seedError)).toBeUndefined();
-
-        const result = await server.client.callTool({
-          name: ToolName.DELETE_TAG,
-          arguments: { tagName },
-        });
-        const text = textContent(result);
-        // the DELETE handler hits the same lagged replica and 404s before tagdef create
-        // propagates; skip honestly rather than fail. afterAll cleanup re-runs DELETE later so
-        // state stays clean.
-        if (text.includes('"error_code":4040001')) {
-          ctx.skip(
-            `CCloud catalog tagdef propagation exceeded test budget for tag ${tagName} (4040001)`,
-          );
-          return;
-        }
-        expect(text).toContain(`Successfully deleted tag: ${tagName}`);
-      },
-    );
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/catalog/list-tags.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.integration.test.ts
@@ -13,39 +13,43 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListTagsHandler();
 const runtime = integrationRuntime();
 
-describe("list-tags-handler", { tags: [Tag.CATALOG] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
-    return;
-  }
+describe(
+  "list-tags-handler",
+  { tags: [Tag.CATALOG, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+      return;
+    }
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-tags in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(tools.find((t) => t.name === ToolName.LIST_TAGS)).toBeDefined();
-    });
-
-    // CCloud's tagdef list endpoint trails the create write by enough that asserting on a
-    // freshly-seeded tag flakes; the prefix check proves the handler is wired and parses the
-    // response shape.
-    it("should return a successful response", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_TAGS,
-        arguments: {},
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toMatch(/^Successfully retrieved tags:/);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-tags in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(tools.find((t) => t.name === ToolName.LIST_TAGS)).toBeDefined();
+      });
+
+      // CCloud's tagdef list endpoint trails the create write by enough that asserting on a
+      // freshly-seeded tag flakes; the prefix check proves the handler is wired and parses the
+      // response shape.
+      it("should return a successful response", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_TAGS,
+          arguments: {},
+        });
+
+        expect(textContent(result)).toMatch(/^Successfully retrieved tags:/);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
@@ -25,146 +25,157 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new RemoveTagFromEntityHandler();
 const runtime = integrationRuntime();
 
-describe("remove-tag-from-entity-handler", { tags: [Tag.CATALOG] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
-    return;
-  }
-  // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
-  // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
-  const conn = runtime.config.getSoleDirectConnection();
-  if (!conn.confluent_cloud) {
-    it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
-    return;
-  }
-  if (
-    !conn.kafka?.bootstrap_servers ||
-    !conn.kafka.auth ||
-    !conn.kafka.cluster_id ||
-    !conn.kafka.env_id
-  ) {
-    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id + kafka.env_id config", () => {});
-    return;
-  }
+describe(
+  "remove-tag-from-entity-handler",
+  {
+    tags: [
+      Tag.CATALOG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+      Tag.REQUIRES_KAFKA_CONFIG,
+      Tag.REQUIRES_SCHEMA_REGISTRY_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires schema_registry.endpoint + schema_registry.auth (api_key) config", () => {});
+      return;
+    }
+    // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
+    // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
+    const conn = runtime.config.getSoleDirectConnection();
+    if (!conn.confluent_cloud) {
+      it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
+      return;
+    }
+    if (
+      !conn.kafka?.bootstrap_servers ||
+      !conn.kafka.auth ||
+      !conn.kafka.cluster_id ||
+      !conn.kafka.env_id
+    ) {
+      it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id + kafka.env_id config", () => {});
+      return;
+    }
 
-  // installs beforeAll/afterAll at this describe scope: SR REST client + tag cleanup, kafka admin
-  // + topic cleanup, SR SDK + subject cleanup (registering a `<topic>-value` subject is what gets
-  // the topic indexed in catalog so the pre-test tag assignment is accepted)
-  const { client, createdTags } = withSharedCatalogTagsClient();
-  const { admin, createdTopics } = withSharedAdminClient();
-  const { client: srClient, createdSubjects } = withSharedSrClient();
-  const kafkaClusterId = getTestClusterId();
-  let srClusterId: string;
-
-  beforeAll(async () => {
-    srClusterId = await getSchemaRegistryClusterId();
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs beforeAll/afterAll at this describe scope: SR REST client + tag cleanup, kafka admin
+    // + topic cleanup, SR SDK + subject cleanup (registering a `<topic>-value` subject is what gets
+    // the topic indexed in catalog so the pre-test tag assignment is accepted)
+    const { client, createdTags } = withSharedCatalogTagsClient();
+    const { admin, createdTopics } = withSharedAdminClient();
+    const { client: srClient, createdSubjects } = withSharedSrClient();
+    const kafkaClusterId = getTestClusterId();
+    let srClusterId: string;
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      srClusterId = await getSchemaRegistryClusterId();
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose remove-tag-from-entity in tools/list", async () => {
-      const { tools } = await server.client.listTools();
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
 
-      expect(
-        tools.find((t) => t.name === ToolName.REMOVE_TAG_FROM_ENTITY),
-      ).toBeDefined();
-    });
+      afterAll(async () => {
+        await server?.stop();
+      });
 
-    it(
-      "should remove a tag assignment from a topic",
-      // 180s covers the 120s catalog-indexing poll plus topic/schema seed, the pre-test
-      // tag-assign POST, and the final remove call
-      { timeout: 180_000 },
-      async (ctx) => {
-        // fresh tag + topic per transport, with the tag pre-assigned so the handler has something
-        // to remove
-        const tagName = uniqueName(`removetag-${transport}`);
-        const topic = uniqueName(`removetag-${transport}`);
-        const subject = `${topic}-value`;
-        createdTags.push(tagName);
-        createdTopics.push(topic);
-        createdSubjects.push(subject);
+      it("should expose remove-tag-from-entity in tools/list", async () => {
+        const { tools } = await server.client.listTools();
 
-        const path = wrapAsPathBasedClient(client());
-        const { error: tagError } = await path[
-          "/catalog/v1/types/tagdefs"
-        ].POST({
-          body: [
-            {
-              entityTypes: ["kafka_topic"],
-              name: tagName,
-              description: "integration test remove target",
+        expect(
+          tools.find((t) => t.name === ToolName.REMOVE_TAG_FROM_ENTITY),
+        ).toBeDefined();
+      });
+
+      it(
+        "should remove a tag assignment from a topic",
+        // 180s covers the 120s catalog-indexing poll plus topic/schema seed, the pre-test
+        // tag-assign POST, and the final remove call
+        { timeout: 180_000 },
+        async (ctx) => {
+          // fresh tag + topic per transport, with the tag pre-assigned so the handler has something
+          // to remove
+          const tagName = uniqueName(`removetag-${transport}`);
+          const topic = uniqueName(`removetag-${transport}`);
+          const subject = `${topic}-value`;
+          createdTags.push(tagName);
+          createdTopics.push(topic);
+          createdSubjects.push(subject);
+
+          const path = wrapAsPathBasedClient(client());
+          const { error: tagError } = await path[
+            "/catalog/v1/types/tagdefs"
+          ].POST({
+            body: [
+              {
+                entityTypes: ["kafka_topic"],
+                name: tagName,
+                description: "integration test remove target",
+              },
+            ],
+          });
+          expect(tagError, JSON.stringify(tagError)).toBeUndefined();
+          await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
+          // registering a schema for `<topic>-value` triggers stream governance to index the topic
+          // entity in catalog; without it the assign POST 404s on 4040009. CCloud indexing policy,
+          // not a catalog API contract - drop if/when CCloud indexes all topics regardless of
+          // schema association
+          await srClient().register(subject, { schema: TEST_AVRO_SCHEMA });
+          const qualifiedName = `${srClusterId}:${kafkaClusterId}:${topic}`;
+          // poll the catalog topic-entity GET until stream governance finishes indexing AND echoes
+          // the qualified name we constructed; a format drift in CCloud's qualified-name encoding
+          // fails fast with a diff here instead of timing out on the pre-test assign POST
+          await expect
+            .poll(
+              async () => {
+                const { data } = await path[
+                  "/catalog/v1/entity/type/{typeName}/name/{qualifiedName}"
+                ].GET({
+                  params: { path: { typeName: "kafka_topic", qualifiedName } },
+                });
+                return data?.entity?.attributes?.qualifiedName;
+              },
+              { timeout: 120_000, interval: 2_000 },
+            )
+            .toBe(qualifiedName);
+          const { error: assignError } = await path[
+            "/catalog/v1/entity/tags"
+          ].POST({
+            body: [
+              {
+                entityType: "kafka_topic",
+                entityName: qualifiedName,
+                typeName: tagName,
+              },
+            ],
+          });
+          expect(assignError, JSON.stringify(assignError)).toBeUndefined();
+
+          const result = await server.client.callTool({
+            name: ToolName.REMOVE_TAG_FROM_ENTITY,
+            arguments: {
+              tagName,
+              typeName: "kafka_topic",
+              qualifiedName,
             },
-          ],
-        });
-        expect(tagError, JSON.stringify(tagError)).toBeUndefined();
-        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
-        // registering a schema for `<topic>-value` triggers stream governance to index the topic
-        // entity in catalog; without it the assign POST 404s on 4040009. CCloud indexing policy,
-        // not a catalog API contract - drop if/when CCloud indexes all topics regardless of
-        // schema association
-        await srClient().register(subject, { schema: TEST_AVRO_SCHEMA });
-        const qualifiedName = `${srClusterId}:${kafkaClusterId}:${topic}`;
-        // poll the catalog topic-entity GET until stream governance finishes indexing AND echoes
-        // the qualified name we constructed; a format drift in CCloud's qualified-name encoding
-        // fails fast with a diff here instead of timing out on the pre-test assign POST
-        await expect
-          .poll(
-            async () => {
-              const { data } = await path[
-                "/catalog/v1/entity/type/{typeName}/name/{qualifiedName}"
-              ].GET({
-                params: { path: { typeName: "kafka_topic", qualifiedName } },
-              });
-              return data?.entity?.attributes?.qualifiedName;
-            },
-            { timeout: 120_000, interval: 2_000 },
-          )
-          .toBe(qualifiedName);
-        const { error: assignError } = await path[
-          "/catalog/v1/entity/tags"
-        ].POST({
-          body: [
-            {
-              entityType: "kafka_topic",
-              entityName: qualifiedName,
-              typeName: tagName,
-            },
-          ],
-        });
-        expect(assignError, JSON.stringify(assignError)).toBeUndefined();
-
-        const result = await server.client.callTool({
-          name: ToolName.REMOVE_TAG_FROM_ENTITY,
-          arguments: {
-            tagName,
-            typeName: "kafka_topic",
-            qualifiedName,
-          },
-        });
-        const text = textContent(result);
-        // the DELETE-by-tag-name lookup trails the assignment POST on a separate replica and
-        // 4040008s before the just-made assignment becomes queryable; skip honestly rather than
-        // poll for minutes since the handler's wiring is already proven by the call going through.
-        if (text.includes('"error_code":4040008')) {
-          ctx.skip(
-            `CCloud catalog tag-on-entity propagation exceeded test budget for tag ${tagName} (4040008)`,
+          });
+          const text = textContent(result);
+          // the DELETE-by-tag-name lookup trails the assignment POST on a separate replica and
+          // 4040008s before the just-made assignment becomes queryable; skip honestly rather than
+          // poll for minutes since the handler's wiring is already proven by the call going through.
+          if (text.includes('"error_code":4040008')) {
+            ctx.skip(
+              `CCloud catalog tag-on-entity propagation exceeded test budget for tag ${tagName} (4040008)`,
+            );
+            return;
+          }
+          expect(text).toContain(
+            `Successfully removed tag ${tagName} from entity ${qualifiedName}`,
           );
-          return;
-        }
-        expect(text).toContain(
-          `Successfully removed tag ${tagName} from entity ${qualifiedName}`,
-        );
-      },
-    );
-  });
-});
+        },
+      );
+    });
+  },
+);

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.integration.test.ts
@@ -28,91 +28,34 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ListClustersHandler();
 
-describe("list-clusters-handler", { tags: [Tag.CLUSTERS] }, () => {
-  // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
-  // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "list-clusters-handler",
+  { tags: [Tag.CLUSTERS, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
+    // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-    const environmentId = getTestEnvironmentId();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-clusters in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        expect(
-          tools.find((t) => t.name === ToolName.LIST_CLUSTERS),
-        ).toBeDefined();
-      });
-
-      it("should return clusters for the resolved environment id", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_CLUSTERS,
-          arguments: { environmentId },
-        });
-
-        expect(textContent(result)).toMatch(
-          /^Successfully retrieved [1-9]\d* clusters:/,
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `getTestEnvironmentId()` reads `kafka.env_id` out of the direct YAML; gate the OAuth
-      // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
-      // direct creds skips cleanly instead of crashing on missing fixture
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
-      // env id is read from the direct YAML; the OAuth-mode handler itself talks to CCloud via OAuth
       const environmentId = getTestEnvironmentId();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-clusters in tools/list", async () => {
@@ -122,9 +65,8 @@ describe("list-clusters-handler", { tags: [Tag.CLUSTERS] }, () => {
           ).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return clusters for the resolved environment id", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_CLUSTERS,
             arguments: { environmentId },
           });
@@ -134,6 +76,68 @@ describe("list-clusters-handler", { tags: [Tag.CLUSTERS] }, () => {
           );
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `getTestEnvironmentId()` reads `kafka.env_id` out of the direct YAML; gate the OAuth
+        // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
+        // direct creds skips cleanly instead of crashing on missing fixture
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+        // env id is read from the direct YAML; the OAuth-mode handler itself talks to CCloud via OAuth
+        const environmentId = getTestEnvironmentId();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-clusters in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            expect(
+              tools.find((t) => t.name === ToolName.LIST_CLUSTERS),
+            ).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return clusters for the resolved environment id", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_CLUSTERS,
+              arguments: { environmentId },
+            });
+
+            expect(textContent(result)).toMatch(
+              /^Successfully retrieved [1-9]\d* clusters:/,
+            );
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/connect/create-connector-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.integration.test.ts
@@ -15,46 +15,50 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new CreateConnectorHandler();
 const runtime = integrationRuntime();
 
-describe("create-connector-handler", { tags: [Tag.CONNECT] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires confluent_cloud.auth + kafka.auth config", () => {});
-    return;
-  }
+describe(
+  "create-connector-handler",
+  { tags: [Tag.CONNECT, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires confluent_cloud.auth + kafka.auth config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (test-side connector cleanup)
-  const { createdConnectors } = withSharedConnectorCleanup();
+    // installs afterAll at this describe scope (test-side connector cleanup)
+    const { createdConnectors } = withSharedConnectorCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should create a Datagen Source connector via the tool", async () => {
-      const connectorName = uniqueName(`connect-create-${transport}`);
-      // track for cleanup before the call so partial creation still gets swept
-      createdConnectors.push(connectorName);
-
-      const result = await server.client.callTool({
-        name: ToolName.CREATE_CONNECTOR,
-        arguments: {
-          connectorName,
-          connectorConfig: {
-            "connector.class": "DatagenSource",
-            "kafka.topic": connectorName,
-            quickstart: "USERS",
-            "tasks.max": "1",
-            "output.data.format": "JSON",
-          },
-        },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toContain(`${connectorName} created:`);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should create a Datagen Source connector via the tool", async () => {
+        const connectorName = uniqueName(`connect-create-${transport}`);
+        // track for cleanup before the call so partial creation still gets swept
+        createdConnectors.push(connectorName);
+
+        const result = await server.client.callTool({
+          name: ToolName.CREATE_CONNECTOR,
+          arguments: {
+            connectorName,
+            connectorConfig: {
+              "connector.class": "DatagenSource",
+              "kafka.topic": connectorName,
+              quickstart: "USERS",
+              "tasks.max": "1",
+              "output.data.format": "JSON",
+            },
+          },
+        });
+
+        expect(textContent(result)).toContain(`${connectorName} created:`);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.integration.test.ts
@@ -18,39 +18,43 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new DeleteConnectorHandler();
 const runtime = integrationRuntime();
 
-describe("delete-connector-handler", { tags: [Tag.CONNECT] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires confluent_cloud.auth config", () => {});
-    return;
-  }
+describe(
+  "delete-connector-handler",
+  { tags: [Tag.CONNECT, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires confluent_cloud.auth config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (idempotent connector cleanup sweep)
-  const { createdConnectors } = withSharedConnectorCleanup();
+    // installs afterAll at this describe scope (idempotent connector cleanup sweep)
+    const { createdConnectors } = withSharedConnectorCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should delete the provisioned connector via the tool", async () => {
-      const connectorName = uniqueName(`connect-delete-${transport}`);
-      createdConnectors.push(connectorName);
-      await provisionTestDatagenConnector(connectorName);
-
-      const result = await server.client.callTool({
-        name: ToolName.DELETE_CONNECTOR,
-        arguments: { connectorName },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toBe(
-        `Successfully deleted connector ${connectorName}`,
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should delete the provisioned connector via the tool", async () => {
+        const connectorName = uniqueName(`connect-delete-${transport}`);
+        createdConnectors.push(connectorName);
+        await provisionTestDatagenConnector(connectorName);
+
+        const result = await server.client.callTool({
+          name: ToolName.DELETE_CONNECTOR,
+          arguments: { connectorName },
+        });
+
+        expect(textContent(result)).toBe(
+          `Successfully deleted connector ${connectorName}`,
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.integration.test.ts
@@ -13,37 +13,41 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListConnectorsHandler();
 const runtime = integrationRuntime();
 
-describe("list-connectors-handler", { tags: [Tag.CONNECT] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires confluent_cloud.auth config", () => {});
-    return;
-  }
+describe(
+  "list-connectors-handler",
+  { tags: [Tag.CONNECT, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires confluent_cloud.auth config", () => {});
+      return;
+    }
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-connectors in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_CONNECTORS),
-      ).toBeDefined();
-    });
-
-    it("should return active connectors for the configured cluster", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_CONNECTORS,
-        arguments: {},
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toMatch(/^Active Connectors:/);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-connectors in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_CONNECTORS),
+        ).toBeDefined();
+      });
+
+      it("should return active connectors for the configured cluster", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_CONNECTORS,
+          arguments: {},
+        });
+
+        expect(textContent(result)).toMatch(/^Active Connectors:/);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/connect/read-connectors-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/read-connectors-handler.integration.test.ts
@@ -18,50 +18,54 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ReadConnectorHandler();
 const runtime = integrationRuntime();
 
-describe("read-connector-handler", { tags: [Tag.CONNECT] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires confluent_cloud.auth config", () => {});
-    return;
-  }
+describe(
+  "read-connector-handler",
+  { tags: [Tag.CONNECT, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires confluent_cloud.auth config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (test-side connector cleanup)
-  const { createdConnectors } = withSharedConnectorCleanup();
+    // installs afterAll at this describe scope (test-side connector cleanup)
+    const { createdConnectors } = withSharedConnectorCleanup();
 
-  // provision once per file - same connector read across all transport iterations
-  let connectorName: string;
-  beforeAll(async () => {
-    connectorName = uniqueName("connect-read");
-    createdConnectors.push(connectorName);
-    await provisionTestDatagenConnector(connectorName);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
-
+    // provision once per file - same connector read across all transport iterations
+    let connectorName: string;
     beforeAll(async () => {
-      server = await startServer({ transport });
+      connectorName = uniqueName("connect-read");
+      createdConnectors.push(connectorName);
+      await provisionTestDatagenConnector(connectorName);
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose read-connector in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-      expect(
-        tools.find((t) => t.name === ToolName.READ_CONNECTOR),
-      ).toBeDefined();
-    });
-
-    it("should return details for the provisioned connector", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.READ_CONNECTOR,
-        arguments: { connectorName },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toContain(
-        `Connector Details for ${connectorName}:`,
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose read-connector in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+        expect(
+          tools.find((t) => t.name === ToolName.READ_CONNECTOR),
+        ).toBeDefined();
+      });
+
+      it("should return details for the provisioned connector", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.READ_CONNECTOR,
+          arguments: { connectorName },
+        });
+
+        expect(textContent(result)).toContain(
+          `Connector Details for ${connectorName}:`,
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/docs/get-product-doc-page-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/docs/get-product-doc-page-handler.integration.test.ts
@@ -32,39 +32,43 @@ const cases = [
   },
 ] as const;
 
-describe("get-product-doc-page-handler", { tags: [Tag.DOCS] }, () => {
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+describe(
+  "get-product-doc-page-handler",
+  { tags: [Tag.DOCS, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
+
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose get-product-doc-page in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+        expect(
+          tools.find((t) => t.name === ToolName.GET_PRODUCT_DOC_PAGE),
+        ).toBeDefined();
+      });
+
+      it.each(cases)(
+        "should fetch and render markdown from $label",
+        async ({ url, expectMarkdown }) => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_PRODUCT_DOC_PAGE,
+            arguments: { url },
+          });
+
+          const text = textContent(result);
+          expect(text).toContain(`# Source: ${url}`);
+          // Above the bare `# Source` header — proves we got a body.
+          expect(text.length).toBeGreaterThan(500);
+          expect(text).toMatch(expectMarkdown);
+        },
+      );
     });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose get-product-doc-page in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-      expect(
-        tools.find((t) => t.name === ToolName.GET_PRODUCT_DOC_PAGE),
-      ).toBeDefined();
-    });
-
-    it.each(cases)(
-      "should fetch and render markdown from $label",
-      async ({ url, expectMarkdown }) => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_PRODUCT_DOC_PAGE,
-          arguments: { url },
-        });
-
-        const text = textContent(result);
-        expect(text).toContain(`# Source: ${url}`);
-        // Above the bare `# Source` header — proves we got a body.
-        expect(text.length).toBeGreaterThan(500);
-        expect(text).toMatch(expectMarkdown);
-      },
-    );
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/docs/search-product-docs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/docs/search-product-docs-handler.integration.test.ts
@@ -13,40 +13,44 @@ interface SearchPayload {
   warnings: string[];
 }
 
-describe("search-product-docs-handler", { tags: [Tag.DOCS] }, () => {
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+describe(
+  "search-product-docs-handler",
+  { tags: [Tag.DOCS, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose search-product-docs in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-      expect(
-        tools.find((t) => t.name === ToolName.SEARCH_PRODUCT_DOCS),
-      ).toBeDefined();
-    });
-
-    // Non-empty results prove ≥1 backend responded and merge/dedupe ran.
-    it("should return hits from at least one backend for a common query", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.SEARCH_PRODUCT_DOCS,
-        arguments: { query: "kafka topic configuration", limit: 5 },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(result.isError, textContent(result)).not.toBe(true);
-      const payload = JSON.parse(textContent(result)) as SearchPayload;
-      expect(payload.results.length).toBeGreaterThan(0);
-      for (const hit of payload.results) {
-        expect(hit.url).toMatch(
-          /^https:\/\/(docs|developer|support)\.confluent\.io\//,
-        );
-      }
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose search-product-docs in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+        expect(
+          tools.find((t) => t.name === ToolName.SEARCH_PRODUCT_DOCS),
+        ).toBeDefined();
+      });
+
+      // Non-empty results prove ≥1 backend responded and merge/dedupe ran.
+      it("should return hits from at least one backend for a common query", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.SEARCH_PRODUCT_DOCS,
+          arguments: { query: "kafka topic configuration", limit: 5 },
+        });
+
+        expect(result.isError, textContent(result)).not.toBe(true);
+        const payload = JSON.parse(textContent(result)) as SearchPayload;
+        expect(payload.results.length).toBeGreaterThan(0);
+        for (const hit of payload.results) {
+          expect(hit.url).toMatch(
+            /^https:\/\/(docs|developer|support)\.confluent\.io\//,
+          );
+        }
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/environments/list-environments-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.integration.test.ts
@@ -26,68 +26,21 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ListEnvironmentsHandler();
 
-describe("list-environments-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
-  // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
-  // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "list-environments-handler",
+  { tags: [Tag.ENVIRONMENTS, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
+    // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-environments in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        expect(
-          tools.find((t) => t.name === ToolName.LIST_ENVIRONMENTS),
-        ).toBeDefined();
-      });
-
-      it("should return at least one environment from CCloud", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_ENVIRONMENTS,
-          arguments: {},
-        });
-        // handler's success line starts with "Successfully retrieved N environments:"
-        expect(textContent(result)).toMatch(
-          /^Successfully retrieved \d+ environments:/,
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+      const directRuntime = integrationRuntime({ oauth: false });
+      if (handler.enabledConnectionIds(directRuntime).length === 0) {
+        it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
@@ -95,11 +48,11 @@ describe("list-environments-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-environments in tools/list", async () => {
@@ -109,9 +62,8 @@ describe("list-environments-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
           ).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return at least one environment from CCloud", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_ENVIRONMENTS,
             arguments: {},
           });
@@ -121,6 +73,58 @@ describe("list-environments-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
           );
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-environments in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            expect(
+              tools.find((t) => t.name === ToolName.LIST_ENVIRONMENTS),
+            ).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return at least one environment from CCloud", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_ENVIRONMENTS,
+              arguments: {},
+            });
+            // handler's success line starts with "Successfully retrieved N environments:"
+            expect(textContent(result)).toMatch(
+              /^Successfully retrieved \d+ environments:/,
+            );
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/environments/read-environment-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.integration.test.ts
@@ -28,89 +28,34 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ReadEnvironmentHandler();
 
-describe("read-environment-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
-  // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
-  // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "read-environment-handler",
+  { tags: [Tag.ENVIRONMENTS, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
+    // `confluent_cloud` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-    const environmentId = getTestEnvironmentId();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose read-environment in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        expect(
-          tools.find((t) => t.name === ToolName.READ_ENVIRONMENT),
-        ).toBeDefined();
-      });
-
-      it("should return details for the resolved environment id", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.READ_ENVIRONMENT,
-          arguments: { environmentId },
-        });
-
-        expect(textContent(result)).toContain(`ID: ${environmentId}`);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `getTestEnvironmentId()` reads `kafka.env_id` out of the direct YAML; gate the OAuth
-      // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
-      // direct creds skips cleanly instead of crashing on missing fixture
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
-      // env id is read from the direct YAML; the OAuth-mode handler itself talks to CCloud via OAuth
       const environmentId = getTestEnvironmentId();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose read-environment in tools/list", async () => {
@@ -120,9 +65,8 @@ describe("read-environment-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
           ).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return details for the resolved environment id", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.READ_ENVIRONMENT,
             arguments: { environmentId },
           });
@@ -130,6 +74,66 @@ describe("read-environment-handler", { tags: [Tag.ENVIRONMENTS] }, () => {
           expect(textContent(result)).toContain(`ID: ${environmentId}`);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `getTestEnvironmentId()` reads `kafka.env_id` out of the direct YAML; gate the OAuth
+        // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
+        // direct creds skips cleanly instead of crashing on missing fixture
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+        // env id is read from the direct YAML; the OAuth-mode handler itself talks to CCloud via OAuth
+        const environmentId = getTestEnvironmentId();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose read-environment in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            expect(
+              tools.find((t) => t.name === ToolName.READ_ENVIRONMENT),
+            ).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return details for the resolved environment id", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.READ_ENVIRONMENT,
+              arguments: { environmentId },
+            });
+
+            expect(textContent(result)).toContain(`ID: ${environmentId}`);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
@@ -23,94 +23,104 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new DescribeTableHandler();
 const runtime = integrationRuntime();
 
-describe("describe-table-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "describe-table-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // also provisions a kafka topic and addresses it by cluster id, so gate
-  // explicitly on the kafka fields the flink predicate doesn't cover
-  const conn = runtime.config.getSoleDirectConnection();
-  if (
-    !conn.kafka?.bootstrap_servers ||
-    !conn.kafka.auth ||
-    !conn.kafka.cluster_id
-  ) {
-    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id config", () => {});
-    return;
-  }
+    // also provisions a kafka topic and addresses it by cluster id, so gate
+    // explicitly on the kafka fields the flink predicate doesn't cover
+    const conn = runtime.config.getSoleDirectConnection();
+    if (
+      !conn.kafka?.bootstrap_servers ||
+      !conn.kafka.auth ||
+      !conn.kafka.cluster_id
+    ) {
+      it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id config", () => {});
+      return;
+    }
 
-  // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
-  const { admin, createdTopics } = withSharedAdminClient();
-  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated.
-  // expect.poll() retries grow the array with every attempt (all leaks land
-  // in the sweep, not just the final one).
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const tableName = uniqueName("flink-tbl");
-
-  beforeAll(async () => {
-    createdTopics.push(tableName);
-    await admin().createTopics({
-      topics: [{ topic: tableName, numPartitions: 1 }],
-    });
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
+    const { admin, createdTopics } = withSharedAdminClient();
+    // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated.
+    // expect.poll() retries grow the array with every attempt (all leaks land
+    // in the sweep, not just the final one).
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const tableName = uniqueName("flink-tbl");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose describe-flink-table in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.DESCRIBE_FLINK_TABLE),
-      ).toBeDefined();
-    });
-
-    it("should return the schema for the seeded kafka-backed table", async () => {
-      // catalog SQL filter uses TABLE_SCHEMA (friendly name), not the lkc-* id, so we need to
-      // resolve the friendly name via list-databases
-      const dbResult = await server.client.callTool({
-        name: ToolName.LIST_FLINK_DATABASES,
-        arguments: {},
+      createdTopics.push(tableName);
+      await admin().createTopics({
+        topics: [{ topic: tableName, numPartitions: 1 }],
       });
-      trackStatementsFromMeta(dbResult, createdStatements);
-      expect(
-        dbResult.isError,
-        `list-databases failed: ${textContent(dbResult)}`,
-      ).not.toBe(true);
-      const databaseName = findFriendlySchemaName(
-        textContent(dbResult),
-        getTestClusterId(),
-      );
-      expect(
-        databaseName,
-        `kafka cluster ${getTestClusterId()} not catalogued in Flink workspace. Verify flink.compute_pool_id is in the same region/provider as the kafka cluster (see test-fixtures/yaml_configs/integration.yaml).`,
-      ).toBeDefined();
+    });
 
-      // CCloud may take a while to auto-discover kafka topics as Flink tables
-      await expect
-        .poll(
-          async () => {
-            const result = await server.client.callTool({
-              name: ToolName.DESCRIBE_FLINK_TABLE,
-              arguments: { tableName, databaseName },
-            });
-            trackStatementsFromMeta(result, createdStatements);
-            if (result.isError === true) throw new Error(textContent(result));
-            return textContent(result);
-          },
-          { timeout: 90_000, interval: 5_000 },
-        )
-        .toContain(`Table '${tableName}' schema:`);
-    }, 120_000);
-  });
-});
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
+
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
+
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose describe-flink-table in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.DESCRIBE_FLINK_TABLE),
+        ).toBeDefined();
+      });
+
+      it("should return the schema for the seeded kafka-backed table", async () => {
+        // catalog SQL filter uses TABLE_SCHEMA (friendly name), not the lkc-* id, so we need to
+        // resolve the friendly name via list-databases
+        const dbResult = await server.client.callTool({
+          name: ToolName.LIST_FLINK_DATABASES,
+          arguments: {},
+        });
+        trackStatementsFromMeta(dbResult, createdStatements);
+        expect(
+          dbResult.isError,
+          `list-databases failed: ${textContent(dbResult)}`,
+        ).not.toBe(true);
+        const databaseName = findFriendlySchemaName(
+          textContent(dbResult),
+          getTestClusterId(),
+        );
+        expect(
+          databaseName,
+          `kafka cluster ${getTestClusterId()} not catalogued in Flink workspace. Verify flink.compute_pool_id is in the same region/provider as the kafka cluster (see test-fixtures/yaml_configs/integration.yaml).`,
+        ).toBeDefined();
+
+        // CCloud may take a while to auto-discover kafka topics as Flink tables
+        await expect
+          .poll(
+            async () => {
+              const result = await server.client.callTool({
+                name: ToolName.DESCRIBE_FLINK_TABLE,
+                arguments: { tableName, databaseName },
+              });
+              trackStatementsFromMeta(result, createdStatements);
+              if (result.isError === true) throw new Error(textContent(result));
+              return textContent(result);
+            },
+            { timeout: 90_000, interval: 5_000 },
+          )
+          .toContain(`Table '${tableName}' schema:`);
+      }, 120_000);
+    });
+  },
+);

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
@@ -23,94 +23,104 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new GetTableInfoHandler();
 const runtime = integrationRuntime();
 
-describe("get-table-info-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "get-table-info-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // also provisions a kafka topic and addresses it by cluster id, so gate
-  // explicitly on the kafka fields the flink predicate doesn't cover
-  const conn = runtime.config.getSoleDirectConnection();
-  if (
-    !conn.kafka?.bootstrap_servers ||
-    !conn.kafka.auth ||
-    !conn.kafka.cluster_id
-  ) {
-    it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id config", () => {});
-    return;
-  }
+    // also provisions a kafka topic and addresses it by cluster id, so gate
+    // explicitly on the kafka fields the flink predicate doesn't cover
+    const conn = runtime.config.getSoleDirectConnection();
+    if (
+      !conn.kafka?.bootstrap_servers ||
+      !conn.kafka.auth ||
+      !conn.kafka.cluster_id
+    ) {
+      it.skip("requires kafka.bootstrap_servers + kafka.auth + kafka.cluster_id config", () => {});
+      return;
+    }
 
-  // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
-  const { admin, createdTopics } = withSharedAdminClient();
-  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated.
-  // expect.poll() retries grow the array with every attempt (all leaks land
-  // in the sweep, not just the final one).
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const tableName = uniqueName("flink-tbl");
-
-  beforeAll(async () => {
-    createdTopics.push(tableName);
-    await admin().createTopics({
-      topics: [{ topic: tableName, numPartitions: 1 }],
-    });
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs beforeAll/afterAll at this describe scope (admin client + topic cleanup)
+    const { admin, createdTopics } = withSharedAdminClient();
+    // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated.
+    // expect.poll() retries grow the array with every attempt (all leaks land
+    // in the sweep, not just the final one).
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const tableName = uniqueName("flink-tbl");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose get-flink-table-info in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.GET_FLINK_TABLE_INFO),
-      ).toBeDefined();
-    });
-
-    it("should return metadata for the seeded kafka-backed table", async () => {
-      // catalog SQL filter uses TABLE_SCHEMA (friendly name), not the lkc-* id, so we need to
-      // resolve the friendly name via list-databases
-      const dbResult = await server.client.callTool({
-        name: ToolName.LIST_FLINK_DATABASES,
-        arguments: {},
+      createdTopics.push(tableName);
+      await admin().createTopics({
+        topics: [{ topic: tableName, numPartitions: 1 }],
       });
-      trackStatementsFromMeta(dbResult, createdStatements);
-      expect(
-        dbResult.isError,
-        `list-databases failed: ${textContent(dbResult)}`,
-      ).not.toBe(true);
-      const databaseName = findFriendlySchemaName(
-        textContent(dbResult),
-        getTestClusterId(),
-      );
-      expect(
-        databaseName,
-        `kafka cluster ${getTestClusterId()} not catalogued in Flink workspace. Verify flink.compute_pool_id is in the same region/provider as the kafka cluster (see test-fixtures/yaml_configs/integration.yaml).`,
-      ).toBeDefined();
+    });
 
-      // CCloud may take a while to auto-discover kafka topics as Flink tables
-      await expect
-        .poll(
-          async () => {
-            const result = await server.client.callTool({
-              name: ToolName.GET_FLINK_TABLE_INFO,
-              arguments: { tableName, databaseName },
-            });
-            trackStatementsFromMeta(result, createdStatements);
-            if (result.isError === true) throw new Error(textContent(result));
-            return textContent(result);
-          },
-          { timeout: 90_000, interval: 5_000 },
-        )
-        .toContain(`Table info for '${tableName}':`);
-    }, 120_000);
-  });
-});
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
+
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
+
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose get-flink-table-info in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.GET_FLINK_TABLE_INFO),
+        ).toBeDefined();
+      });
+
+      it("should return metadata for the seeded kafka-backed table", async () => {
+        // catalog SQL filter uses TABLE_SCHEMA (friendly name), not the lkc-* id, so we need to
+        // resolve the friendly name via list-databases
+        const dbResult = await server.client.callTool({
+          name: ToolName.LIST_FLINK_DATABASES,
+          arguments: {},
+        });
+        trackStatementsFromMeta(dbResult, createdStatements);
+        expect(
+          dbResult.isError,
+          `list-databases failed: ${textContent(dbResult)}`,
+        ).not.toBe(true);
+        const databaseName = findFriendlySchemaName(
+          textContent(dbResult),
+          getTestClusterId(),
+        );
+        expect(
+          databaseName,
+          `kafka cluster ${getTestClusterId()} not catalogued in Flink workspace. Verify flink.compute_pool_id is in the same region/provider as the kafka cluster (see test-fixtures/yaml_configs/integration.yaml).`,
+        ).toBeDefined();
+
+        // CCloud may take a while to auto-discover kafka topics as Flink tables
+        await expect
+          .poll(
+            async () => {
+              const result = await server.client.callTool({
+                name: ToolName.GET_FLINK_TABLE_INFO,
+                arguments: { tableName, databaseName },
+              });
+              trackStatementsFromMeta(result, createdStatements);
+              if (result.isError === true) throw new Error(textContent(result));
+              return textContent(result);
+            },
+            { timeout: 90_000, interval: 5_000 },
+          )
+          .toContain(`Table info for '${tableName}':`);
+      }, 120_000);
+    });
+  },
+);

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.integration.test.ts
@@ -17,42 +17,52 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListCatalogsHandler();
 const runtime = integrationRuntime();
 
-describe("list-catalogs-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "list-catalogs-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
-  const { createdStatements } = withSharedFlinkStatementCleanup();
+    // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
+    const { createdStatements } = withSharedFlinkStatementCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-flink-catalogs in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_FLINK_CATALOGS),
-      ).toBeDefined();
-    });
-
-    it("should return at least the configured environment as a catalog", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_FLINK_CATALOGS,
-        arguments: {},
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
-      trackStatementsFromMeta(result, createdStatements);
 
-      expect(textContent(result)).toMatch(/^Catalogs:/);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-flink-catalogs in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_FLINK_CATALOGS),
+        ).toBeDefined();
+      });
+
+      it("should return at least the configured environment as a catalog", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_FLINK_CATALOGS,
+          arguments: {},
+        });
+        trackStatementsFromMeta(result, createdStatements);
+
+        expect(textContent(result)).toMatch(/^Catalogs:/);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.integration.test.ts
@@ -17,43 +17,53 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListDatabasesHandler();
 const runtime = integrationRuntime();
 
-describe("list-databases-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "list-databases-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
-  const { createdStatements } = withSharedFlinkStatementCleanup();
+    // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
+    const { createdStatements } = withSharedFlinkStatementCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-flink-databases in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_FLINK_DATABASES),
-      ).toBeDefined();
-    });
-
-    it("should return databases for the configured catalog", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_FLINK_DATABASES,
-        arguments: {},
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
-      trackStatementsFromMeta(result, createdStatements);
 
-      // fresh test account may have no databases; either response shape is valid
-      expect(textContent(result)).toMatch(/^(Databases:|No databases found)/);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-flink-databases in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_FLINK_DATABASES),
+        ).toBeDefined();
+      });
+
+      it("should return databases for the configured catalog", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_FLINK_DATABASES,
+          arguments: {},
+        });
+        trackStatementsFromMeta(result, createdStatements);
+
+        // fresh test account may have no databases; either response shape is valid
+        expect(textContent(result)).toMatch(/^(Databases:|No databases found)/);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.integration.test.ts
@@ -17,45 +17,55 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListTablesHandler();
 const runtime = integrationRuntime();
 
-describe("list-tables-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "list-tables-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
-  const { createdStatements } = withSharedFlinkStatementCleanup();
+    // sweeps mcp-query-* statements surfaced via _meta.flinkStatementsCreated
+    const { createdStatements } = withSharedFlinkStatementCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-flink-tables in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_FLINK_TABLES),
-      ).toBeDefined();
-    });
-
-    it("should return tables (or the empty-set string) for the configured catalog", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_FLINK_TABLES,
-        arguments: {},
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
-      trackStatementsFromMeta(result, createdStatements);
 
-      // handler filters out INFORMATION_SCHEMA; a fresh env may have no user tables
-      expect(textContent(result)).toMatch(
-        /^(Tables in catalog|No tables found)/,
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-flink-tables in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_FLINK_TABLES),
+        ).toBeDefined();
+      });
+
+      it("should return tables (or the empty-set string) for the configured catalog", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_FLINK_TABLES,
+          arguments: {},
+        });
+        trackStatementsFromMeta(result, createdStatements);
+
+        // handler filters out INFORMATION_SCHEMA; a fresh env may have no user tables
+        expect(textContent(result)).toMatch(
+          /^(Tables in catalog|No tables found)/,
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.integration.test.ts
@@ -15,48 +15,58 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new CreateFlinkStatementHandler();
 const runtime = integrationRuntime();
 
-describe("create-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "create-flink-statement-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (sweeps tool-created statements)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
+    // installs afterAll at this describe scope (sweeps tool-created statements)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose create-flink-statement in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.CREATE_FLINK_STATEMENT),
-      ).toBeDefined();
-    });
-
-    it("should create a SELECT 1 statement", async () => {
-      const statementName = uniqueName("create-stmt");
-      createdStatements.push(statementName);
-
-      const result = await server.client.callTool({
-        name: ToolName.CREATE_FLINK_STATEMENT,
-        arguments: {
-          statementName,
-          statement: "SELECT 1;",
-        },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      // just check for the name since the handler returns the stringified JSON response
-      expect(textContent(result)).toContain(`"name":"${statementName}"`);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose create-flink-statement in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.CREATE_FLINK_STATEMENT),
+        ).toBeDefined();
+      });
+
+      it("should create a SELECT 1 statement", async () => {
+        const statementName = uniqueName("create-stmt");
+        createdStatements.push(statementName);
+
+        const result = await server.client.callTool({
+          name: ToolName.CREATE_FLINK_STATEMENT,
+          arguments: {
+            statementName,
+            statement: "SELECT 1;",
+          },
+        });
+
+        // just check for the name since the handler returns the stringified JSON response
+        expect(textContent(result)).toContain(`"name":"${statementName}"`);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.integration.test.ts
@@ -18,48 +18,58 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new DeleteFlinkStatementHandler();
 const runtime = integrationRuntime();
 
-describe("delete-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "delete-flink-statement-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (sweeps any leftover tracked statements)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
+    // installs afterAll at this describe scope (sweeps any leftover tracked statements)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose delete-flink-statements in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.DELETE_FLINK_STATEMENTS),
-      ).toBeDefined();
-    });
-
-    it("should delete a test-side provisioned statement", async () => {
-      const statementName = uniqueName("delete-stmt");
-      // track first so a failure mid-create still gets swept by afterAll
-      createdStatements.push(statementName);
-      await provisionTestFlinkStatement(statementName);
-
-      const result = await server.client.callTool({
-        name: ToolName.DELETE_FLINK_STATEMENTS,
-        arguments: { statementName },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toMatch(
-        /^Flink SQL Statement Deletion Status Code:/,
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose delete-flink-statements in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.DELETE_FLINK_STATEMENTS),
+        ).toBeDefined();
+      });
+
+      it("should delete a test-side provisioned statement", async () => {
+        const statementName = uniqueName("delete-stmt");
+        // track first so a failure mid-create still gets swept by afterAll
+        createdStatements.push(statementName);
+        await provisionTestFlinkStatement(statementName);
+
+        const result = await server.client.callTool({
+          name: ToolName.DELETE_FLINK_STATEMENTS,
+          arguments: { statementName },
+        });
+
+        expect(textContent(result)).toMatch(
+          /^Flink SQL Statement Deletion Status Code:/,
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.integration.test.ts
@@ -18,49 +18,59 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new CheckHealthHandler();
 const runtime = integrationRuntime();
 
-describe("check-health-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "check-health-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (cleans up the seeded statement)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const statementName = uniqueName("health-stmt");
-
-  beforeAll(async () => {
-    await provisionTestFlinkStatement(statementName);
-    createdStatements.push(statementName);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs afterAll at this describe scope (cleans up the seeded statement)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const statementName = uniqueName("health-stmt");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      await provisionTestFlinkStatement(statementName);
+      createdStatements.push(statementName);
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose check-flink-statement-health in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.CHECK_FLINK_STATEMENT_HEALTH),
-      ).toBeDefined();
-    });
-
-    it("should return a health report for the seeded statement", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.CHECK_FLINK_STATEMENT_HEALTH,
-        arguments: { statementName },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toMatch(
-        new RegExp(`^Health check for '${statementName}':`),
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose check-flink-statement-health in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.CHECK_FLINK_STATEMENT_HEALTH),
+        ).toBeDefined();
+      });
+
+      it("should return a health report for the seeded statement", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.CHECK_FLINK_STATEMENT_HEALTH,
+          arguments: { statementName },
+        });
+
+        expect(textContent(result)).toMatch(
+          new RegExp(`^Health check for '${statementName}':`),
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.integration.test.ts
@@ -18,53 +18,63 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new DetectIssuesHandler();
 const runtime = integrationRuntime();
 
-describe("detect-issues-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "detect-issues-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (cleans up the seeded statement)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const statementName = uniqueName("issues-stmt");
-
-  beforeAll(async () => {
-    await provisionTestFlinkStatement(statementName);
-    createdStatements.push(statementName);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs afterAll at this describe scope (cleans up the seeded statement)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const statementName = uniqueName("issues-stmt");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      await provisionTestFlinkStatement(statementName);
+      createdStatements.push(statementName);
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose detect-flink-statement-issues in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.DETECT_FLINK_STATEMENT_ISSUES),
-      ).toBeDefined();
-    });
-
-    it("should return an issue report for the seeded statement", async () => {
-      // includeMetrics: false skips the Telemetry roundtrip
-      const result = await server.client.callTool({
-        name: ToolName.DETECT_FLINK_STATEMENT_ISSUES,
-        arguments: { statementName, includeMetrics: false },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      // SELECT 1 typically reports no issues; accept either response prefix.
-      expect(textContent(result)).toMatch(
-        new RegExp(
-          `(No issues detected|Detected \\d+ issue).*'${statementName}'`,
-        ),
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose detect-flink-statement-issues in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.DETECT_FLINK_STATEMENT_ISSUES),
+        ).toBeDefined();
+      });
+
+      it("should return an issue report for the seeded statement", async () => {
+        // includeMetrics: false skips the Telemetry roundtrip
+        const result = await server.client.callTool({
+          name: ToolName.DETECT_FLINK_STATEMENT_ISSUES,
+          arguments: { statementName, includeMetrics: false },
+        });
+
+        // SELECT 1 typically reports no issues; accept either response prefix.
+        expect(textContent(result)).toMatch(
+          new RegExp(
+            `(No issues detected|Detected \\d+ issue).*'${statementName}'`,
+          ),
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.integration.test.ts
@@ -19,54 +19,64 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new QueryProfilerHandler();
 const runtime = integrationRuntime();
 
-describe("query-profiler-handler", { tags: [Tag.FLINK] }, () => {
-  // composes hasFlink + hasTelemetry, stricter than the rest of the flink suite
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink + telemetry config", () => {});
-    return;
-  }
+describe(
+  "query-profiler-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    // composes hasFlink + hasTelemetry, stricter than the rest of the flink suite
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink + telemetry config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (cleans up the seeded statement)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const statementName = uniqueName("profile-stmt");
-
-  beforeAll(async () => {
-    await provisionTestFlinkStatement(statementName);
-    createdStatements.push(statementName);
-    // profiler needs the task graph, which materializes once the statement leaves PENDING.
-    // SELECT 1 is bounded and can blow through RUNNING into COMPLETED between polls, so accept
-    // both - either state means the task graph exists.
-    await waitForFlinkStatementPhase(statementName, ["RUNNING", "COMPLETED"]);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs afterAll at this describe scope (cleans up the seeded statement)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const statementName = uniqueName("profile-stmt");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      await provisionTestFlinkStatement(statementName);
+      createdStatements.push(statementName);
+      // profiler needs the task graph, which materializes once the statement leaves PENDING.
+      // SELECT 1 is bounded and can blow through RUNNING into COMPLETED between polls, so accept
+      // both - either state means the task graph exists.
+      await waitForFlinkStatementPhase(statementName, ["RUNNING", "COMPLETED"]);
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose get-flink-statement-profile in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.GET_FLINK_STATEMENT_PROFILE),
-      ).toBeDefined();
-    });
-
-    it("should return a profiler report for the seeded statement", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.GET_FLINK_STATEMENT_PROFILE,
-        arguments: { statementName, includeAnalysis: false },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(textContent(result)).toMatch(
-        new RegExp(`^Query Profiler for '${statementName}':`),
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose get-flink-statement-profile in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.GET_FLINK_STATEMENT_PROFILE),
+        ).toBeDefined();
+      });
+
+      it("should return a profiler report for the seeded statement", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.GET_FLINK_STATEMENT_PROFILE,
+          arguments: { statementName, includeAnalysis: false },
+        });
+
+        expect(textContent(result)).toMatch(
+          new RegExp(`^Query Profiler for '${statementName}':`),
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.integration.test.ts
@@ -18,50 +18,60 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new GetFlinkExceptionsHandler();
 const runtime = integrationRuntime();
 
-describe("get-flink-exceptions-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "get-flink-exceptions-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (cleans up the seeded statement)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const statementName = uniqueName("exc-stmt");
-
-  beforeAll(async () => {
-    await provisionTestFlinkStatement(statementName);
-    createdStatements.push(statementName);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs afterAll at this describe scope (cleans up the seeded statement)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const statementName = uniqueName("exc-stmt");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      await provisionTestFlinkStatement(statementName);
+      createdStatements.push(statementName);
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose get-flink-statement-exceptions in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.GET_FLINK_STATEMENT_EXCEPTIONS),
-      ).toBeDefined();
-    });
-
-    it("should return either an empty or populated exceptions response", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.GET_FLINK_STATEMENT_EXCEPTIONS,
-        arguments: { statementName },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      // SELECT 1 typically completes cleanly, so accept either response shape
-      expect(textContent(result)).toMatch(
-        /^(No exceptions found|Flink Statement Exceptions)/,
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose get-flink-statement-exceptions in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.GET_FLINK_STATEMENT_EXCEPTIONS),
+        ).toBeDefined();
+      });
+
+      it("should return either an empty or populated exceptions response", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.GET_FLINK_STATEMENT_EXCEPTIONS,
+          arguments: { statementName },
+        });
+
+        // SELECT 1 typically completes cleanly, so accept either response shape
+        expect(textContent(result)).toMatch(
+          /^(No exceptions found|Flink Statement Exceptions)/,
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts
@@ -18,77 +18,87 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListFlinkStatementsHandler();
 const runtime = integrationRuntime();
 
-describe("list-flink-statements-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "list-flink-statements-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (tracks the seed statement for delete)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const seedName = uniqueName("list-stmts");
-
-  beforeAll(async () => {
-    await provisionTestFlinkStatement(seedName);
-    createdStatements.push(seedName);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs afterAll at this describe scope (tracks the seed statement for delete)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const seedName = uniqueName("list-stmts");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      await provisionTestFlinkStatement(seedName);
+      createdStatements.push(seedName);
     });
 
-    afterAll(async () => {
-      await server?.stop();
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
+
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
+
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-flink-statements in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_FLINK_STATEMENTS),
+        ).toBeDefined();
+      });
+
+      it("should return a JSON payload that includes the seeded statement", async () => {
+        // Pagination guard: the test account is shared, so accumulated state (e.g. `mcp-query-*`
+        // from catalog handler leaks) can push the seed off the first page of 100. Walk pages until
+        // we find it, with a cap.
+        const MAX_PAGES = 20;
+        let pageToken: string | undefined;
+        let pagesChecked = 0;
+        let found = false;
+        let totalSeen = 0;
+
+        do {
+          const result = await server.client.callTool({
+            name: ToolName.LIST_FLINK_STATEMENTS,
+            arguments: pageToken ? { pageToken } : {},
+          });
+          const text = textContent(result);
+          const body = JSON.parse(text) as {
+            data?: Array<{ name: string }>;
+            metadata?: { next?: string };
+          };
+          const names = body.data?.map((s) => s.name) ?? [];
+          totalSeen += names.length;
+          if (names.includes(seedName)) {
+            found = true;
+            break;
+          }
+          pageToken = extractPageToken(body.metadata?.next);
+          pagesChecked++;
+        } while (pageToken && pagesChecked < MAX_PAGES);
+
+        expect(
+          found,
+          `seed statement ${seedName} not found after scanning ${totalSeen} statement(s) across ${pagesChecked} page(s). Check to make sure statements are not piling up in the test environment.`,
+        ).toBe(true);
+      });
     });
-
-    it("should expose list-flink-statements in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_FLINK_STATEMENTS),
-      ).toBeDefined();
-    });
-
-    it("should return a JSON payload that includes the seeded statement", async () => {
-      // Pagination guard: the test account is shared, so accumulated state (e.g. `mcp-query-*`
-      // from catalog handler leaks) can push the seed off the first page of 100. Walk pages until
-      // we find it, with a cap.
-      const MAX_PAGES = 20;
-      let pageToken: string | undefined;
-      let pagesChecked = 0;
-      let found = false;
-      let totalSeen = 0;
-
-      do {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_FLINK_STATEMENTS,
-          arguments: pageToken ? { pageToken } : {},
-        });
-        const text = textContent(result);
-        const body = JSON.parse(text) as {
-          data?: Array<{ name: string }>;
-          metadata?: { next?: string };
-        };
-        const names = body.data?.map((s) => s.name) ?? [];
-        totalSeen += names.length;
-        if (names.includes(seedName)) {
-          found = true;
-          break;
-        }
-        pageToken = extractPageToken(body.metadata?.next);
-        pagesChecked++;
-      } while (pageToken && pagesChecked < MAX_PAGES);
-
-      expect(
-        found,
-        `seed statement ${seedName} not found after scanning ${totalSeen} statement(s) across ${pagesChecked} page(s). Check to make sure statements are not piling up in the test environment.`,
-      ).toBe(true);
-    });
-  });
-});
+  },
+);
 
 /**
  * Extracts the `page_token` from a CCloud `metadata.next` value, falling back

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.integration.test.ts
@@ -18,55 +18,65 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ReadFlinkStatementHandler();
 const runtime = integrationRuntime();
 
-describe("read-flink-statement-handler", { tags: [Tag.FLINK] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires flink config", () => {});
-    return;
-  }
+describe(
+  "read-flink-statement-handler",
+  {
+    tags: [
+      Tag.FLINK,
+      Tag.REQUIRES_FLINK_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires flink config", () => {});
+      return;
+    }
 
-  // installs afterAll at this describe scope (cleans up the seeded statement)
-  const { createdStatements } = withSharedFlinkStatementCleanup();
-  const statementName = uniqueName("read-stmt");
-
-  beforeAll(async () => {
-    await provisionTestFlinkStatement(statementName);
-    createdStatements.push(statementName);
-  });
-
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    // installs afterAll at this describe scope (cleans up the seeded statement)
+    const { createdStatements } = withSharedFlinkStatementCleanup();
+    const statementName = uniqueName("read-stmt");
 
     beforeAll(async () => {
-      server = await startServer({ transport });
+      await provisionTestFlinkStatement(statementName);
+      createdStatements.push(statementName);
     });
 
-    afterAll(async () => {
-      await server?.stop();
-    });
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    it("should expose read-flink-statement in tools/list", async () => {
-      const { tools } = await server.client.listTools();
+      beforeAll(async () => {
+        server = await startServer({ transport });
+      });
 
-      expect(
-        tools.find((t) => t.name === ToolName.READ_FLINK_STATEMENT),
-      ).toBeDefined();
-    });
+      afterAll(async () => {
+        await server?.stop();
+      });
 
-    it("should read the seeded statement and return a results header", async () => {
-      // CCloud briefly returns 409 "Results not ready" between statement creation time and the time
-      // results are available
-      await expect
-        .poll(
-          async () => {
-            const result = await server.client.callTool({
-              name: ToolName.READ_FLINK_STATEMENT,
-              arguments: { statementName, timeoutInMilliseconds: 5000 },
-            });
-            return textContent(result);
-          },
-          { timeout: 30_000, interval: 2_000 },
-        )
-        .toMatch(/^Flink SQL Statement Results:/);
+      it("should expose read-flink-statement in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.READ_FLINK_STATEMENT),
+        ).toBeDefined();
+      });
+
+      it("should read the seeded statement and return a results header", async () => {
+        // CCloud briefly returns 409 "Results not ready" between statement creation time and the time
+        // results are available
+        await expect
+          .poll(
+            async () => {
+              const result = await server.client.callTool({
+                name: ToolName.READ_FLINK_STATEMENT,
+                arguments: { statementName, timeoutInMilliseconds: 5000 },
+              });
+              return textContent(result);
+            },
+            { timeout: 30_000, interval: 2_000 },
+          )
+          .toMatch(/^Flink SQL Statement Results:/);
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
@@ -33,121 +33,48 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new AlterTopicConfigHandler();
 
-describe("alter-topic-config", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaRestWithAuthOrOAuth` predicate accepts either a direct
-  // `kafka.rest_endpoint + kafka.auth` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "alter-topic-config",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaRestWithAuthOrOAuth` predicate accepts either a direct
+    // `kafka.rest_endpoint + kafka.auth` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.rest_endpoint + kafka.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    const clusterId = getTestClusterId();
-    // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
-    const { admin, createdTopics } = withSharedAdminClient();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should alter retention.ms on the test topic via the REST proxy", async () => {
-        const topic = uniqueName(`alter-${transport}`);
-        createdTopics.push(topic);
-        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
-
-        const result = await server.client.callTool({
-          name: ToolName.ALTER_TOPIC_CONFIG,
-          arguments: {
-            clusterId,
-            topicName: topic,
-            topicConfigs: [
-              {
-                name: "retention.ms",
-                value: "3600000",
-                operation: "SET",
-              },
-            ],
-            validateOnly: false,
-          },
-        });
-
-        expect(textContent(result)).toMatch(
-          /Successfully altered topic config/,
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `getTestClusterId()`/`withSharedAdminClient()` read api-key kafka config from the direct
-      // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
-      // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.rest_endpoint + kafka.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // REST-tool handler resolves the cluster URL from `clusterId` + `environmentId` at call
-      // time under OAuth (no `kafka.rest_endpoint` in OAuth connections); the handler errors
-      // when either is omitted
       const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-      // seed via the api-key-authed admin client; ALTER_TOPIC_CONFIG goes via OAuth
+      // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
       const { admin, createdTopics } = withSharedAdminClient();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should alter retention.ms on the test topic via the REST proxy", async () => {
-          const topic = uniqueName(`alter-oauth-${transport}`);
+          const topic = uniqueName(`alter-${transport}`);
           createdTopics.push(topic);
           await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
 
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.ALTER_TOPIC_CONFIG,
             arguments: {
               clusterId,
-              environmentId,
               topicName: topic,
               topicConfigs: [
                 {
@@ -165,6 +92,85 @@ describe("alter-topic-config", { tags: [Tag.KAFKA] }, () => {
           );
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `getTestClusterId()`/`withSharedAdminClient()` read api-key kafka config from the direct
+        // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
+        // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // REST-tool handler resolves the cluster URL from `clusterId` + `environmentId` at call
+        // time under OAuth (no `kafka.rest_endpoint` in OAuth connections); the handler errors
+        // when either is omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+        // seed via the api-key-authed admin client; ALTER_TOPIC_CONFIG goes via OAuth
+        const { admin, createdTopics } = withSharedAdminClient();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should alter retention.ms on the test topic via the REST proxy", async () => {
+            const topic = uniqueName(`alter-oauth-${transport}`);
+            createdTopics.push(topic);
+            await admin().createTopics({
+              topics: [{ topic, numPartitions: 1 }],
+            });
+
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.ALTER_TOPIC_CONFIG,
+              arguments: {
+                clusterId,
+                environmentId,
+                topicName: topic,
+                topicConfigs: [
+                  {
+                    name: "retention.ms",
+                    value: "3600000",
+                    operation: "SET",
+                  },
+                ],
+                validateOnly: false,
+              },
+            });
+
+            expect(textContent(result)).toMatch(
+              /Successfully altered topic config/,
+            );
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -35,363 +35,32 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ConsumeKafkaMessagesHandler();
 
-describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
-  //
-  // The OAuth describe only exercises the basic consume flow — the per-feature variants
-  // (partition pinning, offset seeking, timestamp seeking, mixed-direction) live in the direct
-  // describe since they exercise consumer-driver behavior that doesn't change between auth modes.
+describe(
+  "consume-kafka-messages-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
+    //
+    // The OAuth describe only exercises the basic consume flow — the per-feature variants
+    // (partition pinning, offset seeking, timestamp seeking, mixed-direction) live in the direct
+    // describe since they exercise consumer-driver behavior that doesn't change between auth modes.
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // seed a shared test topic with messages (no need to split by transport)
-    let admin: KafkaJS.Admin;
-    let producer: KafkaJS.Producer;
-    const topic = uniqueName("consume");
-    const seededValues = ["msg-0", "msg-1", "msg-2"];
-
-    beforeAll(async () => {
-      admin = await connectTestAdmin();
-      await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
-      producer = await connectTestProducer();
-      await producer.send({
-        topic,
-        messages: seededValues.map((value) => ({ value })),
-      });
-    });
-
-    afterAll(async () => {
-      await producer.disconnect().catch(() => {
-        // disconnect race during teardown isn't actionable
-      });
-      await admin.deleteTopics({ topics: [topic] }).catch(() => {
-        // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-      });
-      await admin.disconnect().catch(() => {
-        // disconnect race during teardown isn't actionable
-      });
-    });
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should consume the seeded messages from the topic", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.CONSUME_MESSAGES,
-          arguments: {
-            topics: [{ name: topic }],
-            maxMessages: seededValues.length,
-            timeoutMs: 15_000,
-            valueFormat: { disableSchemaRegistry: true },
-          },
-        });
-
-        const text = textContent(result);
-        expect(text).toMatch(/^Consumed \d+ messages/);
-        for (const value of seededValues) {
-          expect(text).toContain(value);
-        }
-      });
-
-      it("should restrict consumption to one partition when `partition` is set on the topic entry", async () => {
-        // Seed a 3-partition topic with three records on the keep
-        // partition and one record each on the suppressed partitions,
-        // then ask for partition 0 only. `maxMessages: 3` lets the call
-        // exit as soon as the three p0 records land instead of waiting
-        // out the `timeoutMs` floor, but it also forces the handler to
-        // stay alive long enough that a leaked p1/p2 record from a
-        // broken pause has a high probability of landing in the
-        // response (librdkafka round-robins across partitions, so 3
-        // consecutive p0 deliveries before any p1/p2 is unlikely).
-        // Asserts: every p0 record appears AND neither suppressed
-        // partition's record does — proving the pause step suppressed
-        // the non-keep partitions end-to-end against librdkafka, not
-        // just against mocks.
-        const multiTopic = uniqueName("consume-part");
-        await admin.createTopics({
-          topics: [{ topic: multiTopic, numPartitions: 3 }],
-        });
-        try {
-          await producer.send({
-            topic: multiTopic,
-            messages: [
-              { partition: 0, value: "p0-msg-a" },
-              { partition: 0, value: "p0-msg-b" },
-              { partition: 0, value: "p0-msg-c" },
-              { partition: 1, value: "p1-msg" },
-              { partition: 2, value: "p2-msg" },
-            ],
-          });
-
-          const result = await server.client.callTool({
-            name: ToolName.CONSUME_MESSAGES,
-            arguments: {
-              topics: [{ name: multiTopic, partition: 0, start: "earliest" }],
-              maxMessages: 3,
-              timeoutMs: 15_000,
-              valueFormat: { disableSchemaRegistry: true },
-            },
-          });
-
-          const text = textContent(result);
-          expect(text).toContain("p0-msg-a");
-          expect(text).toContain("p0-msg-b");
-          expect(text).toContain("p0-msg-c");
-          expect(text).not.toContain("p1-msg");
-          expect(text).not.toContain("p2-msg");
-        } finally {
-          await admin.deleteTopics({ topics: [multiTopic] }).catch(() => {
-            // teardown-only; a cleanup failure shouldn't fail an
-            // already-asserted test
-          });
-        }
-      });
-
-      it("should seek to an absolute partition offset when `start: {offset}` is set", async () => {
-        // Seed a single-partition topic with 5 records; their offsets
-        // within the partition are 0..4 (sequential, one batch). Seek
-        // to offset 3 and assert: the two later values appear AND the
-        // three earlier ones do not. maxMessages = 2 (the count we
-        // expect post-seek) so the call returns quickly on success
-        // and surfaces a seek failure immediately via the
-        // negative-presence assertions on offsets 0..2 if the consumer
-        // accidentally landed at the low watermark.
-        const offsetTopic = uniqueName("consume-off");
-        await admin.createTopics({
-          topics: [{ topic: offsetTopic, numPartitions: 1 }],
-        });
-        try {
-          await producer.send({
-            topic: offsetTopic,
-            messages: [
-              { value: "off-0" },
-              { value: "off-1" },
-              { value: "off-2" },
-              { value: "off-3" },
-              { value: "off-4" },
-            ],
-          });
-
-          const result = await server.client.callTool({
-            name: ToolName.CONSUME_MESSAGES,
-            arguments: {
-              topics: [
-                {
-                  name: offsetTopic,
-                  partition: 0,
-                  start: { offset: "3" },
-                },
-              ],
-              maxMessages: 2,
-              timeoutMs: 15_000,
-              valueFormat: { disableSchemaRegistry: true },
-            },
-          });
-
-          const text = textContent(result);
-          // Pin to the JSON `"value": "..."` shape rather than bare
-          // substring matching — `uniqueName("consume-off")` produces a
-          // topic name like `int-consume-off-1779...` which contains the
-          // substring `off-1`, so a loose `toContain("off-1")` would
-          // false-positive against the topic name in the response prose.
-          expect(text).toContain('"value": "off-3"');
-          expect(text).toContain('"value": "off-4"');
-          expect(text).not.toContain('"value": "off-0"');
-          expect(text).not.toContain('"value": "off-1"');
-          expect(text).not.toContain('"value": "off-2"');
-        } finally {
-          await admin.deleteTopics({ topics: [offsetTopic] }).catch(() => {
-            // teardown-only; a cleanup failure shouldn't fail an
-            // already-asserted test
-          });
-        }
-      });
-
-      it("should seek to the broker-resolved offset for a midpoint timestamp, returning only records produced past it", async () => {
-        // Produce batch A, sleep, produce batch B. The wall-clock gap
-        // between the two batches gives us a midpoint timestamp that
-        // sits after every A record's broker-assigned timestamp and
-        // before every B record's, so the broker's timestamp index
-        // should resolve our seek target to the first B offset.
-        // Exercises the live `admin.fetchTopicOffsetsByTimestamp` path
-        // and the silent-substitution defense — neither is reachable
-        // through the unit-test mocks.
-        const tsTopic = uniqueName("consume-ts");
-        await admin.createTopics({
-          topics: [{ topic: tsTopic, numPartitions: 1 }],
-        });
-        try {
-          await producer.send({
-            topic: tsTopic,
-            messages: [{ value: "a-0" }, { value: "a-1" }, { value: "a-2" }],
-          });
-          const afterA = Date.now();
-
-          // ~2s gap — long enough that round-trip timestamp jitter
-          // (producer assigns at send time; broker may add a few ms) can't
-          // muddle the midpoint window.
-          await new Promise<void>((r) => setTimeout(r, 2000));
-
-          const beforeB = Date.now();
-          await producer.send({
-            topic: tsTopic,
-            messages: [{ value: "b-0" }, { value: "b-1" }, { value: "b-2" }],
-          });
-
-          const midpointMs = Math.floor((afterA + beforeB) / 2);
-
-          const result = await server.client.callTool({
-            name: ToolName.CONSUME_MESSAGES,
-            arguments: {
-              topics: [{ name: tsTopic, start: { timestamp: midpointMs } }],
-              maxMessages: 3,
-              timeoutMs: 15_000,
-              valueFormat: { disableSchemaRegistry: true },
-            },
-          });
-
-          const text = textContent(result);
-          // Only batch B should be present; the seek must have skipped
-          // past every A record.
-          expect(text).toContain('"value": "b-0"');
-          expect(text).toContain('"value": "b-1"');
-          expect(text).toContain('"value": "b-2"');
-          expect(text).not.toContain('"value": "a-0"');
-          expect(text).not.toContain('"value": "a-1"');
-          expect(text).not.toContain('"value": "a-2"');
-        } finally {
-          await admin.deleteTopics({ topics: [tsTopic] }).catch(() => {
-            // teardown-only; a cleanup failure shouldn't fail an
-            // already-asserted test
-          });
-        }
-      });
-
-      it("should honor a mixed-direction call: replay history on a topic asking for `start: 'earliest'` while parking at the high watermark on a peer topic asking for `start: 'latest'`", async () => {
-        // Two topics, both seeded with history before the consume call.
-        // Topic A asks for "earliest" → the orchestrator's mixed-direction
-        // path issues an explicit low-watermark seek for A while leaving
-        // the consumer-wide `auto.offset.reset` at "latest" for B.
-        // Result: A's history replays, B contributes nothing because
-        // nothing is produced to it during the consume window.
-        const topicA = uniqueName("consume-mix-a");
-        const topicB = uniqueName("consume-mix-b");
-        await admin.createTopics({
-          topics: [
-            { topic: topicA, numPartitions: 1 },
-            { topic: topicB, numPartitions: 1 },
-          ],
-        });
-        try {
-          await producer.send({
-            topic: topicA,
-            messages: [
-              { value: "alpha-0" },
-              { value: "alpha-1" },
-              { value: "alpha-2" },
-            ],
-          });
-          await producer.send({
-            topic: topicB,
-            messages: [
-              { value: "beta-0" },
-              { value: "beta-1" },
-              { value: "beta-2" },
-            ],
-          });
-
-          const result = await server.client.callTool({
-            name: ToolName.CONSUME_MESSAGES,
-            arguments: {
-              topics: [
-                { name: topicA, start: "earliest" },
-                { name: topicB, start: "latest" },
-              ],
-              // Exactly the count of A's seeded history. On success the
-              // call resolves as soon as those 3 land; B's "latest"
-              // arm contributes nothing because no producer is writing
-              // to it during the window.
-              maxMessages: 3,
-              timeoutMs: 15_000,
-              valueFormat: { disableSchemaRegistry: true },
-            },
-          });
-
-          const text = textContent(result);
-          // Topic A's history must replay end-to-end.
-          expect(text).toContain('"value": "alpha-0"');
-          expect(text).toContain('"value": "alpha-1"');
-          expect(text).toContain('"value": "alpha-2"');
-          // Topic B's history must NOT appear — `start: "latest"` parks
-          // the consumer at B's high watermark, and nothing is produced
-          // post-call.
-          expect(text).not.toContain('"value": "beta-0"');
-          expect(text).not.toContain('"value": "beta-1"');
-          expect(text).not.toContain('"value": "beta-2"');
-        } finally {
-          await admin.deleteTopics({ topics: [topicA, topicB] }).catch(() => {
-            // teardown-only; a cleanup failure shouldn't fail an
-            // already-asserted test
-          });
-        }
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `connectTestAdmin()`/`connectTestProducer()` build api-key kafka clients from the direct
-      // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
-      // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // seed via the api-key-authed admin + producer; the CONSUME_MESSAGES call goes via OAuth
+      // seed a shared test topic with messages (no need to split by transport)
       let admin: KafkaJS.Admin;
       let producer: KafkaJS.Producer;
-      const topic = uniqueName("consume-oauth");
+      const topic = uniqueName("consume");
       const seededValues = ["msg-0", "msg-1", "msg-2"];
 
       beforeAll(async () => {
@@ -420,24 +89,21 @@ describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should consume the seeded messages from the topic", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.CONSUME_MESSAGES,
             arguments: {
-              topics: [{ name: topic, start: "earliest" }],
+              topics: [{ name: topic }],
               maxMessages: seededValues.length,
               timeoutMs: 15_000,
               valueFormat: { disableSchemaRegistry: true },
-              cluster_id: clusterId,
-              environment_id: environmentId,
             },
           });
 
@@ -447,7 +113,345 @@ describe("consume-kafka-messages-handler", { tags: [Tag.KAFKA] }, () => {
             expect(text).toContain(value);
           }
         });
+
+        it("should restrict consumption to one partition when `partition` is set on the topic entry", async () => {
+          // Seed a 3-partition topic with three records on the keep
+          // partition and one record each on the suppressed partitions,
+          // then ask for partition 0 only. `maxMessages: 3` lets the call
+          // exit as soon as the three p0 records land instead of waiting
+          // out the `timeoutMs` floor, but it also forces the handler to
+          // stay alive long enough that a leaked p1/p2 record from a
+          // broken pause has a high probability of landing in the
+          // response (librdkafka round-robins across partitions, so 3
+          // consecutive p0 deliveries before any p1/p2 is unlikely).
+          // Asserts: every p0 record appears AND neither suppressed
+          // partition's record does — proving the pause step suppressed
+          // the non-keep partitions end-to-end against librdkafka, not
+          // just against mocks.
+          const multiTopic = uniqueName("consume-part");
+          await admin.createTopics({
+            topics: [{ topic: multiTopic, numPartitions: 3 }],
+          });
+          try {
+            await producer.send({
+              topic: multiTopic,
+              messages: [
+                { partition: 0, value: "p0-msg-a" },
+                { partition: 0, value: "p0-msg-b" },
+                { partition: 0, value: "p0-msg-c" },
+                { partition: 1, value: "p1-msg" },
+                { partition: 2, value: "p2-msg" },
+              ],
+            });
+
+            const result = await server.client.callTool({
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [{ name: multiTopic, partition: 0, start: "earliest" }],
+                maxMessages: 3,
+                timeoutMs: 15_000,
+                valueFormat: { disableSchemaRegistry: true },
+              },
+            });
+
+            const text = textContent(result);
+            expect(text).toContain("p0-msg-a");
+            expect(text).toContain("p0-msg-b");
+            expect(text).toContain("p0-msg-c");
+            expect(text).not.toContain("p1-msg");
+            expect(text).not.toContain("p2-msg");
+          } finally {
+            await admin.deleteTopics({ topics: [multiTopic] }).catch(() => {
+              // teardown-only; a cleanup failure shouldn't fail an
+              // already-asserted test
+            });
+          }
+        });
+
+        it("should seek to an absolute partition offset when `start: {offset}` is set", async () => {
+          // Seed a single-partition topic with 5 records; their offsets
+          // within the partition are 0..4 (sequential, one batch). Seek
+          // to offset 3 and assert: the two later values appear AND the
+          // three earlier ones do not. maxMessages = 2 (the count we
+          // expect post-seek) so the call returns quickly on success
+          // and surfaces a seek failure immediately via the
+          // negative-presence assertions on offsets 0..2 if the consumer
+          // accidentally landed at the low watermark.
+          const offsetTopic = uniqueName("consume-off");
+          await admin.createTopics({
+            topics: [{ topic: offsetTopic, numPartitions: 1 }],
+          });
+          try {
+            await producer.send({
+              topic: offsetTopic,
+              messages: [
+                { value: "off-0" },
+                { value: "off-1" },
+                { value: "off-2" },
+                { value: "off-3" },
+                { value: "off-4" },
+              ],
+            });
+
+            const result = await server.client.callTool({
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [
+                  {
+                    name: offsetTopic,
+                    partition: 0,
+                    start: { offset: "3" },
+                  },
+                ],
+                maxMessages: 2,
+                timeoutMs: 15_000,
+                valueFormat: { disableSchemaRegistry: true },
+              },
+            });
+
+            const text = textContent(result);
+            // Pin to the JSON `"value": "..."` shape rather than bare
+            // substring matching — `uniqueName("consume-off")` produces a
+            // topic name like `int-consume-off-1779...` which contains the
+            // substring `off-1`, so a loose `toContain("off-1")` would
+            // false-positive against the topic name in the response prose.
+            expect(text).toContain('"value": "off-3"');
+            expect(text).toContain('"value": "off-4"');
+            expect(text).not.toContain('"value": "off-0"');
+            expect(text).not.toContain('"value": "off-1"');
+            expect(text).not.toContain('"value": "off-2"');
+          } finally {
+            await admin.deleteTopics({ topics: [offsetTopic] }).catch(() => {
+              // teardown-only; a cleanup failure shouldn't fail an
+              // already-asserted test
+            });
+          }
+        });
+
+        it("should seek to the broker-resolved offset for a midpoint timestamp, returning only records produced past it", async () => {
+          // Produce batch A, sleep, produce batch B. The wall-clock gap
+          // between the two batches gives us a midpoint timestamp that
+          // sits after every A record's broker-assigned timestamp and
+          // before every B record's, so the broker's timestamp index
+          // should resolve our seek target to the first B offset.
+          // Exercises the live `admin.fetchTopicOffsetsByTimestamp` path
+          // and the silent-substitution defense — neither is reachable
+          // through the unit-test mocks.
+          const tsTopic = uniqueName("consume-ts");
+          await admin.createTopics({
+            topics: [{ topic: tsTopic, numPartitions: 1 }],
+          });
+          try {
+            await producer.send({
+              topic: tsTopic,
+              messages: [{ value: "a-0" }, { value: "a-1" }, { value: "a-2" }],
+            });
+            const afterA = Date.now();
+
+            // ~2s gap — long enough that round-trip timestamp jitter
+            // (producer assigns at send time; broker may add a few ms) can't
+            // muddle the midpoint window.
+            await new Promise<void>((r) => setTimeout(r, 2000));
+
+            const beforeB = Date.now();
+            await producer.send({
+              topic: tsTopic,
+              messages: [{ value: "b-0" }, { value: "b-1" }, { value: "b-2" }],
+            });
+
+            const midpointMs = Math.floor((afterA + beforeB) / 2);
+
+            const result = await server.client.callTool({
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [{ name: tsTopic, start: { timestamp: midpointMs } }],
+                maxMessages: 3,
+                timeoutMs: 15_000,
+                valueFormat: { disableSchemaRegistry: true },
+              },
+            });
+
+            const text = textContent(result);
+            // Only batch B should be present; the seek must have skipped
+            // past every A record.
+            expect(text).toContain('"value": "b-0"');
+            expect(text).toContain('"value": "b-1"');
+            expect(text).toContain('"value": "b-2"');
+            expect(text).not.toContain('"value": "a-0"');
+            expect(text).not.toContain('"value": "a-1"');
+            expect(text).not.toContain('"value": "a-2"');
+          } finally {
+            await admin.deleteTopics({ topics: [tsTopic] }).catch(() => {
+              // teardown-only; a cleanup failure shouldn't fail an
+              // already-asserted test
+            });
+          }
+        });
+
+        it("should honor a mixed-direction call: replay history on a topic asking for `start: 'earliest'` while parking at the high watermark on a peer topic asking for `start: 'latest'`", async () => {
+          // Two topics, both seeded with history before the consume call.
+          // Topic A asks for "earliest" → the orchestrator's mixed-direction
+          // path issues an explicit low-watermark seek for A while leaving
+          // the consumer-wide `auto.offset.reset` at "latest" for B.
+          // Result: A's history replays, B contributes nothing because
+          // nothing is produced to it during the consume window.
+          const topicA = uniqueName("consume-mix-a");
+          const topicB = uniqueName("consume-mix-b");
+          await admin.createTopics({
+            topics: [
+              { topic: topicA, numPartitions: 1 },
+              { topic: topicB, numPartitions: 1 },
+            ],
+          });
+          try {
+            await producer.send({
+              topic: topicA,
+              messages: [
+                { value: "alpha-0" },
+                { value: "alpha-1" },
+                { value: "alpha-2" },
+              ],
+            });
+            await producer.send({
+              topic: topicB,
+              messages: [
+                { value: "beta-0" },
+                { value: "beta-1" },
+                { value: "beta-2" },
+              ],
+            });
+
+            const result = await server.client.callTool({
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [
+                  { name: topicA, start: "earliest" },
+                  { name: topicB, start: "latest" },
+                ],
+                // Exactly the count of A's seeded history. On success the
+                // call resolves as soon as those 3 land; B's "latest"
+                // arm contributes nothing because no producer is writing
+                // to it during the window.
+                maxMessages: 3,
+                timeoutMs: 15_000,
+                valueFormat: { disableSchemaRegistry: true },
+              },
+            });
+
+            const text = textContent(result);
+            // Topic A's history must replay end-to-end.
+            expect(text).toContain('"value": "alpha-0"');
+            expect(text).toContain('"value": "alpha-1"');
+            expect(text).toContain('"value": "alpha-2"');
+            // Topic B's history must NOT appear — `start: "latest"` parks
+            // the consumer at B's high watermark, and nothing is produced
+            // post-call.
+            expect(text).not.toContain('"value": "beta-0"');
+            expect(text).not.toContain('"value": "beta-1"');
+            expect(text).not.toContain('"value": "beta-2"');
+          } finally {
+            await admin.deleteTopics({ topics: [topicA, topicB] }).catch(() => {
+              // teardown-only; a cleanup failure shouldn't fail an
+              // already-asserted test
+            });
+          }
+        });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `connectTestAdmin()`/`connectTestProducer()` build api-key kafka clients from the direct
+        // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
+        // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // seed via the api-key-authed admin + producer; the CONSUME_MESSAGES call goes via OAuth
+        let admin: KafkaJS.Admin;
+        let producer: KafkaJS.Producer;
+        const topic = uniqueName("consume-oauth");
+        const seededValues = ["msg-0", "msg-1", "msg-2"];
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
+          producer = await connectTestProducer();
+          await producer.send({
+            topic,
+            messages: seededValues.map((value) => ({ value })),
+          });
+        });
+
+        afterAll(async () => {
+          await producer.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should consume the seeded messages from the topic", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [{ name: topic, start: "earliest" }],
+                maxMessages: seededValues.length,
+                timeoutMs: 15_000,
+                valueFormat: { disableSchemaRegistry: true },
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            const text = textContent(result);
+            expect(text).toMatch(/^Consumed \d+ messages/);
+            for (const value of seededValues) {
+              expect(text).toContain(value);
+            }
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
@@ -33,117 +33,47 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new CreateTopicsHandler();
 
-describe("create-topics-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "create-topics-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
-    const { admin, createdTopics } = withSharedAdminClient();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should create the requested Kafka topic", async () => {
-        const topic = uniqueName(`create-${transport}`);
-        // track for cleanup before the call so a thrown callTool still enqueues
-        // the topic for afterAll deletion if creation partially succeeded
-        createdTopics.push(topic);
-
-        const result = await server.client.callTool({
-          name: ToolName.CREATE_TOPICS,
-          arguments: { topics: [{ topic, numPartitions: 1 }] },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-
-        await expect
-          .poll(() => admin().listTopics(), {
-            timeout: 15_000,
-            interval: 500,
-          })
-          .toContain(topic);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `withSharedAdminClient()` builds an api-key kafka client from the direct fixture; gate
-      // the OAuth describe on the same predicate the direct describe uses so an OAuth-only CI
-      // lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // verification uses the api-key-authed admin client to confirm the OAuth-mode server's call
-      // actually mutated the cluster
+      // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
       const { admin, createdTopics } = withSharedAdminClient();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should create the requested Kafka topic", async () => {
-          const topic = uniqueName(`create-oauth-${transport}`);
+          const topic = uniqueName(`create-${transport}`);
+          // track for cleanup before the call so a thrown callTool still enqueues
+          // the topic for afterAll deletion if creation partially succeeded
           createdTopics.push(topic);
 
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.CREATE_TOPICS,
-            arguments: {
-              topics: [{ topic, numPartitions: 1 }],
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: { topics: [{ topic, numPartitions: 1 }] },
           });
 
           expect(result.isError, textContent(result)).not.toBe(true);
@@ -156,6 +86,80 @@ describe("create-topics-handler", { tags: [Tag.KAFKA] }, () => {
             .toContain(topic);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `withSharedAdminClient()` builds an api-key kafka client from the direct fixture; gate
+        // the OAuth describe on the same predicate the direct describe uses so an OAuth-only CI
+        // lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // verification uses the api-key-authed admin client to confirm the OAuth-mode server's call
+        // actually mutated the cluster
+        const { admin, createdTopics } = withSharedAdminClient();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should create the requested Kafka topic", async () => {
+            const topic = uniqueName(`create-oauth-${transport}`);
+            createdTopics.push(topic);
+
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.CREATE_TOPICS,
+              arguments: {
+                topics: [{ topic, numPartitions: 1 }],
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(result.isError, textContent(result)).not.toBe(true);
+
+            await expect
+              .poll(() => admin().listTopics(), {
+                timeout: 15_000,
+                interval: 500,
+              })
+              .toContain(topic);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
@@ -33,115 +33,43 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new DeleteTopicsHandler();
 
-describe("delete-topics-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "delete-topics-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
-    const { admin, createdTopics } = withSharedAdminClient();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should delete the requested Kafka topic", async () => {
-        const topic = uniqueName(`delete-${transport}`);
-        createdTopics.push(topic);
-        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
-        // wait for the newly-created topic to be visible before deleting it
-        await expect
-          .poll(() => admin().listTopics(), {
-            timeout: 15_000,
-            interval: 500,
-          })
-          .toContain(topic);
-
-        const result = await server.client.callTool({
-          name: ToolName.DELETE_TOPICS,
-          arguments: { topicNames: [topic] },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-
-        await expect
-          .poll(() => admin().listTopics(), {
-            timeout: 15_000,
-            interval: 500,
-          })
-          .not.toContain(topic);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `withSharedAdminClient()` builds an api-key kafka client from the direct fixture; gate
-      // the OAuth describe on the same predicate the direct describe uses so an OAuth-only CI
-      // lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // seed + verify via the api-key-authed admin client; only the DELETE_TOPICS call goes via OAuth
+      // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
       const { admin, createdTopics } = withSharedAdminClient();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should delete the requested Kafka topic", async () => {
-          const topic = uniqueName(`delete-oauth-${transport}`);
+          const topic = uniqueName(`delete-${transport}`);
           createdTopics.push(topic);
           await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
+          // wait for the newly-created topic to be visible before deleting it
           await expect
             .poll(() => admin().listTopics(), {
               timeout: 15_000,
@@ -149,13 +77,9 @@ describe("delete-topics-handler", { tags: [Tag.KAFKA] }, () => {
             })
             .toContain(topic);
 
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.DELETE_TOPICS,
-            arguments: {
-              topicNames: [topic],
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: { topicNames: [topic] },
           });
 
           expect(result.isError, textContent(result)).not.toBe(true);
@@ -168,6 +92,88 @@ describe("delete-topics-handler", { tags: [Tag.KAFKA] }, () => {
             .not.toContain(topic);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `withSharedAdminClient()` builds an api-key kafka client from the direct fixture; gate
+        // the OAuth describe on the same predicate the direct describe uses so an OAuth-only CI
+        // lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // seed + verify via the api-key-authed admin client; only the DELETE_TOPICS call goes via OAuth
+        const { admin, createdTopics } = withSharedAdminClient();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should delete the requested Kafka topic", async () => {
+            const topic = uniqueName(`delete-oauth-${transport}`);
+            createdTopics.push(topic);
+            await admin().createTopics({
+              topics: [{ topic, numPartitions: 1 }],
+            });
+            await expect
+              .poll(() => admin().listTopics(), {
+                timeout: 15_000,
+                interval: 500,
+              })
+              .toContain(topic);
+
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.DELETE_TOPICS,
+              arguments: {
+                topicNames: [topic],
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(result.isError, textContent(result)).not.toBe(true);
+
+            await expect
+              .poll(() => admin().listTopics(), {
+                timeout: 15_000,
+                interval: 500,
+              })
+              .not.toContain(topic);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.integration.test.ts
@@ -36,195 +36,201 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new DescribeConsumerGroupHandler();
 
-describe("describe-consumer-group-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
-  //
-  // The OAuth describe only runs the happy-path describe call — the not-found error-surface
-  // test lives in the direct describe since it exercises handler logic that doesn't change
-  // between auth modes.
+describe(
+  "describe-consumer-group-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
+    //
+    // The OAuth describe only runs the happy-path describe call — the not-found error-surface
+    // test lives in the direct describe since it exercises handler logic that doesn't change
+    // between auth modes.
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // Test-side admin client used once (outer-scope beforeAll) to discover a
-    // real group ID to describe. Without an existing group the test has nothing
-    // meaningful to assert against; skip vs. assert is a judgment call — picked
-    // skip here because "no consumer groups on the test cluster" is a legitimate
-    // env state (e.g. nothing's been provisioned yet), not the kind of broken-env
-    // failure that should page someone.
-    const { admin } = withSharedAdminClient();
-    let discoveredGroupId: string | undefined;
-
-    beforeAll(async () => {
-      const { groups } = await admin().listGroups();
-      discoveredGroupId = groups[0]?.groupId;
-    });
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose describe-consumer-group in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-
-        const describeConsumerGroup = tools.find(
-          (t) => t.name === ToolName.DESCRIBE_CONSUMER_GROUP,
-        );
-        expect(describeConsumerGroup).toBeDefined();
-      });
-
-      it("should describe an existing consumer group end-to-end", async (ctx) => {
-        if (discoveredGroupId === undefined) {
-          ctx.skip(
-            "no consumer groups present on the test cluster to describe",
-          );
-          return;
-        }
-
-        const result = await server.client.callTool({
-          name: ToolName.DESCRIBE_CONSUMER_GROUP,
-          arguments: { groupId: discoveredGroupId },
-        });
-
-        // The handler emits a `Consumer group "<id>" is <state> ...` prefix on
-        // every success path (Stable / Empty / etc.), and the requested id
-        // appears verbatim in the text — so this proves the tool ran
-        // end-to-end against a real broker AND returned the right group.
-        // Use a literal `startsWith` (via the text-and-message expect form)
-        // rather than `new RegExp(...)` — consumer group IDs can legally
-        // contain regex metacharacters (`.`, `[`, etc.), which would either
-        // throw on RegExp construction or false-match in the assertion.
-        const text = textContent(result);
-        const expectedPrefix = `Consumer group "${discoveredGroupId}" is `;
-        expect(text.startsWith(expectedPrefix), text).toBe(true);
-      });
-
-      it("should return the caller-friendly not-found error for an unknown group ID", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.DESCRIBE_CONSUMER_GROUP,
-          arguments: { groupId: "int-no-such-group-2147483647" },
-        });
-
-        expect(result.isError).toBe(true);
-        expect(textContent(result)).toBe(
-          'Consumer group "int-no-such-group-2147483647" not found on this cluster.',
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `withSharedAdminClient()` builds an api-key kafka client from the direct fixture; gate
-      // the OAuth describe on the same predicate the direct describe uses so an OAuth-only CI
-      // lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth handlers don't carry a `kafka` block, so the broker is resolved at call time from
-      // `cluster_id` + `environment_id`; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // Seed a dedicated group rather than discovering an existing one: other test files
-      // (`get-consumer-group-lag`) run in parallel processes (vitest `pool: "forks"`) and create
-      // + delete `int-lag-group-*` groups concurrently, so a discovered group can vanish
-      // between `listGroups()` and the OAuth-flow tool call. An ephemeral group we own is
-      // race-free.
-      let admin: KafkaJS.Admin;
-      const topic = uniqueName("describe-oauth");
-      const groupId = uniqueName("describe-oauth-group");
+      // Test-side admin client used once (outer-scope beforeAll) to discover a
+      // real group ID to describe. Without an existing group the test has nothing
+      // meaningful to assert against; skip vs. assert is a judgment call — picked
+      // skip here because "no consumer groups on the test cluster" is a legitimate
+      // env state (e.g. nothing's been provisioned yet), not the kind of broken-env
+      // failure that should page someone.
+      const { admin } = withSharedAdminClient();
+      let discoveredGroupId: string | undefined;
 
       beforeAll(async () => {
-        admin = await connectTestAdmin();
-        await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
-        // `commitOffsets` with an explicit topic-partition-offset writes to __consumer_offsets
-        // via the group coordinator regardless of whether the consumer ever polled — enough to
-        // make the group visible to describe-consumer-group.
-        const consumer = await connectTestConsumer(groupId);
-        try {
-          await consumer.commitOffsets([{ topic, partition: 0, offset: "0" }]);
-        } finally {
-          await consumer.disconnect().catch(() => {
-            // disconnect race during fixture teardown isn't actionable
-          });
-        }
-      });
-
-      afterAll(async () => {
-        await admin.deleteGroups([groupId]).catch(() => {
-          // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-        });
-        await admin.deleteTopics({ topics: [topic] }).catch(() => {
-          // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-        });
-        await admin.disconnect().catch(() => {
-          // disconnect race during teardown isn't actionable
-        });
+        const { groups } = await admin().listGroups();
+        discoveredGroupId = groups[0]?.groupId;
       });
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-        it("should describe the seeded consumer group end-to-end", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+        it("should expose describe-consumer-group in tools/list", async () => {
+          const { tools } = await server.client.listTools();
+
+          const describeConsumerGroup = tools.find(
+            (t) => t.name === ToolName.DESCRIBE_CONSUMER_GROUP,
+          );
+          expect(describeConsumerGroup).toBeDefined();
+        });
+
+        it("should describe an existing consumer group end-to-end", async (ctx) => {
+          if (discoveredGroupId === undefined) {
+            ctx.skip(
+              "no consumer groups present on the test cluster to describe",
+            );
+            return;
+          }
+
+          const result = await server.client.callTool({
             name: ToolName.DESCRIBE_CONSUMER_GROUP,
-            arguments: {
-              groupId,
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: { groupId: discoveredGroupId },
           });
 
+          // The handler emits a `Consumer group "<id>" is <state> ...` prefix on
+          // every success path (Stable / Empty / etc.), and the requested id
+          // appears verbatim in the text — so this proves the tool ran
+          // end-to-end against a real broker AND returned the right group.
+          // Use a literal `startsWith` (via the text-and-message expect form)
+          // rather than `new RegExp(...)` — consumer group IDs can legally
+          // contain regex metacharacters (`.`, `[`, etc.), which would either
+          // throw on RegExp construction or false-match in the assertion.
           const text = textContent(result);
-          const expectedPrefix = `Consumer group "${groupId}" is `;
+          const expectedPrefix = `Consumer group "${discoveredGroupId}" is `;
           expect(text.startsWith(expectedPrefix), text).toBe(true);
         });
+
+        it("should return the caller-friendly not-found error for an unknown group ID", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.DESCRIBE_CONSUMER_GROUP,
+            arguments: { groupId: "int-no-such-group-2147483647" },
+          });
+
+          expect(result.isError).toBe(true);
+          expect(textContent(result)).toBe(
+            'Consumer group "int-no-such-group-2147483647" not found on this cluster.',
+          );
+        });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `withSharedAdminClient()` builds an api-key kafka client from the direct fixture; gate
+        // the OAuth describe on the same predicate the direct describe uses so an OAuth-only CI
+        // lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth handlers don't carry a `kafka` block, so the broker is resolved at call time from
+        // `cluster_id` + `environment_id`; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // Seed a dedicated group rather than discovering an existing one: other test files
+        // (`get-consumer-group-lag`) run in parallel processes (vitest `pool: "forks"`) and create
+        // + delete `int-lag-group-*` groups concurrently, so a discovered group can vanish
+        // between `listGroups()` and the OAuth-flow tool call. An ephemeral group we own is
+        // race-free.
+        let admin: KafkaJS.Admin;
+        const topic = uniqueName("describe-oauth");
+        const groupId = uniqueName("describe-oauth-group");
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
+          // `commitOffsets` with an explicit topic-partition-offset writes to __consumer_offsets
+          // via the group coordinator regardless of whether the consumer ever polled — enough to
+          // make the group visible to describe-consumer-group.
+          const consumer = await connectTestConsumer(groupId);
+          try {
+            await consumer.commitOffsets([
+              { topic, partition: 0, offset: "0" },
+            ]);
+          } finally {
+            await consumer.disconnect().catch(() => {
+              // disconnect race during fixture teardown isn't actionable
+            });
+          }
+        });
+
+        afterAll(async () => {
+          await admin.deleteGroups([groupId]).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should describe the seeded consumer group end-to-end", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.DESCRIBE_CONSUMER_GROUP,
+              arguments: {
+                groupId,
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            const text = textContent(result);
+            const expectedPrefix = `Consumer group "${groupId}" is `;
+            expect(text.startsWith(expectedPrefix), text).toBe(true);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.integration.test.ts
@@ -44,244 +44,49 @@ const SEEDED_MESSAGE_COUNT = 10;
 const COMMITTED_OFFSET = 4;
 const EXPECTED_LAG = SEEDED_MESSAGE_COUNT - COMMITTED_OFFSET;
 
-describe("get-consumer-group-lag-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
-  //
-  // The OAuth describe only runs the deterministic-lag happy-path call — the topics-filter,
-  // never-committed-topic, and not-found error-surface tests live in the direct describe since
-  // they exercise handler logic that doesn't change between auth modes.
+describe(
+  "get-consumer-group-lag-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
+    //
+    // The OAuth describe only runs the deterministic-lag happy-path call — the topics-filter,
+    // never-committed-topic, and not-found error-surface tests live in the direct describe since
+    // they exercise handler logic that doesn't change between auth modes.
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    let admin: KafkaJS.Admin;
-    let producer: KafkaJS.Producer;
-    const topic = uniqueName("lag");
-    // Second topic stays exist-but-untouched so below can prove the
-    // "filter includes a topic the group has never committed to" path returns
-    // `partitions: []` rather than silently dropping the topic.
-    const untouchedTopic = uniqueName("lag-untouched");
-    const groupId = uniqueName("lag-group");
-
-    beforeAll(async () => {
-      admin = await connectTestAdmin();
-      await admin.createTopics({
-        topics: [
-          { topic, numPartitions: NUM_PARTITIONS },
-          { topic: untouchedTopic, numPartitions: 1 },
-        ],
-      });
-      producer = await connectTestProducer();
-      // Pin every seed write to partition 0 so the per-partition lag
-      // assertion below compares against an exact known number rather than
-      // a sum across whatever partition the default hash picked.
-      await producer.send({
-        topic,
-        messages: Array.from({ length: SEEDED_MESSAGE_COUNT }, (_, i) => ({
-          value: `msg-${i}`,
-          partition: 0,
-        })),
-      });
-
-      // Bind a consumer instance to the test groupId and write the committed
-      // offset explicitly. `commitOffsets([...])` with explicit
-      // topic-partition-offsets writes to the __consumer_offsets topic via
-      // the group coordinator regardless of whether the consumer has been
-      // subscribed or assigned anything — no poll loop or rebalance needed.
-      const consumer = await connectTestConsumer(groupId);
-      try {
-        await consumer.commitOffsets([
-          { topic, partition: 0, offset: String(COMMITTED_OFFSET) },
-        ]);
-      } finally {
-        await consumer.disconnect().catch(() => {
-          // disconnect race during fixture teardown isn't actionable
-        });
-      }
-    });
-
-    afterAll(async () => {
-      await producer.disconnect().catch(() => {
-        // disconnect race during teardown isn't actionable
-      });
-      // Best-effort group cleanup — leaves the broker in the state CI expects
-      // (no orphaned `int-lag-group-*` groups accumulating across runs).
-      // `deleteGroups` may reject if the group already has live members, but
-      // we disconnected the only consumer above so that shouldn't fire.
-      await admin.deleteGroups([groupId]).catch(() => {
-        // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-      });
-      await admin
-        .deleteTopics({ topics: [topic, untouchedTopic] })
-        .catch(() => {
-          // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-        });
-      await admin.disconnect().catch(() => {
-        // disconnect race during teardown isn't actionable
-      });
-    });
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose get-consumer-group-lag in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        const tool = tools.find(
-          (t) => t.name === ToolName.GET_CONSUMER_GROUP_LAG,
-        );
-        expect(tool).toBeDefined();
-      });
-
-      it("should return the deterministic lag for the seeded group on the seeded topic", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_CONSUMER_GROUP_LAG,
-          arguments: { groupId },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-        const payload = result.structuredContent as GetConsumerGroupLagResponse;
-        expect(payload.groupId).toBe(groupId);
-        // Group committed to partition 0 of `topic` only, so the response
-        // carries exactly one topic with exactly one partition row — the other
-        // partitions never received a commit and are absent from the
-        // fetchOffsets response (distinct from the `offset === "-1"` rewound
-        // case the unit suite covers).
-        expect(payload.topics).toHaveLength(1);
-        const topicEntry = payload.topics[0]!;
-        expect(topicEntry.topic).toBe(topic);
-        expect(topicEntry.partitions).toHaveLength(1);
-        expect(topicEntry.partitions[0]).toMatchObject({
-          partition: 0,
-          committedOffset: String(COMMITTED_OFFSET),
-          highWatermark: String(SEEDED_MESSAGE_COUNT),
-          lag: EXPECTED_LAG,
-        });
-        expect(payload.totalLag).toBe(EXPECTED_LAG);
-        expect(textContent(result)).toContain(
-          `Consumer group "${groupId}" has ${EXPECTED_LAG} message(s) of lag across 1 topic(s).`,
-        );
-      });
-
-      it("should narrow the response to the requested topic when a topics filter is supplied", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_CONSUMER_GROUP_LAG,
-          arguments: { groupId, topics: [topic] },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-        const payload = result.structuredContent as GetConsumerGroupLagResponse;
-        expect(payload.topics).toHaveLength(1);
-        expect(payload.topics[0]!.topic).toBe(topic);
-        expect(payload.totalLag).toBe(EXPECTED_LAG);
-      });
-
-      it("should include a never-committed-but-existing topic as {topic, partitions: []} when present in the filter", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_CONSUMER_GROUP_LAG,
-          arguments: { groupId, topics: [topic, untouchedTopic] },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-        const payload = result.structuredContent as GetConsumerGroupLagResponse;
-        const untouched = payload.topics.find(
-          (t) => t.topic === untouchedTopic,
-        );
-        expect(untouched).toEqual({ topic: untouchedTopic, partitions: [] });
-        // The seeded topic's row stays intact.
-        const seeded = payload.topics.find((t) => t.topic === topic);
-        expect(seeded?.partitions).toHaveLength(1);
-        expect(payload.totalLag).toBe(EXPECTED_LAG);
-      });
-
-      it("should return the caller-friendly not-found error for an unknown group ID", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_CONSUMER_GROUP_LAG,
-          arguments: { groupId: "int-no-such-group-2147483647" },
-        });
-
-        expect(result.isError).toBe(true);
-        expect(textContent(result)).toBe(
-          'Consumer group "int-no-such-group-2147483647" not found on this cluster.',
-        );
-      });
-
-      it("should return the caller-friendly not-found error when the topics filter names a nonexistent topic", async () => {
-        const nonexistent = uniqueName("nonexistent-topic");
-        const result = await server.client.callTool({
-          name: ToolName.GET_CONSUMER_GROUP_LAG,
-          arguments: { groupId, topics: [nonexistent] },
-        });
-
-        expect(result.isError).toBe(true);
-        expect(textContent(result)).toBe(
-          `Topic "${nonexistent}" not found on this cluster.`,
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `connectTestAdmin/Producer/Consumer` build api-key kafka clients from the direct
-      // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
-      // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth handlers don't carry a `kafka` block, so the broker is resolved at call time from
-      // `cluster_id` + `environment_id`; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // seed via the api-key-authed admin + producer + consumer; the GET_CONSUMER_GROUP_LAG call
-      // goes via OAuth
       let admin: KafkaJS.Admin;
       let producer: KafkaJS.Producer;
-      const topic = uniqueName("lag-oauth");
-      const groupId = uniqueName("lag-group-oauth");
+      const topic = uniqueName("lag");
+      // Second topic stays exist-but-untouched so below can prove the
+      // "filter includes a topic the group has never committed to" path returns
+      // `partitions: []` rather than silently dropping the topic.
+      const untouchedTopic = uniqueName("lag-untouched");
+      const groupId = uniqueName("lag-group");
 
       beforeAll(async () => {
         admin = await connectTestAdmin();
         await admin.createTopics({
-          topics: [{ topic, numPartitions: NUM_PARTITIONS }],
+          topics: [
+            { topic, numPartitions: NUM_PARTITIONS },
+            { topic: untouchedTopic, numPartitions: 1 },
+          ],
         });
         producer = await connectTestProducer();
+        // Pin every seed write to partition 0 so the per-partition lag
+        // assertion below compares against an exact known number rather than
+        // a sum across whatever partition the default hash picked.
         await producer.send({
           topic,
           messages: Array.from({ length: SEEDED_MESSAGE_COUNT }, (_, i) => ({
@@ -290,6 +95,11 @@ describe("get-consumer-group-lag-handler", { tags: [Tag.KAFKA] }, () => {
           })),
         });
 
+        // Bind a consumer instance to the test groupId and write the committed
+        // offset explicitly. `commitOffsets([...])` with explicit
+        // topic-partition-offsets writes to the __consumer_offsets topic via
+        // the group coordinator regardless of whether the consumer has been
+        // subscribed or assigned anything — no poll loop or rebalance needed.
         const consumer = await connectTestConsumer(groupId);
         try {
           await consumer.commitOffsets([
@@ -306,12 +116,18 @@ describe("get-consumer-group-lag-handler", { tags: [Tag.KAFKA] }, () => {
         await producer.disconnect().catch(() => {
           // disconnect race during teardown isn't actionable
         });
+        // Best-effort group cleanup — leaves the broker in the state CI expects
+        // (no orphaned `int-lag-group-*` groups accumulating across runs).
+        // `deleteGroups` may reject if the group already has live members, but
+        // we disconnected the only consumer above so that shouldn't fire.
         await admin.deleteGroups([groupId]).catch(() => {
           // teardown-only; a cleanup failure shouldn't fail an already-asserted test
         });
-        await admin.deleteTopics({ topics: [topic] }).catch(() => {
-          // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-        });
+        await admin
+          .deleteTopics({ topics: [topic, untouchedTopic] })
+          .catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
         await admin.disconnect().catch(() => {
           // disconnect race during teardown isn't actionable
         });
@@ -321,31 +137,222 @@ describe("get-consumer-group-lag-handler", { tags: [Tag.KAFKA] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
+        it("should expose get-consumer-group-lag in tools/list", async () => {
+          const { tools } = await server.client.listTools();
+          const tool = tools.find(
+            (t) => t.name === ToolName.GET_CONSUMER_GROUP_LAG,
+          );
+          expect(tool).toBeDefined();
+        });
+
         it("should return the deterministic lag for the seeded group on the seeded topic", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.GET_CONSUMER_GROUP_LAG,
-            arguments: {
-              groupId,
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: { groupId },
           });
 
           expect(result.isError, textContent(result)).not.toBe(true);
           const payload =
             result.structuredContent as GetConsumerGroupLagResponse;
           expect(payload.groupId).toBe(groupId);
+          // Group committed to partition 0 of `topic` only, so the response
+          // carries exactly one topic with exactly one partition row — the other
+          // partitions never received a commit and are absent from the
+          // fetchOffsets response (distinct from the `offset === "-1"` rewound
+          // case the unit suite covers).
+          expect(payload.topics).toHaveLength(1);
+          const topicEntry = payload.topics[0]!;
+          expect(topicEntry.topic).toBe(topic);
+          expect(topicEntry.partitions).toHaveLength(1);
+          expect(topicEntry.partitions[0]).toMatchObject({
+            partition: 0,
+            committedOffset: String(COMMITTED_OFFSET),
+            highWatermark: String(SEEDED_MESSAGE_COUNT),
+            lag: EXPECTED_LAG,
+          });
+          expect(payload.totalLag).toBe(EXPECTED_LAG);
+          expect(textContent(result)).toContain(
+            `Consumer group "${groupId}" has ${EXPECTED_LAG} message(s) of lag across 1 topic(s).`,
+          );
+        });
+
+        it("should narrow the response to the requested topic when a topics filter is supplied", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_CONSUMER_GROUP_LAG,
+            arguments: { groupId, topics: [topic] },
+          });
+
+          expect(result.isError, textContent(result)).not.toBe(true);
+          const payload =
+            result.structuredContent as GetConsumerGroupLagResponse;
+          expect(payload.topics).toHaveLength(1);
+          expect(payload.topics[0]!.topic).toBe(topic);
           expect(payload.totalLag).toBe(EXPECTED_LAG);
         });
+
+        it("should include a never-committed-but-existing topic as {topic, partitions: []} when present in the filter", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_CONSUMER_GROUP_LAG,
+            arguments: { groupId, topics: [topic, untouchedTopic] },
+          });
+
+          expect(result.isError, textContent(result)).not.toBe(true);
+          const payload =
+            result.structuredContent as GetConsumerGroupLagResponse;
+          const untouched = payload.topics.find(
+            (t) => t.topic === untouchedTopic,
+          );
+          expect(untouched).toEqual({ topic: untouchedTopic, partitions: [] });
+          // The seeded topic's row stays intact.
+          const seeded = payload.topics.find((t) => t.topic === topic);
+          expect(seeded?.partitions).toHaveLength(1);
+          expect(payload.totalLag).toBe(EXPECTED_LAG);
+        });
+
+        it("should return the caller-friendly not-found error for an unknown group ID", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_CONSUMER_GROUP_LAG,
+            arguments: { groupId: "int-no-such-group-2147483647" },
+          });
+
+          expect(result.isError).toBe(true);
+          expect(textContent(result)).toBe(
+            'Consumer group "int-no-such-group-2147483647" not found on this cluster.',
+          );
+        });
+
+        it("should return the caller-friendly not-found error when the topics filter names a nonexistent topic", async () => {
+          const nonexistent = uniqueName("nonexistent-topic");
+          const result = await server.client.callTool({
+            name: ToolName.GET_CONSUMER_GROUP_LAG,
+            arguments: { groupId, topics: [nonexistent] },
+          });
+
+          expect(result.isError).toBe(true);
+          expect(textContent(result)).toBe(
+            `Topic "${nonexistent}" not found on this cluster.`,
+          );
+        });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `connectTestAdmin/Producer/Consumer` build api-key kafka clients from the direct
+        // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
+        // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth handlers don't carry a `kafka` block, so the broker is resolved at call time from
+        // `cluster_id` + `environment_id`; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // seed via the api-key-authed admin + producer + consumer; the GET_CONSUMER_GROUP_LAG call
+        // goes via OAuth
+        let admin: KafkaJS.Admin;
+        let producer: KafkaJS.Producer;
+        const topic = uniqueName("lag-oauth");
+        const groupId = uniqueName("lag-group-oauth");
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({
+            topics: [{ topic, numPartitions: NUM_PARTITIONS }],
+          });
+          producer = await connectTestProducer();
+          await producer.send({
+            topic,
+            messages: Array.from({ length: SEEDED_MESSAGE_COUNT }, (_, i) => ({
+              value: `msg-${i}`,
+              partition: 0,
+            })),
+          });
+
+          const consumer = await connectTestConsumer(groupId);
+          try {
+            await consumer.commitOffsets([
+              { topic, partition: 0, offset: String(COMMITTED_OFFSET) },
+            ]);
+          } finally {
+            await consumer.disconnect().catch(() => {
+              // disconnect race during fixture teardown isn't actionable
+            });
+          }
+        });
+
+        afterAll(async () => {
+          await producer.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+          await admin.deleteGroups([groupId]).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return the deterministic lag for the seeded group on the seeded topic", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.GET_CONSUMER_GROUP_LAG,
+              arguments: {
+                groupId,
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(result.isError, textContent(result)).not.toBe(true);
+            const payload =
+              result.structuredContent as GetConsumerGroupLagResponse;
+            expect(payload.groupId).toBe(groupId);
+            expect(payload.totalLag).toBe(EXPECTED_LAG);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.integration.test.ts
@@ -41,174 +41,31 @@ const handler = new GetPartitionOffsetsHandler();
 const NUM_PARTITIONS = 3;
 const SEEDED_VALUES = ["msg-0", "msg-1", "msg-2", "msg-3"];
 
-describe("get-partition-offsets-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
-  //
-  // The OAuth describe only exercises the basic-coverage tool call — the partition-pinning and
-  // error-surface tests live in the direct describe since they exercise handler logic that
-  // doesn't change between auth modes.
+describe(
+  "get-partition-offsets-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path.
+    //
+    // The OAuth describe only exercises the basic-coverage tool call — the partition-pinning and
+    // error-surface tests live in the direct describe since they exercise handler logic that
+    // doesn't change between auth modes.
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    let admin: KafkaJS.Admin;
-    let producer: KafkaJS.Producer;
-    const topic = uniqueName("offsets");
-
-    beforeAll(async () => {
-      admin = await connectTestAdmin();
-      await admin.createTopics({
-        topics: [{ topic, numPartitions: NUM_PARTITIONS }],
-      });
-      producer = await connectTestProducer();
-      // Pin every seed write to partition 0 so the per-partition `messageCount`
-      // assertion below can compare against an exact known number rather than
-      // a sum across whatever partition the default hash picked.
-      await producer.send({
-        topic,
-        messages: SEEDED_VALUES.map((value) => ({ value, partition: 0 })),
-      });
-    });
-
-    afterAll(async () => {
-      await producer.disconnect().catch(() => {
-        // disconnect race during teardown isn't actionable
-      });
-      await admin.deleteTopics({ topics: [topic] }).catch(() => {
-        // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-      });
-      await admin.disconnect().catch(() => {
-        // disconnect race during teardown isn't actionable
-      });
-    });
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose get-partition-offsets in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        const tool = tools.find(
-          (t) => t.name === ToolName.GET_PARTITION_OFFSETS,
-        );
-        expect(tool).toBeDefined();
-      });
-
-      it("should return every partition with messageCount totaling the seeded writes", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_PARTITION_OFFSETS,
-          arguments: { topicName: topic },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-        const payload = result.structuredContent as GetPartitionOffsetsResponse;
-        expect(payload.topicName).toBe(topic);
-        expect(payload.partitions).toHaveLength(NUM_PARTITIONS);
-
-        const partition0 = payload.partitions.find((p) => p.partition === 0);
-        expect(partition0?.messageCount).toBe(SEEDED_VALUES.length);
-        expect(partition0?.lowWatermark).toBe("0");
-        expect(partition0?.highWatermark).toBe(String(SEEDED_VALUES.length));
-
-        const otherPartitions = payload.partitions.filter(
-          (p) => p.partition !== 0,
-        );
-        for (const p of otherPartitions) {
-          expect(p.messageCount).toBe(0);
-        }
-      });
-
-      it("should restrict the response to one partition when `partition` is supplied", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_PARTITION_OFFSETS,
-          arguments: { topicName: topic, partition: 0 },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-        const payload = result.structuredContent as GetPartitionOffsetsResponse;
-        expect(payload.partitions).toHaveLength(1);
-        expect(payload.partitions[0]!.partition).toBe(0);
-        expect(payload.partitions[0]!.messageCount).toBe(SEEDED_VALUES.length);
-      });
-
-      it("should surface a clean out-of-range error citing the actual partition span", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_PARTITION_OFFSETS,
-          arguments: { topicName: topic, partition: 99 },
-        });
-
-        expect(result.isError).toBe(true);
-        expect(textContent(result)).toContain(
-          `Topic "${topic}" has ${NUM_PARTITIONS} partition(s) (0..${NUM_PARTITIONS - 1}); requested partition 99 is out of range`,
-        );
-      });
-
-      it("should surface a clean 'topic not found' error for an unknown topic without leaking librdkafka text", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.GET_PARTITION_OFFSETS,
-          arguments: { topicName: uniqueName("nonexistent") },
-        });
-
-        expect(result.isError).toBe(true);
-        expect(textContent(result)).toMatch(
-          /Topic ".+" not found on this cluster/,
-        );
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `connectTestAdmin()`/`connectTestProducer()` build api-key kafka clients from the direct
-      // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
-      // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // seed via the api-key-authed admin + producer; the GET_PARTITION_OFFSETS call goes via OAuth
       let admin: KafkaJS.Admin;
       let producer: KafkaJS.Producer;
-      const topic = uniqueName("offsets-oauth");
+      const topic = uniqueName("offsets");
 
       beforeAll(async () => {
         admin = await connectTestAdmin();
@@ -216,6 +73,9 @@ describe("get-partition-offsets-handler", { tags: [Tag.KAFKA] }, () => {
           topics: [{ topic, numPartitions: NUM_PARTITIONS }],
         });
         producer = await connectTestProducer();
+        // Pin every seed write to partition 0 so the per-partition `messageCount`
+        // assertion below can compare against an exact known number rather than
+        // a sum across whatever partition the default hash picked.
         await producer.send({
           topic,
           messages: SEEDED_VALUES.map((value) => ({ value, partition: 0 })),
@@ -238,22 +98,25 @@ describe("get-partition-offsets-handler", { tags: [Tag.KAFKA] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
+        it("should expose get-partition-offsets in tools/list", async () => {
+          const { tools } = await server.client.listTools();
+          const tool = tools.find(
+            (t) => t.name === ToolName.GET_PARTITION_OFFSETS,
+          );
+          expect(tool).toBeDefined();
+        });
+
         it("should return every partition with messageCount totaling the seeded writes", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.GET_PARTITION_OFFSETS,
-            arguments: {
-              topicName: topic,
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: { topicName: topic },
           });
 
           expect(result.isError, textContent(result)).not.toBe(true);
@@ -264,8 +127,155 @@ describe("get-partition-offsets-handler", { tags: [Tag.KAFKA] }, () => {
 
           const partition0 = payload.partitions.find((p) => p.partition === 0);
           expect(partition0?.messageCount).toBe(SEEDED_VALUES.length);
+          expect(partition0?.lowWatermark).toBe("0");
+          expect(partition0?.highWatermark).toBe(String(SEEDED_VALUES.length));
+
+          const otherPartitions = payload.partitions.filter(
+            (p) => p.partition !== 0,
+          );
+          for (const p of otherPartitions) {
+            expect(p.messageCount).toBe(0);
+          }
+        });
+
+        it("should restrict the response to one partition when `partition` is supplied", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_PARTITION_OFFSETS,
+            arguments: { topicName: topic, partition: 0 },
+          });
+
+          expect(result.isError, textContent(result)).not.toBe(true);
+          const payload =
+            result.structuredContent as GetPartitionOffsetsResponse;
+          expect(payload.partitions).toHaveLength(1);
+          expect(payload.partitions[0]!.partition).toBe(0);
+          expect(payload.partitions[0]!.messageCount).toBe(
+            SEEDED_VALUES.length,
+          );
+        });
+
+        it("should surface a clean out-of-range error citing the actual partition span", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_PARTITION_OFFSETS,
+            arguments: { topicName: topic, partition: 99 },
+          });
+
+          expect(result.isError).toBe(true);
+          expect(textContent(result)).toContain(
+            `Topic "${topic}" has ${NUM_PARTITIONS} partition(s) (0..${NUM_PARTITIONS - 1}); requested partition 99 is out of range`,
+          );
+        });
+
+        it("should surface a clean 'topic not found' error for an unknown topic without leaking librdkafka text", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.GET_PARTITION_OFFSETS,
+            arguments: { topicName: uniqueName("nonexistent") },
+          });
+
+          expect(result.isError).toBe(true);
+          expect(textContent(result)).toMatch(
+            /Topic ".+" not found on this cluster/,
+          );
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `connectTestAdmin()`/`connectTestProducer()` build api-key kafka clients from the direct
+        // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
+        // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // seed via the api-key-authed admin + producer; the GET_PARTITION_OFFSETS call goes via OAuth
+        let admin: KafkaJS.Admin;
+        let producer: KafkaJS.Producer;
+        const topic = uniqueName("offsets-oauth");
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({
+            topics: [{ topic, numPartitions: NUM_PARTITIONS }],
+          });
+          producer = await connectTestProducer();
+          await producer.send({
+            topic,
+            messages: SEEDED_VALUES.map((value) => ({ value, partition: 0 })),
+          });
+        });
+
+        afterAll(async () => {
+          await producer.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect().catch(() => {
+            // disconnect race during teardown isn't actionable
+          });
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return every partition with messageCount totaling the seeded writes", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.GET_PARTITION_OFFSETS,
+              arguments: {
+                topicName: topic,
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(result.isError, textContent(result)).not.toBe(true);
+            const payload =
+              result.structuredContent as GetPartitionOffsetsResponse;
+            expect(payload.topicName).toBe(topic);
+            expect(payload.partitions).toHaveLength(NUM_PARTITIONS);
+
+            const partition0 = payload.partitions.find(
+              (p) => p.partition === 0,
+            );
+            expect(partition0?.messageCount).toBe(SEEDED_VALUES.length);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
@@ -33,125 +33,131 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new GetTopicConfigHandler();
 
-describe("get-topic-config", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaRestWithAuthOrOAuth` predicate accepts either a direct
-  // `kafka.rest_endpoint + kafka.auth` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "get-topic-config",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaRestWithAuthOrOAuth` predicate accepts either a direct
+    // `kafka.rest_endpoint + kafka.auth` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.rest_endpoint + kafka.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    const clusterId = getTestClusterId();
-    // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
-    const { admin, createdTopics } = withSharedAdminClient();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should return the topic configuration for an existing topic", async () => {
-        const topic = uniqueName(`get-config-${transport}`);
-        createdTopics.push(topic);
-        await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
-
-        const result = await server.client.callTool({
-          name: ToolName.GET_TOPIC_CONFIG,
-          arguments: {
-            clusterId,
-            topicName: topic,
-          },
-        });
-
-        // handler embeds a JSON blob with both topicDetails and topicConfig
-        const text = textContent(result);
-        expect(text).toContain(`Topic configuration for '${topic}'`);
-        expect(text).toContain("topicDetails");
-        expect(text).toContain("topicConfig");
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `getTestClusterId()`/`withSharedAdminClient()` read api-key kafka config from the direct
-      // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
-      // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.rest_endpoint + kafka.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // REST-tool handler resolves the cluster URL from `clusterId` + `environmentId` at call
-      // time under OAuth (no `kafka.rest_endpoint` in OAuth connections); the handler errors
-      // when either is omitted
       const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-      // seed via the api-key-authed admin client; GET_TOPIC_CONFIG goes via OAuth
+      // installs beforeAll/afterAll at this describe scope (shared admin client, topic cleanup)
       const { admin, createdTopics } = withSharedAdminClient();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should return the topic configuration for an existing topic", async () => {
-          const topic = uniqueName(`get-config-oauth-${transport}`);
+          const topic = uniqueName(`get-config-${transport}`);
           createdTopics.push(topic);
           await admin().createTopics({ topics: [{ topic, numPartitions: 1 }] });
 
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.GET_TOPIC_CONFIG,
             arguments: {
               clusterId,
-              environmentId,
               topicName: topic,
             },
           });
 
+          // handler embeds a JSON blob with both topicDetails and topicConfig
           const text = textContent(result);
           expect(text).toContain(`Topic configuration for '${topic}'`);
           expect(text).toContain("topicDetails");
           expect(text).toContain("topicConfig");
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `getTestClusterId()`/`withSharedAdminClient()` read api-key kafka config from the direct
+        // fixture; gate the OAuth describe on the same predicate the direct describe uses so an
+        // OAuth-only CI lane without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // REST-tool handler resolves the cluster URL from `clusterId` + `environmentId` at call
+        // time under OAuth (no `kafka.rest_endpoint` in OAuth connections); the handler errors
+        // when either is omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+        // seed via the api-key-authed admin client; GET_TOPIC_CONFIG goes via OAuth
+        const { admin, createdTopics } = withSharedAdminClient();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return the topic configuration for an existing topic", async () => {
+            const topic = uniqueName(`get-config-oauth-${transport}`);
+            createdTopics.push(topic);
+            await admin().createTopics({
+              topics: [{ topic, numPartitions: 1 }],
+            });
+
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.GET_TOPIC_CONFIG,
+              arguments: {
+                clusterId,
+                environmentId,
+                topicName: topic,
+              },
+            });
+
+            const text = textContent(result);
+            expect(text).toContain(`Topic configuration for '${topic}'`);
+            expect(text).toContain("topicDetails");
+            expect(text).toContain("topicConfig");
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.integration.test.ts
@@ -29,118 +29,122 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ListConsumerGroupsHandler();
 
-describe("list-consumer-groups-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "list-consumer-groups-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-consumer-groups in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-
-        const listConsumerGroups = tools.find(
-          (t) => t.name === ToolName.LIST_CONSUMER_GROUPS,
-        );
-        expect(listConsumerGroups).toBeDefined();
-      });
-
-      it("should return the consumer groups from the configured Kafka cluster", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_CONSUMER_GROUPS,
-          arguments: {},
-        });
-
-        // handler always emits a "Found N consumer group(s)" prefix on the
-        // text summary whether the cluster has zero groups or many, so this
-        // proves the tool ran end-to-end against a real broker.
-        expect(textContent(result)).toMatch(/^Found \d+ consumer group/);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `getTestClusterId()`/`getTestEnvironmentId()` read from the direct YAML; gate the OAuth
-      // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
-      // direct creds skips cleanly instead of crashing on missing fixture
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-consumer-groups in tools/list", async () => {
           const { tools } = await server.client.listTools();
+
           const listConsumerGroups = tools.find(
             (t) => t.name === ToolName.LIST_CONSUMER_GROUPS,
           );
           expect(listConsumerGroups).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return the consumer groups from the configured Kafka cluster", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_CONSUMER_GROUPS,
-            arguments: {
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: {},
           });
 
+          // handler always emits a "Found N consumer group(s)" prefix on the
+          // text summary whether the cluster has zero groups or many, so this
+          // proves the tool ran end-to-end against a real broker.
           expect(textContent(result)).toMatch(/^Found \d+ consumer group/);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `getTestClusterId()`/`getTestEnvironmentId()` read from the direct YAML; gate the OAuth
+        // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
+        // direct creds skips cleanly instead of crashing on missing fixture
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-consumer-groups in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            const listConsumerGroups = tools.find(
+              (t) => t.name === ToolName.LIST_CONSUMER_GROUPS,
+            );
+            expect(listConsumerGroups).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return the consumer groups from the configured Kafka cluster", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_CONSUMER_GROUPS,
+              arguments: {
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(textContent(result)).toMatch(/^Found \d+ consumer group/);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.integration.test.ts
@@ -29,114 +29,120 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ListTopicsHandler();
 
-describe("list-topics-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "list-topics-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-topics in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-
-        const listTopics = tools.find((t) => t.name === ToolName.LIST_TOPICS);
-        expect(listTopics).toBeDefined();
-      });
-
-      it("should return the topics from the configured Kafka cluster", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_TOPICS,
-          arguments: {},
-        });
-
-        // handler response is always prefixed with "Kafka topics:" whether the
-        // cluster is empty or not, so this proves the tool ran end-to-end
-        expect(textContent(result)).toMatch(/^Kafka topics:/);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `getTestClusterId()`/`getTestEnvironmentId()` read from the direct YAML; gate the OAuth
-      // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
-      // direct creds skips cleanly instead of crashing on missing fixture
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when
-      // these args are omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-topics in tools/list", async () => {
           const { tools } = await server.client.listTools();
+
           const listTopics = tools.find((t) => t.name === ToolName.LIST_TOPICS);
           expect(listTopics).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return the topics from the configured Kafka cluster", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_TOPICS,
-            arguments: {
-              cluster_id: clusterId,
-              environment_id: environmentId,
-            },
+            arguments: {},
           });
 
+          // handler response is always prefixed with "Kafka topics:" whether the
+          // cluster is empty or not, so this proves the tool ran end-to-end
           expect(textContent(result)).toMatch(/^Kafka topics:/);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `getTestClusterId()`/`getTestEnvironmentId()` read from the direct YAML; gate the OAuth
+        // describe on the same predicate the direct describe uses so an OAuth-only CI lane without
+        // direct creds skips cleanly instead of crashing on missing fixture
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when
+        // these args are omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-topics in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            const listTopics = tools.find(
+              (t) => t.name === ToolName.LIST_TOPICS,
+            );
+            expect(listTopics).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return the topics from the configured Kafka cluster", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_TOPICS,
+              arguments: {
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(textContent(result)).toMatch(/^Kafka topics:/);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -34,101 +34,27 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ProduceKafkaMessageHandler();
 
-describe("produce-kafka-message-handler", { tags: [Tag.KAFKA] }, () => {
-  // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
-  // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "produce-kafka-message-handler",
+  { tags: [Tag.KAFKA, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    // the handler's `kafkaBootstrapOrOAuth` predicate accepts either a direct
+    // `kafka.bootstrap_servers` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // single shared topic for all transports (cheaper than creating one per transport)
-    let admin: KafkaJS.Admin;
-    const topic = uniqueName("produce");
-
-    beforeAll(async () => {
-      admin = await connectTestAdmin();
-      await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
-    });
-
-    afterAll(async () => {
-      await admin.deleteTopics({ topics: [topic] }).catch(() => {
-        // teardown-only; a cleanup failure shouldn't fail an already-asserted test
-      });
-      await admin.disconnect();
-    });
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should produce a raw-string message and return a partition+offset delivery report", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.PRODUCE_MESSAGE,
-          arguments: {
-            topicName: topic,
-            value: { message: `hello from ${transport}` },
-          },
-        });
-
-        // handler formats each delivery report as:
-        //   "Message produced successfully to [Topic: ..., Partition: ..., Offset: ...]"
-        const text = textContent(result);
-        expect(text).toMatch(/Message produced successfully to \[Topic: /);
-        expect(text).toContain(topic);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `connectTestAdmin()` builds an api-key kafka client from the direct fixture; gate the
-      // OAuth describe on the same predicate the direct describe uses so an OAuth-only CI lane
-      // without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires kafka.bootstrap_servers in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth connections carry no `kafka` block, so the handler resolves the broker from
-      // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
-      const clusterId = getTestClusterId();
-      const environmentId = getTestEnvironmentId();
-
-      // seed via the api-key-authed admin client; the PRODUCE_MESSAGE call goes via OAuth
+      // single shared topic for all transports (cheaper than creating one per transport)
       let admin: KafkaJS.Admin;
-      const topic = uniqueName("produce-oauth");
+      const topic = uniqueName("produce");
 
       beforeAll(async () => {
         admin = await connectTestAdmin();
@@ -146,30 +72,108 @@ describe("produce-kafka-message-handler", { tags: [Tag.KAFKA] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should produce a raw-string message and return a partition+offset delivery report", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.PRODUCE_MESSAGE,
             arguments: {
               topicName: topic,
-              value: { message: `hello from oauth ${transport}` },
-              cluster_id: clusterId,
-              environment_id: environmentId,
+              value: { message: `hello from ${transport}` },
             },
           });
 
+          // handler formats each delivery report as:
+          //   "Message produced successfully to [Topic: ..., Partition: ..., Offset: ...]"
           const text = textContent(result);
           expect(text).toMatch(/Message produced successfully to \[Topic: /);
           expect(text).toContain(topic);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `connectTestAdmin()` builds an api-key kafka client from the direct fixture; gate the
+        // OAuth describe on the same predicate the direct describe uses so an OAuth-only CI lane
+        // without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth connections carry no `kafka` block, so the handler resolves the broker from
+        // `cluster_id` + `environment_id` at call time; under OAuth the handler errors when omitted
+        const clusterId = getTestClusterId();
+        const environmentId = getTestEnvironmentId();
+
+        // seed via the api-key-authed admin client; the PRODUCE_MESSAGE call goes via OAuth
+        let admin: KafkaJS.Admin;
+        const topic = uniqueName("produce-oauth");
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
+        });
+
+        afterAll(async () => {
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect();
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should produce a raw-string message and return a partition+offset delivery report", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.PRODUCE_MESSAGE,
+              arguments: {
+                topicName: topic,
+                value: { message: `hello from oauth ${transport}` },
+                cluster_id: clusterId,
+                environment_id: environmentId,
+              },
+            });
+
+            const text = textContent(result);
+            expect(text).toMatch(/Message produced successfully to \[Topic: /);
+            expect(text).toContain(topic);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.integration.test.ts
@@ -13,40 +13,46 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListMetricsHandler();
 const runtime = integrationRuntime();
 
-describe("list-metrics-handler", { tags: [Tag.METRICS] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires telemetry.auth config", () => {});
-    return;
-  }
+describe(
+  "list-metrics-handler",
+  { tags: [Tag.METRICS, Tag.REQUIRES_TELEMETRY_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires telemetry.auth config", () => {});
+      return;
+    }
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-metrics in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(tools.find((t) => t.name === ToolName.LIST_METRICS)).toBeDefined();
-    });
-
-    it("should list metrics filtered by resource_type=kafka", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_METRICS,
-        arguments: { resource_type: "kafka" },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      const text = textContent(result);
-      // received_bytes is a stable kafka.server metric, so finding it proves the end-to-end call
-      // returned kafka data
-      expect(text).toMatch(/Available Metrics \(kafka\): [1-9]\d*/);
-      expect(text).toContain("io.confluent.kafka.server/received_bytes");
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-metrics in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_METRICS),
+        ).toBeDefined();
+      });
+
+      it("should list metrics filtered by resource_type=kafka", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_METRICS,
+          arguments: { resource_type: "kafka" },
+        });
+
+        const text = textContent(result);
+        // received_bytes is a stable kafka.server metric, so finding it proves the end-to-end call
+        // returned kafka data
+        expect(text).toMatch(/Available Metrics \(kafka\): [1-9]\d*/);
+        expect(text).toContain("io.confluent.kafka.server/received_bytes");
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.integration.test.ts
@@ -13,46 +13,50 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new QueryMetricsHandler();
 const runtime = integrationRuntime();
 
-describe("query-metrics-handler", { tags: [Tag.METRICS] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires telemetry.auth config", () => {});
-    return;
-  }
+describe(
+  "query-metrics-handler",
+  { tags: [Tag.METRICS, Tag.REQUIRES_TELEMETRY_CONFIG] },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires telemetry.auth config", () => {});
+      return;
+    }
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose query-metrics in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.QUERY_METRICS),
-      ).toBeDefined();
-    });
-
-    it("should query a kafka.server metric for the configured cluster", async () => {
-      // `filter` is omitted: for io.confluent.kafka.server/* metrics the handler auto-injects
-      // resource.kafka.id (from kafka.cluster_id in integration.yaml)
-      const result = await server.client.callTool({
-        name: ToolName.QUERY_METRICS,
-        arguments: {
-          metric: "io.confluent.kafka.server/received_bytes",
-          granularity: "PT5M",
-        },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      // idle cluster may show "No data returned for metric"
-      expect(textContent(result)).toMatch(
-        /^(Metrics Query Results|No data returned for metric)/,
-      );
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose query-metrics in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.QUERY_METRICS),
+        ).toBeDefined();
+      });
+
+      it("should query a kafka.server metric for the configured cluster", async () => {
+        // `filter` is omitted: for io.confluent.kafka.server/* metrics the handler auto-injects
+        // resource.kafka.id (from kafka.cluster_id in integration.yaml)
+        const result = await server.client.callTool({
+          name: ToolName.QUERY_METRICS,
+          arguments: {
+            metric: "io.confluent.kafka.server/received_bytes",
+            granularity: "PT5M",
+          },
+        });
+
+        // idle cluster may show "No data returned for metric"
+        expect(textContent(result)).toMatch(
+          /^(Metrics Query Results|No data returned for metric)/,
+        );
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.integration.test.ts
@@ -26,65 +26,21 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ListOrganizationsHandler();
 
-describe("list-organizations-handler", { tags: [Tag.ORGANIZATIONS] }, () => {
-  // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
-  // `confluent_cloud` block or an OAuth connection; sibling describe blocks exercise each path
+describe(
+  "list-organizations-handler",
+  { tags: [Tag.ORGANIZATIONS, Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG] },
+  () => {
+    // the handler's `hasConfluentCloudOrOAuth` predicate accepts either an API-key-authed
+    // `confluent_cloud` block or an OAuth connection; sibling describe blocks exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-organizations in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-        expect(
-          tools.find((t) => t.name === ToolName.LIST_ORGANIZATIONS),
-        ).toBeDefined();
-      });
-
-      it("should return at least one organization from CCloud", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_ORGANIZATIONS,
-          arguments: {},
-        });
-        expect(textContent(result)).toMatch(/^Retrieved \d+ organizations?:/);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+      const directRuntime = integrationRuntime({ oauth: false });
+      if (handler.enabledConnectionIds(directRuntime).length === 0) {
+        it.skip("requires confluent_cloud.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
@@ -92,11 +48,11 @@ describe("list-organizations-handler", { tags: [Tag.ORGANIZATIONS] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-organizations in tools/list", async () => {
@@ -106,15 +62,65 @@ describe("list-organizations-handler", { tags: [Tag.ORGANIZATIONS] }, () => {
           ).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return at least one organization from CCloud", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_ORGANIZATIONS,
             arguments: {},
           });
           expect(textContent(result)).toMatch(/^Retrieved \d+ organizations?:/);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-organizations in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            expect(
+              tools.find((t) => t.name === ToolName.LIST_ORGANIZATIONS),
+            ).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return at least one organization from CCloud", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_ORGANIZATIONS,
+              arguments: {},
+            });
+            expect(textContent(result)).toMatch(
+              /^Retrieved \d+ organizations?:/,
+            );
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
@@ -33,118 +33,44 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new DeleteSchemaHandler();
 
-describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
-  // the handler's `hasSchemaRegistryOrOAuth` predicate accepts either a direct
-  // `schema_registry` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "delete-schema-handler",
+  { tags: [Tag.SCHEMA, Tag.REQUIRES_SCHEMA_REGISTRY_CONFIG] },
+  () => {
+    // the handler's `hasSchemaRegistryOrOAuth` predicate accepts either a direct
+    // `schema_registry` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // installs beforeAll/afterAll at this describe scope (shared SR client, subject cleanup)
-    const { client, createdSubjects } = withSharedSrClient();
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should soft-delete a registered subject", async () => {
-        // create a new schema+subject before we try to delete it
-        const subject = uniqueName(`delete-${transport}`);
-        createdSubjects.push(subject);
-        await client().register(subject, { schema: TEST_AVRO_SCHEMA });
-        // SR's listing is eventually consistent; poll until the new subject is visible before deleting
-        await expect
-          .poll(() => client().getAllSubjects(), {
-            timeout: 15_000,
-            interval: 500,
-          })
-          .toContain(subject);
-
-        const result = await server.client.callTool({
-          name: ToolName.DELETE_SCHEMA,
-          arguments: { subject },
-        });
-
-        expect(textContent(result)).toContain(
-          `Successfully deleted subject "${subject}"`,
-        );
-        // a soft delete removes the subject from the default `getAllSubjects()` listing
-        await expect
-          .poll(() => client().getAllSubjects(), {
-            timeout: 15_000,
-            interval: 500,
-          })
-          .not.toContain(subject);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `withSharedSrClient()` builds an api-key SR client from the direct fixture; gate the
-      // OAuth describe on the same predicate the direct describe uses so an OAuth-only CI lane
-      // without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth handlers don't carry a `schema_registry` block, so the SR endpoint is resolved at
-      // call time from `environment_id`; under OAuth the handler errors when this arg is omitted
-      const environmentId = getTestEnvironmentId();
-
-      // seed via the test-side SR client (api-key auth); the server-side OAuth path is what
-      // we're exercising via the DELETE_SCHEMA call below
+      // installs beforeAll/afterAll at this describe scope (shared SR client, subject cleanup)
       const { client, createdSubjects } = withSharedSrClient();
 
       describe.each(activeTransports)("via %s transport", (transport) => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
-
-        afterAll(async () => {
-          await stopOAuthServer(server);
+          server = await startServer({ transport });
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+        afterAll(async () => {
+          await server?.stop();
+        });
+
         it("should soft-delete a registered subject", async () => {
-          const subject = uniqueName(`delete-oauth-${transport}`);
+          // create a new schema+subject before we try to delete it
+          const subject = uniqueName(`delete-${transport}`);
           createdSubjects.push(subject);
           await client().register(subject, { schema: TEST_AVRO_SCHEMA });
+          // SR's listing is eventually consistent; poll until the new subject is visible before deleting
           await expect
             .poll(() => client().getAllSubjects(), {
               timeout: 15_000,
@@ -152,14 +78,15 @@ describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
             })
             .toContain(subject);
 
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.DELETE_SCHEMA,
-            arguments: { subject, environment_id: environmentId },
+            arguments: { subject },
           });
 
           expect(textContent(result)).toContain(
             `Successfully deleted subject "${subject}"`,
           );
+          // a soft delete removes the subject from the default `getAllSubjects()` listing
           await expect
             .poll(() => client().getAllSubjects(), {
               timeout: 15_000,
@@ -168,6 +95,83 @@ describe("delete-schema-handler", { tags: [Tag.SCHEMA] }, () => {
             .not.toContain(subject);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `withSharedSrClient()` builds an api-key SR client from the direct fixture; gate the
+        // OAuth describe on the same predicate the direct describe uses so an OAuth-only CI lane
+        // without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth handlers don't carry a `schema_registry` block, so the SR endpoint is resolved at
+        // call time from `environment_id`; under OAuth the handler errors when this arg is omitted
+        const environmentId = getTestEnvironmentId();
+
+        // seed via the test-side SR client (api-key auth); the server-side OAuth path is what
+        // we're exercising via the DELETE_SCHEMA call below
+        const { client, createdSubjects } = withSharedSrClient();
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should soft-delete a registered subject", async () => {
+            const subject = uniqueName(`delete-oauth-${transport}`);
+            createdSubjects.push(subject);
+            await client().register(subject, { schema: TEST_AVRO_SCHEMA });
+            await expect
+              .poll(() => client().getAllSubjects(), {
+                timeout: 15_000,
+                interval: 500,
+              })
+              .toContain(subject);
+
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.DELETE_SCHEMA,
+              arguments: { subject, environment_id: environmentId },
+            });
+
+            expect(textContent(result)).toContain(
+              `Successfully deleted subject "${subject}"`,
+            );
+            await expect
+              .poll(() => client().getAllSubjects(), {
+                timeout: 15_000,
+                interval: 500,
+              })
+              .not.toContain(subject);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
@@ -33,100 +33,29 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new ListSchemasHandler();
 
-describe("list-schemas-handler", { tags: [Tag.SCHEMA] }, () => {
-  // the handler's `hasSchemaRegistryOrOAuth` predicate accepts either a direct
-  // `schema_registry` block or an OAuth connection; sibling describes exercise each path
+describe(
+  "list-schemas-handler",
+  { tags: [Tag.SCHEMA, Tag.REQUIRES_SCHEMA_REGISTRY_CONFIG] },
+  () => {
+    // the handler's `hasSchemaRegistryOrOAuth` predicate accepts either a direct
+    // `schema_registry` block or an OAuth connection; sibling describes exercise each path
 
-  describe(`with a ${ConnectionType.DIRECT} connection`, () => {
-    if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
-      it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
-      return;
-    }
-    const directRuntime = integrationRuntime({ oauth: false });
-    if (handler.enabledConnectionIds(directRuntime).length === 0) {
-      it.skip("requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
-      return;
-    }
-
-    // installs beforeAll/afterAll at this describe scope (shared SR client, subject cleanup)
-    const { client, createdSubjects } = withSharedSrClient();
-    const subject = uniqueName("list");
-
-    // seed one subject so the assertion still fires against a brand-new empty registry
-    beforeAll(async () => {
-      await client().register(subject, { schema: TEST_AVRO_SCHEMA });
-      createdSubjects.push(subject);
-    });
-
-    describe.each(activeTransports)("via %s transport", (transport) => {
-      let server: StartedServer;
-
-      beforeAll(async () => {
-        server = await startServer({ transport });
-      });
-
-      afterAll(async () => {
-        await server?.stop();
-      });
-
-      it("should expose list-schemas in tools/list", async () => {
-        const { tools } = await server.client.listTools();
-
-        const listSchemas = tools.find((t) => t.name === ToolName.LIST_SCHEMAS);
-        expect(listSchemas).toBeDefined();
-      });
-
-      it("should return a subject map that includes the seeded subject", async () => {
-        const result = await server.client.callTool({
-          name: ToolName.LIST_SCHEMAS,
-          arguments: { subjectPrefix: subject },
-        });
-
-        expect(result.isError, textContent(result)).not.toBe(true);
-        // handler stringifies a `Record<subject, metadata>` map; the prefix filter narrows the
-        // response to a single-key object
-        const parsed = JSON.parse(textContent(result));
-        expect(parsed).toHaveProperty(subject);
-      });
-    });
-  });
-
-  describe(
-    `with a ${ConnectionType.OAUTH} connection`,
-    { tags: [Tag.OAUTH] },
-    () => {
-      if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
-        it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+    describe(`with a ${ConnectionType.DIRECT} connection`, () => {
+      if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+        it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
         return;
       }
-      const oauthRuntime = integrationRuntime({ oauth: true });
-      if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
-        it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
-        return;
-      }
-      const credentials = getOAuthCredentialsFromEnv();
-      if (!credentials) {
-        it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
-        return;
-      }
-      // `withSharedSrClient()` builds an api-key SR client from the direct fixture; gate the
-      // OAuth describe on the same predicate the direct describe uses so an OAuth-only CI lane
-      // without direct creds skips cleanly instead of crashing in beforeAll
       const directRuntime = integrationRuntime({ oauth: false });
       if (handler.enabledConnectionIds(directRuntime).length === 0) {
-        it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+        it.skip("requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml", () => {});
         return;
       }
 
-      // OAuth handlers don't carry a `schema_registry` block, so the SR endpoint is resolved at
-      // call time from `environment_id`; under OAuth the handler errors when this arg is omitted
-      const environmentId = getTestEnvironmentId();
-
-      // seed via the test-side SR client (api-key auth); the server-side OAuth path is what
-      // we're exercising via the LIST_SCHEMAS call below
+      // installs beforeAll/afterAll at this describe scope (shared SR client, subject cleanup)
       const { client, createdSubjects } = withSharedSrClient();
-      const subject = uniqueName("list-oauth");
+      const subject = uniqueName("list");
 
+      // seed one subject so the assertion still fires against a brand-new empty registry
       beforeAll(async () => {
         await client().register(subject, { schema: TEST_AVRO_SCHEMA });
         createdSubjects.push(subject);
@@ -136,36 +65,113 @@ describe("list-schemas-handler", { tags: [Tag.SCHEMA] }, () => {
         let server: StartedServer;
 
         beforeAll(async () => {
-          server = await startOAuthServer({ transport });
-        }, 180_000);
+          server = await startServer({ transport });
+        });
 
         afterAll(async () => {
-          await stopOAuthServer(server);
+          await server?.stop();
         });
 
         it("should expose list-schemas in tools/list", async () => {
           const { tools } = await server.client.listTools();
+
           const listSchemas = tools.find(
             (t) => t.name === ToolName.LIST_SCHEMAS,
           );
           expect(listSchemas).toBeDefined();
         });
 
-        // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
         it("should return a subject map that includes the seeded subject", async () => {
-          const result = await callToolWithOAuthFlow(server, credentials, {
+          const result = await server.client.callTool({
             name: ToolName.LIST_SCHEMAS,
-            arguments: {
-              subjectPrefix: subject,
-              environment_id: environmentId,
-            },
+            arguments: { subjectPrefix: subject },
           });
 
           expect(result.isError, textContent(result)).not.toBe(true);
+          // handler stringifies a `Record<subject, metadata>` map; the prefix filter narrows the
+          // response to a single-key object
           const parsed = JSON.parse(textContent(result));
           expect(parsed).toHaveProperty(subject);
         });
       });
-    },
-  );
-});
+    });
+
+    describe(
+      `with a ${ConnectionType.OAUTH} connection`,
+      { tags: [Tag.OAUTH] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.OAUTH)) {
+          it.skip(CONNECTION_TYPE_OAUTH_FILTERED_REASON, () => {});
+          return;
+        }
+        const oauthRuntime = integrationRuntime({ oauth: true });
+        if (handler.enabledConnectionIds(oauthRuntime).length === 0) {
+          it.skip(OAUTH_FIXTURE_NOT_LOADED_REASON, () => {});
+          return;
+        }
+        const credentials = getOAuthCredentialsFromEnv();
+        if (!credentials) {
+          it.skip(OAUTH_USER_CREDS_MISSING_REASON, () => {});
+          return;
+        }
+        // `withSharedSrClient()` builds an api-key SR client from the direct fixture; gate the
+        // OAuth describe on the same predicate the direct describe uses so an OAuth-only CI lane
+        // without direct creds skips cleanly instead of crashing in beforeAll
+        const directRuntime = integrationRuntime({ oauth: false });
+        if (handler.enabledConnectionIds(directRuntime).length === 0) {
+          it.skip(DIRECT_FIXTURE_REQUIRED_FOR_OAUTH_SEEDING_REASON, () => {});
+          return;
+        }
+
+        // OAuth handlers don't carry a `schema_registry` block, so the SR endpoint is resolved at
+        // call time from `environment_id`; under OAuth the handler errors when this arg is omitted
+        const environmentId = getTestEnvironmentId();
+
+        // seed via the test-side SR client (api-key auth); the server-side OAuth path is what
+        // we're exercising via the LIST_SCHEMAS call below
+        const { client, createdSubjects } = withSharedSrClient();
+        const subject = uniqueName("list-oauth");
+
+        beforeAll(async () => {
+          await client().register(subject, { schema: TEST_AVRO_SCHEMA });
+          createdSubjects.push(subject);
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startOAuthServer({ transport });
+          }, 180_000);
+
+          afterAll(async () => {
+            await stopOAuthServer(server);
+          });
+
+          it("should expose list-schemas in tools/list", async () => {
+            const { tools } = await server.client.listTools();
+            const listSchemas = tools.find(
+              (t) => t.name === ToolName.LIST_SCHEMAS,
+            );
+            expect(listSchemas).toBeDefined();
+          });
+
+          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+          it("should return a subject map that includes the seeded subject", async () => {
+            const result = await callToolWithOAuthFlow(server, credentials, {
+              name: ToolName.LIST_SCHEMAS,
+              arguments: {
+                subjectPrefix: subject,
+                environment_id: environmentId,
+              },
+            });
+
+            expect(result.isError, textContent(result)).not.toBe(true);
+            const parsed = JSON.parse(textContent(result));
+            expect(parsed).toHaveProperty(subject);
+          });
+        });
+      },
+    );
+  },
+);

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.integration.test.ts
@@ -15,7 +15,13 @@ const runtime = integrationRuntime();
 
 describe(
   "list-tableflow-catalog-integrations-handler",
-  { tags: [Tag.TABLEFLOW] },
+  {
+    tags: [
+      Tag.TABLEFLOW,
+      Tag.REQUIRES_TABLEFLOW_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
   () => {
     if (handler.enabledConnectionIds(runtime).length === 0) {
       it.skip("requires tableflow.auth config", () => {});

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.integration.test.ts
@@ -13,84 +13,94 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListTableFlowRegionsHandler();
 const runtime = integrationRuntime();
 
-describe("list-tableflow-regions-handler", { tags: [Tag.TABLEFLOW] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires tableflow.auth config", () => {});
-    return;
-  }
+describe(
+  "list-tableflow-regions-handler",
+  {
+    tags: [
+      Tag.TABLEFLOW,
+      Tag.REQUIRES_TABLEFLOW_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires tableflow.auth config", () => {});
+      return;
+    }
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-tableflow-regions in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_TABLEFLOW_REGIONS),
-      ).toBeDefined();
-    });
-
-    it("should return AWS regions when filtered by cloud=AWS", async () => {
-      // CCloud's REST surface expects uppercase cloud codes ("AWS", "GCP", "AZURE").
-      const result = await server.client.callTool({
-        name: ToolName.LIST_TABLEFLOW_REGIONS,
-        arguments: { cloud: "AWS" },
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      const text = textContent(result);
-      expect(text).toMatch(/^Tableflow Regions:/);
-      expect(text).toContain("us-east-2");
-    });
-
-    it("should return AZURE regions when filtered by cloud=AZURE", async () => {
-      const result = await server.client.callTool({
-        name: ToolName.LIST_TABLEFLOW_REGIONS,
-        arguments: { cloud: "AZURE" },
+      afterAll(async () => {
+        await server?.stop();
       });
 
-      const text = textContent(result);
-      expect(text).toMatch(/^Tableflow Regions:/);
-      expect(text).toContain("eastus2");
-    });
+      it("should expose list-tableflow-regions in tools/list", async () => {
+        const { tools } = await server.client.listTools();
 
-    it("should return GCP regions when filtered by cloud=GCP", async (ctx) => {
-      // CCloud has no GCP tableflow regions today (call returns total_size=0). Skip rather than
-      // fail so this auto-validates when GCP lands. A real "filter ignored" regression isn't
-      // masked: total_size > 0 bypasses the skip, and the GCP cloud assertion catches it.
-      const result = await server.client.callTool({
-        name: ToolName.LIST_TABLEFLOW_REGIONS,
-        arguments: { cloud: "GCP" },
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_TABLEFLOW_REGIONS),
+        ).toBeDefined();
       });
 
-      const text = textContent(result);
-      expect(text).toMatch(/^Tableflow Regions:/);
-      if (/"total_size":0\b/.test(text)) {
-        ctx.skip("CCloud has no GCP tableflow regions configured");
-      }
-      expect(text).toMatch(/"cloud":"GCP"/);
-    });
+      it("should return AWS regions when filtered by cloud=AWS", async () => {
+        // CCloud's REST surface expects uppercase cloud codes ("AWS", "GCP", "AZURE").
+        const result = await server.client.callTool({
+          name: ToolName.LIST_TABLEFLOW_REGIONS,
+          arguments: { cloud: "AWS" },
+        });
 
-    it("should succeed when cloud is omitted", async () => {
-      // regression for #129: omitted cloud must not send `?cloud=undefined`, which CCloud rejects
-      // with 400. The success-prefix match below is the regression guard.
-      const result = await server.client.callTool({
-        name: ToolName.LIST_TABLEFLOW_REGIONS,
-        arguments: {},
+        const text = textContent(result);
+        expect(text).toMatch(/^Tableflow Regions:/);
+        expect(text).toContain("us-east-2");
       });
 
-      const text = textContent(result);
-      expect(text).toMatch(/^Tableflow Regions:/);
-      expect(text).toMatch(/"cloud":"AWS"/);
-      // FUTURE: update this test when CCloud returns multiple cloud providers when `cloud` isn't
-      // specified
+      it("should return AZURE regions when filtered by cloud=AZURE", async () => {
+        const result = await server.client.callTool({
+          name: ToolName.LIST_TABLEFLOW_REGIONS,
+          arguments: { cloud: "AZURE" },
+        });
+
+        const text = textContent(result);
+        expect(text).toMatch(/^Tableflow Regions:/);
+        expect(text).toContain("eastus2");
+      });
+
+      it("should return GCP regions when filtered by cloud=GCP", async (ctx) => {
+        // CCloud has no GCP tableflow regions today (call returns total_size=0). Skip rather than
+        // fail so this auto-validates when GCP lands. A real "filter ignored" regression isn't
+        // masked: total_size > 0 bypasses the skip, and the GCP cloud assertion catches it.
+        const result = await server.client.callTool({
+          name: ToolName.LIST_TABLEFLOW_REGIONS,
+          arguments: { cloud: "GCP" },
+        });
+
+        const text = textContent(result);
+        expect(text).toMatch(/^Tableflow Regions:/);
+        if (/"total_size":0\b/.test(text)) {
+          ctx.skip("CCloud has no GCP tableflow regions configured");
+        }
+        expect(text).toMatch(/"cloud":"GCP"/);
+      });
+
+      it("should succeed when cloud is omitted", async () => {
+        // regression for #129: omitted cloud must not send `?cloud=undefined`, which CCloud rejects
+        // with 400. The success-prefix match below is the regression guard.
+        const result = await server.client.callTool({
+          name: ToolName.LIST_TABLEFLOW_REGIONS,
+          arguments: {},
+        });
+
+        const text = textContent(result);
+        expect(text).toMatch(/^Tableflow Regions:/);
+        expect(text).toMatch(/"cloud":"AWS"/);
+        // FUTURE: update this test when CCloud returns multiple cloud providers when `cloud` isn't
+        // specified
+      });
     });
-  });
-});
+  },
+);

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.integration.test.ts
@@ -13,42 +13,52 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 const handler = new ListTableFlowTopicsHandler();
 const runtime = integrationRuntime();
 
-describe("list-tableflow-topics-handler", { tags: [Tag.TABLEFLOW] }, () => {
-  if (handler.enabledConnectionIds(runtime).length === 0) {
-    it.skip("requires tableflow.auth config", () => {});
-    return;
-  }
+describe(
+  "list-tableflow-topics-handler",
+  {
+    tags: [
+      Tag.TABLEFLOW,
+      Tag.REQUIRES_TABLEFLOW_CONFIG,
+      Tag.REQUIRES_CONFLUENT_CLOUD_CONFIG,
+    ],
+  },
+  () => {
+    if (handler.enabledConnectionIds(runtime).length === 0) {
+      it.skip("requires tableflow.auth config", () => {});
+      return;
+    }
 
-  describe.each(activeTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
+    describe.each(activeTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await server?.stop();
-    });
-
-    it("should expose list-tableflow-topics in tools/list", async () => {
-      const { tools } = await server.client.listTools();
-
-      expect(
-        tools.find((t) => t.name === ToolName.LIST_TABLEFLOW_TOPICS),
-      ).toBeDefined();
-    });
-
-    it("should list tableflow topics for the configured cluster", async () => {
-      // omit env/cluster args: handler falls back to kafka.env_id and kafka.cluster_id from
-      // the YAML fixture. an empty data array is a valid happy-path response when no kafka topics
-      // have tableflow enabled in the test cluster.
-      const result = await server.client.callTool({
-        name: ToolName.LIST_TABLEFLOW_TOPICS,
-        arguments: {},
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
 
-      expect(result.isError).not.toBe(true);
-      expect(textContent(result)).toMatch(/^Tableflow Topics:/);
+      afterAll(async () => {
+        await server?.stop();
+      });
+
+      it("should expose list-tableflow-topics in tools/list", async () => {
+        const { tools } = await server.client.listTools();
+
+        expect(
+          tools.find((t) => t.name === ToolName.LIST_TABLEFLOW_TOPICS),
+        ).toBeDefined();
+      });
+
+      it("should list tableflow topics for the configured cluster", async () => {
+        // omit env/cluster args: handler falls back to kafka.env_id and kafka.cluster_id from
+        // the YAML fixture. an empty data array is a valid happy-path response when no kafka topics
+        // have tableflow enabled in the test cluster.
+        const result = await server.client.callTool({
+          name: ToolName.LIST_TABLEFLOW_TOPICS,
+          arguments: {},
+        });
+
+        expect(result.isError).not.toBe(true);
+        expect(textContent(result)).toMatch(/^Tableflow Topics:/);
+      });
     });
-  });
-});
+  },
+);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,7 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
 /** Properties recorded for each tool invocation. */
@@ -57,14 +56,6 @@ export function createMcpServer({
       },
       async (args, context) => {
         const startTime = Date.now();
-        // TEMPORARY INSTRUMENTATION: log every handler invocation with tool name + timestamp.
-        // Diagnosing the CI OAuth tests where the auth URL is emitted server-side ~30s before
-        // `driveOAuthFlow`'s listener attaches. If a handler fires twice (or fires from an
-        // unexpected path like the SDK's tools/list response), this surfaces it.
-        logger.info(
-          { toolName: name, t: startTime, sessionId: context?.sessionId },
-          "tool handler invoked",
-        );
         // per-instance lookup so concurrent HTTP sessions don't clobber each other's telemetry
         const clientInfo = srv.server.getClientVersion();
         const baseProps = {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
 /** Properties recorded for each tool invocation. */
@@ -56,6 +57,14 @@ export function createMcpServer({
       },
       async (args, context) => {
         const startTime = Date.now();
+        // TEMPORARY INSTRUMENTATION: log every handler invocation with tool name + timestamp.
+        // Diagnosing the CI OAuth tests where the auth URL is emitted server-side ~30s before
+        // `driveOAuthFlow`'s listener attaches. If a handler fires twice (or fires from an
+        // unexpected path like the SDK's tools/list response), this surfaces it.
+        logger.info(
+          { toolName: name, t: startTime, sessionId: context?.sessionId },
+          "tool handler invoked",
+        );
         // per-instance lookup so concurrent HTTP sessions don't clobber each other's telemetry
         const clientInfo = srv.server.getClientVersion();
         const baseProps = {

--- a/src/mcp/transports/auth.integration.test.ts
+++ b/src/mcp/transports/auth.integration.test.ts
@@ -19,59 +19,63 @@ const runtime = integrationRuntime();
 const TEST_API_KEY =
   "integration-auth-smoke-test-key-not-a-real-credential-do-not-reuse";
 
-describe("HTTP auth middleware", { tags: [Tag.SMOKE] }, () => {
-  if (Object.keys(runtime.config.connections).length === 0) {
-    it.skip("requires at least one configured connection in integration.yaml", () => {});
-    return;
-  }
+describe(
+  "HTTP auth middleware",
+  { tags: [Tag.SMOKE, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    if (Object.keys(runtime.config.connections).length === 0) {
+      it.skip("requires at least one configured connection in integration.yaml", () => {});
+      return;
+    }
 
-  let server: StartedServer;
+    let server: StartedServer;
 
-  beforeAll(async () => {
-    server = await startServer({
-      transport: TransportType.HTTP,
-      auth: { apiKey: TEST_API_KEY },
-    });
-  });
-
-  afterAll(async () => {
-    await server?.stop();
-  });
-
-  it(`should reject requests with no ${CFLT_MCP_API_KEY_HEADER} header with 401`, async () => {
-    const response = await fetch(`${server.baseUrl}/mcp`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    beforeAll(async () => {
+      server = await startServer({
+        transport: TransportType.HTTP,
+        auth: { apiKey: TEST_API_KEY },
+      });
     });
 
-    expect(response.status).toBe(401);
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("Unauthorized");
-  });
-
-  it(`should reject requests with the wrong ${CFLT_MCP_API_KEY_HEADER} with 401`, async () => {
-    const response = await fetch(`${server.baseUrl}/mcp`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        [CFLT_MCP_API_KEY_HEADER]: "not-the-server-key",
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    afterAll(async () => {
+      await server?.stop();
     });
 
-    expect(response.status).toBe(401);
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("Unauthorized");
-  });
+    it(`should reject requests with no ${CFLT_MCP_API_KEY_HEADER} header with 401`, async () => {
+      const response = await fetch(`${server.baseUrl}/mcp`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
 
-  it("should accept the SDK client roundtrip when the correct key is supplied", async () => {
-    // beforeAll already connected the SDK client with the correct header via the
-    // harness; a successful tools/list round-trip proves the same header reaches
-    // the auth-protected /mcp endpoint and the middleware accepts it. the
-    // returned tool count is irrelevant here (a future fixture may have a
-    // connection with no service blocks and zero tools); only the resolved
-    // promise matters.
-    await expect(server.client.listTools()).resolves.toBeDefined();
-  });
-});
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Unauthorized");
+    });
+
+    it(`should reject requests with the wrong ${CFLT_MCP_API_KEY_HEADER} with 401`, async () => {
+      const response = await fetch(`${server.baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [CFLT_MCP_API_KEY_HEADER]: "not-the-server-key",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Unauthorized");
+    });
+
+    it("should accept the SDK client roundtrip when the correct key is supplied", async () => {
+      // beforeAll already connected the SDK client with the correct header via the
+      // harness; a successful tools/list round-trip proves the same header reaches
+      // the auth-protected /mcp endpoint and the middleware accepts it. the
+      // returned tool count is irrelevant here (a future fixture may have a
+      // connection with no service blocks and zero tools); only the resolved
+      // promise matters.
+      await expect(server.client.listTools()).resolves.toBeDefined();
+    });
+  },
+);

--- a/src/mcp/transports/multi-client.integration.test.ts
+++ b/src/mcp/transports/multi-client.integration.test.ts
@@ -20,67 +20,73 @@ const multiClientTransports = activeTransports.filter(
   (t) => t === TransportType.HTTP || t === TransportType.SSE,
 );
 
-describe("multi-client", { tags: [Tag.SMOKE] }, () => {
-  if (Object.keys(runtime.config.connections).length === 0) {
-    it.skip("requires at least one configured connection in integration.yaml", () => {});
-    return;
-  }
+describe(
+  "multi-client",
+  { tags: [Tag.SMOKE, Tag.REQUIRES_KAFKA_CONFIG] },
+  () => {
+    if (Object.keys(runtime.config.connections).length === 0) {
+      it.skip("requires at least one configured connection in integration.yaml", () => {});
+      return;
+    }
 
-  if (multiClientTransports.length === 0) {
-    it.skip("multi-client coverage applies only to HTTP/SSE transports", () => {});
-    return;
-  }
+    if (multiClientTransports.length === 0) {
+      it.skip("multi-client coverage applies only to HTTP/SSE transports", () => {});
+      return;
+    }
 
-  describe.each(multiClientTransports)("via %s transport", (transport) => {
-    let server: StartedServer;
-    let secondClient: Client | undefined;
+    describe.each(multiClientTransports)("via %s transport", (transport) => {
+      let server: StartedServer;
+      let secondClient: Client | undefined;
 
-    beforeAll(async () => {
-      server = await startServer({ transport });
-    });
-
-    afterAll(async () => {
-      await secondClient?.close();
-      await server?.stop();
-    });
-
-    it("should let a second client connect to an active server", async () => {
-      // per-session McpServer wiring (HttpTransport + SseTransport) is what makes the second
-      // handshake succeed — a single shared server would throw "Already connected to a transport"
-      secondClient = new Client({
-        name: "mcp-confluent-multi-client-2",
-        version: "0.0.0-test",
+      beforeAll(async () => {
+        server = await startServer({ transport });
       });
-      const secondTransport =
-        transport === TransportType.HTTP
-          ? new StreamableHTTPClientTransport(new URL(`${server.baseUrl}/mcp`))
-          : new SSEClientTransport(new URL(`${server.baseUrl}/sse`));
 
-      await expect(
-        secondClient.connect(secondTransport),
-      ).resolves.toBeUndefined();
+      afterAll(async () => {
+        await secondClient?.close();
+        await server?.stop();
+      });
 
-      // HTTP exposes sessionId publicly; SSE doesn't (the session is embedded in the SDK
-      // transport's private messaging URL). Guard the distinctness check on HTTP only.
-      if (
-        secondTransport instanceof StreamableHTTPClientTransport &&
-        server.client.transport instanceof StreamableHTTPClientTransport
-      ) {
-        expect(secondTransport.sessionId).toMatch(/^[0-9a-f-]{36}$/);
-        expect(secondTransport.sessionId).not.toEqual(
-          server.client.transport.sessionId,
-        );
-      }
+      it("should let a second client connect to an active server", async () => {
+        // per-session McpServer wiring (HttpTransport + SseTransport) is what makes the second
+        // handshake succeed — a single shared server would throw "Already connected to a transport"
+        secondClient = new Client({
+          name: "mcp-confluent-multi-client-2",
+          version: "0.0.0-test",
+        });
+        const secondTransport =
+          transport === TransportType.HTTP
+            ? new StreamableHTTPClientTransport(
+                new URL(`${server.baseUrl}/mcp`),
+              )
+            : new SSEClientTransport(new URL(`${server.baseUrl}/sse`));
 
-      // both sessions see the same tool set; equality matters, count doesn't
-      const [firstTools, secondTools] = await Promise.all([
-        server.client.listTools(),
-        secondClient.listTools(),
-      ]);
+        await expect(
+          secondClient.connect(secondTransport),
+        ).resolves.toBeUndefined();
 
-      const firstNames = firstTools.tools.map((t) => t.name).sort();
-      const secondNames = secondTools.tools.map((t) => t.name).sort();
-      expect(secondNames).toEqual(firstNames);
+        // HTTP exposes sessionId publicly; SSE doesn't (the session is embedded in the SDK
+        // transport's private messaging URL). Guard the distinctness check on HTTP only.
+        if (
+          secondTransport instanceof StreamableHTTPClientTransport &&
+          server.client.transport instanceof StreamableHTTPClientTransport
+        ) {
+          expect(secondTransport.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+          expect(secondTransport.sessionId).not.toEqual(
+            server.client.transport.sessionId,
+          );
+        }
+
+        // both sessions see the same tool set; equality matters, count doesn't
+        const [firstTools, secondTools] = await Promise.all([
+          server.client.listTools(),
+          secondClient.listTools(),
+        ]);
+
+        const firstNames = firstTools.tools.map((t) => t.name).sort();
+        const secondNames = secondTools.tools.map((t) => t.name).sort();
+        expect(secondNames).toEqual(firstNames);
+      });
     });
-  });
-});
+  },
+);

--- a/tests/harness/connection-types.ts
+++ b/tests/harness/connection-types.ts
@@ -12,8 +12,8 @@ export enum ConnectionType {
 /**
  * Resolves active connection types from `INTEGRATION_TEST_CONNECTION_TYPE`. Unset or `"all"`
  * (case-insensitive) means both modes; `"direct"` or `"oauth"` (case-insensitive) limits to one.
- * `"all"` is the sentinel because Semaphore Tasks UI dropdowns serialize an empty-string option
- * as the literal 2-char string `""`, which trips the `!raw` check below; a real word avoids that.
+ * `"all"` is the explicit sentinel because Semaphore Tasks UI dropdowns serialize an empty-string
+ * option as the literal 2-char string `""`, which would slip past a plain emptiness check.
  * @throws on unknown values.
  */
 function resolveActiveConnectionTypes(): ConnectionType[] {

--- a/tests/harness/connection-types.ts
+++ b/tests/harness/connection-types.ts
@@ -10,21 +10,22 @@ export enum ConnectionType {
 }
 
 /**
- * Resolves active connection types based on whether `INTEGRATION_TEST_CONNECTION_TYPE` is set.
- * If unset, both 'direct' and 'oauth' connection types will be used.
- * If set, must be a case-insensitive value of either 'direct' or 'oauth'.
+ * Resolves active connection types from `INTEGRATION_TEST_CONNECTION_TYPE`. Unset or `"all"`
+ * (case-insensitive) means both modes; `"direct"` or `"oauth"` (case-insensitive) limits to one.
+ * `"all"` is the sentinel because Semaphore Tasks UI dropdowns serialize an empty-string option
+ * as the literal 2-char string `""`, which trips the `!raw` check below; a real word avoids that.
  * @throws on unknown values.
  */
 function resolveActiveConnectionTypes(): ConnectionType[] {
   const known = Object.values(ConnectionType);
   const raw = process.env.INTEGRATION_TEST_CONNECTION_TYPE;
-  if (!raw) {
+  if (!raw || raw.toLowerCase() === "all") {
     return known;
   }
   const filter = raw.toLowerCase() as ConnectionType;
   if (!known.includes(filter)) {
     throw new Error(
-      `INTEGRATION_TEST_CONNECTION_TYPE must be one of ${known.join("|")}; got: ${raw}`,
+      `INTEGRATION_TEST_CONNECTION_TYPE must be one of all|${known.join("|")}; got: ${raw}`,
     );
   }
   return [filter];

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -139,10 +139,14 @@ export async function driveOAuthFlow(
       await consentButton.first().click();
     }
     try {
-      await page.waitForURL(/127\.0\.0\.1/, {
-        // `load` stalls on the success page's external favicon under restricted CI egress, and
-        // `networkidle` never fires because the page holds an open EventSource (and is discouraged
-        // in playwright docs; see https://playwright.dev/docs/api/class-page#page-wait-for-url)
+      // Hostname predicate (not the literal regex /127\.0\.0\.1/) because Auth0's login URL
+      // carries the OAuth `redirect_uri` as a query parameter, and dots in 127.0.0.1 stay
+      // unencoded after URL-encoding (dots are valid URL characters). The substring regex
+      // matches immediately on Auth0's URL before the browser ever leaves it.
+      // `load` stalls on the success page's external favicon under restricted CI egress, and
+      // `networkidle` never fires because the page holds an open EventSource (and is discouraged
+      // in playwright docs; see https://playwright.dev/docs/api/class-page#page-wait-for-url)
+      await page.waitForURL((url) => url.hostname === "127.0.0.1", {
         waitUntil: "domcontentloaded",
         timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
       });

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -11,7 +11,7 @@ import {
   startServer,
   type StartedServer,
 } from "@tests/harness/start-server.js";
-import { chromium } from "playwright-core";
+import { chromium, type Page } from "playwright-core";
 
 /** Skip reason when the OAuth fixture failed to load (creds missing from .env.integration). */
 export const OAUTH_FIXTURE_NOT_LOADED_REASON =
@@ -91,10 +91,7 @@ export async function driveOAuthFlow(
       "driveOAuthFlow requires startServer({ oauth: true }) so child stderr is piped",
     );
   }
-  // attach the stderr listener synchronously so a fast log line emitted before our first await
-  // isn't lost
-  const authUrlPromise = waitForAuthUrl(server.stderr);
-  const authUrl = await authUrlPromise;
+  const authUrl = await waitForAuthUrl(server);
 
   const browser = await chromium.launch({
     // set INTEGRATION_TEST_PLAYWRIGHT_HEADLESS=false to watch the CCloud OAuth flow in a browser for debugging
@@ -124,10 +121,16 @@ export async function driveOAuthFlow(
     if (consentVisible) {
       await consentButton.first().click();
     }
-    await page.waitForURL(/127\.0\.0\.1/, {
-      waitUntil: "networkidle",
-      timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
-    });
+    try {
+      await page.waitForURL(/127\.0\.0\.1/, {
+        waitUntil: "networkidle",
+        timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
+      });
+    } catch (error) {
+      // capture where Auth0 actually landed so the next CI failure surfaces an anomaly screen,
+      // captcha, password-rotation prompt, etc. instead of a generic playwright timeout
+      throw await augmentCallbackTimeout(server, page, error);
+    }
   } finally {
     await browser.close();
   }
@@ -153,15 +156,30 @@ export async function callToolWithOAuthFlow(
   return result;
 }
 
-/** Reads pino JSON log lines from stderr, resolves with the `authUrl` field once the
- * `Opening Auth0 authorization URL` line appears. Detaches the listener on resolve/reject. */
+/**
+ * Resolves with the `authUrl` field of the first pino line matching `Opening Auth0 authorization
+ * URL`. Races three sources so a stuck OAuth flow surfaces a useful error instead of a generic
+ * 30s timeout: (1) the URL appears on stderr, (2) the child exits before emitting it, (3) the
+ * timeout elapses. The exit and timeout paths both dump {@link StartedServer.stderrSnapshot}
+ * so the failure message names what the server actually said.
+ */
 function waitForAuthUrl(
-  stderr: NodeJS.ReadableStream,
+  server: StartedServer,
   timeoutMs = WAIT_FOR_AUTH_URL_TIMEOUT_MS,
 ): Promise<string> {
+  const stderr = server.stderr;
+  if (!stderr) {
+    return Promise.reject(
+      new Error(
+        "waitForAuthUrl requires startServer({ oauth: true }) so child stderr is piped",
+      ),
+    );
+  }
   return new Promise((resolve, reject) => {
+    let settled = false;
     let buffer = "";
     const cleanup = () => {
+      settled = true;
       stderr.off("data", onData);
       clearTimeout(timer);
     };
@@ -181,14 +199,28 @@ function waitForAuthUrl(
       }
     };
     const timer = setTimeout(() => {
+      if (settled) return;
       cleanup();
       reject(
         new Error(
-          `did not see ${AUTH_URL_LOG_MSG} on server stderr within ${timeoutMs}ms`,
+          `did not see ${AUTH_URL_LOG_MSG} on server stderr within ${timeoutMs}ms.\n` +
+            `Captured stderr:\n${server.stderrSnapshot?.() ?? "(stderrSnapshot unavailable - non-OAuth spawn?)"}`,
         ),
       );
     }, timeoutMs);
     stderr.on("data", onData);
+    // race against child exit so a server that dies during OAuth init fails fast with the exit
+    // code instead of waiting out the full timeout
+    server.childExit?.then(({ code, signal }) => {
+      if (settled) return;
+      cleanup();
+      reject(
+        new Error(
+          `server exited (code=${code}, signal=${signal ?? "null"}) before emitting ${AUTH_URL_LOG_MSG}.\n` +
+            `Captured stderr:\n${server.stderrSnapshot?.() ?? "(no snapshot)"}`,
+        ),
+      );
+    });
   });
 }
 
@@ -203,4 +235,38 @@ function extractAuthUrl(line: string): string | undefined {
   const record = parsed as Record<string, unknown>;
   if (record.msg !== AUTH_URL_LOG_MSG) return undefined;
   return typeof record.authUrl === "string" ? record.authUrl : undefined;
+}
+
+/** Body-excerpt cap when dumping the page after a callback-redirect timeout. */
+const PAGE_BODY_EXCERPT_BYTES = 800;
+
+/**
+ * Enriches a `page.waitForURL` timeout with the URL/title/body excerpt of wherever Auth0 actually
+ * landed, plus the server's stderr snapshot. Wraps the original error as `cause` so the stack is
+ * preserved. Each capture step is best-effort: if the page is in an unusual state we skip the
+ * field rather than masking the original timeout with a secondary failure.
+ */
+async function augmentCallbackTimeout(
+  server: StartedServer,
+  page: Page,
+  cause: unknown,
+): Promise<Error> {
+  const url = await Promise.resolve(page.url()).catch(
+    () => "(could not read page url)",
+  );
+  const title = await page.title().catch(() => "(could not read page title)");
+  const bodyText = await page
+    .locator("body")
+    .innerText({ timeout: 1_000 })
+    .then((text: string) => text.slice(0, PAGE_BODY_EXCERPT_BYTES))
+    .catch(() => "(could not read page body)");
+  const stderr = server.stderrSnapshot?.() ?? "(no snapshot)";
+  return new Error(
+    `OAuth callback redirect timed out after ${CALLBACK_REDIRECT_TIMEOUT_MS}ms. Auth0 stayed on:\n` +
+      `  url:   ${url}\n` +
+      `  title: ${title}\n` +
+      `  body:  ${bodyText.replace(/\n/g, " ")}\n` +
+      `Captured stderr:\n${stderr}`,
+    { cause },
+  );
 }

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -153,9 +153,27 @@ export async function callToolWithOAuthFlow(
   credentials: { email: string; password: string },
   toolCall: CallToolArgs,
 ): Promise<CallToolResponse> {
+  // TEMPORARY INSTRUMENTATION: tag each step with a timestamp so we can correlate test-side
+  // ordering with server-side "tool handler invoked" + "Starting OAuth login" log lines.
+  // Diagnosing the ~30s gap between expected listener attach and observed URL emission.
+  const tEntry = Date.now();
+  process.stderr.write(
+    `[OAUTH-TIMING] callToolWithOAuthFlow entry t=${tEntry} toolName=${toolCall.name}\n`,
+  );
   const flowPromise = driveOAuthFlow(server, credentials);
+  const tFlow = Date.now();
+  process.stderr.write(
+    `[OAUTH-TIMING] driveOAuthFlow returned promise t=${tFlow} (Δ=${tFlow - tEntry}ms)\n`,
+  );
   const callPromise = server.client.callTool(toolCall);
+  const tCall = Date.now();
+  process.stderr.write(
+    `[OAUTH-TIMING] callTool returned promise t=${tCall} (Δ=${tCall - tFlow}ms)\n`,
+  );
   const [, result] = await Promise.all([flowPromise, callPromise]);
+  process.stderr.write(
+    `[OAUTH-TIMING] callToolWithOAuthFlow resolved t=${Date.now()} (totalΔ=${Date.now() - tEntry}ms)\n`,
+  );
   return result;
 }
 
@@ -181,12 +199,16 @@ function waitForAuthUrl(
   return new Promise((resolve, reject) => {
     let settled = false;
     let buffer = "";
+    let firstDataT: number | undefined;
+    let dataChunks = 0;
     const cleanup = () => {
       settled = true;
       stderr.off("data", onData);
       clearTimeout(timer);
     };
     const onData = (chunk: Buffer | string) => {
+      dataChunks += 1;
+      firstDataT ??= Date.now();
       buffer += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
       let newlineIndex = buffer.indexOf("\n");
       while (newlineIndex !== -1) {
@@ -204,13 +226,24 @@ function waitForAuthUrl(
     const timer = setTimeout(() => {
       if (settled) return;
       cleanup();
+      // TEMPORARY INSTRUMENTATION: include listener-attach time, timeout-fire time, and a count
+      // of data chunks received in the window. If `dataChunks=0` we know stderr was completely
+      // silent for the listener's lifetime; if `firstDataT` is set but no URL matched, we know
+      // data flowed but nothing matched the AUTH_URL_LOG_MSG line.
       reject(
         new Error(
           `did not see ${AUTH_URL_LOG_MSG} on server stderr within ${timeoutMs}ms.\n` +
+            `Listener attached: ${listenerAttachT}\n` +
+            `Timeout fired:    ${Date.now()}\n` +
+            `Data chunks seen: ${dataChunks} (first at ${firstDataT ?? "never"})\n` +
             `Captured stderr:\n${server.stderrSnapshot?.() ?? "(stderrSnapshot unavailable - non-OAuth spawn?)"}`,
         ),
       );
     }, timeoutMs);
+    const listenerAttachT = Date.now();
+    process.stderr.write(
+      `[OAUTH-TIMING] waitForAuthUrl listener attached t=${listenerAttachT}\n`,
+    );
     stderr.on("data", onData);
     // race against child exit so a server that dies during OAuth init fails fast with the exit
     // code instead of waiting out the full timeout

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -100,6 +100,23 @@ export async function driveOAuthFlow(
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
+    // TEMPORARY INSTRUMENTATION: capture browser-side network events. Hypothesis: the OAuth
+    // callback never reaches the server even when waitForURL succeeds, which would happen if
+    // chromium's connection to 127.0.0.1:26640 is failing and the URL bar shows the target URL
+    // anyway (because Chrome's error page reuses the requested URL).
+    page.on("requestfailed", (req) => {
+      process.stderr.write(
+        `[OAUTH-NETWORK] requestfailed url=${req.url()} method=${req.method()} reason=${req.failure()?.errorText}\n`,
+      );
+    });
+    page.on("response", (resp) => {
+      const url = resp.url();
+      if (url.includes("127.0.0.1") || url.includes("login.confluent.io")) {
+        process.stderr.write(
+          `[OAUTH-NETWORK] response url=${url} status=${resp.status()}\n`,
+        );
+      }
+    });
     await page.goto(authUrl);
     // Auth0's email-then-password flow: one form per page, both submitted via [type=submit]
     await page
@@ -129,6 +146,20 @@ export async function driveOAuthFlow(
         waitUntil: "domcontentloaded",
         timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
       });
+      // TEMPORARY INSTRUMENTATION: dump page state immediately after waitForURL resolves. If
+      // chromium reached a connection-refused error page, the URL bar still matches /127.0.0.1/
+      // but the title/body reveal the failure. Comparing this against the server-side "OAuth
+      // callback server received request" log tells us whether the GET reached the server.
+      const postUrl = page.url();
+      const postTitle = await page.title().catch(() => "(title read failed)");
+      const postBody = await page
+        .locator("body")
+        .innerText({ timeout: 1_000 })
+        .then((t: string) => t.slice(0, 200).replace(/\s+/g, " "))
+        .catch(() => "(body read failed)");
+      process.stderr.write(
+        `[OAUTH-NETWORK] post-waitForURL url=${postUrl} title="${postTitle}" body="${postBody}"\n`,
+      );
     } catch (error) {
       // capture where Auth0 actually landed so the next CI failure surfaces an anomaly screen,
       // captcha, password-rotation prompt, etc. instead of a generic playwright timeout

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -123,7 +123,9 @@ export async function driveOAuthFlow(
     }
     try {
       await page.waitForURL(/127\.0\.0\.1/, {
-        waitUntil: "networkidle",
+        // don't use 'networkidle' here since it may cause timeouts and is discouraged in the docs:
+        // see https://playwright.dev/docs/api/class-page#page-wait-for-url
+        waitUntil: "load",
         timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
       });
     } catch (error) {

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -123,9 +123,10 @@ export async function driveOAuthFlow(
     }
     try {
       await page.waitForURL(/127\.0\.0\.1/, {
-        // don't use 'networkidle' here since it may cause timeouts and is discouraged in the docs:
-        // see https://playwright.dev/docs/api/class-page#page-wait-for-url
-        waitUntil: "load",
+        // `load` stalls on the success page's external favicon under restricted CI egress, and
+        // `networkidle` never fires because the page holds an open EventSource (and is discouraged
+        // in playwright docs; see https://playwright.dev/docs/api/class-page#page-wait-for-url)
+        waitUntil: "domcontentloaded",
         timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
       });
     } catch (error) {

--- a/tests/harness/oauth-flow.ts
+++ b/tests/harness/oauth-flow.ts
@@ -100,23 +100,6 @@ export async function driveOAuthFlow(
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
-    // TEMPORARY INSTRUMENTATION: capture browser-side network events. Hypothesis: the OAuth
-    // callback never reaches the server even when waitForURL succeeds, which would happen if
-    // chromium's connection to 127.0.0.1:26640 is failing and the URL bar shows the target URL
-    // anyway (because Chrome's error page reuses the requested URL).
-    page.on("requestfailed", (req) => {
-      process.stderr.write(
-        `[OAUTH-NETWORK] requestfailed url=${req.url()} method=${req.method()} reason=${req.failure()?.errorText}\n`,
-      );
-    });
-    page.on("response", (resp) => {
-      const url = resp.url();
-      if (url.includes("127.0.0.1") || url.includes("login.confluent.io")) {
-        process.stderr.write(
-          `[OAUTH-NETWORK] response url=${url} status=${resp.status()}\n`,
-        );
-      }
-    });
     await page.goto(authUrl);
     // Auth0's email-then-password flow: one form per page, both submitted via [type=submit]
     await page
@@ -150,20 +133,6 @@ export async function driveOAuthFlow(
         waitUntil: "domcontentloaded",
         timeout: CALLBACK_REDIRECT_TIMEOUT_MS,
       });
-      // TEMPORARY INSTRUMENTATION: dump page state immediately after waitForURL resolves. If
-      // chromium reached a connection-refused error page, the URL bar still matches /127.0.0.1/
-      // but the title/body reveal the failure. Comparing this against the server-side "OAuth
-      // callback server received request" log tells us whether the GET reached the server.
-      const postUrl = page.url();
-      const postTitle = await page.title().catch(() => "(title read failed)");
-      const postBody = await page
-        .locator("body")
-        .innerText({ timeout: 1_000 })
-        .then((t: string) => t.slice(0, 200).replace(/\s+/g, " "))
-        .catch(() => "(body read failed)");
-      process.stderr.write(
-        `[OAUTH-NETWORK] post-waitForURL url=${postUrl} title="${postTitle}" body="${postBody}"\n`,
-      );
     } catch (error) {
       // capture where Auth0 actually landed so the next CI failure surfaces an anomaly screen,
       // captcha, password-rotation prompt, etc. instead of a generic playwright timeout
@@ -188,27 +157,9 @@ export async function callToolWithOAuthFlow(
   credentials: { email: string; password: string },
   toolCall: CallToolArgs,
 ): Promise<CallToolResponse> {
-  // TEMPORARY INSTRUMENTATION: tag each step with a timestamp so we can correlate test-side
-  // ordering with server-side "tool handler invoked" + "Starting OAuth login" log lines.
-  // Diagnosing the ~30s gap between expected listener attach and observed URL emission.
-  const tEntry = Date.now();
-  process.stderr.write(
-    `[OAUTH-TIMING] callToolWithOAuthFlow entry t=${tEntry} toolName=${toolCall.name}\n`,
-  );
   const flowPromise = driveOAuthFlow(server, credentials);
-  const tFlow = Date.now();
-  process.stderr.write(
-    `[OAUTH-TIMING] driveOAuthFlow returned promise t=${tFlow} (Δ=${tFlow - tEntry}ms)\n`,
-  );
   const callPromise = server.client.callTool(toolCall);
-  const tCall = Date.now();
-  process.stderr.write(
-    `[OAUTH-TIMING] callTool returned promise t=${tCall} (Δ=${tCall - tFlow}ms)\n`,
-  );
   const [, result] = await Promise.all([flowPromise, callPromise]);
-  process.stderr.write(
-    `[OAUTH-TIMING] callToolWithOAuthFlow resolved t=${Date.now()} (totalΔ=${Date.now() - tEntry}ms)\n`,
-  );
   return result;
 }
 
@@ -234,16 +185,12 @@ function waitForAuthUrl(
   return new Promise((resolve, reject) => {
     let settled = false;
     let buffer = "";
-    let firstDataT: number | undefined;
-    let dataChunks = 0;
     const cleanup = () => {
       settled = true;
       stderr.off("data", onData);
       clearTimeout(timer);
     };
     const onData = (chunk: Buffer | string) => {
-      dataChunks += 1;
-      firstDataT ??= Date.now();
       buffer += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
       let newlineIndex = buffer.indexOf("\n");
       while (newlineIndex !== -1) {
@@ -261,37 +208,28 @@ function waitForAuthUrl(
     const timer = setTimeout(() => {
       if (settled) return;
       cleanup();
-      // TEMPORARY INSTRUMENTATION: include listener-attach time, timeout-fire time, and a count
-      // of data chunks received in the window. If `dataChunks=0` we know stderr was completely
-      // silent for the listener's lifetime; if `firstDataT` is set but no URL matched, we know
-      // data flowed but nothing matched the AUTH_URL_LOG_MSG line.
       reject(
         new Error(
           `did not see ${AUTH_URL_LOG_MSG} on server stderr within ${timeoutMs}ms.\n` +
-            `Listener attached: ${listenerAttachT}\n` +
-            `Timeout fired:    ${Date.now()}\n` +
-            `Data chunks seen: ${dataChunks} (first at ${firstDataT ?? "never"})\n` +
             `Captured stderr:\n${server.stderrSnapshot?.() ?? "(stderrSnapshot unavailable - non-OAuth spawn?)"}`,
         ),
       );
     }, timeoutMs);
-    const listenerAttachT = Date.now();
-    process.stderr.write(
-      `[OAUTH-TIMING] waitForAuthUrl listener attached t=${listenerAttachT}\n`,
-    );
     stderr.on("data", onData);
     // race against child exit so a server that dies during OAuth init fails fast with the exit
     // code instead of waiting out the full timeout
-    server.childExit?.then(({ code, signal }) => {
-      if (settled) return;
-      cleanup();
-      reject(
-        new Error(
-          `server exited (code=${code}, signal=${signal ?? "null"}) before emitting ${AUTH_URL_LOG_MSG}.\n` +
-            `Captured stderr:\n${server.stderrSnapshot?.() ?? "(no snapshot)"}`,
-        ),
-      );
-    });
+    server.childExit
+      ?.then(({ code, signal }) => {
+        if (settled) return;
+        cleanup();
+        reject(
+          new Error(
+            `server exited (code=${code}, signal=${signal ?? "null"}) before emitting ${AUTH_URL_LOG_MSG}.\n` +
+              `Captured stderr:\n${server.stderrSnapshot?.() ?? "(stderrSnapshot unavailable - non-OAuth spawn?)"}`,
+          ),
+        );
+      })
+      .catch(() => {});
   });
 }
 
@@ -331,7 +269,9 @@ async function augmentCallbackTimeout(
     .innerText({ timeout: 1_000 })
     .then((text: string) => text.slice(0, PAGE_BODY_EXCERPT_BYTES))
     .catch(() => "(could not read page body)");
-  const stderr = server.stderrSnapshot?.() ?? "(no snapshot)";
+  const stderr =
+    server.stderrSnapshot?.() ??
+    "(stderrSnapshot unavailable - non-OAuth spawn?)";
   return new Error(
     `OAuth callback redirect timed out after ${CALLBACK_REDIRECT_TIMEOUT_MS}ms. Auth0 stayed on:\n` +
       `  url:   ${url}\n` +

--- a/tests/harness/start-server.ts
+++ b/tests/harness/start-server.ts
@@ -49,18 +49,9 @@ export interface StartedServer {
    * Read by {@linkcode driveOAuthFlow} to extract the Auth0 authorization URL.
    */
   stderr?: Readable;
-  /**
-   * OAuth-only: returns a rolling string of everything the child has written to stderr since
-   * spawn, capped at {@linkcode STDERR_SNAPSHOT_MAX_BYTES} with a `(truncated front)` marker.
-   * Included in {@link driveOAuthFlow} timeout/exit error messages so a failed run shows what
-   * the server actually logged instead of a generic 30s timeout.
-   */
+  /** OAuth-only: rolling stderr capture (capped at {@linkcode STDERR_SNAPSHOT_MAX_BYTES}), dumped in {@link driveOAuthFlow} timeout/exit messages. */
   stderrSnapshot?: () => string;
-  /**
-   * OAuth-only: resolves when the spawned child exits. {@link driveOAuthFlow} races this against
-   * its auth-URL wait so a server that dies during OAuth init fails fast with the exit code +
-   * captured stderr instead of timing out.
-   */
+  /** OAuth-only: resolves when the spawned child exits. {@link driveOAuthFlow} races it against the auth-URL wait so a dying server fails fast. */
   childExit?: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
   /** Sends SIGTERM to the child, awaits exit, and closes the MCP client. */
   stop: () => Promise<void>;
@@ -70,17 +61,23 @@ export interface StartedServer {
 const STDERR_SNAPSHOT_MAX_BYTES = 65_536;
 
 /**
- * Attaches a data listener that accumulates stderr into a capped rolling string, and returns a
- * getter for it. Doubles as the drain that keeps the child from blocking on a full pipe buffer,
- * so this is the only stderr `data` listener needed on OAuth spawns.
+ * Attaches a data listener that accumulates stderr into a capped rolling string and returns a
+ * getter. Doubles as the pipe drain for OAuth spawns. Truncation runs at 1.5× cap so the O(cap)
+ * string copy amortizes across ~32KB of writes instead of firing per chunk past the cap.
  */
 function createStderrCapture(stderr: Readable): () => string {
+  const truncateAt = Math.floor(STDERR_SNAPSHOT_MAX_BYTES * 1.5);
   let buf = "";
   stderr.on("data", (chunk: Buffer | string) => {
     buf += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
-    if (buf.length > STDERR_SNAPSHOT_MAX_BYTES) {
+    if (buf.length > truncateAt) {
       buf = "...(truncated front)...\n" + buf.slice(-STDERR_SNAPSHOT_MAX_BYTES);
     }
+  });
+  // Surface stream errors in the snapshot rather than letting them bubble as unhandled `error`
+  // events that would crash the test worker mid-run.
+  stderr.on("error", (err) => {
+    buf += `\n[stderr stream error: ${err.message}]\n`;
   });
   return () => buf;
 }
@@ -94,11 +91,7 @@ function captureChildExit(
   });
 }
 
-/**
- * Returns the `stderrSnapshot` + `childExit` pair on OAuth spawns, or an empty object otherwise.
- * Spread into the {@link StartedServer} literal so non-OAuth spawns stay byte-identical to the
- * pre-instrumentation shape.
- */
+/** Returns the OAuth diagnostics pair when applicable; non-OAuth callers spread an empty object. */
 function oauthDiagnostics(
   options: StartServerOptions,
   child: ChildProcess | undefined,

--- a/tests/harness/start-server.ts
+++ b/tests/harness/start-server.ts
@@ -49,8 +49,65 @@ export interface StartedServer {
    * Read by {@linkcode driveOAuthFlow} to extract the Auth0 authorization URL.
    */
   stderr?: Readable;
+  /**
+   * OAuth-only: returns a rolling string of everything the child has written to stderr since
+   * spawn, capped at {@linkcode STDERR_SNAPSHOT_MAX_BYTES} with a `(truncated front)` marker.
+   * Included in {@link driveOAuthFlow} timeout/exit error messages so a failed run shows what
+   * the server actually logged instead of a generic 30s timeout.
+   */
+  stderrSnapshot?: () => string;
+  /**
+   * OAuth-only: resolves when the spawned child exits. {@link driveOAuthFlow} races this against
+   * its auth-URL wait so a server that dies during OAuth init fails fast with the exit code +
+   * captured stderr instead of timing out.
+   */
+  childExit?: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
   /** Sends SIGTERM to the child, awaits exit, and closes the MCP client. */
   stop: () => Promise<void>;
+}
+
+/** Cap for {@link createStderrCapture}: large enough to hold ~hundreds of pino JSON lines. */
+const STDERR_SNAPSHOT_MAX_BYTES = 65_536;
+
+/**
+ * Attaches a data listener that accumulates stderr into a capped rolling string, and returns a
+ * getter for it. Doubles as the drain that keeps the child from blocking on a full pipe buffer,
+ * so this is the only stderr `data` listener needed on OAuth spawns.
+ */
+function createStderrCapture(stderr: Readable): () => string {
+  let buf = "";
+  stderr.on("data", (chunk: Buffer | string) => {
+    buf += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    if (buf.length > STDERR_SNAPSHOT_MAX_BYTES) {
+      buf = "...(truncated front)...\n" + buf.slice(-STDERR_SNAPSHOT_MAX_BYTES);
+    }
+  });
+  return () => buf;
+}
+
+/** Resolves with the child's exit `code` and `signal` once it exits. Never rejects. */
+function captureChildExit(
+  child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+/**
+ * Returns the `stderrSnapshot` + `childExit` pair on OAuth spawns, or an empty object otherwise.
+ * Spread into the {@link StartedServer} literal so non-OAuth spawns stay byte-identical to the
+ * pre-instrumentation shape.
+ */
+function oauthDiagnostics(
+  options: StartServerOptions,
+  child: ChildProcess | undefined,
+): Pick<StartedServer, "stderrSnapshot" | "childExit"> {
+  if (!options.oauth || !child?.stderr) return {};
+  return {
+    stderrSnapshot: createStderrCapture(child.stderr),
+    childExit: captureChildExit(child),
+  };
 }
 
 // resolve from the worktree root (vitest runs with cwd at the project root)
@@ -104,6 +161,7 @@ async function startHttp(options: StartServerOptions): Promise<StartedServer> {
     client,
     baseUrl,
     stderr: options.oauth ? (child.stderr ?? undefined) : undefined,
+    ...oauthDiagnostics(options, child),
     stop: makeHttpStop(client, child),
   };
 }
@@ -134,6 +192,7 @@ async function startSse(options: StartServerOptions): Promise<StartedServer> {
     client,
     baseUrl,
     stderr: options.oauth ? (child.stderr ?? undefined) : undefined,
+    ...oauthDiagnostics(options, child),
     stop: makeHttpStop(client, child),
   };
 }
@@ -179,11 +238,10 @@ async function startStdio(options: StartServerOptions): Promise<StartedServer> {
   // as of v1.x).
   const child = (transport as unknown as { _process?: ChildProcess })._process;
 
-  if (options.oauth) {
-    // keep the piped stderr draining after driveOAuthFlow's scraper detaches; otherwise the
-    // child stalls once the OS pipe buffer fills
-    child?.stderr?.on("data", () => {});
-  }
+  // OAuth spawns need a stderr drain so the child doesn't block on a full pipe buffer.
+  // `createStderrCapture` (inside `oauthDiagnostics`) already attaches a `data` listener, which
+  // doubles as that drain, so no separate keep-alive listener is needed here.
+  const diagnostics = oauthDiagnostics(options, child);
 
   // No SIGTERM here: client.close() routes through transport.close() which
   // already kills the SDK-owned child; we just await its exit afterward.
@@ -198,6 +256,7 @@ async function startStdio(options: StartServerOptions): Promise<StartedServer> {
   return {
     client,
     stderr: options.oauth ? (child?.stderr ?? undefined) : undefined,
+    ...diagnostics,
     stop,
   };
 }

--- a/tests/tags.ts
+++ b/tests/tags.ts
@@ -1,10 +1,21 @@
 /**
- * Tags for filtering integration tests. Tool-group tags map 1:1 to
- * directories under `src/confluent/tools/handlers/`; `SMOKE` and `OAUTH`
- * are cross-cutting tags. `SMOKE` marks transport-layer tests (e.g. the
- * auth middleware) that don't belong to any tool group. `OAUTH` marks
- * tests that can run against an OAuth connection via the harness's
- * `oauth: true` opt-in.
+ * Tags for filtering integration tests.
+ *
+ * Two axes:
+ *
+ * - **Tool-group axis** ({@link Tag.KAFKA}, {@link Tag.FLINK}, ...) - matches
+ *   handler directories under `src/confluent/tools/handlers/`. Used to scope
+ *   per-PR auto-promotions to the handler dir the PR touched.
+ * - **Service-config axis** ({@link Tag.REQUIRES_KAFKA_CONFIG}, ...) - matches
+ *   the per-service blocks on `MCPServerConfiguration` (`kafka`, `flink`,
+ *   etc.). Drives `integration.yml`'s matrix axis: each job provisions one
+ *   service config's worth of setup and runs every test tagged with that
+ *   service config.
+ *
+ * Cross-cutting tags: {@link Tag.SMOKE} marks transport-layer tests that
+ * don't belong to any tool group; {@link Tag.OAUTH} marks tests that exercise
+ * the OAuth flow.
+ *
  * {@see https://vitest.dev/guide/test-tags}
  */
 export enum Tag {
@@ -13,7 +24,7 @@ export enum Tag {
   // Tests that work with an OAuth connection
   OAUTH = "@oauth",
 
-  // Tool group specific tags, matching handler directories
+  // Tool-group axis: matches handler directories
   BILLING = "@billing",
   CATALOG = "@catalog",
   CLUSTERS = "@clusters",
@@ -27,4 +38,14 @@ export enum Tag {
   SCHEMA = "@schema",
   SEARCH = "@search",
   TABLEFLOW = "@tableflow",
+
+  // Service-config axis: drives integration.yml's matrix axis. Each value
+  // matches a service block on MCPServerConfiguration (see
+  // src/config/models.ts).
+  REQUIRES_KAFKA_CONFIG = "@requires-kafka-config",
+  REQUIRES_SCHEMA_REGISTRY_CONFIG = "@requires-schema-registry-config",
+  REQUIRES_CONFLUENT_CLOUD_CONFIG = "@requires-confluent-cloud-config",
+  REQUIRES_FLINK_CONFIG = "@requires-flink-config",
+  REQUIRES_TABLEFLOW_CONFIG = "@requires-tableflow-config",
+  REQUIRES_TELEMETRY_CONFIG = "@requires-telemetry-config",
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Overhauls the main CI pipeline so only tool group specific integration tests will run if their related handler directories are included in files changed by the PR, and the `integration.yml` pipeline (scheduled daily run groups and manual promotions) go by **service config** (the YAML blocks on `MCPServerConfiguration`) rather than by transport. OAuth coverage now runs alongside direct mode in every block (sequentially in-job, not as a Semaphore axis).

Closes #380.

### Before

Integration tests would only run by PRs through manual promotion. Integration tests fanned out per transport, then matrix across tool groups within each transport block.

Scheduled daily run uses the same shape via `service.yml`'s `scheduled-integration-tests` task: 10 tool groups x 3 transports = 30 jobs.

<img width="367" height="726" alt="image" src="https://github.com/user-attachments/assets/83dbd489-8071-4410-98bb-53d096ca57a5" />

### After

#### Per-PR (semaphore.yml)

Blocks are structured around tool groups + a smoke block, each gated by `run.when: change_in('/src/confluent/tools/handlers/<dir>/')`. Only the blocks whose handler dirs the PR touched actually run. Transport (stdio/http/sse) and connection types (direct/oauth) run sequentially in-job via the harness, not as Semaphore axes.
<img width="423" height="616" alt="image" src="https://github.com/user-attachments/assets/c47559d0-f446-4bb2-9c11-fc71c51780d7" />
(These _all_ ran because they were all changes in their respective handler directories in this branch.)

[Sample PR](https://github.com/confluentinc/mcp-confluent/pull/520) showing the behavior to trigger [specific integration test runs in CI](https://semaphore.ci.confluent.io/workflows/075d8b81-e29e-4311-802a-f91353b4e5c0?pipeline_id=b94c8c68-5082-4438-97d0-e41f1d22aa2e) (`@smoke` and `@schema`) based on the branch's file changes (no `@diagnostics` tag+tests yet):
<img width="430" height="393" alt="image" src="https://github.com/user-attachments/assets/4ae3cb03-593e-42f4-a5c4-9aec6c704681" />

#### Scheduled / manual full (integration.yml + service.yml)

Blocks are structured around new `@requires-*-config` service config tags from `tests/tags.ts`. Each block matrices over `TOOL_GROUP`. Multi-tagged tests (e.g. flink tests carrying both `@requires-flink-config` and `@requires-confluent-cloud-config`) run in every block they declare a need for — intentional structural coverage.
<img width="409" height="655" alt="image" src="https://github.com/user-attachments/assets/4ca0e832-aff4-4eda-9439-ebdebdd4105b" />
(See task workflow [here](https://semaphore.ci.confluent.io/workflows/1e8b56ad-4c52-4b22-82e9-e1047e56d778))

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- **`tests/tags.ts`** gains a `@requires-*-config` axis alongside the existing `@<tool-group>` tags. Every integration test now declares both axes.
- **`Makefile`** composes `SERVICE_CONFIG + TAGS + CONNECTION_TYPE` into a single vitest `--tags-filter` expression. Unset or `=all` runs both modes; `=oauth` appends `&& @oauth` (only OAuth describes); `=direct` appends `&& !@oauth` (excludes them, avoiding double-execution of direct-only tests in the OAuth lane).
- **`make test-integration`** skips `npm run build` when `dist/index.js` already exists (CI's prologue builds first; local cold runs auto-build).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
