### PR TITLE
MINOR fix: remove `max` from list-flink-statements `pageToken`

### DIFF
--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
@@ -30,7 +30,6 @@ const listFlinkStatementsArguments = z.object({
     ),
   pageToken: z
     .string()
-    .max(255)
     .optional()
     .describe("An opaque pagination token for collection requests."),
   labelSelector: z

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -23,10 +23,9 @@ const listTableFlowRegionsArguments = z.object({
     ),
   pageToken: z
     .string()
-    .max(255)
     .optional()
     .describe(
-      "Opaque pagination token from a previous response (max 255 characters). Omit on first request.",
+      "Opaque pagination token from a previous response. Omit on first request.",
     ),
 });
 


### PR DESCRIPTION
Integration tests for the `list-flink-statements` handler started [failing](https://semaphore.ci.confluent.io/jobs/ffc076d3-e2b8-41ac-bb55-c0abc0491981) recently:
```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via http transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via http transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via http transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via sse transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via sse transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via sse transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via stdio transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via stdio transport > should return a JSON payload that includes the seeded statement
 FAIL   integration  src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts > list-flink-statements-handler > via stdio transport > should return a JSON payload that includes the seeded statement
SyntaxError: Unexpected token 'M', "MCP error "... is not valid JSON
 ❯ src/confluent/tools/handlers/flink/list-flink-statements-handler.integration.test.ts:80:29
     78|           });
     79|           const text = textContent(result);
     80|           const body = JSON.parse(text) as {
       |                             ^
     81|             data?: Array<{ name: string }>;
     82|             metadata?: { next?: string };
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/9]⎯
 Test Files  1 failed | 12 passed (13)
      Tests  3 failed | 75 passed (78)
```
Reproduced locally with additional logging, we see:
```
MCP error -32602: Input validation error: Invalid arguments for tool list-flink-statements: [
  {
    "origin": "string",
    "code": "too_big",
    "maximum": 255,
    "inclusive": true,
    "path": [
      "pageToken"
    ],
    "message": "Too big: expected string to have <=255 characters"
  }
]
```

This was because the Flink statements started piling up in the CCloud environment (due to another project, not this one) and the tests had to start paging through the available data. The problem with this specific handler was that it expected <=255 characters in the `pageToken` value handled during pagination, which wasn't correct - one of the values returned by CCloud was over 300 characters.

The only other schema that enforces a character limit on `pageToken` is for the `list-tableflow-regions` handler, which doesn't accumulate data at the same rate as Flink statements, but its `max(255)` is also being removed here for consistency.