### PR TITLE
Implement `BaseToolHandler.resolveConnection()` and `.resolveDirectConnection()`.

### DIFF
--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -366,6 +366,27 @@ describe("base-tools.ts", () => {
         },
       );
 
+      it.each([
+        ["a number", 123, "number"],
+        ["null", null, "object"],
+        ["an object", { id: "a" }, "object"],
+      ])(
+        "should throw rather than auto-route when connectionId is present but %s, even with a sole viable connection",
+        (_label, requested, typeofName) => {
+          // Sole viable connection: absent the guard, a non-string would fall
+          // through to the omitted-path and silently auto-route to "a".
+          const runtime = runtimeWithConnections({ a: KAFKA, b: {} });
+
+          expect(() =>
+            resolveConnectionOf(kafkaHandler())(runtime, {
+              connectionId: requested,
+            }),
+          ).toThrow(
+            `Wacky -- connectionId present but not a string (got ${typeofName}); the injected schema should have rejected this`,
+          );
+        },
+      );
+
       it("should resolve a sole OAuth connection without narrowing its type", () => {
         const { conn } = resolveConnectionOf(new StubHandler())(
           ccloudOAuthRuntime(),

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -269,6 +269,176 @@ describe("base-tools.ts", () => {
       });
     });
 
+    describe("resolveConnection()", () => {
+      const KAFKA = { kafka: { bootstrap_servers: "b:9092" } };
+
+      /** Binds the protected resolveConnection off a (possibly predicate-gated)
+       * handler so each case can target a handler with the right viability. */
+      function resolveConnectionOf(handler: StubHandler) {
+        return handler["resolveConnection"].bind(
+          handler,
+        ) as (typeof handler)["resolveConnection"];
+      }
+
+      const kafkaHandler = () => new StubHandler({ predicate: hasKafka });
+
+      it("should route to the explicitly requested connection (not merely the first viable one)", () => {
+        const runtime = runtimeWithConnections({
+          "conn-a": KAFKA,
+          "conn-b": KAFKA,
+        });
+
+        const { connId, conn, clientManager } = resolveConnectionOf(
+          kafkaHandler(),
+        )(runtime, { connectionId: "conn-b" });
+
+        expect(connId).toBe("conn-b");
+        expect(conn).toBe(runtime.config.connections["conn-b"]);
+        expect(clientManager).toBe(runtime.clientManagers["conn-b"]);
+      });
+
+      it.each([
+        [
+          "an id absent from the configuration entirely",
+          () => kafkaHandler(),
+          () => runtimeWithConnections({ a: KAFKA, b: KAFKA }),
+          "ghost",
+          'Wacky -- connection "ghost" is not an enabled connection for this tool; enabled: a, b',
+        ],
+        [
+          "a configured id that this tool's predicate does not enable",
+          () => kafkaHandler(),
+          () => runtimeWithConnections({ a: KAFKA, b: {} }),
+          "b",
+          'Wacky -- connection "b" is not an enabled connection for this tool; enabled: a',
+        ],
+      ])(
+        "should throw a listing error for %s",
+        (_label, handler, buildRuntime, requested, message) => {
+          expect(() =>
+            resolveConnectionOf(handler())(buildRuntime(), {
+              connectionId: requested,
+            }),
+          ).toThrow(message);
+        },
+      );
+
+      it("should auto-route to the sole viable connection when connectionId is omitted", () => {
+        const runtime = runtimeWithConnections({ a: KAFKA, b: {} });
+
+        const { connId, conn, clientManager } = resolveConnectionOf(
+          kafkaHandler(),
+        )(runtime, {});
+
+        expect(connId).toBe("a");
+        expect(conn).toBe(runtime.config.connections["a"]);
+        expect(clientManager).toBe(runtime.clientManagers["a"]);
+      });
+
+      it("should auto-route when toolArguments is undefined entirely", () => {
+        const runtime = runtimeWithConnections({ only: KAFKA });
+
+        const { connId } = resolveConnectionOf(kafkaHandler())(
+          runtime,
+          undefined,
+        );
+
+        expect(connId).toBe("only");
+      });
+
+      it.each([
+        [
+          "two or more are viable (ambiguous; schema should have required connectionId)",
+          () => runtimeWithConnections({ a: KAFKA, b: KAFKA }),
+          "Wacky -- connectionId omitted but this tool is enabled for 2 connections (a, b); cannot auto-route",
+        ],
+        [
+          "none are viable (registration backstop; tool should not have registered)",
+          () => runtimeWithConnections({ a: {}, b: {} }),
+          "Wacky -- connectionId omitted but this tool is enabled for 0 connections (none); cannot auto-route",
+        ],
+      ])(
+        "should throw when connectionId is omitted and %s",
+        (_label, buildRuntime, message) => {
+          expect(() =>
+            resolveConnectionOf(kafkaHandler())(buildRuntime(), {}),
+          ).toThrow(message);
+        },
+      );
+
+      it("should resolve a sole OAuth connection without narrowing its type", () => {
+        const { conn } = resolveConnectionOf(new StubHandler())(
+          ccloudOAuthRuntime(),
+          undefined,
+        );
+
+        expect(conn.type).toBe("oauth");
+      });
+    });
+
+    describe("resolveDirectConnection()", () => {
+      const KAFKA = { kafka: { bootstrap_servers: "b:9092" } };
+
+      function resolveDirectConnectionOf(handler: StubHandler) {
+        return handler["resolveDirectConnection"].bind(
+          handler,
+        ) as (typeof handler)["resolveDirectConnection"];
+      }
+
+      const kafkaHandler = () => new StubHandler({ predicate: hasKafka });
+
+      it("should narrow the explicitly requested direct connection's id, config, and client manager", () => {
+        const runtime = runtimeWithConnections({
+          "conn-a": KAFKA,
+          "conn-b": KAFKA,
+        });
+
+        const { connId, conn, clientManager } = resolveDirectConnectionOf(
+          kafkaHandler(),
+        )(runtime, { connectionId: "conn-b" });
+
+        expect(connId).toBe("conn-b");
+        expect(conn.type).toBe("direct");
+        expect(conn).toBe(runtime.config.connections["conn-b"]);
+        expect(clientManager).toBe(runtime.clientManagers["conn-b"]);
+      });
+
+      it("should auto-route to the sole direct connection when connectionId is omitted", () => {
+        const runtime = runtimeWithConnections({ a: KAFKA, b: {} });
+
+        const { connId, conn } = resolveDirectConnectionOf(kafkaHandler())(
+          runtime,
+          {},
+        );
+
+        expect(connId).toBe("a");
+        expect(conn.type).toBe("direct");
+      });
+
+      it("should throw when the resolved connection is OAuth-typed (direct-only backstop)", () => {
+        expect(() =>
+          resolveDirectConnectionOf(new StubHandler())(
+            ccloudOAuthRuntime(),
+            undefined,
+          ),
+        ).toThrow(
+          'Wacky -- connection "default" is oauth-typed; this tool requires a direct connection',
+        );
+      });
+
+      it("should propagate resolveConnection's listing error for an unknown id (delegation)", () => {
+        const runtime = runtimeWithConnections({ a: KAFKA, b: KAFKA });
+
+        expect(() =>
+          resolveDirectConnectionOf(kafkaHandler())(runtime, {
+            connectionId: "ghost",
+          }),
+        ).toThrow(
+          'Wacky -- connection "ghost" is not an enabled connection for this tool; enabled: a, b',
+        );
+      });
+    });
+
     describe("resolveParam()", () => {
       // BaseToolHandler.resolveParam() is protected, so we have to work a little bit to get at
       // it for this test suite.

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -291,9 +291,10 @@ export abstract class BaseToolHandler implements ToolHandler {
   /**
    * Resolves which connection a tool call targets: the explicit `connectionId`
    * argument when present, else the sole connection enabled for this tool.
-   * Throws a listing error when the id is unknown/not-enabled, or when omitted
-   * while two or more connections are candidates (the augmented schema makes the
-   * latter unreachable in normal MCP flow — this is the defensive backstop).
+   * Throws a listing error when the id is unknown/not-enabled, when it is
+   * present but not a string, or when omitted while two or more connections are
+   * candidates (the augmented schema makes all three unreachable in normal MCP
+   * flow — these are defensive backstops against internal call sites).
    *
    * Reads `connectionId` off the **raw** `toolArguments` rather than off the
    * handler's locally-parsed object: the framework already validated it against
@@ -312,8 +313,9 @@ export abstract class BaseToolHandler implements ToolHandler {
     // What connection ids this tool possibly supports.
     const enabledIds = this.enabledConnectionIds(runtime);
 
-    // The requested connection id, if the caller provided one. If provided, will be a string and must
-    // be one of the enabled ids per the Zod schema injected by `getRegisteredToolConfig()`.
+    // The requested connection id, if the caller provided one. Per the Zod schema injected by
+    // `getRegisteredToolConfig()` it should be a string that is one of the enabled ids; both
+    // expectations are enforced below rather than assumed.
     const requestedId = toolArguments?.connectionId;
 
     if (typeof requestedId === "string") {
@@ -325,6 +327,18 @@ export abstract class BaseToolHandler implements ToolHandler {
       // Explicit requested ID must be valid based on the injected schema enum already having validated it, so can
       // at this point trust fully.
       determinedId = requestedId;
+    } else if (requestedId !== undefined) {
+      // Unreachable in normal operation: Zod has already validated `args`
+      // against the registered schema before `handle()` runs, and that schema
+      // either declares `connectionId` as a string enum (multi-connection
+      // tools — a non-string fails parsing) or omits it entirely (single-
+      // connection tools — an unknown key is stripped). Either way a non-string
+      // can't survive to reach this branch. It exists purely as a symmetric
+      // peer to the two backstops below, so a malformed value can never quietly
+      // masquerade as an omission and auto-route.
+      throw new Error(
+        `Wacky -- connectionId present but not a string (got ${typeof requestedId}); the injected schema should have rejected this`,
+      );
     } else if (enabledIds.length === 1) {
       // No requested ID, but only one enabled connection — unambiguous, so route there.
       determinedId = enabledIds[0]!;

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -1,5 +1,8 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-import type { ConnectionConfig } from "@src/config/models.js";
+import type {
+  ConnectionConfig,
+  DirectConnectionConfig,
+} from "@src/config/models.js";
 import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
@@ -112,6 +115,30 @@ export interface ToolConfig {
   inputSchema: ZodRawShape;
   annotations: ToolAnnotations;
 }
+
+/**
+ * What the connection-resolution helpers hand back: the chosen connection id,
+ * its resolved config, and the client manager bound to it.
+ *
+ * Generic over the connection arm so the type-neutral resolvers
+ * ({@linkcode BaseToolHandler.resolveConnection}) and the direct-narrowing one
+ * ({@linkcode BaseToolHandler.resolveDirectConnection}) share a single name —
+ * the latter instantiates it via the {@link ResolvedDirectConnection} alias.
+ */
+export interface ResolvedConnection<
+  C extends ConnectionConfig = ConnectionConfig,
+> {
+  connId: string;
+  conn: C;
+  clientManager: BaseClientManager;
+}
+
+/**
+ * A {@link ResolvedConnection} pre-narrowed to the direct arm — the return type
+ * of {@linkcode BaseToolHandler.resolveDirectConnection}.
+ */
+export type ResolvedDirectConnection =
+  ResolvedConnection<DirectConnectionConfig>;
 
 export abstract class BaseToolHandler implements ToolHandler {
   abstract handle(
@@ -252,17 +279,100 @@ export abstract class BaseToolHandler implements ToolHandler {
    * connection, so this is unambiguous; if multi-connection support lands
    * later, handlers can switch to iterating ids.
    */
-  protected resolveSoleConnection(runtime: ServerRuntime): {
-    connId: string;
-    conn: ConnectionConfig;
-    clientManager: BaseClientManager;
-  } {
+  protected resolveSoleConnection(runtime: ServerRuntime): ResolvedConnection {
     const connId = this.enabledConnectionIds(runtime)[0]!;
     return {
       connId,
       conn: runtime.config.connections[connId]!,
       clientManager: runtime.clientManagers[connId]!,
     };
+  }
+
+  /**
+   * Resolves which connection a tool call targets: the explicit `connectionId`
+   * argument when present, else the sole connection enabled for this tool.
+   * Throws a listing error when the id is unknown/not-enabled, or when omitted
+   * while two or more connections are candidates (the augmented schema makes the
+   * latter unreachable in normal MCP flow — this is the defensive backstop).
+   *
+   * Reads `connectionId` off the **raw** `toolArguments` rather than off the
+   * handler's locally-parsed object: the framework already validated it against
+   * the registered schema (see {@linkcode getRegisteredToolConfig}), and a
+   * handler's own `z.object` re-`parse()` would strip the key it never declared.
+   *
+   * @final — concrete on `BaseToolHandler`; subclasses must not override.
+   */
+  protected resolveConnection(
+    runtime: ServerRuntime,
+    toolArguments: Record<string, unknown> | undefined,
+  ): ResolvedConnection {
+    // The connection this tool call should route to.
+    let determinedId: string;
+
+    // What connection ids this tool possibly supports.
+    const enabledIds = this.enabledConnectionIds(runtime);
+
+    // The requested connection id, if the caller provided one. If provided, will be a string and must
+    // be one of the enabled ids per the Zod schema injected by `getRegisteredToolConfig()`.
+    const requestedId = toolArguments?.connectionId;
+
+    if (typeof requestedId === "string") {
+      if (!enabledIds.includes(requestedId)) {
+        throw new Error(
+          `Wacky -- connection "${requestedId}" is not an enabled connection for this tool; enabled: ${enabledIds.join(", ")}`,
+        );
+      }
+      // Explicit requested ID must be valid based on the injected schema enum already having validated it, so can
+      // at this point trust fully.
+      determinedId = requestedId;
+    } else if (enabledIds.length === 1) {
+      // No requested ID, but only one enabled connection — unambiguous, so route there.
+      determinedId = enabledIds[0]!;
+    } else {
+      // Not a string and not a sole enabled connection. Should have been blocked by the injected schema.
+      throw new Error(
+        `Wacky -- connectionId omitted but this tool is enabled for ${enabledIds.length} connections (${enabledIds.join(", ") || "none"}); cannot auto-route`,
+      );
+    }
+
+    return {
+      connId: determinedId,
+      conn: runtime.config.connections[determinedId]!,
+      clientManager: runtime.clientManagers[determinedId]!,
+    };
+  }
+
+  /**
+   * Like {@linkcode resolveConnection}, but narrows the resolved connection to
+   * a {@link DirectConnectionConfig} — throwing if the addressed connection is
+   * OAuth-typed. The throw is a defensive backstop: a tool's `connectionId`
+   * enum only offers connections its predicate enables, and the direct-block
+   * predicates exclude OAuth, so an OAuth connection is unreachable here via
+   * normal MCP flow.
+   *
+   * @final — concrete on `BaseToolHandler`; subclasses must not override.
+   */
+  protected resolveDirectConnection(
+    runtime: ServerRuntime,
+    toolArguments: Record<string, unknown> | undefined,
+  ): ResolvedDirectConnection {
+    // Reuse resolveConnection for id selection + validation; this method only
+    // adds the direct-vs-oauth narrowing on top of its type-neutral result.
+    const { connId, conn, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
+
+    // A resolved OAuth connection means the wiring is broken (a non-oauth tool
+    // somehow offered an oauth id), not that a caller legitimately asked for one.
+    if (conn.type !== "direct") {
+      throw new Error(
+        `Wacky -- connection "${connId}" is ${conn.type}-typed; this tool requires a direct connection`,
+      );
+    }
+
+    // conn is narrowed to DirectConnectionConfig by the guard above.
+    return { connId, conn, clientManager };
   }
 
   /**


### PR DESCRIPTION
## The tool handler consume-side seam

- New `@final protected resolveConnection(runtime, toolArguments)` resolves which connection a tool call targets and returns a `ResolvedConnection`.  It returns the same shape as the `resolveSoleConnection()` it will ultimately replace, so it will be able to be droped straight into a handler's `handle()` during the later porting waves.
- It reads `connectionId` off the **raw** `toolArguments`, not a handler's locally-parsed object. The framework already validated the value against the registered schema (#533), and a handler's own `z.object` re-`parse()` would strip the key it never declared. So handlers never carry `connectionId` in their own schema — the base class owns the param on both the publish and consume sides.
- Resolution rules: an explicit `connectionId` must be among the tool's `enabledConnectionIds`, else it throws; omitted with a single viable connection auto-routes to it; omitted with two or more viable connections throws an ambiguous-selection error listing the candidates.
- The two error paths are defensive backstops, not user-facing conditions, so both carry the team's `"Wacky -- "` prefix. The bad-id throw is unreachable because the #533 enum rejects an unknown/not-enabled id before `handle()` runs (and in the single-viable case the registered `z.object` strips an undeclared `connectionId` entirely). The omitted-but-not-single-viable throw folds two unreachable conditions into one arm: two-or-more candidates (the enum would have required `connectionId`) and zero candidates (registration only wires tools with ≥1 enabled connection — `src/index.ts` Pass 2); the message's count distinguishes them for a debugging reader without a second branch.

## The direct-narrowing variant

- New `@final protected resolveDirectConnection(runtime, toolArguments)` delegates id selection and validation to `resolveConnection()`, then narrows the result's `conn` to `DirectConnectionConfig`, throwing a `"Wacky -- "` error if the resolved connection is OAuth-typed. That throw is unreachable in normal MCP flow: a tool's `connectionId` enum only offers connections its predicate enables, and the direct-block predicates exclude OAuth.
- It replaces the `runtime.config.getSoleDirectConnection()` calls in the non-OAuth handler majority, again during #539 / #541.

## The shared return type

- The `{ connId, conn, clientManager }` shape, previously written inline on `resolveSoleConnection()` and `resolveConnection()`, is lifted into one exported `ResolvedConnection<C extends ConnectionConfig = ConnectionConfig>` interface that all three resolvers return.
  It's generic over the connection arm so `resolveDirectConnection()` returns the `ResolvedDirectConnection` alias (`ResolvedConnection<DirectConnectionConfig>`) rather than forking the shape.
- No handler changes from the rename: every one of the 14 `resolveSoleConnection()` call sites destructures the result, so the named interface is invisible to them (whole-repo `tsc --noEmit` confirms).

## Proof

- Full unit suite in `base-tools.test.ts` for `resolveConnection()` mirroring the #533 thoroughness: explicit routing to a non-first candidate (asserting the matching `conn` **and** `clientManager` instance, not just the id); an `it.each` over unknown-id and configured-but-not-enabled-id, each pinning the exact listing-error message; single-viable auto-route (and the `toolArguments === undefined` variant); the ambiguous-selection and zero-enabled backstops folded into one `it.each`; and a sole-OAuth case proving the type-neutral result.
- `resolveDirectConnection()` tests cover the delta plus a delegation proof: explicit-id narrowing (asserting `conn.type === "direct"`, id, and client manager), sole-connection auto-route, the OAuth-typed backstop throw, and propagation of `resolveConnection()`'s listing error for an unknown id.

## Out of scope

- This branch only **adds** the two resolvers.
  `resolveSoleConnection()` and `getSoleDirectConnection()` stay put and no handlers are ported yet — that's #539 / #541.

## Relationships

- Closes #534 (`resolveConnection()`). Closes #538 (`resolveDirectConnection()`) — the two consume-side resolvers landed together because #538 is a thin narrowing wrapper over #534 and they share the new return interface.
- Child of #532 (Epic: Multi-connection support).
- Consume-side mirror of #533's `getRegisteredToolConfig()`, which injects the `connectionId` these methods read back off.
- Consumed by the porting waves #539 (Kafka) and #541 (the rest), which swap handler `handle()` bodies from the sole-connection accessors onto these.

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1. Zero functional changes. No tool handlers call these new buggers yet.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
