### PR TITLE
feat: add automated npm publish with Vault TOTP to release pipeline

### DIFF
--- a/.semaphore/release-version.yml
+++ b/.semaphore/release-version.yml
@@ -148,3 +148,33 @@ blocks:
                 exit 1
               fi
             - gh release upload "$RELEASE_NAME" "$TGZ_FILE" --clobber
+
+  - name: "Publish to npm"
+    dependencies: ["Upload to GitHub Release"]
+    task:
+      jobs:
+        - name: "Publish to npm"
+          commands:
+            - |
+              if [ "$PUBLISH_TO_NPM" != "true" ]; then
+                echo "Skipping npm publish (PUBLISH_TO_NPM=$PUBLISH_TO_NPM)"
+                exit 0
+              fi
+            - artifact pull workflow release-assets/
+            - TGZ_FILE=$(find release-assets/ -name "*.tgz" | head -1)
+            - |
+              if [ -z "$TGZ_FILE" ]; then
+                echo "Error: no .tgz file found in release-assets/"
+                exit 1
+              fi
+            # Authenticate to npm registry
+            - . vault-get-secret --vault-role=mcp-confluent --secret-key=NPM_TOKEN --export-as=NPM_TOKEN mcpconfluent/npm
+            - npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
+            # Get TOTP code and publish (keep these adjacent to stay within the 30s TOTP window)
+            - OTP=$(vault-get-totp confluent-npm --vault-role mcp-confluent)
+            - |
+              if [ "$IS_PRERELEASE" = "true" ]; then
+                npm publish "$TGZ_FILE" --otp="$OTP" --tag next
+              else
+                npm publish "$TGZ_FILE" --otp="$OTP"
+              fi

--- a/.semaphore/release-version.yml
+++ b/.semaphore/release-version.yml
@@ -171,7 +171,7 @@ blocks:
             - . vault-get-secret --vault-role=mcp-confluent --secret-key=NPM_TOKEN --export-as=NPM_TOKEN mcpconfluent/npm
             - npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
             # Get TOTP code and publish (keep these adjacent to stay within the 30s TOTP window)
-            - OTP=$(vault-get-totp confluent-npm --vault-role mcp-confluent)
+            - OTP=$(vault-get-totp npm-publishing --vault-role mcp-confluent)
             - |
               if [ "$IS_PRERELEASE" = "true" ]; then
                 npm publish "$TGZ_FILE" --otp="$OTP" --tag next

--- a/service.yml
+++ b/service.yml
@@ -46,6 +46,13 @@ semaphore:
         - name: COMMIT_SHA
           required: true
           description: 'The commit SHA to create the release and tag from, must be a valid SHA/tag/branch.'
+        - name: PUBLISH_TO_NPM
+          required: true
+          options:
+            - "true"
+            - "false"
+          default_value: "true"
+          description: 'Whether to publish the package to the npm registry after creating the GitHub release.'
         - name: PREVIOUS_RELEASE_TAG
           required: false
           description: 'The previous release tag for generating release notes. If not provided, will use the latest (non-prerelease) GitHub Release.'


### PR DESCRIPTION
## Summary
- Adds a **"Publish to npm"** block to the release pipeline that authenticates via Vault-stored npm token + TOTP code for 2FA
- Controlled by a new `PUBLISH_TO_NPM` parameter (default: `true`, can be set to `false` to skip)
- Uses `--tag next` for prereleases, default `latest` tag for stable releases

This eliminates the need to manually publish with 1Password OTP credentials. The TOTP code is generated programmatically from a seed stored in Vault's TOTP engine ([RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238)).

## How it works
1. `vault-get-secret` retrieves the npm granular access token from `mcpconfluent/npm`
2. `vault-get-totp` retrieves a fresh TOTP code from Vault's `npm-publishing` key (kept adjacent to `npm publish` to stay within the 30s validity window)
3. `npm publish <tgz> --otp=<code>` publishes the pre-built tarball

## Vault prerequisites (must be completed before first use)
| What | How |
|------|-----|
| **npm auth token** | Store a [granular access token](https://docs.npmjs.com/creating-and-viewing-access-tokens) at Vault path `mcpconfluent/npm` with key `NPM_TOKEN` |
| **TOTP seed** | Seed the npm account's TOTP secret in the Vault TOTP engine under key name `npm-publishing` (shared across repos) |
| **cire-vault role update** | Add `totp_secrets = ["npm-publishing"]` and `semaphore/mcpconfluent/npm` to the `mcp-confluent` role in cire-vault |

## Related PRs
- [ci-build-agent-infra #2194](https://github.com/confluentinc/ci-build-agent-infra/pull/2194) — `vault-get-totp` tooling (merged)
- [confluent-docker-build-images #354](https://github.com/confluentinc/confluent-docker-build-images/pull/354) — adds TOTP tooling to Docker CI images
- [cire-vault #3674](https://github.com/confluentinc/cire-vault/pull/3674) — grants mcp-confluent role access to npm token + TOTP
- [cire-vault #3359](https://github.com/confluentinc/cire-vault/pull/3359) — Vault TOTP engine setup (merged)

## Documentation
- [Vault V3 Secrets — TOTP section](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/4341728493/Use+Vault+V3+Secrets+In+Semaphore+Pipelines#TOTP-Secrets-for-2FA-(e.g.,-npm-publish))

## Context
npm [revoked classic tokens](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/) in Dec 2025. [Trusted publishers](https://docs.npmjs.com/trusted-publishers) (OIDC) don't support Semaphore. This Vault TOTP approach provides automated 2FA without requiring manual 1Password intervention. See [Slack thread](https://confluent.slack.com/archives/C09EP1SS3/p1775485155476389) for discussion.

## Test plan
- [ ] Complete Vault prerequisites (npm token, TOTP seed, cire-vault role update)
- [ ] Trigger release task with `PUBLISH_TO_NPM=true` and `IS_PRERELEASE=true` — verify package publishes to npm with `next` tag
- [ ] Trigger release task with `PUBLISH_TO_NPM=false` — verify publish step is skipped
