### PR TITLE
Port the Tableflow suite + environments + metrics to routing-aware connection resolution

### DIFF
--- a/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
@@ -61,7 +61,7 @@ describe("list-environments-handler.ts", () => {
             "resolve with a validation-error response when the API returns an unexpected payload",
           args: {},
           cloudGetData: { not: "an EnvironmentList" },
-          outcome: { resolves: "Invalid environment list data" },
+          outcome: { resolves: "Invalid environment list data", isError: true },
         },
       ];
 

--- a/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
@@ -1,0 +1,90 @@
+import { ListEnvironmentsHandler } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
+import {
+  CCLOUD_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+  type HandleCase,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+const ENV_FIXTURE = {
+  api_version: "org/v2",
+  kind: "Environment",
+  id: "env-abc123",
+  display_name: "production",
+  metadata: {
+    self: "https://api.confluent.cloud/org/v2/environments/env-abc123",
+    resource_name: "crn://confluent.cloud/environment=env-abc123",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+  },
+};
+
+describe("list-environments-handler.ts", () => {
+  describe("ListEnvironmentsHandler", () => {
+    const handler = new ListEnvironmentsHandler();
+
+    // Every case runs against runtimeWithDecoy, so assertHandleCase routes to
+    // the real connection and asserts the decoy's client manager stays
+    // untouched — making each a routing test for the resolveConnection port.
+    describe("handle()", () => {
+      type EnvsCase = HandleCase & { cloudGetData: unknown };
+      const cases: EnvsCase[] = [
+        {
+          label:
+            "resolve with 'retrieved 0 environments' when the API returns an empty list",
+          args: {},
+          cloudGetData: {
+            api_version: "org/v2",
+            kind: "EnvironmentList",
+            data: [],
+          },
+          outcome: { resolves: "Successfully retrieved 0 environments" },
+        },
+        {
+          label:
+            "resolve with the environment's display name when the API returns one entry",
+          args: {},
+          cloudGetData: {
+            api_version: "org/v2",
+            kind: "EnvironmentList",
+            data: [ENV_FIXTURE],
+          },
+          outcome: { resolves: "production" },
+        },
+        {
+          label:
+            "resolve with a validation-error response when the API returns an unexpected payload",
+          args: {},
+          cloudGetData: { not: "an EnvironmentList" },
+          outcome: { resolves: "Invalid environment list data" },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({ args, outcome, cloudGetData }) => {
+          const clientManager = getMockedClientManager();
+          clientManager
+            .getConfluentCloudRestClient()
+            .GET.mockResolvedValue({ data: cloudGetData });
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWithDecoy(
+              CCLOUD_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientManager,
+          });
+        },
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -64,8 +64,8 @@ export class ListEnvironmentsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { pageToken } = listEnvironmentsArguments.parse(toolArguments);
+    const { clientManager } = this.resolveConnection(runtime, toolArguments);
 
     try {
       const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/environments/read-environment-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.test.ts
@@ -1,0 +1,89 @@
+import { ReadEnvironmentHandler } from "@src/confluent/tools/handlers/environments/read-environment-handler.js";
+import {
+  CCLOUD_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+  type HandleCase,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+const ENV_FIXTURE = {
+  api_version: "org/v2",
+  kind: "Environment",
+  id: "env-abc123",
+  display_name: "production",
+  metadata: {
+    self: "https://api.confluent.cloud/org/v2/environments/env-abc123",
+    resource_name: "crn://confluent.cloud/environment=env-abc123",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+  },
+};
+
+describe("read-environment-handler.ts", () => {
+  describe("ReadEnvironmentHandler", () => {
+    const handler = new ReadEnvironmentHandler();
+
+    // Every case runs against runtimeWithDecoy, so assertHandleCase routes to
+    // the real connection and asserts the decoy's client manager stays
+    // untouched — making each a routing test for the resolveConnection port.
+    describe("handle()", () => {
+      type ReadEnvCase = HandleCase & { cloudGetData?: unknown };
+      const cases: ReadEnvCase[] = [
+        {
+          label: "resolve with the environment's display name on success",
+          args: { environmentId: "env-abc123" },
+          cloudGetData: ENV_FIXTURE,
+          outcome: { resolves: "production" },
+        },
+        {
+          label: "resolve with an error response when the API returns an error",
+          args: { environmentId: "env-abc123" },
+          cloudGetData: undefined,
+          outcome: { resolves: "Failed to fetch environment", isError: true },
+        },
+        {
+          label:
+            "resolve with a validation-error response on an unexpected payload",
+          args: { environmentId: "env-abc123" },
+          cloudGetData: { not: "an Environment" },
+          outcome: { resolves: "Invalid environment data", isError: true },
+        },
+        {
+          label: "throw a ZodError when environmentId is absent",
+          args: {},
+          outcome: { throws: "ZodError" },
+        },
+      ];
+
+      it.each(cases)(
+        "should $label",
+        async ({ args, outcome, cloudGetData }) => {
+          const clientManager = getMockedClientManager();
+          clientManager
+            .getConfluentCloudRestClient()
+            .GET.mockResolvedValue(
+              cloudGetData === undefined
+                ? { error: { message: "not found" } }
+                : { data: cloudGetData },
+            );
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWithDecoy(
+              CCLOUD_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args,
+            outcome,
+            clientManager,
+          });
+        },
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/environments/read-environment-handler.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.ts
@@ -28,8 +28,8 @@ export class ReadEnvironmentHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { environmentId } = readEnvironmentArguments.parse(toolArguments);
+    const { clientManager } = this.resolveConnection(runtime, toolArguments);
 
     try {
       const pathBasedClient = wrapAsPathBasedClient(

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
@@ -5,6 +5,7 @@ import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -96,7 +97,7 @@ describe("list-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -114,7 +115,7 @@ describe("list-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -206,7 +207,7 @@ describe("list-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -221,7 +222,7 @@ describe("list-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -145,8 +145,11 @@ export class ListMetricsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { resource_type } = listMetricsArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     try {
       const telemetryClient =

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_CONNECTION_ID,
   HandleCaseWithConn,
   runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -262,7 +263,7 @@ describe("query-metrics-handler.ts", () => {
 
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,
@@ -303,7 +304,7 @@ describe("query-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -326,7 +327,7 @@ describe("query-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,
@@ -348,7 +349,7 @@ describe("query-metrics-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(
+          runtime: runtimeWithDecoy(
             TELEMETRY_CONN,
             DEFAULT_CONNECTION_ID,
             clientManager,

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -73,8 +73,11 @@ export class QueryMetricsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const args = queryMetricsArguments.parse(toolArguments);
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const {
       metric,
       dataset = "cloud",
@@ -90,8 +93,7 @@ export class QueryMetricsHandler extends BaseToolHandler {
     try {
       const telemetryClient =
         clientManager.getConfluentCloudTelemetryRestClient();
-      const connKafkaClusterId =
-        runtime.config.getSoleDirectConnection().kafka?.cluster_id;
+      const connKafkaClusterId = conn.kafka?.cluster_id;
       const effectiveFilter = buildEffectiveFilter(
         filter,
         metric,

--- a/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.test.ts
@@ -1,7 +1,7 @@
 import { CreateTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -114,7 +114,7 @@ describe("create-tableflow-catalog-integration-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
@@ -49,12 +49,15 @@ export class CreateTableFlowCatalogIntegrationHandler extends TableflowToolHandl
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { environmentId, clusterId, tableflowCatalogIntegrationConfig } =
       createTableflowCatalogIntegrationArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.test.ts
@@ -1,7 +1,7 @@
 import { DeleteTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -103,7 +103,7 @@ describe("delete-tableflow-catalog-integration-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
@@ -25,12 +25,15 @@ export class DeleteTableFlowCatalogIntegrationHandler extends TableflowToolHandl
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { id, environmentId, clusterId } =
       deleteTableflowCatalogIntegrationArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.test.ts
@@ -69,6 +69,7 @@ describe("list-tableflow-catalog-integrations-handler.ts", () => {
           mockResponse: { error: { message: "unauthorized" } },
           outcome: {
             resolves: "Failed to list Tableflow catalog integrations",
+            isError: true,
           },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.test.ts
@@ -1,7 +1,7 @@
 import { ListTableFlowCatalogIntegrationsHandler } from "@src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -93,7 +93,7 @@ describe("list-tableflow-catalog-integrations-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
@@ -38,12 +38,15 @@ export class ListTableFlowCatalogIntegrationsHandler extends TableflowToolHandle
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId } =
       listTableFlowCatalogIntegrationsArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.test.ts
@@ -1,7 +1,7 @@
 import { ReadTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -99,7 +99,7 @@ describe("read-tableflow-catalog-integration-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
@@ -25,12 +25,15 @@ export class ReadTableFlowCatalogIntegrationHandler extends TableflowToolHandler
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { id, environmentId, clusterId } =
       readTableflowCatalogIntegrationArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.test.ts
@@ -1,7 +1,8 @@
 import { UpdateTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
+  TABLEFLOW_CONN,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -31,7 +32,11 @@ describe("update-tableflow-catalog-integration-handler.ts", () => {
           .POST.mockResolvedValue({ data: { display_name: "my-catalog" } });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: UPDATE_ARGS,
           outcome: {
             resolves: "Tableflow Catalog Integration my-catalog updated",
@@ -47,7 +52,11 @@ describe("update-tableflow-catalog-integration-handler.ts", () => {
           .POST.mockResolvedValue({ error: { message: "not found" } });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: UPDATE_ARGS,
           outcome: {
             resolves:
@@ -66,7 +75,11 @@ describe("update-tableflow-catalog-integration-handler.ts", () => {
         });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: UPDATE_ARGS,
           outcome: {
             resolves: "Tableflow Catalog Integration my-catalog updated",

--- a/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
@@ -47,9 +47,13 @@ export class UpdateTableFlowCatalogIntegrationHandler extends TableflowToolHandl
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { tableflowCatalogIntegrationConfig } =
       updateTableflowCatalogIntegrationArguments.parse(toolArguments);
+
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.test.ts
@@ -48,7 +48,10 @@ describe("list-tableflow-regions-handler.ts", () => {
             clientManager,
           ),
           args: { cloud: "AWS" },
-          outcome: { resolves: "Failed to list Tableflow regions:" },
+          outcome: {
+            resolves: "Failed to list Tableflow regions:",
+            isError: true,
+          },
           clientManager,
         });
       });

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.test.ts
@@ -1,7 +1,8 @@
 import { ListTableFlowRegionsHandler } from "@src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
+  TABLEFLOW_CONN,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -22,7 +23,11 @@ describe("list-tableflow-regions-handler.ts", () => {
           .GET.mockResolvedValue({ data: [] });
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { cloud: "AWS" },
           outcome: { resolves: "Tableflow Regions" },
           clientManager,
@@ -37,7 +42,11 @@ describe("list-tableflow-regions-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { cloud: "AWS" },
           outcome: { resolves: "Failed to list Tableflow regions:" },
           clientManager,
@@ -52,7 +61,11 @@ describe("list-tableflow-regions-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { cloud: "AWS" },
           outcome: { resolves: "Tableflow Regions" },
           clientManager,
@@ -81,7 +94,11 @@ describe("list-tableflow-regions-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: {},
           outcome: { resolves: "Tableflow Regions" },
           clientManager,
@@ -112,7 +129,11 @@ describe("list-tableflow-regions-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { pageSize: 20, pageToken: "abc" },
           outcome: { resolves: "Tableflow Regions" },
           clientManager,

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -34,9 +34,13 @@ export class ListTableFlowRegionsHandler extends TableflowToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { cloud, pageSize, pageToken } =
       listTableFlowRegionsArguments.parse(toolArguments);
+
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.test.ts
@@ -3,7 +3,6 @@ import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { runtimeWith } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
 
 class StubTableflowHandler extends TableflowToolHandler {
@@ -39,7 +38,7 @@ describe("tableflow-tool-handler.ts", () => {
       it("should prefer explicit args over connection config", () => {
         expect(
           handler["resolveTableflowEnvAndClusterId"](
-            runtimeWith(connWithBoth),
+            connWithBoth,
             "env-from-arg",
             "lkc-from-arg",
           ),
@@ -52,7 +51,7 @@ describe("tableflow-tool-handler.ts", () => {
       it("should fall back to connection config when args are absent", () => {
         expect(
           handler["resolveTableflowEnvAndClusterId"](
-            runtimeWith(connWithBoth),
+            connWithBoth,
             undefined,
             undefined,
           ),
@@ -65,7 +64,7 @@ describe("tableflow-tool-handler.ts", () => {
       it("should use the env arg and fall back to config for cluster_id when only env arg is supplied", () => {
         expect(
           handler["resolveTableflowEnvAndClusterId"](
-            runtimeWith(connWithBoth),
+            connWithBoth,
             "env-from-arg",
             undefined,
           ),
@@ -78,7 +77,7 @@ describe("tableflow-tool-handler.ts", () => {
       it("should fall back to config for env_id and use the cluster arg when only cluster arg is supplied", () => {
         expect(
           handler["resolveTableflowEnvAndClusterId"](
-            runtimeWith(connWithBoth),
+            connWithBoth,
             undefined,
             "lkc-from-arg",
           ),
@@ -105,7 +104,7 @@ describe("tableflow-tool-handler.ts", () => {
         };
         expect(() =>
           handler["resolveTableflowEnvAndClusterId"](
-            runtimeWith(connNoEnv),
+            connNoEnv,
             undefined,
             undefined,
           ),
@@ -123,7 +122,7 @@ describe("tableflow-tool-handler.ts", () => {
         };
         expect(() =>
           handler["resolveTableflowEnvAndClusterId"](
-            runtimeWith(connNoCluster),
+            connNoCluster,
             undefined,
             undefined,
           ),

--- a/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.ts
@@ -1,9 +1,9 @@
+import { DirectConnectionConfig } from "@src/config/models.js";
 import {
   BaseToolHandler,
   ToolCategory,
 } from "@src/confluent/tools/base-tools.js";
 import { hasTableflow } from "@src/confluent/tools/connection-predicates.js";
-import { ServerRuntime } from "@src/server-runtime.js";
 
 /**
  * Base for all Tableflow handlers. Requires only a tableflow auth block.
@@ -24,11 +24,10 @@ export abstract class TableflowToolHandler extends BaseToolHandler {
    * preferring explicit tool arguments over connection config fallbacks.
    */
   protected resolveTableflowEnvAndClusterId(
-    runtime: ServerRuntime,
+    conn: DirectConnectionConfig,
     envIdArg: string | undefined,
     clusterIdArg: string | undefined,
   ): { environment_id: string; kafka_cluster_id: string } {
-    const conn = runtime.config.getSoleDirectConnection();
     return {
       environment_id: this.resolveParam(
         envIdArg,

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.test.ts
@@ -1,7 +1,7 @@
 import { CreateTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -115,7 +115,7 @@ describe("create-tableflow-topic-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.test.ts
@@ -91,6 +91,7 @@ describe("create-tableflow-topic-handler.ts", () => {
           mockResponse: { error: { message: "conflict" } },
           outcome: {
             resolves: "Failed to create Tableflow topic for  my-topic",
+            isError: true,
           },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
@@ -70,12 +70,15 @@ export class CreateTableFlowTopicHandler extends TableflowToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { environmentId, clusterId, tableflowTopicConfig } =
       createTableflowTopicArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.test.ts
@@ -1,7 +1,7 @@
 import { DeleteTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -99,7 +99,7 @@ describe("delete-tableflow-topic-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
@@ -27,12 +27,15 @@ export class DeleteTableFlowTopicHandler extends TableflowToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { display_name, environmentId, clusterId } =
       deleteTableflowTopicArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.test.ts
@@ -67,7 +67,10 @@ describe("list-tableflow-topics-handler.ts", () => {
           connectionConfig: TABLEFLOW_CONN,
           args: {},
           mockResponse: { error: { message: "unauthorized" } },
-          outcome: { resolves: "Failed to list Tableflow topics" },
+          outcome: {
+            resolves: "Failed to list Tableflow topics",
+            isError: true,
+          },
           expectedEnvId: "env-from-config",
           expectedClusterId: "lkc-from-config",
         },

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.test.ts
@@ -1,7 +1,7 @@
 import { ListTableFlowTopicsHandler } from "@src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -91,7 +91,7 @@ describe("list-tableflow-topics-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
@@ -38,12 +38,15 @@ export class ListTableFlowTopicsHandler extends TableflowToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { clusterId, environmentId } =
       listTableFlowTopicArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.test.ts
@@ -1,7 +1,7 @@
 import { ReadTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
   TABLEFLOW_CONN,
   TableflowHandleCase,
 } from "@tests/factories/runtime.js";
@@ -97,7 +97,7 @@ describe("read-tableflow-topic-handler.ts", () => {
           }
           await assertHandleCase({
             handler,
-            runtime: runtimeWith(
+            runtime: runtimeWithDecoy(
               connectionConfig,
               DEFAULT_CONNECTION_ID,
               clientManager,

--- a/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
@@ -27,12 +27,15 @@ export class ReadTableFlowTopicHandler extends TableflowToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { display_name, environmentId, clusterId } =
       readTableflowTopicArguments.parse(toolArguments);
 
+    const { conn, clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const { environment_id, kafka_cluster_id } =
-      this.resolveTableflowEnvAndClusterId(runtime, environmentId, clusterId);
+      this.resolveTableflowEnvAndClusterId(conn, environmentId, clusterId);
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),

--- a/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.test.ts
@@ -1,7 +1,8 @@
 import { UpdateTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
+  TABLEFLOW_CONN,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -49,7 +50,11 @@ describe("update-tableflow-topic-handler.ts", () => {
           );
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: UPDATE_ARGS,
           outcome: { resolves: `Tableflow Topic ${TOPIC_NAME} updated` },
           clientManager,
@@ -64,7 +69,11 @@ describe("update-tableflow-topic-handler.ts", () => {
           .PATCH.mockResolvedValue({ error: { message: "not found" } } as any);
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: UPDATE_ARGS,
           outcome: {
             resolves: `Failed to update Tableflow topic for  ${TOPIC_NAME}`,
@@ -83,7 +92,11 @@ describe("update-tableflow-topic-handler.ts", () => {
         );
         await assertHandleCase({
           handler,
-          runtime: runtimeWith({}, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            TABLEFLOW_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: UPDATE_ARGS,
           outcome: { resolves: `Tableflow Topic ${TOPIC_NAME} updated` },
           clientManager,

--- a/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
@@ -71,9 +71,13 @@ export class UpdateTableFlowTopicHandler extends TableflowToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown> | undefined,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { display_name, tableflowTopicConfig } =
       updateTableflowTopicArguments.parse(toolArguments);
+
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudTableflowRestClient(),


### PR DESCRIPTION
## Tableflow handlers honor an explicit `connectionId`

The eleven Tableflow handlers (regions, five topic tools, five catalog tools) previously grabbed the eager singular `runtime.clientManager`, and the eight that resolve `environmentId`/`clusterId` did so through `TableflowToolHandler.resolveTableflowEnvAndClusterId(runtime, …)` — which reached for `getSoleDirectConnection()` internally. Each now resolves once through `resolveDirectConnection(runtime, toolArguments)`. Tableflow is OAuth-disabled (it needs the direct service block), so the direct-narrowing resolver is the right one.

The enabling refactor mirrors the Flink wave (#567): the base-class helper now takes the already-resolved `DirectConnectionConfig` rather than the whole runtime, reading `conn.kafka?.env_id` / `conn.kafka?.cluster_id` directly. The eight helper-using handlers feed it the `conn` from their single resolve; the three that need only the client manager (regions and the two update handlers) destructure just `clientManager`.

## environments and metrics honor an explicit `connectionId`

- **environments → `resolveConnection`.** `list-environments` and `read-environment` are OAuth-enabled (`hasConfluentCloudOrOAuth`) and need only the client manager, so they take the type-neutral resolver, swapping their inline `runtime.clientManager`.
- **metrics → `resolveDirectConnection`.** `list-metrics` and `query-metrics` are gated on `hasTelemetry`, which excludes OAuth, so they take the direct resolver. `query-metrics` additionally read `getSoleDirectConnection().kafka?.cluster_id`; that now comes from the resolved `conn`.

## Routing coverage, and the unit tests environments never had

The Tableflow and metrics suites already drove `handle()` through the shared harness, so routing rides along by swapping `runtimeWith` for `runtimeWithDecoy` (whole-suite for the Tableflow suites; only the `assertHandleCase` runtimes for the two metrics suites, which also make direct `handle()` calls). Against the un-ported handlers the decoy runtime makes every converted case throw "ServerRuntime has multiple client managers" — the red that flips green once resolution routes by id.

`environments` had **no `handle()` unit tests at all** — only integration tests. This wave adds them for both handlers, built on `runtimeWithDecoy` so they are routing tests from birth: each asserts the handler routes to the addressed connection and never touches the decoy's client manager, alongside the usual success / API-error / validation-error / `ZodError` cases.

## Two test-honesty fixes the port surfaced

Both are the same shape as the query-profiler finding in #567: a `handle()` test that under-specified its connection and got away with it only because the old singular getter never consulted the predicate.

- The three client-manager-only Tableflow tests (regions + the two updates) built their runtime from an **empty** `{}` connection config. Routing-aware resolution checks `hasTableflow`, so an empty connection is no longer a valid route; they now use the `TABLEFLOW_CONN` fixture that actually carries the tableflow block.
- The `TableflowToolHandler` base-class test was updated for the new `resolveTableflowEnvAndClusterId(conn, …)` signature — passing its already-`DirectConnectionConfig` fixtures straight in instead of wrapping them in a runtime.

## Remaining sole-accessor call sites

`handle()` across all three domains is free of the retired accessors. The surviving `getSoleDirectConnection()` calls in the Tableflow integration harness are the same test-side usage left untouched elsewhere, slated for #554's repo-wide sweep.

## Relationships

- Closes #568.
- Child of #564 (port all handlers off the sole-connection accessors), itself a child of #532 (Epic: Multi-connection support).
- Builds on #551 (`resolveConnection()` / `resolveDirectConnection()`).
- Peer of #539 (Kafka), #541 (Connect + Billing), and #567 (Flink + clusters + organizations), whose `runtimeWithDecoy` harness and resolver-selection rationale this PR reuses.
