### PR TITLE
[semaphore]: fix npm-publish 

### DIFF
--- a/.semaphore/publish-npm.yml
+++ b/.semaphore/publish-npm.yml
@@ -44,7 +44,7 @@ blocks:
             - . vault-setup --version v3 --role mcp-confluent
             # Download the .tgz asset from the existing GitHub Release
             - gh release download "$RELEASE_NAME" --pattern "*.tgz" --dir release-assets/
-            - TGZ_FILE=$(find release-assets/ -name "*.tgz" | head -1)
+            - TGZ_FILE=$(find ./release-assets/ -name "*.tgz" | head -1)
             - |
               if [ -z "$TGZ_FILE" ]; then
                 echo "Error: no .tgz asset found on GitHub Release $RELEASE_NAME"

--- a/.semaphore/publish-npm.yml
+++ b/.semaphore/publish-npm.yml
@@ -54,5 +54,4 @@ blocks:
             - . vault-get-secret --vault-role=mcp-confluent --secret-key=NPM_TOKEN --export-as=NPM_TOKEN mcpconfluent/npm
             - npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
             # Get TOTP code and publish (keep these adjacent to stay within the 30s TOTP window)
-            - OTP=$(vault-get-totp npm-publishing --vault-role mcp-confluent)
             - npm publish "$TGZ_FILE" --otp="$OTP"

--- a/.semaphore/publish-npm.yml
+++ b/.semaphore/publish-npm.yml
@@ -41,6 +41,7 @@ blocks:
       jobs:
         - name: "Publish to npm"
           commands:
+            - . vault-setup --version v3 --role mcp-confluent
             # Download the .tgz asset from the existing GitHub Release
             - gh release download "$RELEASE_NAME" --pattern "*.tgz" --dir release-assets/
             - TGZ_FILE=$(find release-assets/ -name "*.tgz" | head -1)

--- a/.semaphore/publish-npm.yml
+++ b/.semaphore/publish-npm.yml
@@ -20,6 +20,7 @@ blocks:
       jobs:
         - name: "Confirm Publish"
           commands:
+            - . vault-setup --version v3 --role mcp-confluent
             - |
               if [ "$CONFIRM_PUBLISH" != "yes" ]; then
                 echo "Aborting: set CONFIRM_PUBLISH=yes to publish $RELEASE_NAME to npm (got '$CONFIRM_PUBLISH')."

--- a/.semaphore/publish-npm.yml
+++ b/.semaphore/publish-npm.yml
@@ -12,7 +12,6 @@ global_job_config:
     commands:
       - sem-version node 22
       - checkout
-      - . vault-setup --version v3 --role mcp-confluent
 
 blocks:
   - name: "Confirm Publish"


### PR DESCRIPTION
`remove OTP=$(vault-get-totp npm-publishing --vault-role mcp-confluent)` was causing a failure, and all we needed was the granular access token to be run on each npm block. 

also added a leading slash that was missing. 