### PR TITLE
[npm publish]: fix script

### DIFF
--- a/.semaphore/publish-npm.yml
+++ b/.semaphore/publish-npm.yml
@@ -33,7 +33,7 @@ blocks:
                 echo "Aborting: $RELEASE_NAME is a prerelease (isPrerelease=$IS_PRERELEASE); this task only publishes stable releases to the 'latest' tag."
                 exit 1
               fi
-            - echo "Confirmed: publishing $RELEASE_NAME to npm."
+            - 'echo "Confirmed: publishing $RELEASE_NAME to npm."'
 
   - name: "Publish to npm"
     dependencies: ["Confirm Publish"]


### PR DESCRIPTION
## Summary of Changes




Pipeline failed with:
```
Unprocessable YAML file.
Error: [{"Type mismatch. Expected String but got Object.", "#/blocks/0/task/jobs/0/commands/2"}]
```





Claude's diagnosis:

> The error points to blocks[0].task.jobs[0].commands[2], which is line 36:

> - echo "Confirmed: publishing $RELEASE_NAME to npm."

 > The problem: this is an unquoted (plain) YAML scalar that contains a colon-followed-by-space (Confirmed: publishing). YAML treats :  as a
  key/value separator, so the parser reads echo "Confirmed as a key and publishing ... as a value — turning what should be a string command
  into a mapping (Object). Hence "Expected String but got Object."

>  Commands[0] and [1] don't hit this because they're inside | literal blocks, where :  is taken literally.

 > The fix: quote the whole command so it's an explicit string.
### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `npm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

