### PR TITLE
feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,139 @@
+name: "Report a bug"
+description: Report a bug with the Confluent MCP server.
+type: Bug
+labels:
+  - "bug"
+  - "needs triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug with the Confluent MCP server!
+
+        Before opening a new issue, please [search existing issues](https://github.com/confluentinc/mcp-confluent/issues) and 👍 upvote a matching one instead — this helps us prioritize and resolve it faster.
+
+        For setup and configuration help, see the [README](https://github.com/confluentinc/mcp-confluent/blob/main/README.md) and [CONFIGURATION.md](https://github.com/confluentinc/mcp-confluent/blob/main/CONFIGURATION.md).
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/confluentinc/mcp-confluent/blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true
+  - type: input
+    id: server_version
+    attributes:
+      label: MCP server version
+      description: What version of the Confluent MCP server are you running? (e.g. the `version` from `package.json`, an npm release, or a git commit SHA)
+      placeholder: "ex. 1.2.3 or git SHA"
+    validations:
+      required: true
+  - type: input
+    id: node_version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`. Node ≥22 is required.
+      placeholder: "ex. v22.14.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: On what operating system are you seeing the problem?
+      multiple: true
+      options:
+        - macOS (Intel/x64)
+        - macOS (Apple/arm64)
+        - Linux (x64)
+        - Linux (arm64)
+        - Windows (x64)
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Which transport are you using?
+      multiple: true
+      options:
+        - stdio
+        - HTTP (Streamable HTTP)
+        - SSE
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: config_method
+    attributes:
+      label: How is the server configured?
+      options:
+        - YAML config file (-c <path>)
+        - Environment variables / CLI flags
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: mcp_client
+    attributes:
+      label: MCP client
+      description: Which MCP client/host are you connecting with, and its version?
+      placeholder: "ex. Claude Desktop, Claude Code, Cursor, VS Code, Gemini CLI, Goose, Windsurf, MCP Inspector"
+    validations:
+      required: false
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Which area(s) are affected? (Select all that apply)
+      multiple: true
+      options:
+        - "Not sure"
+        - "Startup / configuration"
+        - "Authentication"
+        - "Kafka (topics / produce / consume)"
+        - "Flink"
+        - "Schema Registry"
+        - "Connectors / Connect"
+        - "Tableflow"
+        - "Billing"
+        - "Catalog"
+        - "Metrics"
+        - "Search / product docs"
+        - "Environments / Clusters / Organizations"
+        - "Transport (stdio / HTTP / SSE)"
+        - "Tool enablement / discovery"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: To Reproduce
+      description: A step-by-step description of how to reproduce the issue. Include the tool you invoked and any arguments. Redact API keys, secrets, and other sensitive data.
+      placeholder: |
+        1. Configure the server with ...
+        2. Invoke the `list-topics` tool with ...
+        3. The following error is returned ...
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Current vs. Expected behavior
+      description: A clear and concise description of what the bug is, and what you expected to happen.
+      placeholder: "I expected A to happen, but I observed B instead."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Copy and paste any relevant server log output. This will be automatically formatted into code, so no need for backticks. **Please redact API keys, tokens, and other secrets before pasting.**
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any extra information that might help us investigate. Does the issue happen every time or intermittently? Anything unusual about your Confluent Cloud setup?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/confluentinc/mcp-confluent/blob/main/README.md
+    about: Check the README and the docs/ guides for setup, configuration, and client integration before opening an issue.
+  - name: Configuration help
+    url: https://github.com/confluentinc/mcp-confluent/blob/main/CONFIGURATION.md
+    about: See CONFIGURATION.md for the YAML/env configuration reference.
+  - name: Contributing guide
+    url: https://github.com/confluentinc/mcp-confluent/blob/main/CONTRIBUTING.md
+    about: Want to contribute a fix or feature? Start here.
+  - name: Confluent Cloud support
+    url: https://support.confluent.io/
+    about: For issues with your Confluent Cloud account, billing, or services (not this server), contact Confluent support.

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,0 +1,34 @@
+name: "Report a documentation issue"
+description: Report an issue with the Confluent MCP server documentation.
+title: "Docs: "
+labels:
+  - "documentation"
+  - "needs triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve the docs!
+
+        Spotting a small fix you could make yourself? Contributions are welcome — see the [Contributing Guide](https://github.com/confluentinc/mcp-confluent/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is the documentation issue?
+      description: "Example: The HTTP transport setup steps in CONFIGURATION.md are stale / missing a required field."
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Where is the affected documentation? Please link to it.
+      description: "Example: README.md, CONFIGURATION.md, or a file under docs/"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Is there any context that might help us understand?
+      description: A clear description of what's incorrect, confusing, or missing, and what you expected to find.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: "Request a feature"
+description: Suggest a new tool, capability, or improvement for the Confluent MCP server.
+type: Feature
+labels:
+  - "enhancement"
+  - "needs triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement to the Confluent MCP server!
+
+        Before opening a new request, please [search existing issues](https://github.com/confluentinc/mcp-confluent/issues) and 👍 upvote a matching one instead — this helps us gauge demand and prioritize.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/confluentinc/mcp-confluent/blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: A clear and concise description of the problem or limitation. What are you trying to do that you can't do today?
+      placeholder: "I'm always frustrated when ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the solution you'd like
+      description: What new tool, capability, or behavior would solve this? If you're proposing a new tool, describe the Confluent resource/API it would wrap.
+    validations:
+      required: true
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Which area(s) does this relate to? (Select all that apply)
+      multiple: true
+      options:
+        - "Not sure / general"
+        - "Kafka"
+        - "Flink"
+        - "Schema Registry"
+        - "Connectors / Connect"
+        - "Tableflow"
+        - "Billing"
+        - "Catalog"
+        - "Metrics"
+        - "Search / product docs"
+        - "Environments / Clusters / Organizations"
+        - "Configuration"
+        - "Transports (stdio / HTTP / SSE)"
+        - "Developer experience"
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, links to Confluent Cloud APIs/docs, or screenshots about the request here.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary of Changes

Add structured issue forms to reduce triage cost (#484):
- bug_report.yml: captures server/Node version, OS, transport, config method, MCP client, and affected service area
- feature_request.yml: feature/enhancement requests (Discussions is disabled on this repo, so these land as issues)
- docs_report.yml: documentation issues
- config.yml: keeps blank issues enabled, adds contact links

Closes #484