### PR TITLE
Per-connection `description` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this MCP server will be documented in this file.
 
 - **`list-connections` tool.** Read-only, always-enabled discovery tool mapping each configured connection id to the connection-routable tools enabled on it.
 
+#### Configuration
+
+- **Per-connection `description` field.** Optional free-text label on any connection, echoed back by `list-connections`.
+
 ## 1.4.0
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -71,6 +71,7 @@ server:
 connections:
   ccloud-oauth:
     type: oauth
+    description: "Confluent Cloud Production"
 ```
 
 Get a starter file via `--init-oauth-config`.
@@ -89,8 +90,9 @@ server:
   log_level: info
 
 connections:
-  default:
+  staging:
     type: direct
+    description: "Confluent Cloud Staging via API Keys"
     kafka: { ... }
     schema_registry: { ... }
     confluent_cloud: { ... }
@@ -100,6 +102,8 @@ connections:
 ```
 
 The connection name (`default` above) is freeform.
+Either connection flavor also accepts an optional `description` — a free-text label echoed back by the `list-connections` tool so an agent can tell your connections apart.
+A blank or whitespace-only `description` is treated as no description.
 
 #### Service blocks
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -101,7 +101,7 @@ connections:
     telemetry: { ... }
 ```
 
-The connection name (`default` above) is freeform.
+The connection name (`staging` above) is freeform.
 Either connection flavor also accepts an optional `description` — a free-text label echoed back by the `list-connections` tool so an agent can tell your connections apart.
 A blank or whitespace-only `description` is treated as no description.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,6 +71,11 @@ connections:
   default:
     type: direct
 
+    # Optional human-readable label for this connection, echoed back by the
+    # `list-connections` tool so an agent can tell your connections apart.
+    # A blank value is treated as no description.
+    description: "Primary Confluent Cloud connection"
+
     # --- Kafka ---
     # `bootstrap_servers` is required for any Kafka client (admin, producer,
     # consumer). `rest_endpoint` + `cluster_id` + `env_id` are required for

--- a/config.oauth.example.yaml
+++ b/config.oauth.example.yaml
@@ -37,6 +37,11 @@ connections:
   ccloud-oauth:
     type: oauth
 
+    # Optional human-readable label for this connection, echoed back by the
+    # `list-connections` tool so an agent can tell your connections apart.
+    # A blank value is treated as no description.
+    description: "Confluent Cloud (OAuth login)"
+
     # librdkafka `debug` contexts to emit on stderr for this OAuth connection's
     # native Kafka client. Reach for it when an OAuth/OAUTHBEARER SASL handshake
     # misbehaves and you need to see which side broke — works the same in

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -808,10 +808,12 @@ describe("config/models.ts", () => {
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        const conn = result.data.connections.foo as unknown as Record<
-          string,
-          unknown
-        >;
+        const conn = result.data.connections.foo;
+        // Narrow off the discriminant so `.description` is read through the
+        // OAuth arm's type — this keeps compile-time proof that the arm
+        // actually exposes the field, which an untyped cast would erase.
+        if (conn?.type !== "oauth")
+          throw new Error("expected oauth connection after type assertion");
         expect(conn.description).toBe("My CCloud login");
       }
     });

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -780,6 +780,83 @@ describe("config/models.ts", () => {
     });
   });
 
+  describe("connection description", () => {
+    it("should parse and trim a description on a direct connection", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: {
+          production: {
+            type: "direct",
+            description: "  Production east cluster  ",
+            kafka: { bootstrap_servers: "broker:9092" },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(
+          (result.data.connections["production"] as DirectConnectionConfig)
+            .description,
+        ).toBe("Production east cluster");
+      }
+    });
+
+    it("should parse a description on an oauth connection", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: {
+          foo: { type: "oauth", description: "My CCloud login" },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const conn = result.data.connections.foo as unknown as Record<
+          string,
+          unknown
+        >;
+        expect(conn.description).toBe("My CCloud login");
+      }
+    });
+
+    it.each(["", "   ", "\t\n"])(
+      "should coerce a blank description (%j) to undefined rather than rejecting",
+      (description) => {
+        const result = mcpConfigSchema.safeParse({
+          connections: {
+            production: {
+              type: "direct",
+              description,
+              kafka: { bootstrap_servers: "broker:9092" },
+            },
+          },
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(
+            (result.data.connections["production"] as DirectConnectionConfig)
+              .description,
+          ).toBeUndefined();
+        }
+      },
+    );
+
+    it("should leave description undefined when omitted", () => {
+      const result = mcpConfigSchema.safeParse({
+        connections: {
+          production: {
+            type: "direct",
+            kafka: { bootstrap_servers: "broker:9092" },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(
+          (result.data.connections["production"] as DirectConnectionConfig)
+            .description,
+        ).toBeUndefined();
+      }
+    });
+  });
+
   describe("oauth connection arm", () => {
     it("should default ccloud_env to 'prod' when omitted", () => {
       const result = mcpConfigSchema.safeParse({

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
  */
 export interface DirectConnectionConfig {
   readonly type: "direct";
+  readonly description?: string;
   readonly kafka?: KafkaDirectConfig;
   readonly schema_registry?: SchemaRegistryDirectConfig;
   readonly confluent_cloud?: ConfluentCloudDirectConfig;
@@ -44,6 +45,7 @@ export interface DirectConnectionConfig {
  */
 export interface OAuthConnectionConfig {
   readonly type: "oauth";
+  readonly description?: string;
   readonly ccloud_env: "devel" | "stag" | "prod";
   readonly kafka_debug?: string;
 }
@@ -305,10 +307,23 @@ const apiKeyAuthSchema = z
 
 const authConfigSchema = z.discriminatedUnion("type", [apiKeyAuthSchema]);
 
+/**
+ * Optional human-readable label for a connection, shared by both connection arms.
+ * A blank or whitespace-only value trims to empty and coerces to `undefined` — an empty
+ * description is harmless, just uninformative, so it is treated as if the field were omitted
+ * rather than failing the parse.
+ */
+const connectionDescriptionSchema = z
+  .string()
+  .trim()
+  .transform((s) => (s.length === 0 ? undefined : s))
+  .optional();
+
 /** Zod schema for direct connection type */
 const directConnectionSchema = z
   .object({
     type: z.literal("direct"),
+    description: connectionDescriptionSchema,
     confluent_cloud: z
       .object({
         endpoint: z
@@ -458,6 +473,7 @@ const TELEMETRY_DEFAULT_ENDPOINT = "https://api.telemetry.confluent.cloud";
 const oauthConnectionSchema = z
   .object({
     type: z.literal("oauth"),
+    description: connectionDescriptionSchema,
     ccloud_env: z.enum(["devel", "stag", "prod"]).default("prod"),
     kafka_debug: z
       .string()

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -24,6 +24,7 @@ describe("config/yaml-fixtures.test.ts", () => {
       );
       const conn = config.getSoleDirectConnection();
       expect(conn.type).toBe("direct");
+      expect(conn.description).toBe("Local dev broker");
       expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
       expect(conn.kafka?.auth).toBeUndefined();
       expect(conn.schema_registry).toBeUndefined();
@@ -199,6 +200,7 @@ describe("config/yaml-fixtures.test.ts", () => {
       // also serves as a compile-time check on the OAuth arm of ConnectionConfig.
       if (conn.type !== "oauth")
         throw new Error("expected oauth connection after type assertion");
+      expect(conn.description).toBe("CCloud devel via OAuth");
       expect(conn.ccloud_env).toBe("devel");
     });
   });

--- a/src/confluent/tools/handlers/diagnostics/list-connections-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-connections-handler.test.ts
@@ -125,6 +125,37 @@ describe("ListConnectionsHandler", () => {
       expect(textOf(result)).toContain("bare (0 tools): (none)");
     });
 
+    it("should echo a connection's description into the structured payload and text summary", () => {
+      const runtime = runtimeWithConnections({
+        k: { description: "Prod east", ...KAFKA },
+      });
+
+      const result = handlerWith(threeToolUniverse()).handle(runtime);
+
+      expect(result.structuredContent).toEqual({
+        connections: {
+          k: {
+            description: "Prod east",
+            enabledTools: [ToolName.CREATE_TOPICS, ToolName.LIST_TOPICS],
+          },
+        },
+      });
+      expect(textOf(result)).toContain('k — "Prod east" (2 tools):');
+    });
+
+    it("should omit the description key for a connection that has none", () => {
+      const runtime = runtimeWithConnections({ k: KAFKA });
+
+      const result = handlerWith(threeToolUniverse()).handle(runtime);
+
+      const bucket = (
+        result.structuredContent as {
+          connections: Record<string, unknown>;
+        }
+      ).connections.k;
+      expect(bucket).not.toHaveProperty("description");
+    });
+
     it("should return an empty mapping with explanatory text when no connections are configured", () => {
       const result = handlerWith(threeToolUniverse()).handle(
         runtimeWithConnections({}),

--- a/src/confluent/tools/handlers/diagnostics/list-connections-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-connections-handler.test.ts
@@ -143,6 +143,20 @@ describe("ListConnectionsHandler", () => {
       expect(textOf(result)).toContain('k — "Prod east" (2 tools):');
     });
 
+    it("should escape quotes and newlines in the description so the summary line stays single-line and unambiguous", () => {
+      const runtime = runtimeWithConnections({
+        k: { description: 'say "hi"\nthere', ...KAFKA },
+      });
+
+      const result = handlerWith(threeToolUniverse()).handle(runtime);
+
+      // JSON.stringify escapes the embedded quote and collapses the newline to
+      // a literal \n, so the label cannot break the summary across lines.
+      expect(textOf(result)).toContain('k — "say \\"hi\\"\\nthere" (2 tools):');
+      // The raw newline must not survive into the rendered text.
+      expect(textOf(result)).not.toContain('say "hi"\nthere');
+    });
+
     it("should omit the description key for a connection that has none", () => {
       const runtime = runtimeWithConnections({ k: KAFKA });
 

--- a/src/confluent/tools/handlers/diagnostics/list-connections-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-connections-handler.ts
@@ -13,6 +13,15 @@ import { z } from "zod";
 const listConnectionsArguments = z.object({});
 
 /**
+ * Per-connection entry in the `list-connections` payload. `description` is the operator's
+ * optional label from config, present only when the connection defined a non-blank one.
+ */
+interface ConnectionListing {
+  description?: string;
+  enabledTools: ToolName[];
+}
+
+/**
  * Discovery tool: maps each configured connection id to the tools an agent can
  * actually invoke against it. "Actually invokable" means a tool both survived
  * the operator's allow/block-list and whose predicate enables that specific
@@ -35,9 +44,15 @@ export class ListConnectionsHandler extends ToolMetadataHandler {
   ): CallToolResult {
     listConnectionsArguments.parse(toolArguments ?? {});
 
-    const connections: Record<string, { enabledTools: ToolName[] }> = {};
-    for (const connId of Object.keys(runtime.config.connections)) {
-      connections[connId] = { enabledTools: [] };
+    const connections: Record<string, ConnectionListing> = {};
+    for (const [connId, conn] of Object.entries(runtime.config.connections)) {
+      // Omit the key entirely when there is no description (a blank one coerces
+      // to undefined at config-parse time), so the listing never carries an
+      // empty-string label.
+      connections[connId] =
+        conn.description !== undefined
+          ? { description: conn.description, enabledTools: [] }
+          : { enabledTools: [] };
     }
 
     // Single pass over the catalog: compute each tool's enabled connection ids
@@ -86,17 +101,16 @@ export class ListConnectionsHandler extends ToolMetadataHandler {
  * payload is authoritative; this text is the at-a-glance view. Handler tests
  * pin the empty-config sentence so the no-connections path stays stable.
  */
-function renderSummary(
-  connections: Record<string, { enabledTools: ToolName[] }>,
-): string {
+function renderSummary(connections: Record<string, ConnectionListing>): string {
   const entries = Object.entries(connections);
   if (entries.length === 0) {
     return "No connections are configured.";
   }
-  const lines = entries.map(([id, { enabledTools }]) => {
+  const lines = entries.map(([id, { description, enabledTools }]) => {
     const count = enabledTools.length;
     const list = count > 0 ? enabledTools.join(", ") : "(none)";
-    return `  ${id} (${count} tool${count === 1 ? "" : "s"}): ${list}`;
+    const label = description !== undefined ? `${id} — "${description}"` : id;
+    return `  ${label} (${count} tool${count === 1 ? "" : "s"}): ${list}`;
   });
   return [
     `${entries.length} connection${entries.length === 1 ? "" : "s"} configured:`,

--- a/src/confluent/tools/handlers/diagnostics/list-connections-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-connections-handler.ts
@@ -109,7 +109,10 @@ function renderSummary(connections: Record<string, ConnectionListing>): string {
   const lines = entries.map(([id, { description, enabledTools }]) => {
     const count = enabledTools.length;
     const list = count > 0 ? enabledTools.join(", ") : "(none)";
-    const label = description !== undefined ? `${id} — "${description}"` : id;
+    // JSON.stringify quotes and escapes the description so an embedded quote or
+    // newline can't make the summary line ambiguous or wrap onto another line.
+    const label =
+      description !== undefined ? `${id} — ${JSON.stringify(description)}` : id;
     return `  ${label} (${count} tool${count === 1 ? "" : "s"}): ${list}`;
   });
   return [

--- a/src/confluent/tools/handlers/diagnostics/list-connections-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-connections-handler.ts
@@ -50,9 +50,9 @@ export class ListConnectionsHandler extends ToolMetadataHandler {
       // to undefined at config-parse time), so the listing never carries an
       // empty-string label.
       connections[connId] =
-        conn.description !== undefined
-          ? { description: conn.description, enabledTools: [] }
-          : { enabledTools: [] };
+        conn.description === undefined
+          ? { enabledTools: [] }
+          : { description: conn.description, enabledTools: [] };
     }
 
     // Single pass over the catalog: compute each tool's enabled connection ids
@@ -112,7 +112,7 @@ function renderSummary(connections: Record<string, ConnectionListing>): string {
     // JSON.stringify quotes and escapes the description so an embedded quote or
     // newline can't make the summary line ambiguous or wrap onto another line.
     const label =
-      description !== undefined ? `${id} — ${JSON.stringify(description)}` : id;
+      description === undefined ? id : `${id} — ${JSON.stringify(description)}`;
     return `  ${label} (${count} tool${count === 1 ? "" : "s"}): ${list}`;
   });
   return [

--- a/test-fixtures/yaml_configs/valid/ccloud-oauth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-oauth.yaml
@@ -1,4 +1,5 @@
 connections:
   default:
     type: oauth
+    description: "CCloud devel via OAuth"
     ccloud_env: devel

--- a/test-fixtures/yaml_configs/valid/kafka-only.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-only.yaml
@@ -1,5 +1,6 @@
 connections:
   local:
     type: direct
+    description: "Local dev broker"
     kafka:
       bootstrap_servers: "localhost:9092"


### PR DESCRIPTION
## Connection-level `description`

- Adds an optional `description?: string` to every connection block (both the `direct` and `oauth` arms), giving operators a place to label what a connection is for. It is connection-level — a peer of `type` and the service blocks — not a per-service-block field.
- A blank or whitespace-only `description` trims to empty and coerces to `undefined`, so it is treated exactly as if the field were omitted. There is no rejection: an empty description is harmless, just uninformative, so the schema silently drops it rather than failing the parse.

## `list-connections` echoes the description

- `list-connections` now carries each connection's `description` (when present) in both the `structuredContent` payload and the human-readable text summary, so an agent picking a `connectionId` can read the operator's own label for each connection.
- Connections without a description omit the key entirely rather than emitting `description: null` / an empty string — the blank-coerces-to-undefined rule keeps the listing clean.

## Examples, fixtures, and docs

- `config.example.yaml` and `config.oauth.example.yaml` carry a live, commented `description` so the field is discoverable on both connection flavors.
- A subset of the valid YAML test fixtures carry a `description`; the rest stay bare to keep the optional-and-omittable path covered.
- `CONFIGURATION.md` documents the field on both connection sections (noting the blank-is-no-op behaviour and the `list-connections` echo); `CHANGELOG.md` gets a one-line Added entry.

## Relationships

- Closes #561
- Child of #532 (Epic: Multi-connection support)
