### PR TITLE
Port the Connect + Billing tool handlers to routing-aware connection resolution

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -373,6 +373,22 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
 - Use `as any` only on partial mock return values (e.g., a mock admin client with only
   `listTopics`), not on the `ClientManager` mock itself; add an eslint-disable comment when needed.
 
+### Routing tests for multi-connection handlers
+
+A handler that resolves its connection via `resolveConnection(runtime, toolArguments)` (or `resolveDirectConnection`) must route to the caller-addressed `connectionId`, not unconditionally to `enabledConnectionIds[0]`.
+`runtimeWithDecoy` (in `tests/factories/runtime.ts`) is a drop-in replacement for `runtimeWith` that proves this: it plants a "decoy" connection — same service blocks, enabled for the same tools, its own auto-minted client manager — inserted _before_ the real one, so a handler that still grabs the first enabled connection lands on the decoy.
+`assertHandleCase` recognizes a decoy-bearing runtime (by the reserved `DECOY_CONNECTION_ID`), auto-injects `connectionId` for the real connection when the caller omitted it, and asserts the decoy's client manager was never touched.
+
+There are two ways to get this coverage, and which one a suite uses depends on how its `handle()` tests are already written:
+
+- **Suites whose `handle()` tests run through `assertHandleCase`** (the `it.each` suites and the per-`it()` `assertHandleCase` suites): swap the suite's `runtimeWith` for `runtimeWithDecoy`.
+  That one-word change turns every existing success case into a routing test — no new test body, and no `connectionId` in the args (the harness injects it).
+  The `it.each` suites need the edit only in the loop's runtime expression; the per-`it()` suites swap each `handle()` runtime.
+- **Suites whose main `handle()` tests call `handler.handle(...)` directly** (not through the harness — e.g. the consumer-group / offsets suites that need bespoke `mockResolvedValueOnce` sequencing): the auto-route and auto-assert fire only inside `assertHandleCase`, so a direct call sees no decoy handling.
+  Add one dedicated routing test that calls `assertHandleCase` with a `runtimeWithDecoy` runtime, alongside the suite's direct-call tests.
+
+A reverted handler (one that goes back to `resolveSoleConnection()`) trips the decoy's untouched assertion on every converted case, so the coverage is not vacuous.
+
 ## Test Server & Runtime Fixtures
 
 - `createTestServer(clientManager, toolNames?)` from `@tests/server.js` boots a real `McpServer`
@@ -382,4 +398,5 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
   `@tests/factories/runtime.js`: `bareRuntime()`, `kafkaRuntime()`, `flinkRuntime()`,
   `tableflowRuntime()`, `schemaRegistryRuntime()`, `confluentCloudRuntime()`,
   `telemetryRuntime()`, etc. For uncommon shapes, use `runtimeWith(connectionConfig?, connectionId?, clientManager?)` (all args optional; `connectionId` defaults to `"default"`).
+  Reach for `runtimeWithDecoy(...)` (same signature) when the `handle()` test should double as a routing test — see "Routing tests for multi-connection handlers" above.
   These same factories are used by `base-tools.test.ts` and `connection-predicates.test.ts` for the centralized enablement coverage — handler `*.test.ts` files should not re-derive that coverage (see the Handler Tests section above).

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -5,8 +5,12 @@ import {
   CCLOUD_CONN,
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
-import { getMockedClientManager } from "@tests/stubs/index.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
 
@@ -28,6 +32,29 @@ describe("list-billing-costs-handler.ts", () => {
     });
 
     describe("handle()", () => {
+      it("should route only to its resolved connection in a multi-connection config", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
+          data: { api_version: "v1", kind: "CostList", data: [] },
+        });
+
+        // runtimeWithDecoy plants a same-shaped decoy connection first; the
+        // handler must route to DEFAULT_CONNECTION_ID, not enabledIds[0].
+        // assertHandleCase injects that id and asserts the decoy's manager
+        // stays untouched, so args deliberately omits connectionId.
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: { resolves: "Successfully retrieved billing costs" },
+          clientManager,
+        });
+      });
+
       it("should aggregate line items, sort product breakdown by amount desc, and surface totals in _meta", async () => {
         const clientManager = getMockedClientManager();
         clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -131,9 +131,9 @@ export class ListBillingCostsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { startDate, endDate, pageSize, pageToken } =
       listBillingCostsArguments.parse(toolArguments);
+    const { clientManager } = this.resolveConnection(runtime, toolArguments);
 
     try {
       const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
@@ -4,7 +4,7 @@ import {
   CONNECT_CONN_WITH_AUTH,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -103,7 +103,7 @@ describe("create-connector-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -137,7 +137,7 @@ describe("create-connector-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             CONNECT_CONN_WITH_AUTH,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -73,11 +73,13 @@ export class CreateConnectorHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName, connectorConfig } =
       createConnectorArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
     // The canCreateDirectConnector predicate guarantees kafka.auth is present.

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.test.ts
@@ -4,7 +4,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -90,7 +90,7 @@ describe("delete-connector-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.ts
@@ -29,11 +29,13 @@ export class DeleteConnectorHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       deleteConnectorArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/get-connector-config-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-config-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -94,7 +94,7 @@ describe("get-connector-config-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/get-connector-config-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-config-handler.ts
@@ -13,11 +13,13 @@ export class GetConnectorConfigHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/get-connector-error-recommendations-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-recommendations-handler.test.ts
@@ -5,8 +5,10 @@ import {
   CONNECT_CONN,
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
+  assertHandleCase,
   getMockedClientManager,
   type MockedClientManager,
 } from "@tests/stubs/index.js";
@@ -45,6 +47,32 @@ describe("get-connector-error-recommendations-handler.ts", () => {
     });
 
     describe("handle()", () => {
+      it("should route only to its resolved connection in a multi-connection config", async () => {
+        clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
+          data: {
+            error: null,
+            event_id: "evt-routed",
+            recommendations: ["check the credentials"],
+          },
+        });
+
+        // runtimeWithDecoy plants a same-shaped decoy connection first; the
+        // handler must route to DEFAULT_CONNECTION_ID, not enabledIds[0].
+        // assertHandleCase injects that id and asserts the decoy's manager
+        // stays untouched, so args deliberately omits connectionId.
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CONNECT_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: baseArgs,
+          outcome: { resolves: "Error recommendations for cypher-source" },
+          clientManager,
+        });
+      });
+
       it("should project the cypher-source fixture into recommendations", async () => {
         const recommendations = [
           "Verify that the 'database.user' and 'database.password' values in the connector configuration are correct and match the credentials for the PostgreSQL database.",

--- a/src/confluent/tools/handlers/connect/get-connector-error-recommendations-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-recommendations-handler.ts
@@ -19,11 +19,13 @@ export class GetConnectorErrorRecommendationsHandler extends ConnectToolHandler 
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.test.ts
@@ -5,8 +5,10 @@ import {
   CONNECT_CONN,
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
+  assertHandleCase,
   getMockedClientManager,
   type MockedClientManager,
 } from "@tests/stubs/index.js";
@@ -45,6 +47,33 @@ describe("get-connector-error-summary-handler.ts", () => {
     });
 
     describe("handle()", () => {
+      it("should route only to its resolved connection in a multi-connection config", async () => {
+        clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
+          data: {
+            name: "cypher-source",
+            connector: { state: "RUNNING", worker_id: "w1", trace: "" },
+            tasks: [{ id: 0, state: "RUNNING", worker_id: "w1" }],
+            type: "source",
+          },
+        });
+
+        // runtimeWithDecoy plants a same-shaped decoy connection first; the
+        // handler must route to DEFAULT_CONNECTION_ID, not enabledIds[0].
+        // assertHandleCase injects that id and asserts the decoy's manager
+        // stays untouched, so args deliberately omits connectionId.
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CONNECT_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: baseArgs,
+          outcome: { resolves: "Connector cypher-source is RUNNING" },
+          clientManager,
+        });
+      });
+
       it("should return a one-liner when the connector is healthy", async () => {
         clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
           data: {

--- a/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.ts
@@ -167,11 +167,13 @@ export class GetConnectorErrorSummaryHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/get-connector-logs-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-logs-handler.test.ts
@@ -5,8 +5,10 @@ import {
   CONNECT_CONN,
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
+  assertHandleCase,
   getMockedClientManager,
   mockFetch,
   type MockedClientManager,
@@ -92,6 +94,50 @@ describe("get-connector-logs-handler.ts", () => {
     });
 
     describe("handle()", () => {
+      it("should route only to its resolved connection in a multi-connection config", async () => {
+        // Omit organizationId from args and config so the handler must resolve
+        // it via the REST client — the only routing-observable client-manager
+        // call here (token exchange and log search both go through fetch).
+        clientManager
+          .getConfluentCloudRestClient()
+          .GET.mockResolvedValue({ data: { data: [{ id: "org-routed" }] } });
+        fetchSpy.mockResolvedValueOnce(tokenResponse()).mockResolvedValueOnce(
+          jsonResponse({
+            data: [
+              {
+                level: "ERROR",
+                task_id: "task-0",
+                id: "lcc-routed",
+                message: "boom",
+                timestamp: "2026-04-29T04:47:22.097Z",
+              },
+            ],
+          }),
+        );
+
+        const argsWithoutOrg = {
+          environmentId: baseArgs.environmentId,
+          clusterId: baseArgs.clusterId,
+          connectorName: baseArgs.connectorName,
+        };
+
+        // runtimeWithDecoy plants a same-shaped decoy connection first; the
+        // handler must route to DEFAULT_CONNECTION_ID, not enabledIds[0].
+        // assertHandleCase injects that id and asserts the decoy's manager
+        // stays untouched, so args deliberately omits connectionId.
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CONNECT_CONN_WITH_CC,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: argsWithoutOrg,
+          outcome: { resolves: "Logs for cypher-source" },
+          clientManager,
+        });
+      });
+
       it("should exchange API key for a data-plane token then call the logging API with Bearer auth", async () => {
         const entries = [
           {

--- a/src/confluent/tools/handlers/connect/get-connector-logs-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-logs-handler.ts
@@ -212,10 +212,12 @@ export class GetConnectorLogsHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const args = getConnectorLogsArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(
         conn,

--- a/src/confluent/tools/handlers/connect/get-connector-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-offsets-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -94,7 +94,7 @@ describe("get-connector-offsets-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/get-connector-offsets-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-offsets-handler.ts
@@ -13,11 +13,13 @@ export class GetConnectorOffsetsHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/get-connector-status-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-status-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -135,7 +135,7 @@ describe("get-connector-status-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/get-connector-status-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-status-handler.ts
@@ -13,11 +13,13 @@ export class GetConnectorStatusHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/get-connector-tasks-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-tasks-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -99,7 +99,7 @@ describe("get-connector-tasks-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/get-connector-tasks-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-tasks-handler.ts
@@ -13,11 +13,13 @@ export class GetConnectorTasksHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
@@ -4,7 +4,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -97,7 +97,7 @@ describe("list-connectors-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.ts
@@ -27,11 +27,13 @@ export class ListConnectorsHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId } =
       listConnectorArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/pause-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/pause-connector-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -100,7 +100,7 @@ describe("pause-connector-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/pause-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/pause-connector-handler.ts
@@ -13,11 +13,13 @@ export class PauseConnectorHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/restart-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/restart-connector-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -100,7 +100,7 @@ describe("restart-connector-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/restart-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/restart-connector-handler.ts
@@ -13,11 +13,13 @@ export class RestartConnectorHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/resume-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/resume-connector-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -100,7 +100,7 @@ describe("resume-connector-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/resume-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/resume-connector-handler.ts
@@ -13,11 +13,13 @@ export class ResumeConnectorHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName } =
       connectorByNameArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 

--- a/src/confluent/tools/handlers/connect/update-connector-config-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/update-connector-config-handler.test.ts
@@ -6,7 +6,7 @@ import {
   CONNECT_CONN,
   ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -113,7 +113,7 @@ describe("update-connector-config-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/connect/update-connector-config-handler.ts
+++ b/src/confluent/tools/handlers/connect/update-connector-config-handler.ts
@@ -23,11 +23,13 @@ export class UpdateConnectorConfigHandler extends ConnectToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId, connectorName, connectorConfig } =
       updateConnectorConfigArguments.parse(toolArguments);
 
-    const conn = runtime.config.getSoleDirectConnection();
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
       this.resolveConnectEnvAndClusterId(conn, environmentId, clusterId);
 


### PR DESCRIPTION
## Connect and Billing handlers honor an explicit `connectionId`

The fourteen Connect handlers and the `list-billing-costs` handler previously grabbed `runtime.clientManager` — the singular `ServerRuntime` accessor that throws the moment a runtime holds more than one connection — and the Connect handlers additionally read their connection config via `runtime.config.getSoleDirectConnection()`. Both ignore any caller-supplied `connectionId`. Each now resolves through the seam #551 added, reading `connectionId` off the raw tool arguments and routing to the addressed connection.

The two domains resolve through different doors, and the choice is load-bearing rather than cosmetic:

- **Connect → `resolveDirectConnection`.** Connect tools are OAuth-_disabled_ (they need the Kafka block for env/cluster fallback), so an addressed Connect connection is always `direct`-typed. `resolveDirectConnection` returns a `DirectConnectionConfig`, which is exactly what `resolveConnectEnvAndClusterId(conn, …)` consumes — so the swap preserves the type that `getSoleDirectConnection()` used to hand back, with no narrowing or cast at the call site.
- **Billing → `resolveConnection`.** `list-billing-costs` is OAuth-_enabled_ (`hasConfluentCloudOrOAuth`) and only needs the client manager, never a typed connection. The type-neutral `resolveConnection` is correct here; narrowing to direct would wrongly reject an OAuth connection the tool is happy to serve.

The resolved `{ conn, clientManager }` shape is otherwise unchanged, so each handler's body is a two-line edit: drop the eager `runtime.clientManager`, and replace the sole-connection lookup with a destructure of the routing-aware resolver.

## Routing coverage folded into the existing handle() tests

Routing verification rides on the shared harness rather than a bespoke per-suite test, mirroring #539:

- The eleven Connect suites that drive `handle()` through `assertHandleCase` swap `runtimeWith` for `runtimeWithDecoy` — a one-word change per suite. The decoy connection carries the same service blocks (enabled for the same tool) and is planted first, so a handler that still resolved via `enabledConnectionIds[0]` would land on the decoy; `assertHandleCase` injects the real connection's id and asserts the decoy's client manager went untouched.
- The four suites that call `handle()` directly (`get-connector-error-recommendations`, `get-connector-error-summary`, `get-connector-logs`, and `list-billing-costs`) keep their existing single-connection tests and gain one dedicated routing test each, built on `runtimeWithDecoy`. `get-connector-logs` is the subtle one: its only client-manager touch is auto-resolving the organization id, so that test deliberately omits `organizationId` from both args and config to force the REST call that makes routing observable — otherwise the decoy-untouched assertion would pass vacuously.

These tests are not vacuous: against the un-ported handlers (which call the singular `runtime.clientManager`) the decoy runtime makes every converted case throw "ServerRuntime has multiple client managers," which is precisely the red that flips green once the handler routes by id.

## Remaining sole-accessor call sites

`handle()` in the Connect and Billing domains is now free of the retired accessors. The lone surviving connect-domain `getSoleDirectConnection()` calls are fixture construction in `connect-tool-handler.test.ts` and the integration harness — the same test-side usage left untouched in the config and harness suites, all slated for the repo-wide sweep when #554 deletes the accessors.

## Relationships

- Closes #541.
- Child of #564 (port all handlers off the sole-connection accessors), itself a child of #532 (Epic: Multi-connection support).
- Builds on #551 (`resolveConnection()` / `resolveDirectConnection()`), the seam this PR consumes.
- Peer of #539 (Kafka suite, the first wave), whose `runtimeWithDecoy` harness this PR reuses.
