### PR TITLE
Make kafka tools multi connection capable

### DIFF
--- a/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
@@ -4,6 +4,7 @@ import {
   HandleCaseWithConn,
   KAFKA_CONN,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -77,6 +78,32 @@ describe("alter-topic-config.ts", () => {
           });
         },
       );
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        const restClient =
+          await clientManager.getConfluentCloudKafkaRestClient();
+        restClient.POST.mockResolvedValue({ data: undefined });
+
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          KAFKA_CONN,
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: {
+            topicName: "my-topic",
+            topicConfigs: VALID_CONFIGS,
+            connectionId: DEFAULT_CONNECTION_ID,
+          },
+          outcome: { resolves: "Successfully altered topic config" },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
+        });
+      });
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_CONNECTION_ID,
   HandleCaseWithConn,
   KAFKA_CONN,
-  runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
@@ -67,7 +66,10 @@ describe("alter-topic-config.ts", () => {
           restClient.POST.mockResolvedValue({ data: undefined });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            // runtimeWithDecoy plants a second same-config connection; assertHandleCase
+            // routes to the real one and asserts the decoy stays untouched, so every
+            // case here doubles as a routing test.
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -78,32 +80,6 @@ describe("alter-topic-config.ts", () => {
           });
         },
       );
-
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const clientManager = getMockedClientManager();
-        const restClient =
-          await clientManager.getConfluentCloudKafkaRestClient();
-        restClient.POST.mockResolvedValue({ data: undefined });
-
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          KAFKA_CONN,
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: {
-            topicName: "my-topic",
-            topicConfigs: VALID_CONFIGS,
-            connectionId: DEFAULT_CONNECTION_ID,
-          },
-          outcome: { resolves: "Successfully altered topic config" },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
-        });
-      });
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -50,7 +50,10 @@ export class AlterTopicConfigHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = alterTopicConfigArguments.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const { clusterId, envId } = resolveKafkaRestArgs(parsed, runtime, connId);
 
     const restClient = await clientManager.getConfluentCloudKafkaRestClient(

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -448,29 +448,6 @@ describe("consume-kafka-messages-handler.ts", () => {
         consumer.disconnect.mockResolvedValue(undefined);
       });
 
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: {
-            topics: [{ name: "smoke", start: "earliest" }],
-            maxMessages: 1,
-            timeoutMs: 50,
-            valueFormat: {},
-            connectionId: DEFAULT_CONNECTION_ID,
-          },
-          outcome: { resolves: "Consumed 0 messages from topics smoke" },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
-        });
-      });
-
       it("should pass derived offsetReset='earliest' to buildKafkaConsumer when every entry agrees on `start: 'earliest'`", async () => {
         // The consumer's `auto.offset.reset` is no longer a peer top-level
         // input; the handler derives it from the per-topic `start` values.
@@ -479,7 +456,7 @@ describe("consume-kafka-messages-handler.ts", () => {
         // are needed (the simple-call fast path is preserved).
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -508,7 +485,7 @@ describe("consume-kafka-messages-handler.ts", () => {
       it("should propagate the default offsetReset ('earliest') to buildKafkaConsumer when every entry omits `start`", async () => {
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -546,7 +523,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -577,7 +554,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -608,7 +585,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -640,7 +617,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             {
               kafka: { bootstrap_servers: "broker:9092" },
               schema_registry: { endpoint: "https://sr.example" },
@@ -670,7 +647,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             {
               kafka: { bootstrap_servers: "broker:9092" },
               schema_registry: { endpoint: "https://sr.example" },
@@ -699,7 +676,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -728,7 +705,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             {
               kafka: { bootstrap_servers: "broker:9092" },
               schema_registry: { endpoint: "https://sr.example" },
@@ -754,7 +731,7 @@ describe("consume-kafka-messages-handler.ts", () => {
         // first thing buildPreflightPlan does).
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -780,7 +757,7 @@ describe("consume-kafka-messages-handler.ts", () => {
         // pick a default that surprises a caller.
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -806,7 +783,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -835,7 +812,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -864,7 +841,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -890,7 +867,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -921,7 +898,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -954,7 +931,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -998,7 +975,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1040,7 +1017,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1078,7 +1055,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1118,7 +1095,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1173,7 +1150,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1238,7 +1215,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1289,7 +1266,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1336,7 +1313,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1391,7 +1368,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1446,7 +1423,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1500,7 +1477,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1532,7 +1509,7 @@ describe("consume-kafka-messages-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -1580,6 +1557,9 @@ describe("consume-kafka-messages-handler.ts", () => {
         // in production, where the SDK has already validated and
         // defaulted the inputs.
         const handlePromise = handler.handle(
+          // Direct handle() call (not assertHandleCase), so no decoy/auto-route
+          // here — a single-connection runtime keeps this orchestrator-race test
+          // focused on the maxReached arm.
           runtimeWith(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -445,6 +446,29 @@ describe("consume-kafka-messages-handler.ts", () => {
         consumer.subscribe.mockResolvedValue(undefined);
         consumer.run.mockResolvedValue(undefined);
         consumer.disconnect.mockResolvedValue(undefined);
+      });
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: {
+            topics: [{ name: "smoke", start: "earliest" }],
+            maxMessages: 1,
+            timeoutMs: 50,
+            valueFormat: {},
+            connectionId: DEFAULT_CONNECTION_ID,
+          },
+          outcome: { resolves: "Consumed 0 messages from topics smoke" },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
+        });
       });
 
       it("should pass derived offsetReset='earliest' to buildKafkaConsumer when every entry agrees on `start: 'earliest'`", async () => {

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1028,9 +1028,11 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
    * @param runtime - The {@link ServerRuntime} (config + active client
    *   manager + OAuth holder). Supplied by the MCP server dispatcher;
    *   the handler resolves cluster/env/registry clients off of it.
-   * @param toolArguments - Parsed args matching `consumeKafkaMessagesArgs`.
-   *   The handler re-parses internally to apply defaults at the
-   *   boundary.
+   * @param toolArguments - Raw tool arguments (`Record<string, unknown>`) as
+   *   handed in by the MCP dispatcher. The handler parses them with
+   *   `consumeKafkaMessagesArgs` to apply defaults; `resolveConnection` reads
+   *   `connectionId` off this unparsed object (a handler-local `z.object`
+   *   re-parse would strip the key it never declared).
    * @returns A {@link CallToolResult}. Success path emits a text block
    *   summarizing the consumed messages; failures (build/preflight/run
    *   errors) surface via `createResponse(text, true)` with the

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1038,12 +1038,15 @@ export class ConsumeKafkaMessagesHandler extends BaseToolHandler {
    */
   async handle(
     runtime: ServerRuntime,
-    toolArguments: z.infer<typeof consumeKafkaMessagesArgs>,
+    toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = consumeKafkaMessagesArgs.parse(toolArguments);
     const { maxMessages, timeoutMs, valueFormat, keyFormat } = parsed;
 
-    const { connId, conn, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, conn, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
 
     // Auto-decode when SR is reachable on this connection (OAuth always; direct

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.test.ts
@@ -2,7 +2,6 @@ import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { CreateTopicsHandler } from "@src/confluent/tools/handlers/kafka/create-topics-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
@@ -23,7 +22,7 @@ describe("create-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -34,30 +33,6 @@ describe("create-topics-handler.ts", () => {
         });
       });
 
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const clientManager = getMockedClientManager();
-        const admin = await clientManager.getAdminClient();
-        admin.createTopics.mockResolvedValue(true);
-
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: {
-            topics: [{ topic: "smoke", numPartitions: 1 }],
-            connectionId: DEFAULT_CONNECTION_ID,
-          },
-          outcome: { resolves: "Created Kafka topics: smoke" },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
-        });
-      });
-
       it("should surface a failure response when admin.createTopics resolves false", async () => {
         const clientManager = getMockedClientManager();
         const admin = await clientManager.getAdminClient();
@@ -65,7 +40,7 @@ describe("create-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -83,7 +58,7 @@ describe("create-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -114,7 +89,7 @@ describe("create-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.test.ts
@@ -3,6 +3,7 @@ import { CreateTopicsHandler } from "@src/confluent/tools/handlers/kafka/create-
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -30,6 +31,30 @@ describe("create-topics-handler.ts", () => {
           args: { topics: [{ topic: "smoke", numPartitions: 1 }] },
           outcome: { resolves: "Created Kafka topics: smoke" },
           clientManager,
+        });
+      });
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.createTopics.mockResolvedValue(true);
+
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: {
+            topics: [{ topic: "smoke", numPartitions: 1 }],
+            connectionId: DEFAULT_CONNECTION_ID,
+          },
+          outcome: { resolves: "Created Kafka topics: smoke" },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
         });
       });
 

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -51,7 +51,10 @@ export class CreateTopicsHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = createTopicArgs.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
     const admin = await clientManager.getKafkaAdminClient(
       resolved.clusterId,

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.test.ts
@@ -1,7 +1,6 @@
 import { DeleteTopicsHandler } from "@src/confluent/tools/handlers/kafka/delete-topics-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
@@ -22,7 +21,7 @@ describe("delete-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -30,27 +29,6 @@ describe("delete-topics-handler.ts", () => {
           args: { topicNames: ["smoke"] },
           outcome: { resolves: "Deleted Kafka topics: smoke" },
           clientManager,
-        });
-      });
-
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const clientManager = getMockedClientManager();
-        const admin = await clientManager.getAdminClient();
-        admin.deleteTopics.mockResolvedValue(undefined);
-
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: { topicNames: ["smoke"], connectionId: DEFAULT_CONNECTION_ID },
-          outcome: { resolves: "Deleted Kafka topics: smoke" },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
         });
       });
 
@@ -63,7 +41,7 @@ describe("delete-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.test.ts
@@ -2,6 +2,7 @@ import { DeleteTopicsHandler } from "@src/confluent/tools/handlers/kafka/delete-
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -29,6 +30,27 @@ describe("delete-topics-handler.ts", () => {
           args: { topicNames: ["smoke"] },
           outcome: { resolves: "Deleted Kafka topics: smoke" },
           clientManager,
+        });
+      });
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.deleteTopics.mockResolvedValue(undefined);
+
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: { topicNames: ["smoke"], connectionId: DEFAULT_CONNECTION_ID },
+          outcome: { resolves: "Deleted Kafka topics: smoke" },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
         });
       });
 

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -38,7 +38,10 @@ export class DeleteTopicsHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = deleteKafkaTopicsArguments.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
     const admin = await clientManager.getKafkaAdminClient(
       resolved.clusterId,

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
@@ -161,19 +161,16 @@ describe("describe-consumer-group-handler.ts", () => {
         groups: [fakeGroupDescription({ groupId: "my-group" })],
       });
 
-      const { runtime, decoyClientManager } = runtimeWithDecoy(
-        { kafka: { bootstrap_servers: "broker:9092" } },
-        DEFAULT_CONNECTION_ID,
-        clientManager,
-      );
-
       await assertHandleCase({
         handler,
-        runtime,
-        args: { groupId: "my-group", connectionId: DEFAULT_CONNECTION_ID },
+        runtime: runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        ),
+        args: { groupId: "my-group" },
         outcome: { resolves: 'Consumer group "my-group" is' },
         clientManager,
-        untouchedClientManager: decoyClientManager,
       });
     });
 

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
@@ -12,8 +12,15 @@ import {
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
-import { kafkaRuntime } from "@tests/factories/runtime.js";
-import { getMockedClientManager } from "@tests/stubs/index.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  kafkaRuntime,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
 
@@ -146,6 +153,29 @@ describe("describe-consumer-group-handler.ts", () => {
 
   describe("handle()", () => {
     const handler = new DescribeConsumerGroupHandler();
+
+    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+      const clientManager = getMockedClientManager();
+      const admin = await clientManager.getAdminClient();
+      admin.describeGroups.mockResolvedValue({
+        groups: [fakeGroupDescription({ groupId: "my-group" })],
+      });
+
+      const { runtime, decoyClientManager } = runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
+        clientManager,
+      );
+
+      await assertHandleCase({
+        handler,
+        runtime,
+        args: { groupId: "my-group", connectionId: DEFAULT_CONNECTION_ID },
+        outcome: { resolves: 'Consumer group "my-group" is' },
+        clientManager,
+        untouchedClientManager: decoyClientManager,
+      });
+    });
 
     it("should forward the single groupId as a one-element array to describeGroups", async () => {
       const clientManager = getMockedClientManager();

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
@@ -154,13 +154,18 @@ describe("describe-consumer-group-handler.ts", () => {
   describe("handle()", () => {
     const handler = new DescribeConsumerGroupHandler();
 
-    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+    it("should route only to its resolved connection in a multi-connection config", async () => {
       const clientManager = getMockedClientManager();
       const admin = await clientManager.getAdminClient();
       admin.describeGroups.mockResolvedValue({
         groups: [fakeGroupDescription({ groupId: "my-group" })],
       });
 
+      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
+      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
+      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
+      // the provided args for handle(), then asserts the decoy's manager went
+      // untouched — so `args` deliberately omits connectionId here.
       await assertHandleCase({
         handler,
         runtime: runtimeWithDecoy(

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.ts
@@ -120,7 +120,10 @@ export class DescribeConsumerGroupHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = describeConsumerGroupArgs.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const { clusterId, envId } = resolveKafkaClusterArgs(
       parsed,
       runtime,

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
@@ -13,8 +13,15 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
-import { kafkaRuntime } from "@tests/factories/runtime.js";
-import { getMockedClientManager } from "@tests/stubs/index.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  kafkaRuntime,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
 
@@ -201,6 +208,35 @@ describe("get-consumer-group-lag-handler.ts", () => {
 
   describe("handle()", () => {
     const handler = new GetConsumerGroupLagHandler();
+
+    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+      const clientManager = getMockedClientManager();
+      const admin = await clientManager.getAdminClient();
+      admin.fetchOffsets.mockResolvedValue([
+        {
+          topic: "orders",
+          partitions: [fakeFetchedPartition({ partition: 0, offset: "80" })],
+        },
+      ]);
+      admin.fetchTopicOffsets.mockResolvedValue([
+        fakeWatermark({ partition: 0, low: "0", high: "100" }),
+      ]);
+
+      const { runtime, decoyClientManager } = runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
+        clientManager,
+      );
+
+      await assertHandleCase({
+        handler,
+        runtime,
+        args: { groupId: "g1", connectionId: DEFAULT_CONNECTION_ID },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
+        untouchedClientManager: decoyClientManager,
+      });
+    });
 
     it("should forward groupId verbatim to admin.fetchOffsets and not pass a topics field when the filter is omitted", async () => {
       const clientManager = getMockedClientManager();

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
@@ -209,7 +209,7 @@ describe("get-consumer-group-lag-handler.ts", () => {
   describe("handle()", () => {
     const handler = new GetConsumerGroupLagHandler();
 
-    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+    it("should route only to its resolved connection in a multi-connection config", async () => {
       const clientManager = getMockedClientManager();
       const admin = await clientManager.getAdminClient();
       admin.fetchOffsets.mockResolvedValue([
@@ -222,6 +222,11 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 0, low: "0", high: "100" }),
       ]);
 
+      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
+      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
+      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
+      // the provided args for handle(), then asserts the decoy's manager went
+      // untouched — so `args` deliberately omits connectionId here.
       await assertHandleCase({
         handler,
         runtime: runtimeWithDecoy(

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
@@ -222,19 +222,16 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 0, low: "0", high: "100" }),
       ]);
 
-      const { runtime, decoyClientManager } = runtimeWithDecoy(
-        { kafka: { bootstrap_servers: "broker:9092" } },
-        DEFAULT_CONNECTION_ID,
-        clientManager,
-      );
-
       await assertHandleCase({
         handler,
-        runtime,
-        args: { groupId: "g1", connectionId: DEFAULT_CONNECTION_ID },
+        runtime: runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        ),
+        args: { groupId: "g1" },
         outcome: { resolves: 'Consumer group "g1" has' },
         clientManager,
-        untouchedClientManager: decoyClientManager,
       });
     });
 

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.ts
@@ -139,7 +139,10 @@ export class GetConsumerGroupLagHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = getConsumerGroupLagArgs.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const { clusterId, envId } = resolveKafkaClusterArgs(
       parsed,
       runtime,

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
@@ -40,19 +40,16 @@ describe("get-partition-offsets-handler.ts", () => {
         { partition: 0, low: "0", high: "100", offset: "100" },
       ]);
 
-      const { runtime, decoyClientManager } = runtimeWithDecoy(
-        { kafka: { bootstrap_servers: "broker:9092" } },
-        DEFAULT_CONNECTION_ID,
-        clientManager,
-      );
-
       await assertHandleCase({
         handler,
-        runtime,
-        args: { topicName: "orders", connectionId: DEFAULT_CONNECTION_ID },
+        runtime: runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        ),
+        args: { topicName: "orders" },
         outcome: { resolves: 'Partition offsets for "orders"' },
         clientManager,
-        untouchedClientManager: decoyClientManager,
       });
     });
 

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
@@ -33,13 +33,18 @@ describe("get-partition-offsets-handler.ts", () => {
   describe("handle()", () => {
     const handler = new GetPartitionOffsetsHandler();
 
-    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+    it("should route only to its resolved connection in a multi-connection config", async () => {
       const clientManager = getMockedClientManager();
       const admin = await clientManager.getAdminClient();
       admin.fetchTopicOffsets.mockResolvedValue([
         { partition: 0, low: "0", high: "100", offset: "100" },
       ]);
 
+      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
+      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
+      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
+      // the provided args for handle(), then asserts the decoy's manager went
+      // untouched — so `args` deliberately omits connectionId here.
       await assertHandleCase({
         handler,
         runtime: runtimeWithDecoy(

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
@@ -2,8 +2,15 @@ import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { GetPartitionOffsetsHandler } from "@src/confluent/tools/handlers/kafka/get-partition-offsets-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
-import { kafkaRuntime } from "@tests/factories/runtime.js";
-import { getMockedClientManager } from "@tests/stubs/index.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  kafkaRuntime,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
 describe("get-partition-offsets-handler.ts", () => {
@@ -25,6 +32,29 @@ describe("get-partition-offsets-handler.ts", () => {
 
   describe("handle()", () => {
     const handler = new GetPartitionOffsetsHandler();
+
+    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+      const clientManager = getMockedClientManager();
+      const admin = await clientManager.getAdminClient();
+      admin.fetchTopicOffsets.mockResolvedValue([
+        { partition: 0, low: "0", high: "100", offset: "100" },
+      ]);
+
+      const { runtime, decoyClientManager } = runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
+        clientManager,
+      );
+
+      await assertHandleCase({
+        handler,
+        runtime,
+        args: { topicName: "orders", connectionId: DEFAULT_CONNECTION_ID },
+        outcome: { resolves: 'Partition offsets for "orders"' },
+        clientManager,
+        untouchedClientManager: decoyClientManager,
+      });
+    });
 
     it("should return a structured payload with low/highWatermark as strings and computed messageCount for every partition", async () => {
       const clientManager = getMockedClientManager();

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.ts
@@ -104,7 +104,10 @@ export class GetPartitionOffsetsHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = getPartitionOffsetsArgs.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
 
     const admin = await clientManager.getKafkaAdminClient(

--- a/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
@@ -4,6 +4,7 @@ import {
   HandleCaseWithConn,
   KAFKA_CONN,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -70,6 +71,28 @@ describe("get-topic-config.ts", () => {
           });
         },
       );
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        const restClient =
+          await clientManager.getConfluentCloudKafkaRestClient();
+        restClient.GET.mockResolvedValue({ data: {} });
+
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          KAFKA_CONN,
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: { topicName: "my-topic", connectionId: DEFAULT_CONNECTION_ID },
+          outcome: { resolves: "Topic configuration for 'my-topic'" },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
+        });
+      });
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_CONNECTION_ID,
   HandleCaseWithConn,
   KAFKA_CONN,
-  runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
@@ -60,7 +59,10 @@ describe("get-topic-config.ts", () => {
           restClient.GET.mockResolvedValue({ data: {} });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            // runtimeWithDecoy plants a second same-config connection; assertHandleCase
+            // routes to the real one and asserts the decoy stays untouched, so every
+            // case here doubles as a routing test.
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -71,28 +73,6 @@ describe("get-topic-config.ts", () => {
           });
         },
       );
-
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const clientManager = getMockedClientManager();
-        const restClient =
-          await clientManager.getConfluentCloudKafkaRestClient();
-        restClient.GET.mockResolvedValue({ data: {} });
-
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          KAFKA_CONN,
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: { topicName: "my-topic", connectionId: DEFAULT_CONNECTION_ID },
-          outcome: { resolves: "Topic configuration for 'my-topic'" },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
-        });
-      });
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -42,7 +42,10 @@ export class GetTopicConfigHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = getTopicConfigArguments.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const { clusterId, envId } = resolveKafkaRestArgs(parsed, runtime, connId);
 
     const restClient = await clientManager.getConfluentCloudKafkaRestClient(

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
@@ -96,11 +96,16 @@ describe("list-consumer-groups-handler.ts", () => {
   describe("handle()", () => {
     const handler = new ListConsumerGroupsHandler();
 
-    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+    it("should route only to its resolved connection in a multi-connection config", async () => {
       const clientManager = getMockedClientManager();
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
 
+      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
+      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
+      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
+      // the provided args for handle(), then asserts the decoy's manager went
+      // untouched — so `args` deliberately omits connectionId here.
       await assertHandleCase({
         handler,
         runtime: runtimeWithDecoy(

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
@@ -7,8 +7,15 @@ import {
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
-import { kafkaRuntime } from "@tests/factories/runtime.js";
-import { getMockedClientManager } from "@tests/stubs/index.js";
+import {
+  DEFAULT_CONNECTION_ID,
+  kafkaRuntime,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
 
@@ -88,6 +95,27 @@ describe("list-consumer-groups-handler.ts", () => {
 
   describe("handle()", () => {
     const handler = new ListConsumerGroupsHandler();
+
+    it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+      const clientManager = getMockedClientManager();
+      const admin = await clientManager.getAdminClient();
+      admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
+
+      const { runtime, decoyClientManager } = runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
+        clientManager,
+      );
+
+      await assertHandleCase({
+        handler,
+        runtime,
+        args: { connectionId: DEFAULT_CONNECTION_ID },
+        outcome: { resolves: "Found 0 consumer groups." },
+        clientManager,
+        untouchedClientManager: decoyClientManager,
+      });
+    });
 
     it("should return an empty structured payload and 'Found 0 consumer groups.' when listGroups returns nothing", async () => {
       const clientManager = getMockedClientManager();

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
@@ -101,19 +101,16 @@ describe("list-consumer-groups-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
 
-      const { runtime, decoyClientManager } = runtimeWithDecoy(
-        { kafka: { bootstrap_servers: "broker:9092" } },
-        DEFAULT_CONNECTION_ID,
-        clientManager,
-      );
-
       await assertHandleCase({
         handler,
-        runtime,
-        args: { connectionId: DEFAULT_CONNECTION_ID },
+        runtime: runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        ),
+        args: {},
         outcome: { resolves: "Found 0 consumer groups." },
         clientManager,
-        untouchedClientManager: decoyClientManager,
       });
     });
 

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.ts
@@ -93,7 +93,10 @@ export class ListConsumerGroupsHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = listConsumerGroupsArgs.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const { clusterId, envId } = resolveKafkaClusterArgs(
       parsed,
       runtime,

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
@@ -2,6 +2,7 @@ import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topi
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -29,6 +30,27 @@ describe("list-topics-handler.ts", () => {
           args: {},
           outcome: { resolves: "Kafka topics: topic-a,topic-b" },
           clientManager,
+        });
+      });
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        const admin = await clientManager.getAdminClient();
+        admin.listTopics.mockResolvedValue(["topic-a", "topic-b"]);
+
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: { connectionId: DEFAULT_CONNECTION_ID },
+          outcome: { resolves: "Kafka topics: topic-a,topic-b" },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
         });
       });
 

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.test.ts
@@ -1,7 +1,6 @@
 import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topics-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
@@ -22,7 +21,7 @@ describe("list-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -33,27 +32,6 @@ describe("list-topics-handler.ts", () => {
         });
       });
 
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const clientManager = getMockedClientManager();
-        const admin = await clientManager.getAdminClient();
-        admin.listTopics.mockResolvedValue(["topic-a", "topic-b"]);
-
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: { connectionId: DEFAULT_CONNECTION_ID },
-          outcome: { resolves: "Kafka topics: topic-a,topic-b" },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
-        });
-      });
-
       it("should let admin errors propagate (no try/catch around the read op)", async () => {
         const clientManager = getMockedClientManager();
         const admin = await clientManager.getAdminClient();
@@ -61,7 +39,7 @@ describe("list-topics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -35,7 +35,10 @@ export class ListTopicsHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
     const parsed = listTopicArgs.parse(toolArguments);
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
     const admin = await clientManager.getKafkaAdminClient(
       resolved.clusterId,

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
@@ -2,6 +2,7 @@ import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -41,6 +42,40 @@ describe("produce-kafka-message-handler.ts", () => {
             resolves: "Message produced successfully to [Topic: smoke",
           },
           clientManager,
+        });
+      });
+
+      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        const producer = await clientManager.getProducer();
+        producer.send.mockResolvedValue([
+          {
+            topicName: "smoke",
+            partition: 0,
+            offset: "5",
+            errorCode: 0,
+          },
+        ]);
+
+        const { runtime, decoyClientManager } = runtimeWithDecoy(
+          { kafka: { bootstrap_servers: "broker:9092" } },
+          DEFAULT_CONNECTION_ID,
+          clientManager,
+        );
+
+        await assertHandleCase({
+          handler,
+          runtime,
+          args: {
+            topicName: "smoke",
+            value: { message: "hello", useSchemaRegistry: false },
+            connectionId: DEFAULT_CONNECTION_ID,
+          },
+          outcome: {
+            resolves: "Message produced successfully to [Topic: smoke",
+          },
+          clientManager,
+          untouchedClientManager: decoyClientManager,
         });
       });
 

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
@@ -1,7 +1,6 @@
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
@@ -29,7 +28,7 @@ describe("produce-kafka-message-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -45,40 +44,6 @@ describe("produce-kafka-message-handler.ts", () => {
         });
       });
 
-      it("should route to the explicitly addressed connection in a multi-connection config", async () => {
-        const clientManager = getMockedClientManager();
-        const producer = await clientManager.getProducer();
-        producer.send.mockResolvedValue([
-          {
-            topicName: "smoke",
-            partition: 0,
-            offset: "5",
-            errorCode: 0,
-          },
-        ]);
-
-        const { runtime, decoyClientManager } = runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        );
-
-        await assertHandleCase({
-          handler,
-          runtime,
-          args: {
-            topicName: "smoke",
-            value: { message: "hello", useSchemaRegistry: false },
-            connectionId: DEFAULT_CONNECTION_ID,
-          },
-          outcome: {
-            resolves: "Message produced successfully to [Topic: smoke",
-          },
-          clientManager,
-          untouchedClientManager: decoyClientManager,
-        });
-      });
-
       it("should return an isError response when producer.send throws", async () => {
         const clientManager = getMockedClientManager();
         const producer = await clientManager.getProducer();
@@ -86,7 +51,7 @@ describe("produce-kafka-message-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -114,7 +79,7 @@ describe("produce-kafka-message-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -144,7 +109,7 @@ describe("produce-kafka-message-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             { kafka: { bootstrap_servers: "broker:9092" } },
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -121,7 +121,10 @@ export class ProduceKafkaMessageHandler extends BaseToolHandler {
       produceKafkaMessageArguments.parse(toolArguments);
     const { topicName, value, key } = parsed;
 
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolved = resolveKafkaClusterArgs(parsed, runtime, connId);
 
     const needsRegistry =

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -75,6 +75,51 @@ export function runtimeWith(
   );
 }
 
+/** Connection ID of the decoy connection planted by {@link runtimeWithDecoy}. */
+export const DECOY_CONNECTION_ID = "decoy";
+
+/**
+ * Single-connection sugar like {@link runtimeWith}, but plants a second
+ * "decoy" connection carrying the same service blocks — enabled for the same
+ * tools, with its own client manager that correct routing must never touch.
+ *
+ * The decoy is inserted FIRST, so a handler resolving via the legacy
+ * sole-connection accessor (which grabs `enabledConnectionIds[0]`) routes to
+ * the decoy and trips the test. Tests keep addressing the real connection by
+ * its existing id and never name the decoy. Returns that decoy's auto-minted
+ * mock manager so the caller can assert it stayed untouched.
+ */
+export function runtimeWithDecoy(
+  connectionConfig: Omit<DirectConnectionConfig, "type"> = {},
+  connectionId = DEFAULT_CONNECTION_ID,
+  clientManager: Mocked<DirectClientManager> = createMockInstance(
+    DirectClientManager,
+  ),
+  allowedToolNames?: ReadonlySet<ToolName>,
+): { runtime: ServerRuntime; decoyClientManager: Mocked<DirectClientManager> } {
+  if (connectionId === DECOY_CONNECTION_ID) {
+    throw new Error(
+      `Wacky -- runtimeWithDecoy's real connection id collides with the reserved decoy id "${DECOY_CONNECTION_ID}"`,
+    );
+  }
+  const runtime = runtimeWithConnections(
+    {
+      [DECOY_CONNECTION_ID]: connectionConfig,
+      [connectionId]: connectionConfig,
+    },
+    { [connectionId]: clientManager }, // decoy's manager is auto-minted by the factory
+    allowedToolNames,
+  );
+  // runtimeWithConnections minted a fresh createMockInstance(DirectClientManager)
+  // for the decoy; recover its precise mock type for the untouched-assertion.
+  return {
+    runtime,
+    decoyClientManager: runtime.clientManagers[
+      DECOY_CONNECTION_ID
+    ] as Mocked<DirectClientManager>,
+  };
+}
+
 /** Runtime with no service blocks — the disabled-baseline shape used by predicate-derivation tests in `base-tools.test.ts` and as a no-config runtime by handlers that don't read connection state. */
 export function bareRuntime(): ServerRuntime {
   return runtimeWith();

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -8,7 +8,11 @@ import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import type { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import type { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
-import { createMockInstance, type HandleCase } from "@tests/stubs/index.js";
+import {
+  DECOY_CONNECTION_ID,
+  createMockInstance,
+  type HandleCase,
+} from "@tests/stubs/index.js";
 import { fileURLToPath } from "node:url";
 import type { Mocked } from "vitest";
 
@@ -75,19 +79,19 @@ export function runtimeWith(
   );
 }
 
-/** Connection ID of the decoy connection planted by {@link runtimeWithDecoy}. */
-export const DECOY_CONNECTION_ID = "decoy";
-
 /**
- * Single-connection sugar like {@link runtimeWith}, but plants a second
+ * Drop-in replacement for {@link runtimeWith} that additionally plants a
  * "decoy" connection carrying the same service blocks — enabled for the same
- * tools, with its own client manager that correct routing must never touch.
+ * tools, with its own auto-minted client manager that correct routing must
+ * never touch.
  *
  * The decoy is inserted FIRST, so a handler resolving via the legacy
  * sole-connection accessor (which grabs `enabledConnectionIds[0]`) routes to
- * the decoy and trips the test. Tests keep addressing the real connection by
- * its existing id and never name the decoy. Returns that decoy's auto-minted
- * mock manager so the caller can assert it stayed untouched.
+ * the decoy and trips the test. {@link assertHandleCase} recognizes the decoy
+ * (by {@link DECOY_CONNECTION_ID}) and, for any handle() test built on this
+ * runtime, auto-routes to the real connection and asserts the decoy stayed
+ * untouched — so swapping a suite's `runtimeWith` for this turns every existing
+ * success case into a routing test with no other change.
  */
 export function runtimeWithDecoy(
   connectionConfig: Omit<DirectConnectionConfig, "type"> = {},
@@ -96,13 +100,13 @@ export function runtimeWithDecoy(
     DirectClientManager,
   ),
   allowedToolNames?: ReadonlySet<ToolName>,
-): { runtime: ServerRuntime; decoyClientManager: Mocked<DirectClientManager> } {
+): ServerRuntime {
   if (connectionId === DECOY_CONNECTION_ID) {
     throw new Error(
       `Wacky -- runtimeWithDecoy's real connection id collides with the reserved decoy id "${DECOY_CONNECTION_ID}"`,
     );
   }
-  const runtime = runtimeWithConnections(
+  return runtimeWithConnections(
     {
       [DECOY_CONNECTION_ID]: connectionConfig,
       [connectionId]: connectionConfig,
@@ -110,14 +114,6 @@ export function runtimeWithDecoy(
     { [connectionId]: clientManager }, // decoy's manager is auto-minted by the factory
     allowedToolNames,
   );
-  // runtimeWithConnections minted a fresh createMockInstance(DirectClientManager)
-  // for the decoy; recover its precise mock type for the untouched-assertion.
-  return {
-    runtime,
-    decoyClientManager: runtime.clientManagers[
-      DECOY_CONNECTION_ID
-    ] as Mocked<DirectClientManager>,
-  };
 }
 
 /** Runtime with no service blocks — the disabled-baseline shape used by predicate-derivation tests in `base-tools.test.ts` and as a no-config runtime by handlers that don't read connection state. */

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -1,7 +1,8 @@
+import type { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import type { CallToolResult } from "@src/confluent/schema.js";
 import type { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
 import type { ServerRuntime } from "@src/server-runtime.js";
-import { type Mock, expect } from "vitest";
+import { type Mock, type Mocked, expect } from "vitest";
 import { ZodError } from "zod";
 import type { MockedClientManager } from "./clients.js";
 
@@ -34,6 +35,23 @@ export type HandleCase = {
   outcome: HandleOutcome;
 };
 
+/**
+ * Snapshots the current call count of every getter (a `vi.fn()` enumerable
+ * property) on a mocked client manager, so a later comparison counts only the
+ * deltas the handler itself produced.
+ */
+function snapshotGetterCallCounts(
+  clientManager: Mocked<DirectClientManager>,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const [key, value] of Object.entries(clientManager)) {
+    if (typeof value === "function" && "mock" in value) {
+      counts.set(key, (value as Mock).mock.calls.length);
+    }
+  }
+  return counts;
+}
+
 /** Classifies a thrown value into the string used for matching in HandleOutcome. */
 export function classifyThrown(label: string, thrown: unknown): string {
   if (thrown instanceof ZodError) return "ZodError";
@@ -64,6 +82,10 @@ export function classifyThrown(label: string, thrown: unknown): string {
  *   getter on the manager was called on a successful resolve, proving the
  *   handler reached the client layer. Omit in cases that short-circuit
  *   before touching the client.
+ * @param untouchedClientManager - When supplied, asserts that no getter on this
+ *   manager was called by the handler — the negative half of a routing test,
+ *   proving the call did not leak onto a connection it should have avoided
+ *   (e.g. the decoy planted by `runtimeWithDecoy`).
  * @param name - Label prepended to assertion failure messages and used in
  *   discovery-sentinel output. Defaults to `"(handler)"`.
  */
@@ -73,6 +95,7 @@ export async function assertHandleCase(options: {
   args?: Record<string, unknown>;
   outcome: HandleOutcome;
   clientManager?: MockedClientManager;
+  untouchedClientManager?: Mocked<DirectClientManager>;
   name?: string;
 }): Promise<void> {
   const {
@@ -81,6 +104,7 @@ export async function assertHandleCase(options: {
     args = {},
     outcome,
     clientManager,
+    untouchedClientManager,
     name = "(handler)",
   } = options;
 
@@ -94,14 +118,12 @@ export async function assertHandleCase(options: {
   // Snapshot getter call counts before the handler runs so the dynamic walk
   // below only counts deltas from the handler itself, not from test setup
   // calls like `const flinkRest = cm.getConfluentCloudFlinkRestClient()`.
-  const callCountsBefore = new Map<string, number>();
-  if (clientManager) {
-    for (const [key, value] of Object.entries(clientManager)) {
-      if (typeof value === "function" && "mock" in value) {
-        callCountsBefore.set(key, (value as Mock).mock.calls.length);
-      }
-    }
-  }
+  const callCountsBefore = clientManager
+    ? snapshotGetterCallCounts(clientManager)
+    : new Map<string, number>();
+  const untouchedCountsBefore = untouchedClientManager
+    ? snapshotGetterCallCounts(untouchedClientManager)
+    : new Map<string, number>();
 
   let result: CallToolResult | undefined;
   let thrown: unknown;
@@ -129,6 +151,17 @@ export async function assertHandleCase(options: {
     throw new Error(
       `${name}: outcome is "DISCOVER" — replace with: ${discovered}`,
     );
+  }
+
+  if (untouchedClientManager) {
+    for (const [key, value] of Object.entries(untouchedClientManager)) {
+      if (typeof value === "function" && "mock" in value) {
+        expect(
+          (value as Mock).mock.calls.length,
+          `${name}: ${key} on the untouched client manager was called, but routing should have avoided that connection`,
+        ).toBe(untouchedCountsBefore.get(key) ?? 0);
+      }
+    }
   }
 
   if (thrown === undefined) {

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -81,7 +81,11 @@ export function classifyThrown(label: string, thrown: unknown): string {
  *   with `runtimeWith(connectionConfig, connectionId, clientManager)` so the
  *   connection shape and mocked client are both under test control.
  * @param args - Tool arguments forwarded to `handle()`. Defaults to `{}`.
- *   Supply only the fields relevant to the case under test.
+ *   Supply only the fields relevant to the case under test. Not always passed
+ *   through verbatim: against a decoy runtime (see below) the harness injects a
+ *   `connectionId` naming the non-decoy connection id present in the runtime when
+ *   you didn't supply one, so the handler receives `{ ...args, connectionId }`.
+ * Pass your own `connectionId` to opt out of that injection.
  * @param outcome - What to expect: `{ resolves: substring }` asserts the
  *   response text contains the substring; `{ throws: substring }` asserts the
  *   thrown error message contains it (or `"ZodError"` for any {@link ZodError});
@@ -96,10 +100,13 @@ export function classifyThrown(label: string, thrown: unknown): string {
  *
  * When the runtime carries a {@link DECOY_CONNECTION_ID} connection (built via
  * `runtimeWithDecoy`), this also routes the call to the real connection — by
- * injecting `connectionId` when the caller didn't supply one — and asserts the
- * decoy's client manager was never touched. That makes every handle() test a
- * routing test for free; a handler that still grabs `enabledConnectionIds[0]`
- * lands on the (first) decoy and fails the untouched assertion.
+ * injecting `connectionId: <real id>` when the caller didn't supply one, where
+ * `<real id>` is the sole non-decoy connection id (the `connectionId` passed to
+ * `runtimeWithDecoy`, i.e. `DEFAULT_CONNECTION_ID` unless overridden) — and
+ * asserts the decoy's client manager was never touched. That makes every
+ * handle() test a routing test for free; a handler that still grabs
+ * `enabledConnectionIds[0]` lands on the (first) decoy and fails the untouched
+ * assertion.
  */
 export async function assertHandleCase(options: {
   handler: Pick<BaseToolHandler, "handle">;
@@ -118,18 +125,33 @@ export async function assertHandleCase(options: {
     name = "(handler)",
   } = options;
 
-  // When a decoy connection is present, route to the real connection (the
-  // non-decoy id) unless the caller already pinned a connectionId, and capture
-  // the decoy's manager so we can prove the handler never touched it.
-  const decoyManager =
-    DECOY_CONNECTION_ID in runtime.config.connections
-      ? (runtime.clientManagers[
-          DECOY_CONNECTION_ID
-        ] as Mocked<DirectClientManager>)
-      : undefined;
-  const realConnectionId = Object.keys(runtime.config.connections).find(
-    (id) => id !== DECOY_CONNECTION_ID,
-  );
+  // When a decoy connection is present (a runtimeWithDecoy runtime), route the
+  // call to the real connection and capture the decoy's manager so we can prove
+  // the handler never touched it. Validate the runtime shape up front: a decoy
+  // with no manager, or with zero / more than one non-decoy sibling, would
+  // otherwise inject `connectionId: undefined` and silently neuter the routing
+  // assertion instead of failing where the mistake is.
+  let decoyManager: Mocked<DirectClientManager> | undefined;
+  let realConnectionId: string | undefined;
+  if (DECOY_CONNECTION_ID in runtime.config.connections) {
+    decoyManager = runtime.clientManagers[DECOY_CONNECTION_ID] as
+      | Mocked<DirectClientManager>
+      | undefined;
+    if (!decoyManager) {
+      throw new Error(
+        `Wacky -- ${name}: decoy connection "${DECOY_CONNECTION_ID}" has no client manager; build decoy runtimes with runtimeWithDecoy`,
+      );
+    }
+    const nonDecoyIds = Object.keys(runtime.config.connections).filter(
+      (id) => id !== DECOY_CONNECTION_ID,
+    );
+    if (nonDecoyIds.length !== 1) {
+      throw new Error(
+        `Wacky -- ${name}: a decoy runtime must have exactly one non-decoy connection to route to; found ${nonDecoyIds.length} (${nonDecoyIds.join(", ") || "none"})`,
+      );
+    }
+    realConnectionId = nonDecoyIds[0];
+  }
   const effectiveArgs =
     decoyManager && args.connectionId === undefined
       ? { ...args, connectionId: realConnectionId }

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -6,6 +6,15 @@ import { type Mock, type Mocked, expect } from "vitest";
 import { ZodError } from "zod";
 import type { MockedClientManager } from "./clients.js";
 
+/**
+ * Reserved connection id for the decoy connection planted by `runtimeWithDecoy`.
+ * {@link assertHandleCase} recognizes a runtime carrying this connection and,
+ * for it, auto-routes the call to the real connection (injecting `connectionId`)
+ * and asserts the decoy's client manager is never touched — turning any handle()
+ * test into a routing test without a bespoke test body.
+ */
+export const DECOY_CONNECTION_ID = "decoy";
+
 export type Resolves = {
   /** Substring that must appear in the resolved response text. */
   resolves: string;
@@ -82,12 +91,15 @@ export function classifyThrown(label: string, thrown: unknown): string {
  *   getter on the manager was called on a successful resolve, proving the
  *   handler reached the client layer. Omit in cases that short-circuit
  *   before touching the client.
- * @param untouchedClientManager - When supplied, asserts that no getter on this
- *   manager was called by the handler — the negative half of a routing test,
- *   proving the call did not leak onto a connection it should have avoided
- *   (e.g. the decoy planted by `runtimeWithDecoy`).
  * @param name - Label prepended to assertion failure messages and used in
  *   discovery-sentinel output. Defaults to `"(handler)"`.
+ *
+ * When the runtime carries a {@link DECOY_CONNECTION_ID} connection (built via
+ * `runtimeWithDecoy`), this also routes the call to the real connection — by
+ * injecting `connectionId` when the caller didn't supply one — and asserts the
+ * decoy's client manager was never touched. That makes every handle() test a
+ * routing test for free; a handler that still grabs `enabledConnectionIds[0]`
+ * lands on the (first) decoy and fails the untouched assertion.
  */
 export async function assertHandleCase(options: {
   handler: Pick<BaseToolHandler, "handle">;
@@ -95,7 +107,6 @@ export async function assertHandleCase(options: {
   args?: Record<string, unknown>;
   outcome: HandleOutcome;
   clientManager?: MockedClientManager;
-  untouchedClientManager?: Mocked<DirectClientManager>;
   name?: string;
 }): Promise<void> {
   const {
@@ -104,9 +115,25 @@ export async function assertHandleCase(options: {
     args = {},
     outcome,
     clientManager,
-    untouchedClientManager,
     name = "(handler)",
   } = options;
+
+  // When a decoy connection is present, route to the real connection (the
+  // non-decoy id) unless the caller already pinned a connectionId, and capture
+  // the decoy's manager so we can prove the handler never touched it.
+  const decoyManager =
+    DECOY_CONNECTION_ID in runtime.config.connections
+      ? (runtime.clientManagers[
+          DECOY_CONNECTION_ID
+        ] as Mocked<DirectClientManager>)
+      : undefined;
+  const realConnectionId = Object.keys(runtime.config.connections).find(
+    (id) => id !== DECOY_CONNECTION_ID,
+  );
+  const effectiveArgs =
+    decoyManager && args.connectionId === undefined
+      ? { ...args, connectionId: realConnectionId }
+      : args;
 
   if (typeof outcome === "object" && "resolves" in outcome) {
     expect(
@@ -121,14 +148,14 @@ export async function assertHandleCase(options: {
   const callCountsBefore = clientManager
     ? snapshotGetterCallCounts(clientManager)
     : new Map<string, number>();
-  const untouchedCountsBefore = untouchedClientManager
-    ? snapshotGetterCallCounts(untouchedClientManager)
+  const decoyCountsBefore = decoyManager
+    ? snapshotGetterCallCounts(decoyManager)
     : new Map<string, number>();
 
   let result: CallToolResult | undefined;
   let thrown: unknown;
   try {
-    result = await handler.handle(runtime, args, undefined);
+    result = await handler.handle(runtime, effectiveArgs, undefined);
   } catch (err) {
     thrown = err;
   }
@@ -153,13 +180,13 @@ export async function assertHandleCase(options: {
     );
   }
 
-  if (untouchedClientManager) {
-    for (const [key, value] of Object.entries(untouchedClientManager)) {
+  if (decoyManager) {
+    for (const [key, value] of Object.entries(decoyManager)) {
       if (typeof value === "function" && "mock" in value) {
         expect(
           (value as Mock).mock.calls.length,
-          `${name}: ${key} on the untouched client manager was called, but routing should have avoided that connection`,
-        ).toBe(untouchedCountsBefore.get(key) ?? 0);
+          `${name}: ${key} on the decoy connection's client manager was called, but routing should have stayed on the addressed connection`,
+        ).toBe(decoyCountsBefore.get(key) ?? 0);
       }
     }
   }

--- a/tests/stubs/index.ts
+++ b/tests/stubs/index.ts
@@ -17,6 +17,7 @@ export {
   type FlinkTelemetryPoint,
 } from "./flink-telemetry.js";
 export {
+  DECOY_CONNECTION_ID,
   assertHandleCase,
   classifyThrown,
   type HandleCase,


### PR DESCRIPTION
# Port the Kafka tool handlers to `resolveConnection()`

## Kafka handlers honor an explicit `connectionId`

The eleven Kafka tool handlers previously resolved their connection through `BaseToolHandler.resolveSoleConnection()`, which ignores any caller-supplied `connectionId` and unconditionally grabs `enabledConnectionIds[0]`. Each now calls `resolveConnection(runtime, toolArguments)` (landed in #551), reading `connectionId` off the raw tool arguments and routing to the addressed connection — the consume-side seam the epic has been building toward. The resolved `{ connId, conn, clientManager }` shape is unchanged, so the swap is a one-liner per handler. These tools keep their OAuth-widened predicates, so they use the type-neutral `resolveConnection`, not `resolveDirectConnection`.

- `consume-kafka-messages-handler` additionally had its `handle()` `toolArguments` parameter normalized from `z.infer<…>` to `Record<string, unknown>`, matching its ten siblings and `resolveConnection`'s signature.

## Routing coverage folded into the existing handle() tests

Rather than a bespoke "does it route?" test per suite, routing verification is baked into the shared handler-test harness so existing success cases double as routing tests with a one-word change:

- `runtimeWithDecoy(connectionConfig, connectionId?, clientManager?)` in `tests/factories/runtime.ts` is a **drop-in replacement** for `runtimeWith` (same `ServerRuntime` return). It plants a second "decoy" connection carrying the same service blocks (enabled for the same tools) with its own auto-minted client manager, inserted **first** so a handler resolving via the legacy `enabledConnectionIds[0]` accessor lands on the decoy.
- `assertHandleCase` recognizes a decoy-bearing runtime (by the reserved `DECOY_CONNECTION_ID`, which lives in `tests/stubs` to keep the factory→stubs import direction acyclic). For such a runtime it auto-injects `connectionId` for the real connection when the caller didn't supply one, and asserts the decoy's client manager was never touched. No per-test annotation, no `connectionId` in the args.

Net effect: swapping a suite's `runtimeWith` for `runtimeWithDecoy` turns every success case in that suite into a routing test. The `it.each` suites (`get-topic-config`, `alter-topic-config`) needed a single one-word edit in the loop; the per-`it()` `assertHandleCase` suites swapped each handle() runtime. The four consumer-group/offsets suites whose main tests call `handle()` directly (not through `assertHandleCase`) keep one dedicated routing test each, since the auto-route/auto-assert only fires through the harness. A reverted handler trips the decoy assertion on every converted resolve case, confirming the coverage isn't vacuous.

A follow-up issue threads in at the tail of #564 to flip `runtimeWith` itself to plant the decoy by default, making the entire handler corpus multi-connection-by-default and retiring `runtimeWithDecoy`.

## Relationships

- Closes #539.
- Child of #564, the sub-epic for handler porting, itself a child of #532 (Epic: Multi-connection support).
- Builds on #551 (`resolveConnection()` / `resolveDirectConnection()`), which added the seam this PR consumes.
- Unblocks #541 (porting the remaining handlers), which adopts `runtimeWithDecoy` epic-wide.
