### PR TITLE
validate range before round-trip to API 

### DIFF
--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -286,6 +286,14 @@ describe("list-billing-costs-handler.ts", () => {
             pageSize: 1001,
           },
         },
+        {
+          label: "range exceeds the 31-day cap by one day",
+          args: { startDate: "2026-01-01", endDate: "2026-02-02" },
+        },
+        {
+          label: "range is a full year, well over the 31-day cap",
+          args: { startDate: "2026-01-01", endDate: "2027-01-01" },
+        },
       ])(
         "should throw a ZodError and not call the API when $label",
         async ({ args }) => {
@@ -302,6 +310,33 @@ describe("list-billing-costs-handler.ts", () => {
           expect(restClient.GET).not.toHaveBeenCalled();
         },
       );
+
+      it("should name the 31-day cap and the actual span in the ZodError message", async () => {
+        const clientManager = getMockedClientManager();
+
+        await expect(
+          handler.handle(
+            runtimeWith(CCLOUD_CONN, DEFAULT_CONNECTION_ID, clientManager),
+            { startDate: "2026-01-01", endDate: "2026-03-01" },
+          ),
+        ).rejects.toThrowError(/got 59 days.*31 days/);
+      });
+
+      it("should accept the inclusive 31-day boundary and call the API", async () => {
+        const clientManager = getMockedClientManager();
+        const restClient = clientManager.getConfluentCloudRestClient();
+        restClient.GET.mockResolvedValue({
+          data: { api_version: "v1", kind: "CostList", data: [] },
+        });
+
+        const result = await handler.handle(
+          runtimeWith(CCLOUD_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { startDate: "2026-01-01", endDate: "2026-02-01" },
+        );
+
+        expect(result.isError).toBe(false);
+        expect(restClient.GET).toHaveBeenCalledOnce();
+      });
 
       it("should forward start/end/page params to the /billing/v1/costs path", async () => {
         const clientManager = getMockedClientManager();

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -294,6 +294,18 @@ describe("list-billing-costs-handler.ts", () => {
           label: "range is a full year, well over the 31-day cap",
           args: { startDate: "2026-01-01", endDate: "2027-01-01" },
         },
+        {
+          label: "endDate is before startDate",
+          args: { startDate: "2026-02-01", endDate: "2026-01-01" },
+        },
+        {
+          label: "startDate matches the format but is not a real calendar date",
+          args: { startDate: "2026-02-30", endDate: "2026-02-28" },
+        },
+        {
+          label: "endDate matches the format but is not a real calendar date",
+          args: { startDate: "2026-01-01", endDate: "2026-13-01" },
+        },
       ])(
         "should throw a ZodError and not call the API when $label",
         async ({ args }) => {

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 const BILLING_RANGE_MAX_DAYS = 31;
 const MS_PER_DAY = 86_400_000;
 
-const listBillingCostsShape = z.object({
+const listBillingCostsObject = z.object({
   startDate: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
@@ -37,7 +37,7 @@ const listBillingCostsShape = z.object({
     .describe("Token for the next page of results"),
 });
 
-const listBillingCostsArguments = listBillingCostsShape.refine(
+const listBillingCostsArguments = listBillingCostsObject.refine(
   ({ startDate, endDate }) => {
     const diffDays = (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY;
     return diffDays <= BILLING_RANGE_MAX_DAYS;
@@ -229,7 +229,7 @@ Pagination:${metadata.total_size ? `\n  Total Items: ${metadata.total_size}` : "
       name: ToolName.LIST_BILLING_COSTS,
       description:
         "Retrieve billing cost data for a Confluent Cloud organization within a specified date range with pagination support",
-      inputSchema: listBillingCostsShape.shape,
+      inputSchema: listBillingCostsObject.shape,
       annotations: READ_ONLY,
     };
   }

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -37,24 +37,57 @@ const listBillingCostsObject = z.object({
     .describe("Token for the next page of results"),
 });
 
-const listBillingCostsArguments = listBillingCostsObject.refine(
-  ({ startDate, endDate }) => {
-    const diffDays = (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY;
-    return diffDays <= BILLING_RANGE_MAX_DAYS;
-  },
-  {
-    error: (iss) => {
-      const { startDate, endDate } = iss.input as {
-        startDate: string;
-        endDate: string;
-      };
+const listBillingCostsArguments = listBillingCostsObject
+  .refine(
+    ({ startDate, endDate }) =>
+      Number.isFinite(Date.parse(startDate)) &&
+      Number.isFinite(Date.parse(endDate)),
+    {
+      error: (iss) => {
+        const { startDate, endDate } = iss.input as {
+          startDate: string;
+          endDate: string;
+        };
+        const invalid = !Number.isFinite(Date.parse(startDate))
+          ? `startDate=${startDate}`
+          : `endDate=${endDate}`;
+        return `Date must be a valid calendar date (got ${invalid}).`;
+      },
+      path: ["endDate"],
+    },
+  )
+  .refine(
+    ({ startDate, endDate }) => Date.parse(endDate) >= Date.parse(startDate),
+    {
+      error: (iss) => {
+        const { startDate, endDate } = iss.input as {
+          startDate: string;
+          endDate: string;
+        };
+        return `endDate (${endDate}) must be on or after startDate (${startDate}).`;
+      },
+      path: ["endDate"],
+    },
+  )
+  .refine(
+    ({ startDate, endDate }) => {
       const diffDays =
         (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY;
-      return `Date range must be 31 days or fewer (got ${diffDays} days). The CCloud billing API caps queries at 31 days.`;
+      return diffDays <= BILLING_RANGE_MAX_DAYS;
     },
-    path: ["endDate"],
-  },
-);
+    {
+      error: (iss) => {
+        const { startDate, endDate } = iss.input as {
+          startDate: string;
+          endDate: string;
+        };
+        const diffDays =
+          (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY;
+        return `Date range must be ${BILLING_RANGE_MAX_DAYS} days or fewer (got ${diffDays} days). The CCloud billing API caps queries at ${BILLING_RANGE_MAX_DAYS} days.`;
+      },
+      path: ["endDate"],
+    },
+  );
 
 /**
  * Schema for validating billing cost line items

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -43,14 +43,14 @@ const listBillingCostsArguments = listBillingCostsObject
       Number.isFinite(Date.parse(startDate)) &&
       Number.isFinite(Date.parse(endDate)),
     {
-      error: (iss) => {
-        const { startDate, endDate } = iss.input as {
+      error: (issue) => {
+        const { startDate, endDate } = issue.input as {
           startDate: string;
           endDate: string;
         };
-        const invalid = !Number.isFinite(Date.parse(startDate))
-          ? `startDate=${startDate}`
-          : `endDate=${endDate}`;
+        const invalid = Number.isFinite(Date.parse(startDate))
+          ? `endDate=${endDate}`
+          : `startDate=${startDate}`;
         return `Date must be a valid calendar date (got ${invalid}).`;
       },
       path: ["endDate"],
@@ -59,8 +59,8 @@ const listBillingCostsArguments = listBillingCostsObject
   .refine(
     ({ startDate, endDate }) => Date.parse(endDate) >= Date.parse(startDate),
     {
-      error: (iss) => {
-        const { startDate, endDate } = iss.input as {
+      error: (issue) => {
+        const { startDate, endDate } = issue.input as {
           startDate: string;
           endDate: string;
         };
@@ -76,8 +76,8 @@ const listBillingCostsArguments = listBillingCostsObject
       return diffDays <= BILLING_RANGE_MAX_DAYS;
     },
     {
-      error: (iss) => {
-        const { startDate, endDate } = iss.input as {
+      error: (issue) => {
+        const { startDate, endDate } = issue.input as {
           startDate: string;
           endDate: string;
         };

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -12,7 +12,10 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 
-const listBillingCostsArguments = z.object({
+const BILLING_RANGE_MAX_DAYS = 31;
+const MS_PER_DAY = 86_400_000;
+
+const listBillingCostsShape = z.object({
   startDate: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
@@ -33,6 +36,25 @@ const listBillingCostsArguments = z.object({
     .optional()
     .describe("Token for the next page of results"),
 });
+
+const listBillingCostsArguments = listBillingCostsShape.refine(
+  ({ startDate, endDate }) => {
+    const diffDays = (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY;
+    return diffDays <= BILLING_RANGE_MAX_DAYS;
+  },
+  {
+    error: (iss) => {
+      const { startDate, endDate } = iss.input as {
+        startDate: string;
+        endDate: string;
+      };
+      const diffDays =
+        (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY;
+      return `Date range must be 31 days or fewer (got ${diffDays} days). The CCloud billing API caps queries at 31 days.`;
+    },
+    path: ["endDate"],
+  },
+);
 
 /**
  * Schema for validating billing cost line items
@@ -207,7 +229,7 @@ Pagination:${metadata.total_size ? `\n  Total Items: ${metadata.total_size}` : "
       name: ToolName.LIST_BILLING_COSTS,
       description:
         "Retrieve billing cost data for a Confluent Cloud organization within a specified date range with pagination support",
-      inputSchema: listBillingCostsArguments.shape,
+      inputSchema: listBillingCostsShape.shape,
       annotations: READ_ONLY,
     };
   }


### PR DESCRIPTION
## Summary of Changes

Addresses https://github.com/confluentinc/mcp-confluent/issues/343 by validating the range in the handler. 

### Manual testing instructions

Call list-billing-costs with e.g. startDate=2026-01-21, endDate=2026-04-01 to see the refinement error fire, and a valid range to see a successful response.

<img width="735" height="222" alt="Screenshot 2026-05-26 at 1 20 27 PM" src="https://github.com/user-attachments/assets/bdefcaa6-0bcc-490c-8490-d1c828ba944b" />

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
