### PR TITLE
Port the catalog + schema + search handlers to routing-aware connection resolution

### DIFF
--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.test.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.test.ts
@@ -1,0 +1,76 @@
+import { AddTagToTopicHandler } from "@src/confluent/tools/handlers/catalog/add-tags-to-topic.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+const VALID_ARGS = {
+  tagAssignments: [{ entityName: "lsrc:lkc:orders", typeName: "PII" }],
+};
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("add-tags-to-topic.ts", () => {
+  describe("AddTagToTopicHandler", () => {
+    const handler = new AddTagToTopicHandler();
+
+    describe("handle()", () => {
+      it("should resolve with a success message when the tag is assigned", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .POST.mockResolvedValue({
+            data: [{ entityName: "lsrc:lkc:orders" }],
+          });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: { resolves: "Successfully assigned tag" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .POST.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: { resolves: "Failed to assign tag", isError: true },
+          clientManager,
+        });
+      });
+
+      it("should throw a ZodError when tagAssignments is absent", async () => {
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            getMockedClientManager(),
+          ),
+          args: {},
+          outcome: { throws: "ZodError" },
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
@@ -33,8 +33,11 @@ export class AddTagToTopicHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { tagAssignments } = addTagToTopicArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.test.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.test.ts
@@ -1,0 +1,72 @@
+import { CreateTopicTagsHandler } from "@src/confluent/tools/handlers/catalog/create-topic-tags.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+const VALID_ARGS = { tags: [{ tagName: "PII" }] };
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("create-topic-tags.ts", () => {
+  describe("CreateTopicTagsHandler", () => {
+    const handler = new CreateTopicTagsHandler();
+
+    describe("handle()", () => {
+      it("should resolve with a success message when the tag is created", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .POST.mockResolvedValue({ data: [{ name: "PII" }] });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: { resolves: "Successfully created tag" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .POST.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: { resolves: "Failed to create tag", isError: true },
+          clientManager,
+        });
+      });
+
+      it("should throw a ZodError when tags is absent", async () => {
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            getMockedClientManager(),
+          ),
+          args: {},
+          outcome: { throws: "ZodError" },
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.ts
@@ -31,8 +31,11 @@ export class CreateTopicTagsHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { tags } = createTagsArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),

--- a/src/confluent/tools/handlers/catalog/delete-tag.test.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.test.ts
@@ -1,0 +1,70 @@
+import { DeleteTagHandler } from "@src/confluent/tools/handlers/catalog/delete-tag.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("delete-tag.ts", () => {
+  describe("DeleteTagHandler", () => {
+    const handler = new DeleteTagHandler();
+
+    describe("handle()", () => {
+      it("should resolve with a success message naming the deleted tag", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .DELETE.mockResolvedValue({ response: { status: 204 } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { tagName: "PII" },
+          outcome: { resolves: "Successfully deleted tag: PII" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .DELETE.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { tagName: "PII" },
+          outcome: { resolves: "Failed to delete tag", isError: true },
+          clientManager,
+        });
+      });
+
+      it("should throw a ZodError when tagName is absent", async () => {
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            getMockedClientManager(),
+          ),
+          args: {},
+          outcome: { throws: "ZodError" },
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/delete-tag.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.ts
@@ -20,8 +20,11 @@ export class DeleteTagHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { tagName } = deleteTagArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),

--- a/src/confluent/tools/handlers/catalog/list-tags.test.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.test.ts
@@ -1,0 +1,57 @@
+import { ListTagsHandler } from "@src/confluent/tools/handlers/catalog/list-tags.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("list-tags.ts", () => {
+  describe("ListTagsHandler", () => {
+    const handler = new ListTagsHandler();
+
+    describe("handle()", () => {
+      it("should resolve with the tag definitions on success", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .GET.mockResolvedValue({ data: [{ name: "PII" }] });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: { resolves: "Successfully retrieved tags" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .GET.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: { resolves: "Failed to list tags", isError: true },
+          clientManager,
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/list-tags.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.ts
@@ -11,8 +11,14 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class ListTagsHandler extends BaseToolHandler {
-  async handle(runtime: ServerRuntime): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
+  async handle(
+    runtime: ServerRuntime,
+    toolArguments: Record<string, unknown> | undefined,
+  ): Promise<CallToolResult> {
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),
     );

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.test.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.test.ts
@@ -1,0 +1,75 @@
+import { RemoveTagFromEntityHandler } from "@src/confluent/tools/handlers/catalog/remove-tag-from-entity.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+const VALID_ARGS = { tagName: "PII", qualifiedName: "lsrc:lkc:orders" };
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("remove-tag-from-entity.ts", () => {
+  describe("RemoveTagFromEntityHandler", () => {
+    const handler = new RemoveTagFromEntityHandler();
+
+    describe("handle()", () => {
+      it("should resolve with a success message naming the removed tag and entity", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .DELETE.mockResolvedValue({ response: { status: 204 } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: { resolves: "Successfully removed tag PII" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .DELETE.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: VALID_ARGS,
+          outcome: {
+            resolves: "Failed to remove tag from entity",
+            isError: true,
+          },
+          clientManager,
+        });
+      });
+
+      it("should throw a ZodError when qualifiedName is absent", async () => {
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            getMockedClientManager(),
+          ),
+          args: { tagName: "PII" },
+          outcome: { throws: "ZodError" },
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
@@ -34,9 +34,12 @@ export class RemoveTagFromEntityHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { tagName, typeName, qualifiedName } =
       removeTagFromEntityArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
 
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.test.ts
@@ -1,7 +1,7 @@
 import { DeleteSchemaHandler } from "@src/confluent/tools/handlers/schema/delete-schema-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -30,7 +30,11 @@ describe("delete-schema-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subject: "my-subject" },
           outcome: { resolves: 'Successfully deleted subject "my-subject"' },
           clientManager,
@@ -58,7 +62,11 @@ describe("delete-schema-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subject: "my-subject", version: "3" },
           outcome: {
             resolves: 'Successfully deleted version 3 of subject "my-subject"',
@@ -88,7 +96,11 @@ describe("delete-schema-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subject: "my-subject", version: "latest" },
           outcome: { resolves: "Successfully deleted version latest" },
           clientManager,
@@ -115,7 +127,11 @@ describe("delete-schema-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subject: "my-subject", permanent: true },
           outcome: { resolves: 'Successfully deleted subject "my-subject"' },
           clientManager,
@@ -142,7 +158,11 @@ describe("delete-schema-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subject: "my-subject", environment_id: "env-42" },
           outcome: { resolves: "Successfully deleted" },
           clientManager,
@@ -164,7 +184,11 @@ describe("delete-schema-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subject: "missing" },
           outcome: {
             resolves: 'Failed to delete subject "missing"',

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.ts
@@ -40,7 +40,7 @@ export class DeleteSchemaHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const { clientManager } = this.resolveSoleConnection(runtime);
+    const { clientManager } = this.resolveConnection(runtime, toolArguments);
     const { subject, version, permanent, environment_id } =
       deleteSchemaArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -2,7 +2,7 @@ import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
 import {
   DEFAULT_CONNECTION_ID,
-  runtimeWith,
+  runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
@@ -41,7 +41,11 @@ describe("list-schemas-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: {},
           outcome: { resolves: '"subject-a":{"version":1,"id":10' },
           clientManager,
@@ -67,7 +71,11 @@ describe("list-schemas-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { subjectPrefix: "order-" },
           outcome: { resolves: '"order-events"' },
           clientManager,
@@ -85,7 +93,11 @@ describe("list-schemas-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: { environment_id: "env-42" },
           outcome: { resolves: "{}" },
           clientManager,
@@ -101,7 +113,11 @@ describe("list-schemas-handler.ts", () => {
 
         await assertHandleCase({
           handler,
-          runtime: runtimeWith(SR_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
           args: {},
           outcome: {
             resolves: "Failed to list schemas: registry unreachable",

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -40,7 +40,7 @@ export class ListSchemasHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const { clientManager } = this.resolveSoleConnection(runtime);
+    const { clientManager } = this.resolveConnection(runtime, toolArguments);
     const { latestOnly, subjectPrefix, deleted, environment_id } =
       listSchemasArguments.parse(toolArguments);
 

--- a/src/confluent/tools/handlers/search/search-topic-by-tag-handler.test.ts
+++ b/src/confluent/tools/handlers/search/search-topic-by-tag-handler.test.ts
@@ -1,0 +1,64 @@
+import { SearchTopicsByTagHandler } from "@src/confluent/tools/handlers/search/search-topic-by-tag-handler.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("search-topic-by-tag-handler.ts", () => {
+  describe("SearchTopicsByTagHandler", () => {
+    const handler = new SearchTopicsByTagHandler();
+
+    describe("handle()", () => {
+      it("should resolve with the serialized search response on success", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .GET.mockResolvedValue({
+            data: {
+              entities: [{ attributes: { qualifiedName: "lsrc:lkc:orders" } }],
+            },
+          });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { topicTag: "PII" },
+          outcome: { resolves: "lsrc:lkc:orders" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .GET.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { topicTag: "PII" },
+          outcome: {
+            resolves: "Failed to search for topics by tag",
+            isError: true,
+          },
+          clientManager,
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
@@ -29,9 +29,12 @@ export class SearchTopicsByTagHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { topicTag, limit, offset } =
       searchTopicsByTagArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),
     );

--- a/src/confluent/tools/handlers/search/search-topics-by-name-handler.test.ts
+++ b/src/confluent/tools/handlers/search/search-topics-by-name-handler.test.ts
@@ -1,0 +1,77 @@
+import { SearchTopicsByNameHandler } from "@src/confluent/tools/handlers/search/search-topics-by-name-handler.js";
+import {
+  CATALOG_CONN,
+  DEFAULT_CONNECTION_ID,
+  runtimeWithDecoy,
+} from "@tests/factories/runtime.js";
+import {
+  assertHandleCase,
+  getMockedClientManager,
+} from "@tests/stubs/index.js";
+import { describe, it } from "vitest";
+
+// Each case runs against runtimeWithDecoy, so assertHandleCase routes to the
+// real connection and asserts the decoy's client manager stays untouched.
+describe("search-topics-by-name-handler.ts", () => {
+  describe("SearchTopicsByNameHandler", () => {
+    const handler = new SearchTopicsByNameHandler();
+
+    describe("handle()", () => {
+      it("should resolve with matching qualified names on success", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .GET.mockResolvedValue({
+            data: {
+              entities: [{ attributes: { qualifiedName: "lsrc:lkc:orders" } }],
+            },
+          });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { topicName: "orders" },
+          outcome: { resolves: "lsrc:lkc:orders" },
+          clientManager,
+        });
+      });
+
+      it("should resolve with an error response when the API returns an error", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudSchemaRegistryRestClient()
+          .GET.mockResolvedValue({ error: { message: "boom" } });
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { topicName: "orders" },
+          outcome: {
+            resolves: "Failed to search for topics by name",
+            isError: true,
+          },
+          clientManager,
+        });
+      });
+
+      it("should throw a ZodError when topicName is absent", async () => {
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CATALOG_CONN,
+            DEFAULT_CONNECTION_ID,
+            getMockedClientManager(),
+          ),
+          args: {},
+          outcome: { throws: "ZodError" },
+        });
+      });
+    });
+  });
+});

--- a/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
@@ -20,8 +20,11 @@ export class SearchTopicsByNameHandler extends BaseToolHandler {
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
   ): Promise<CallToolResult> {
-    const clientManager = runtime.clientManager;
     const { topicName } = searchTopicsByNameArguments.parse(toolArguments);
+    const { clientManager } = this.resolveDirectConnection(
+      runtime,
+      toolArguments,
+    );
     const pathBasedClient = wrapAsPathBasedClient(
       clientManager.getConfluentCloudSchemaRegistryRestClient(),
     );

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -146,6 +146,20 @@ export const CCLOUD_CONN = {
   },
 };
 
+/**
+ * Catalog/search connection fixture. `hasCCloudCatalogSupport` enables a
+ * connection only when it carries a `confluent_cloud` block and a
+ * `schema_registry` block with api_key auth — so a bare schema-registry
+ * connection is not a valid route for these tools.
+ */
+export const CATALOG_CONN = {
+  ...CCLOUD_CONN,
+  schema_registry: {
+    endpoint: "https://sr.example.com",
+    auth: { type: "api_key" as const, key: "k", secret: "s" },
+  },
+};
+
 /** Shared Flink connection config fixture for handle() tests. */
 export const FLINK_CONN = {
   flink: {


### PR DESCRIPTION
# Port the catalog + schema + search handlers to routing-aware connection resolution

This is the final handler-porting wave under #564: with it, every tool's `handle()` resolves its connection through the routing-aware accessors, leaving the sole-connection scaffolding with zero `handle()` call sites for #554 to delete.

## catalog and search handlers honor an explicit `connectionId`

The five catalog (tag) handlers and the two search handlers previously grabbed the eager singular `runtime.clientManager`. Each now resolves through `resolveDirectConnection(runtime, toolArguments)`. They're gated on `hasCCloudCatalogSupport` (which requires a direct `schema_registry` block with api_key auth plus a `confluent_cloud` block) and so are OAuth-disabled — the direct-narrowing resolver is the right one, and none of them need anything off the connection beyond the client manager.

`list-tags` was the one handler whose `handle()` took no `toolArguments` parameter at all (it has no input schema); it gains the standard `(runtime, toolArguments)` signature so it can pass the arguments to the resolver.

## schema handlers honor an explicit `connectionId`

`list-schemas` and `delete-schema` already resolved through `resolveSoleConnection(runtime)`; they swap to `resolveConnection(runtime, toolArguments)`. Schema Registry tools are OAuth-enabled (`hasSchemaRegistryOrOAuth`), so the type-neutral resolver is correct.

## The unit tests catalog and search never had

`schema` already had `handle()` unit tests, so routing rides along by swapping their `runtimeWith` for `runtimeWithDecoy`.

`catalog` had only integration tests and `search` had no tests at all. This wave adds seven `handle()` unit suites — one per tag and search handler — built on `runtimeWithDecoy` so they are routing tests from birth: each asserts the handler routes to the addressed connection and never touches the decoy's client manager, alongside success, API-error, and (where the schema has a required field) `ZodError` cases.

A shared `CATALOG_CONN` fixture joins the factory set: `hasCCloudCatalogSupport` enables a connection only with both a `confluent_cloud` block and a `schema_registry` block carrying api_key auth, so these suites need a connection that actually clears that bar — a plain schema-registry connection would not be a valid route.

## Remaining sole-accessor call sites

`handle()` across catalog, schema, and search is free of the retired accessors. `resolveSoleConnection` still appears on `list-clusters` (handled by the peer #567) and in `base-tools.test.ts` (the method's own test); both clear once their respective waves land and #554 deletes the accessors.

## Relationships

- Closes #569.
- Child of #564 (port all handlers off the sole-connection accessors), itself a child of #532 (Epic: Multi-connection support); this is the last of #564's porting waves.
- Builds on #551 (`resolveConnection()` / `resolveDirectConnection()`).
- Peer of #539 (Kafka), #541 (Connect + Billing), #567 (Flink + clusters + organizations), and #568 (Tableflow + environments + metrics), whose `runtimeWithDecoy` harness and resolver-selection rationale this PR reuses.
