### PR TITLE
fix(produce-message): use latest registered schema when none provided

### DIFF
--- a/src/confluent/schema-registry-helper.test.ts
+++ b/src/confluent/schema-registry-helper.test.ts
@@ -1,12 +1,17 @@
 import { SerdeType } from "@confluentinc/schemaregistry";
 import { checkSchemaNeeded } from "@src/confluent/schema-registry-helper.js";
 import { getMockedSchemaRegistry } from "@tests/stubs/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("schema-registry-helper.ts", () => {
   describe("checkSchemaNeeded()", () => {
+    let registry: ReturnType<typeof getMockedSchemaRegistry>;
+
+    beforeEach(() => {
+      registry = getMockedSchemaRegistry();
+    });
+
     it("should return null when useSchemaRegistry is false", async () => {
-      const registry = getMockedSchemaRegistry();
       const result = await checkSchemaNeeded(
         "orders",
         { message: "raw", useSchemaRegistry: false },
@@ -18,7 +23,6 @@ describe("schema-registry-helper.ts", () => {
     });
 
     it("should return null when the caller supplied a schema", async () => {
-      const registry = getMockedSchemaRegistry();
       const result = await checkSchemaNeeded(
         "orders",
         {
@@ -38,7 +42,6 @@ describe("schema-registry-helper.ts", () => {
       // Regression test for issue #159: subsequent produce calls without
       // re-specifying the schema must proceed (the serializer falls back to
       // useLatestVersion), not error with "A schema already exists".
-      const registry = getMockedSchemaRegistry();
       registry.getLatestSchemaMetadata.mockResolvedValue({
         id: 7,
         version: 1,
@@ -58,48 +61,42 @@ describe("schema-registry-helper.ts", () => {
       );
     });
 
-    it("should return no-schema when nothing is registered and the caller didn't supply one", async () => {
-      const registry = getMockedSchemaRegistry();
-      registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
-      const result = await checkSchemaNeeded(
-        "orders",
-        { message: { x: 1 }, useSchemaRegistry: true, schemaType: "AVRO" },
-        SerdeType.VALUE,
-        registry,
-      );
-      expect(result).toEqual({ type: "no-schema", subject: "orders-value" });
-    });
-
-    it("should derive a key-suffixed subject for SerdeType.KEY", async () => {
-      const registry = getMockedSchemaRegistry();
-      registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
-      const result = await checkSchemaNeeded(
-        "orders",
-        { message: { x: 1 }, useSchemaRegistry: true, schemaType: "AVRO" },
-        SerdeType.KEY,
-        registry,
-      );
-      expect(result).toEqual({ type: "no-schema", subject: "orders-key" });
-    });
-
-    it("should honor an explicit subject override", async () => {
-      const registry = getMockedSchemaRegistry();
-      registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
-      const result = await checkSchemaNeeded(
-        "orders",
-        {
-          message: { x: 1 },
-          useSchemaRegistry: true,
-          schemaType: "AVRO",
-          subject: "custom-subject",
-        },
-        SerdeType.VALUE,
-        registry,
-      );
-      expect(result).toEqual({
-        type: "no-schema",
+    it.each([
+      {
+        name: "derives a -value subject for SerdeType.VALUE",
+        serdeType: SerdeType.VALUE,
+        subject: undefined,
+        expected: "orders-value",
+      },
+      {
+        name: "derives a -key subject for SerdeType.KEY",
+        serdeType: SerdeType.KEY,
+        subject: undefined,
+        expected: "orders-key",
+      },
+      {
+        name: "honors an explicit subject override",
+        serdeType: SerdeType.VALUE,
         subject: "custom-subject",
-      });
-    });
+        expected: "custom-subject",
+      },
+    ])(
+      "should return no-schema when nothing is registered and it $name",
+      async ({ serdeType, subject, expected }) => {
+        registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
+        const result = await checkSchemaNeeded(
+          "orders",
+          {
+            message: { x: 1 },
+            useSchemaRegistry: true,
+            schemaType: "AVRO",
+            subject,
+          },
+          serdeType,
+          registry,
+        );
+        expect(result).toEqual({ type: "no-schema", subject: expected });
+      },
+    );
   });
 });

--- a/src/confluent/schema-registry-helper.test.ts
+++ b/src/confluent/schema-registry-helper.test.ts
@@ -1,0 +1,105 @@
+import { SerdeType } from "@confluentinc/schemaregistry";
+import { checkSchemaNeeded } from "@src/confluent/schema-registry-helper.js";
+import { getMockedSchemaRegistry } from "@tests/stubs/index.js";
+import { describe, expect, it } from "vitest";
+
+describe("schema-registry-helper.ts", () => {
+  describe("checkSchemaNeeded()", () => {
+    it("should return null when useSchemaRegistry is false", async () => {
+      const registry = getMockedSchemaRegistry();
+      const result = await checkSchemaNeeded(
+        "orders",
+        { message: "raw", useSchemaRegistry: false },
+        SerdeType.VALUE,
+        registry,
+      );
+      expect(result).toBeNull();
+      expect(registry.getLatestSchemaMetadata).not.toHaveBeenCalled();
+    });
+
+    it("should return null when the caller supplied a schema", async () => {
+      const registry = getMockedSchemaRegistry();
+      const result = await checkSchemaNeeded(
+        "orders",
+        {
+          message: { x: 1 },
+          useSchemaRegistry: true,
+          schemaType: "AVRO",
+          schema: '{"type":"record","name":"X","fields":[]}',
+        },
+        SerdeType.VALUE,
+        registry,
+      );
+      expect(result).toBeNull();
+      expect(registry.getLatestSchemaMetadata).not.toHaveBeenCalled();
+    });
+
+    it("should return null when no schema was supplied but one is already registered (use-latest path)", async () => {
+      // Regression test for issue #159: subsequent produce calls without
+      // re-specifying the schema must proceed (the serializer falls back to
+      // useLatestVersion), not error with "A schema already exists".
+      const registry = getMockedSchemaRegistry();
+      registry.getLatestSchemaMetadata.mockResolvedValue({
+        id: 7,
+        version: 1,
+        subject: "orders-value",
+        schema: '{"type":"record","name":"Order","fields":[]}',
+        schemaType: "AVRO",
+      });
+      const result = await checkSchemaNeeded(
+        "orders",
+        { message: { x: 1 }, useSchemaRegistry: true, schemaType: "AVRO" },
+        SerdeType.VALUE,
+        registry,
+      );
+      expect(result).toBeNull();
+      expect(registry.getLatestSchemaMetadata).toHaveBeenCalledWith(
+        "orders-value",
+      );
+    });
+
+    it("should return no-schema when nothing is registered and the caller didn't supply one", async () => {
+      const registry = getMockedSchemaRegistry();
+      registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
+      const result = await checkSchemaNeeded(
+        "orders",
+        { message: { x: 1 }, useSchemaRegistry: true, schemaType: "AVRO" },
+        SerdeType.VALUE,
+        registry,
+      );
+      expect(result).toEqual({ type: "no-schema", subject: "orders-value" });
+    });
+
+    it("should derive a key-suffixed subject for SerdeType.KEY", async () => {
+      const registry = getMockedSchemaRegistry();
+      registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
+      const result = await checkSchemaNeeded(
+        "orders",
+        { message: { x: 1 }, useSchemaRegistry: true, schemaType: "AVRO" },
+        SerdeType.KEY,
+        registry,
+      );
+      expect(result).toEqual({ type: "no-schema", subject: "orders-key" });
+    });
+
+    it("should honor an explicit subject override", async () => {
+      const registry = getMockedSchemaRegistry();
+      registry.getLatestSchemaMetadata.mockRejectedValue({ status: 404 });
+      const result = await checkSchemaNeeded(
+        "orders",
+        {
+          message: { x: 1 },
+          useSchemaRegistry: true,
+          schemaType: "AVRO",
+          subject: "custom-subject",
+        },
+        SerdeType.VALUE,
+        registry,
+      );
+      expect(result).toEqual({
+        type: "no-schema",
+        subject: "custom-subject",
+      });
+    });
+  });
+});

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -55,20 +55,13 @@ export type MessageOptions = {
 
 /**
  * Result of checking if a schema is needed for a message.
- * Can indicate:
- * - A schema is needed and provides the latest schema details
- * - No schema exists and needs to be provided
- * - No schema action is needed
+ * Returned only when the caller did not supply a schema and no schema is
+ * registered for the subject yet — that's the one case the caller must
+ * resolve before serialization can proceed. Otherwise null: either the
+ * caller supplied a schema (register-and-use path) or one is already
+ * registered (use-latest path).
  */
-export type SchemaCheckResult =
-  | {
-      type: "schema-needed";
-      latestSchema: string;
-      subject: string;
-      schemaType: string;
-    }
-  | { type: "no-schema"; subject: string }
-  | null;
+export type SchemaCheckResult = { type: "no-schema"; subject: string } | null;
 
 /**
  * Creates and returns the appropriate serializer instance based on schema type.
@@ -163,14 +156,7 @@ export async function checkSchemaNeeded(
     const latest = registry
       ? await getLatestSchemaIfExists(registry, subject)
       : null;
-    if (latest) {
-      return {
-        type: "schema-needed",
-        latestSchema: latest.schema,
-        subject,
-        schemaType: latest.schemaType,
-      };
-    } else {
+    if (!latest) {
       return { type: "no-schema", subject };
     }
   }

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -55,11 +55,11 @@ export type MessageOptions = {
 
 /**
  * Result of checking if a schema is needed for a message.
- * Returned only when the caller did not supply a schema and no schema is
- * registered for the subject yet — that's the one case the caller must
- * resolve before serialization can proceed. Otherwise null: either the
- * caller supplied a schema (register-and-use path) or one is already
- * registered (use-latest path).
+ * Returned only when schema registry is in use, the caller did not supply a
+ * schema, and no schema is registered for the subject yet — that's the one
+ * case the caller must resolve before serialization can proceed. Otherwise
+ * null: schema registry is disabled, or the caller supplied a schema
+ * (register-and-use path), or one is already registered (use-latest path).
  */
 export type SchemaCheckResult = { type: "no-schema"; subject: string } | null;
 

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
@@ -100,9 +100,9 @@ describe("produce-kafka-message-handler.ts", () => {
         // assertion is on the call shape, not the outcome — the handler
         // is allowed to short-circuit on the schema-missing path.
         const clientManager = getMockedClientManager();
-        // Make subject lookup miss → checkSchemaNeeded returns "no-schema-
-        // needed" → handler returns an isError response without invoking
-        // the producer or serializer. Cheap controlled exit.
+        // Make subject lookup miss → checkSchemaNeeded returns "no-schema"
+        // → handler returns an isError response without invoking the
+        // producer or serializer. Cheap controlled exit.
         clientManager
           .getSchemaRegistryClient()
           .getLatestSchemaMetadata.mockRejectedValue({ status: 404 });

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -85,7 +85,7 @@ type ProduceKafkaMessageArguments = z.infer<
 /**
  * Handler for producing messages to a Kafka topic, with support for Confluent Schema Registry serialization (AVRO, JSON, PROTOBUF) for both key and value.
  *
- * - If schema registry is enabled, the handler checks if a schema is already registered for the topic's key/value subject.
+ * - If schema registry is enabled, `schemaType` is required and the handler checks if a schema is already registered for the topic's key/value subject.
  *   - If a schema is provided, it is registered before serialization.
  *   - If no schema is provided and one is already registered, the serializer uses the latest registered version.
  *   - If no schema is provided and none is registered, it returns an error.

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -86,9 +86,9 @@ type ProduceKafkaMessageArguments = z.infer<
  * Handler for producing messages to a Kafka topic, with support for Confluent Schema Registry serialization (AVRO, JSON, PROTOBUF) for both key and value.
  *
  * - If schema registry is enabled, the handler checks if a schema is already registered for the topic's key/value subject.
- *   - If a schema exists and none is provided, it returns the latest schema to the client for retry.
- *   - If no schema exists and none is provided, it returns an error.
  *   - If a schema is provided, it is registered before serialization.
+ *   - If no schema is provided and one is already registered, the serializer uses the latest registered version.
+ *   - If no schema is provided and none is registered, it returns an error.
  * - Serialization is performed using the appropriate serializer for the schema type.
  * - Produces the message to the specified Kafka topic, handling both key and value serialization as needed.
  */
@@ -100,23 +100,10 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
    */
   handleSchemaCheckResult(result: SchemaCheckResult): CallToolResult | null {
     if (!result) return null;
-
-    if (result.type === "schema-needed") {
-      return this.createResponse(
-        `A schema already exists for subject '${result.subject}'. Please retry with the following schema:\n${result.latestSchema}, schemaType: ${result.schemaType}`,
-        true,
-        {
-          latestSchema: result.latestSchema,
-          subject: result.subject,
-          schemaType: result.schemaType,
-        },
-      );
-    } else {
-      return this.createResponse(
-        `No schema registered for subject '${result.subject}', and no schema provided to register.`,
-        true,
-      );
-    }
+    return this.createResponse(
+      `No schema registered for subject '${result.subject}', and no schema provided to register.`,
+      true,
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes #159.

Adjusts the logic so if schema registry is enabled, `schemaType` is required and the handler checks if a schema is already registered for the topic's key/value subject.

___________________
<img width="694" height="313" alt="Screenshot 2026-05-29 at 12 46 58 PM" src="https://github.com/user-attachments/assets/851261b4-95ec-466f-b9bf-75c459065fc1" />

cc: @leeec1993 

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
