### PR TITLE
 Port the Flink suite + clusters + organizations to routing-aware connection resolution

### DIFF
--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
@@ -4,7 +4,7 @@ import {
   ccloudOAuthRuntime,
   DEFAULT_CONNECTION_ID,
   HandleCaseWithConn,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -56,7 +56,7 @@ describe("list-clusters-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -81,7 +81,7 @@ describe("list-clusters-handler.ts", () => {
       it("should throw a discovery hint under direct when neither environmentId arg nor conn kafka.env_id is present", async () => {
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             CCLOUD_CONN,
             DEFAULT_CONNECTION_ID,
             getMockedClientManager(),

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -69,7 +69,10 @@ export class ListClustersHandler extends BaseToolHandler {
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
     const { environmentId } = listClustersArguments.parse(toolArguments ?? {});
-    const { connId, clientManager } = this.resolveSoleConnection(runtime);
+    const { connId, clientManager } = this.resolveConnection(
+      runtime,
+      toolArguments,
+    );
     const resolvedEnv = resolveEnvArg({ environmentId }, runtime, connId);
 
     try {

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FLINK_CONN,
   HandleCaseWithConn,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -64,7 +65,7 @@ describe("describe-table-handler.ts", () => {
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -133,7 +134,7 @@ describe("describe-table-handler.ts", () => {
         async ({ args, expectedCatalog }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
@@ -56,7 +56,6 @@ export class DescribeTableHandler extends FlinkCatalogToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       organizationId,
       environmentId,
@@ -66,8 +65,11 @@ export class DescribeTableHandler extends FlinkCatalogToolHandler {
       tableName,
     } = describeTableArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
-    const conn = runtime.config.getSoleDirectConnection(); // needed for kafka.cluster_id in resolveDatabaseName
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FLINK_CONN,
   HandleCaseWithConn,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -64,7 +65,7 @@ describe("get-table-info-handler.ts", () => {
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -132,7 +133,7 @@ describe("get-table-info-handler.ts", () => {
         async ({ args, expectedCatalog }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
@@ -56,7 +56,6 @@ export class GetTableInfoHandler extends FlinkCatalogToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       organizationId,
       environmentId,
@@ -66,8 +65,11 @@ export class GetTableInfoHandler extends FlinkCatalogToolHandler {
       tableName,
     } = getTableInfoArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
-    const conn = runtime.config.getSoleDirectConnection(); // needed for kafka.cluster_id in resolveDatabaseName
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FLINK_CONN,
   HandleCaseWithConn,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -56,7 +57,7 @@ describe("list-catalogs-handler.ts", () => {
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -104,7 +105,7 @@ describe("list-catalogs-handler.ts", () => {
       it("should embed config environment_id as catalog name in the POST SQL statement", async () => {
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
@@ -32,11 +32,14 @@ export class ListCatalogsHandler extends FlinkCatalogToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { organizationId, environmentId, computePoolId } =
       listCatalogsArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FLINK_CONN,
   HandleCaseWithConn,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -55,7 +56,7 @@ describe("list-databases-handler.ts", () => {
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -111,7 +112,7 @@ describe("list-databases-handler.ts", () => {
         async ({ args, expectedCatalog }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
@@ -39,11 +39,14 @@ export class ListDatabasesHandler extends FlinkCatalogToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { organizationId, environmentId, computePoolId, catalogName } =
       listDatabasesArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FLINK_CONN,
   HandleCaseWithConn,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -57,7 +58,7 @@ describe("list-tables-handler.ts", () => {
         async ({ args, outcome, connectionConfig = FLINK_CONN }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -113,7 +114,7 @@ describe("list-tables-handler.ts", () => {
         async ({ args, expectedCatalog }) => {
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
@@ -39,11 +39,14 @@ export class ListTablesHandler extends FlinkCatalogToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { organizationId, environmentId, computePoolId, catalogName } =
       listTablesArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.test.ts
@@ -3,7 +3,7 @@ import {
   FLINK_CONN as BASE_FLINK_CONN,
   DEFAULT_CONNECTION_ID,
   HandleCaseWithConn,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -107,7 +107,7 @@ describe("create-flink-statement-handler.ts", () => {
             .POST.mockResolvedValue({ data: {} });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -126,7 +126,7 @@ describe("create-flink-statement-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -159,7 +159,7 @@ describe("create-flink-statement-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN_NO_NAMES,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -189,7 +189,7 @@ describe("create-flink-statement-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -227,7 +227,7 @@ describe("create-flink-statement-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
@@ -62,7 +62,6 @@ export class CreateFlinkStatementHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       catalogName,
       databaseName,
@@ -72,7 +71,11 @@ export class CreateFlinkStatementHandler extends FlinkToolHandler {
       environmentId,
       organizationId,
     } = createFlinkStatementArguments.parse(toolArguments);
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
   HandleCaseWithConn,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -68,7 +68,7 @@ describe("delete-flink-statement-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
@@ -36,10 +36,13 @@ export class DeleteFlinkStatementHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { statementName, environmentId, organizationId } =
       deleteFlinkStatementArguments.parse(toolArguments);
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.test.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
   FlinkGetCase,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -74,7 +74,7 @@ describe("check-health-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -106,7 +106,7 @@ describe("check-health-handler.ts", () => {
           });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -126,7 +126,7 @@ describe("check-health-handler.ts", () => {
         ]);
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -144,7 +144,7 @@ describe("check-health-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -162,7 +162,7 @@ describe("check-health-handler.ts", () => {
         ]);
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -180,7 +180,7 @@ describe("check-health-handler.ts", () => {
           .GET.mockResolvedValueOnce({ error: { code: 500, message: "boom" } });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
@@ -47,11 +47,14 @@ export class CheckHealthHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { statementName, environmentId, organizationId } =
       checkHealthArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
   FlinkGetCase,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -84,7 +84,7 @@ describe("detect-issues-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -129,7 +129,7 @@ describe("detect-issues-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -169,7 +169,7 @@ describe("detect-issues-handler.ts", () => {
           });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -184,7 +184,7 @@ describe("detect-issues-handler.ts", () => {
           wireFlinkPair(clientManager, { status: { phase: "DEGRADED" } });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -199,7 +199,7 @@ describe("detect-issues-handler.ts", () => {
           wireFlinkPair(clientManager, { status: { phase: "STOPPED" } });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -216,7 +216,7 @@ describe("detect-issues-handler.ts", () => {
           });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -233,7 +233,7 @@ describe("detect-issues-handler.ts", () => {
           });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -248,7 +248,7 @@ describe("detect-issues-handler.ts", () => {
           wireFlinkPair(clientManager, { status: { phase: "COMPLETED" } });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               FLINK_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -307,7 +307,7 @@ describe("detect-issues-handler.ts", () => {
             wireFlinkPair(cm, { status: { phase: "RUNNING" } }, exceptions);
             await assertHandleCase({
               handler,
-              runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+              runtime: runtimeWithDecoy(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
               args: { statementName: STATEMENT_NAME, includeMetrics: false },
               outcome: { resolves: expected },
               clientManager: cm,
@@ -323,7 +323,7 @@ describe("detect-issues-handler.ts", () => {
           wireFlinkPair(cm, { status: { phase: "RUNNING" } }, exceptions);
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+            runtime: runtimeWithDecoy(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
             args: { statementName: STATEMENT_NAME, includeMetrics: false },
             outcome: { resolves: "frequent_exceptions" },
             clientManager: cm,
@@ -338,7 +338,7 @@ describe("detect-issues-handler.ts", () => {
           .GET.mockResolvedValueOnce({ error: { code: 500 } });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -361,7 +361,7 @@ describe("detect-issues-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
@@ -56,7 +56,6 @@ export class DetectIssuesHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       statementName,
       environmentId,
@@ -65,7 +64,11 @@ export class DetectIssuesHandler extends FlinkToolHandler {
       includeMetrics,
     } = detectIssuesArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
@@ -3,9 +3,10 @@ import { QueryProfilerHandler } from "@src/confluent/tools/handlers/flink/diagno
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   DEFAULT_CONNECTION_ID,
-  FLINK_CONN,
+  FLINK_TELEMETRY_CONN,
   FlinkGetCase,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -78,7 +79,7 @@ describe("query-profiler-handler.ts", () => {
           args,
           outcome,
           flinkGetData,
-          connectionConfig = FLINK_CONN,
+          connectionConfig = FLINK_TELEMETRY_CONN,
         }) => {
           const clientManager = getMockedClientManager();
           if (flinkGetData !== undefined) {
@@ -91,7 +92,7 @@ describe("query-profiler-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -110,8 +111,8 @@ describe("query-profiler-handler.ts", () => {
           .GET.mockResolvedValueOnce({ error: { code: 500 } });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
-            FLINK_CONN,
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
           ),
@@ -128,8 +129,8 @@ describe("query-profiler-handler.ts", () => {
           .GET.mockResolvedValue({ data: {} });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
-            FLINK_CONN,
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
           ),
@@ -146,8 +147,8 @@ describe("query-profiler-handler.ts", () => {
           .GET.mockResolvedValue({ data: { Graph: "{not json" } });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
-            FLINK_CONN,
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
           ),
@@ -168,7 +169,11 @@ describe("query-profiler-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
+            DEFAULT_CONNECTION_ID,
+            cm,
+          ),
           args: { statementName: STATEMENT_NAME },
           outcome: { resolves: "high_backpressure" },
           clientManager: cm,
@@ -186,7 +191,11 @@ describe("query-profiler-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
+            DEFAULT_CONNECTION_ID,
+            cm,
+          ),
           args: { statementName: STATEMENT_NAME },
           outcome: { resolves: '"severity": "high"' },
           clientManager: cm,
@@ -205,7 +214,11 @@ describe("query-profiler-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
+            DEFAULT_CONNECTION_ID,
+            cm,
+          ),
           args: { statementName: STATEMENT_NAME },
           outcome: { resolves: "high_consumer_lag" },
           clientManager: cm,
@@ -222,7 +235,11 @@ describe("query-profiler-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
+            DEFAULT_CONNECTION_ID,
+            cm,
+          ),
           args: { statementName: STATEMENT_NAME },
           outcome: { resolves: "late_data" },
           clientManager: cm,
@@ -240,7 +257,11 @@ describe("query-profiler-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
+            DEFAULT_CONNECTION_ID,
+            cm,
+          ),
           args: { statementName: STATEMENT_NAME },
           outcome: { resolves: "large_state" },
           clientManager: cm,
@@ -256,7 +277,7 @@ describe("query-profiler-handler.ts", () => {
           data: { data: [] },
         });
         const result = await handler.handle(
-          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, cm),
+          runtimeWith(FLINK_TELEMETRY_CONN, DEFAULT_CONNECTION_ID, cm),
           { statementName: STATEMENT_NAME, includeAnalysis: false },
         );
         const text = result.content

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -110,7 +110,6 @@ export class QueryProfilerHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       statementName,
       environmentId,
@@ -120,7 +119,11 @@ export class QueryProfilerHandler extends FlinkToolHandler {
       includeAnalysis,
     } = queryProfilerArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
@@ -1,13 +1,12 @@
-import { FlinkDirectConfig } from "@src/config/models.js";
+import {
+  DirectConnectionConfig,
+  FlinkDirectConfig,
+} from "@src/config/models.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import {
-  bareRuntime,
-  FLINK_CONN,
-  runtimeWith,
-} from "@tests/factories/runtime.js";
+import { FLINK_CONN } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
 
 const FLINK_CONFIG: FlinkDirectConfig = {
@@ -65,20 +64,14 @@ describe("flink-tool-handler.ts", () => {
 
     describe("getFlinkDirectConfig()", () => {
       it("should return the flink block when present", () => {
-        const runtime = runtimeWith(FLINK_CONN);
-        const flink = handler["getFlinkDirectConfig"](runtime.config);
-        expect(flink).toBe(runtime.config.getSoleDirectConnection().flink);
+        const conn: DirectConnectionConfig = { type: "direct", ...FLINK_CONN };
+        const flink = handler["getFlinkDirectConfig"](conn);
+        expect(flink).toBe(conn.flink);
       });
 
       it("should throw Wacky when the connection has no flink block", () => {
         expect(() =>
-          handler["getFlinkDirectConfig"](bareRuntime().config),
-        ).toThrow("Wacky --");
-      });
-
-      it("should throw Wacky when connection config is empty", () => {
-        expect(() =>
-          handler["getFlinkDirectConfig"](runtimeWith({}).config),
+          handler["getFlinkDirectConfig"]({ type: "direct" }),
         ).toThrow("Wacky --");
       });
     });

--- a/src/confluent/tools/handlers/flink/flink-tool-handler.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.ts
@@ -1,6 +1,6 @@
 import {
+  DirectConnectionConfig,
   FlinkDirectConfig,
-  MCPServerConfiguration,
 } from "@src/config/models.js";
 import {
   BaseToolHandler,
@@ -14,15 +14,15 @@ export abstract class FlinkToolHandler extends BaseToolHandler {
   readonly predicate = hasFlink;
 
   /**
-   * Extracts the Flink config block from the sole connection, asserting it exists.
+   * Extracts the Flink config block from the resolved connection, asserting it exists.
    * Throws "Wacky -- " if called on a connection without a flink block (should be
    * impossible in production given the hasFlink gate, but caught here rather than
    * silently propagating undefined).
    */
   protected getFlinkDirectConfig(
-    config: MCPServerConfiguration,
+    conn: DirectConnectionConfig,
   ): FlinkDirectConfig {
-    const flink = config.getSoleDirectConnection().flink;
+    const flink = conn.flink;
     if (!flink)
       throw new Error(
         "Wacky -- FlinkToolHandler invoked on a connection without a flink block",

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
   FlinkGetCase,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -67,7 +67,7 @@ describe("get-flink-exceptions-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
@@ -34,11 +34,14 @@ export class GetFlinkExceptionsHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { statementName, environmentId, organizationId } =
       getFlinkExceptionsArguments.parse(toolArguments);
 
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
   FlinkGetCase,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -69,7 +69,7 @@ describe("list-flink-statements-handler.ts", () => {
             .GET.mockResolvedValue({ data: flinkGetData });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -88,7 +88,7 @@ describe("list-flink-statements-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             FLINK_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
@@ -49,7 +49,6 @@ export class ListFlinkStatementsHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       pageSize,
       computePoolId,
@@ -59,7 +58,11 @@ export class ListFlinkStatementsHandler extends FlinkToolHandler {
       pageToken,
       statusPhase,
     } = listFlinkStatementsArguments.parse(toolArguments);
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
   FlinkGetCase,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -64,7 +64,7 @@ describe("read-flink-statement-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/flink/read-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/read-flink-statement-handler.ts
@@ -43,14 +43,17 @@ export class ReadFlinkStatementHandler extends FlinkToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const {
       timeoutInMilliseconds,
       statementName,
       environmentId,
       organizationId,
     } = readFlinkStatementArguments.parse(toolArguments);
-    const flink = this.getFlinkDirectConfig(runtime.config);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
+    const flink = this.getFlinkDirectConfig(conn);
     const { organization_id, environment_id } = this.resolveOrgAndEnvIds(
       flink,
       organizationId,

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.test.ts
@@ -2,7 +2,7 @@ import { ListOrganizationsHandler } from "@src/confluent/tools/handlers/organiza
 import {
   CCLOUD_CONN,
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -85,7 +85,7 @@ describe("list-organizations-handler.ts", () => {
             .GET.mockResolvedValue({ data: cloudGetData });
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               CCLOUD_CONN,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.ts
@@ -69,10 +69,11 @@ export class ListOrganizationsHandler extends BaseToolHandler {
     const { pageSize, pageToken } = listOrganizationsArguments.parse(
       toolArguments ?? {},
     );
+    const { clientManager } = this.resolveConnection(runtime, toolArguments);
 
     try {
       const pathBasedClient = wrapAsPathBasedClient(
-        runtime.clientManager.getConfluentCloudRestClient(),
+        clientManager.getConfluentCloudRestClient(),
       );
 
       const { data: response, error } = await pathBasedClient[

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -157,6 +157,19 @@ export const FLINK_CONN = {
   },
 };
 
+/**
+ * Flink + telemetry connection fixture for handle() tests of the query profiler,
+ * whose `flinkWithTelemetry` predicate enables a connection only when both blocks
+ * are present — so routing-aware resolution rejects a flink-only connection.
+ */
+export const FLINK_TELEMETRY_CONN = {
+  ...FLINK_CONN,
+  telemetry: {
+    endpoint: "https://api.telemetry.confluent.cloud",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+  },
+};
+
 /** Shared Kafka connection config fixture for handle() tests. */
 export const KAFKA_CONN = {
   kafka: {


### PR DESCRIPTION
## Flink handlers honor an explicit `connectionId`

The thirteen Flink handlers (five statement tools, five catalog tools, three diagnostics tools) previously resolved their connection two ways at once: the eager singular `runtime.clientManager` for the REST client, and `FlinkToolHandler.getFlinkDirectConfig(runtime.config)` — which reached through `getSoleDirectConnection()` — for the Flink config block. Both ignore any caller-supplied `connectionId`. Each now resolves once through `BaseToolHandler.resolveDirectConnection(runtime, toolArguments)`, reading `connectionId` off the raw arguments and routing both the client manager and the connection to the addressed connection.

Flink tools are OAuth-disabled (they need the direct Flink service block), so `resolveDirectConnection` — which narrows to `DirectConnectionConfig` — is the right resolver, matching the type `getSoleDirectConnection()` used to return.

The enabling refactor lives on the domain base class: `getFlinkDirectConfig` now takes the already-resolved `DirectConnectionConfig` rather than the whole `MCPServerConfiguration`, so it reads `conn.flink` instead of re-deriving the sole connection. Handlers pass it the `conn` from their single `resolveDirectConnection` call:

```typescript
const { conn, clientManager } = this.resolveDirectConnection(
  runtime,
  toolArguments,
);
const flink = this.getFlinkDirectConfig(conn);
```

`describe-flink-table` and `get-flink-table-info` additionally needed `conn` for `kafka.cluster_id`; they previously made a _second_ `getSoleDirectConnection()` call alongside `getFlinkDirectConfig` — now both come from the one resolve.

## clusters and organizations honor an explicit `connectionId`

`list-clusters` and `list-organizations` are OAuth-_enabled_ (`hasConfluentCloudOrOAuth`) and need only the client manager (plus, for clusters, the connection id to resolve the environment arg). They move to the type-neutral `resolveConnection`: `list-clusters` swaps its `resolveSoleConnection(runtime)` call, and `list-organizations` swaps an inline `runtime.clientManager` getter.

## Routing coverage folded into the existing handle() tests

Mirroring #539/#541, routing rides on the shared harness:

- Suites whose `runtimeWith(...)` only ever feeds `assertHandleCase` (all the statement and diagnostics suites, clusters, organizations) swap wholesale to `runtimeWithDecoy`, turning every success case into a routing test.
- The catalog suites and `query-profiler` also make some **direct** `handler.handle(runtimeWith(...))` calls (SQL-shape and error-path assertions that don't go through the harness). Those stay single-connection; only the `assertHandleCase` runtimes in those suites become decoy runtimes, which is enough to prove routing for the suite.

Against the un-ported handlers the decoy runtime makes this concrete: the Flink and organizations handlers throw "ServerRuntime has multiple client managers"; `list-clusters` (whose `resolveSoleConnection` grabbed `enabledConnectionIds[0]` — the decoy) trips the decoy-untouched assertion. Both flip green once resolution routes by id.

## A latent under-specification the port surfaced

`get-flink-statement-profile` is the one Flink tool gated on `flinkWithTelemetry` (`allOf(hasFlink, hasTelemetry)`), not plain `hasFlink`. Its `handle()` tests had been building their runtime from the flink-only `FLINK_CONN` fixture and passing anyway — because the old singular `runtime.clientManager` returned the sole manager without consulting the predicate. Routing-aware resolution _does_ consult enablement, so a flink-only connection is no longer a valid route for this tool, and the tests now use a new `FLINK_TELEMETRY_CONN` fixture carrying both blocks. The handler behavior is unchanged; the test was simply describing a connection the tool would never actually be enabled against.

The `FlinkToolHandler` base-class test was updated for the new `getFlinkDirectConfig(conn)` signature — passing a `DirectConnectionConfig` literal instead of a runtime config, which also let the two redundant "no flink block" cases (empty connection vs. bare runtime — the same code path) collapse into one.

## Remaining sole-accessor call sites

`handle()` across all three domains is free of the retired accessors. The surviving `getSoleDirectConnection()` calls in the Flink integration-test harness are the same test-side usage left untouched elsewhere, slated for #554's repo-wide sweep.

## Relationships

- Closes #567.
- Child of #564 (port all handlers off the sole-connection accessors), itself a child of #532 (Epic: Multi-connection support).
- Builds on #551 (`resolveConnection()` / `resolveDirectConnection()`).
- Peer of #539 (Kafka) and #541 (Connect + Billing), whose `runtimeWithDecoy` harness and resolver-selection rationale this PR reuses.
