### PR TITLE
fix(cp): repair local CP docker stack and consume integration test

### DIFF
--- a/docker-compose.cp-test.yml
+++ b/docker-compose.cp-test.yml
@@ -1,9 +1,9 @@
 # Local Confluent Platform stack for integration testing mcp-confluent.
 #
-# Usage:
+# Usage (or just `make setup-cp-env` / `make remove-cp-env`):
 #   docker compose -f docker-compose.cp-test.yml up -d
-#   # Wait ~30s for Kafka + SR to become ready
-#   RUN_CP_INTEGRATION=1 npm run test -- src/cp-integration.test.ts
+#   # Wait for Kafka + SR to become ready (SR's /subjects answering = both up)
+#   npm run test:integration -- --tags-filter=@cp
 #   docker compose -f docker-compose.cp-test.yml down -v
 #
 # Notes:
@@ -24,15 +24,33 @@ services:
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: "broker,controller"
-      KAFKA_LISTENERS: "SASL_PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
-      KAFKA_ADVERTISED_LISTENERS: "SASL_PLAINTEXT://localhost:9092"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "SASL_PLAINTEXT:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT"
+      # Two SASL_PLAINTEXT listeners: EXTERNAL is advertised as localhost:9092
+      # for host-based test clients; INTERNAL is advertised as kafka:29092 for
+      # in-network clients (schema-registry). A single localhost-advertised
+      # listener would be unreachable from the SR container.
+      #
+      # Listener NAMES are INTERNAL/EXTERNAL rather than SASL_PLAINTEXT on
+      # purpose: the cp-kafka image maps env vars to properties by replacing
+      # `_` with `.`, so a listener literally named SASL_PLAINTEXT would make
+      # KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG resolve to
+      # the wrong property (listener.name.sasl.plaintext...) and the broker
+      # would start with no JAAS. Underscore-free names sidestep that, and
+      # because the advertised string no longer contains "SASL_" the image
+      # skips its `dub ensure KAFKA_OPTS` gate, keeping this env-var-only.
+      KAFKA_LISTENERS: "INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:29092,EXTERNAL://localhost:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:SASL_PLAINTEXT,EXTERNAL:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT"
       KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
-      KAFKA_INTER_BROKER_LISTENER_NAME: "SASL_PLAINTEXT"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
       KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG: >-
+      KAFKA_LISTENER_NAME_INTERNAL_PLAIN_SASL_JAAS_CONFIG: >-
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username="admin" password="admin-secret"
+        user_admin="admin-secret"
+        user_mcp="mcp-secret";
+      KAFKA_LISTENER_NAME_EXTERNAL_PLAIN_SASL_JAAS_CONFIG: >-
         org.apache.kafka.common.security.plain.PlainLoginModule required
         username="admin" password="admin-secret"
         user_admin="admin-secret"
@@ -55,7 +73,7 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: "schema-registry"
       SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "SASL_PLAINTEXT://kafka:9092"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "SASL_PLAINTEXT://kafka:29092"
       SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
       SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM: "PLAIN"
       SCHEMA_REGISTRY_KAFKASTORE_SASL_JAAS_CONFIG: >-

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.cp.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.cp.integration.test.ts
@@ -71,14 +71,14 @@ describe(
         const result = await server.client.callTool({
           name: ToolName.CONSUME_MESSAGES,
           arguments: {
-            topicNames: [topic],
+            topics: [{ name: topic }],
             maxMessages: seededValues.length,
             timeoutMs: 15_000,
-            value: { useSchemaRegistry: false },
+            valueFormat: { disableSchemaRegistry: true },
           },
         });
 
-        expect(result.isError).not.toBe(true);
+        expect(result.isError, textContent(result)).not.toBe(true);
 
         const text = textContent(result);
         expect(text).toMatch(/^Consumed \d+ messages/);


### PR DESCRIPTION
## Summary of Changes

The `@cp` (self-managed Confluent Platform) integration suite added in #345 had never actually run against a live stack — the tests skip without `CP_KAFKA_USERNAME`/`CP_KAFKA_PASSWORD`, and there is no CI block exercising them. Bringing the stack up for the first time surfaced three bugs that prevented the suite from passing. This PR fixes all three; the `@cp` suite now runs green (27 passed) across stdio/HTTP/SSE.

- **`docker-compose.cp-test.yml`: broker never started — JAAS landed under the wrong property.** The listener was named `SASL_PLAINTEXT`, but the cp-kafka image maps env vars to properties by replacing `_` with `.`, so `KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG` resolved to `listener.name.sasl.plaintext...` and the broker booted with no JAAS (`Could not find a 'KafkaServer' entry ...`).
  - Renamed the listeners to `INTERNAL`/`EXTERNAL` (underscore-free), so the inline-JAAS env vars translate correctly. As a bonus, the advertised string no longer contains `SASL_`, so the image skips its `dub ensure KAFKA_OPTS` gate — the stack stays env-var-only with no mounted JAAS file.
- **`docker-compose.cp-test.yml`: Schema Registry couldn't reach Kafka.** A single `localhost:9092` advertised listener is unreachable from the SR container (it resolves to SR itself).
  - Added a second listener: `INTERNAL://kafka:29092` for in-network clients (SR bootstrap now points here) and `EXTERNAL://localhost:9092` for host-based test clients.
- **`consume-kafka-messages-handler.cp.integration.test.ts`: wrong tool arguments.** The test called `consume-messages` with `topicNames: [topic]` and `value: {...}`, but the tool's Zod schema requires `topics: [{ name }]` and `valueFormat: { disableSchemaRegistry: true }`, so every call returned an input-validation error.
  - Fixed the arguments and switched the assertion to `expect(result.isError, textContent(result)).not.toBe(true)` so any future failure surfaces the tool's error text.

Also refreshed the stale usage comment at the top of the compose file (it referenced a `RUN_CP_INTEGRATION` command that no longer exists).

Related to #345. The CI block that will make this stack run automatically on PRs (`make setup-cp-env` + a self-contained `@cp` Semaphore block) follows in a separate PR stacked on this one.

### Click-testing instructions

1. `make setup-cp-env` (brings up the stack, waits for SR, seeds `.env.integration` with the CP creds)
2. `npm run test:integration -- --tags-filter=@cp`
3. Verify the suite passes (7 files, 27 tests) across all three transports
4. `make remove-cp-env` to tear the stack down

> Without `make setup-cp-env` you can do it by hand: `docker compose -f docker-compose.cp-test.yml up -d`, set `CP_KAFKA_USERNAME=mcp` / `CP_KAFKA_PASSWORD=mcp-secret` in `.env.integration`, then run the same vitest command.

### Optional: Any additional details or context that should be provided?

- Before: `docker compose -f docker-compose.cp-test.yml up -d` → Kafka exits immediately (`dub ensure KAFKA_OPTS FAILED`, then `Could not find a 'KafkaServer' entry`); even with the broker up, the consume test fails with an input-validation error.
- After: stack comes up cleanly (SR `/subjects` answering in ~12s), all `@cp` tests pass.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing
