### PR TITLE
 Make the four Kafka direct-call suites uniform with the rest of the corpus

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -378,16 +378,22 @@ object. **Do not reach for `vi.mock`** - if a new dependency seems to require it
 A handler that resolves its connection via `resolveConnection(runtime, toolArguments)` (or `resolveDirectConnection`) must route to the caller-addressed `connectionId`, not unconditionally to `enabledConnectionIds[0]`.
 `runtimeWithDecoy` (in `tests/factories/runtime.ts`) is a drop-in replacement for `runtimeWith` that proves this: it plants a "decoy" connection — same service blocks, enabled for the same tools, its own auto-minted client manager — inserted _before_ the real one, so a handler that still grabs the first enabled connection lands on the decoy.
 `assertHandleCase` recognizes a decoy-bearing runtime (by the reserved `DECOY_CONNECTION_ID`), auto-injects `connectionId` for the real connection when the caller omitted it, and asserts the decoy's client manager was never touched.
+It returns the resolved `CallToolResult` (`undefined` if the handler threw), so a case that pins an exact `structuredContent` shape or an exact/regex `textOf` — beyond the `resolves` substring — can capture the return and assert after the harness call.
 
-There are two ways to get this coverage, and which one a suite uses depends on how its `handle()` tests are already written:
+To get routing coverage, run a suite's `handle()` cases through `assertHandleCase` with a `runtimeWithDecoy` runtime.
+That turns every case into a routing test — no `connectionId` in the args (the harness injects it), and no bespoke routing test body.
+The `it.each` suites need the edit only in the loop's runtime expression; the per-`it()` suites build each case's runtime with `runtimeWithDecoy`.
+The consumer-group and offsets suites (`list-consumer-groups`, `describe-consumer-group`, `get-consumer-group-lag`, `get-partition-offsets`) follow this shape — their behaviour cases all run through the harness, capturing the returned result for the shape/`textOf` assertions the substring check can't express.
 
-- **Suites whose `handle()` tests run through `assertHandleCase`** (the `it.each` suites and the per-`it()` `assertHandleCase` suites): swap the suite's `runtimeWith` for `runtimeWithDecoy`.
-  That one-word change turns every existing success case into a routing test — no new test body, and no `connectionId` in the args (the harness injects it).
-  The `it.each` suites need the edit only in the loop's runtime expression; the per-`it()` suites swap each `handle()` runtime.
-- **Suites whose main `handle()` tests call `handler.handle(...)` directly** (not through the harness — e.g. the consumer-group / offsets suites that need bespoke `mockResolvedValueOnce` sequencing): the auto-route and auto-assert fire only inside `assertHandleCase`, so a direct call sees no decoy handling.
-  Add one dedicated routing test that calls `assertHandleCase` with a `runtimeWithDecoy` runtime, alongside the suite's direct-call tests.
+A few case kinds legitimately stay as direct `handler.handle(...)` calls rather than routing through the harness, because the harness's outcome assertions can't express what they pin:
 
-A reverted handler (one that goes back to `resolveSoleConnection()`) trips the decoy's untouched assertion on every converted case, so the coverage is not vacuous.
+- **Thrown-error field shape.** A case asserting `code` / `errno` / `origin` on a thrown librdkafka error via `.rejects.toMatchObject({ ... })` — the harness's `{ throws }` matcher only sees the message (via `classifyThrown`), so it can't pin those fields.
+- **Zod-boundary rejections.** A case pinning `issues[].path` / `issues[].code` on a `ZodError` — `classifyThrown` collapses every `ZodError` to the string `"ZodError"`, so `{ throws: "ZodError" }` would discard the field-path specificity.
+  These also throw before connection resolution, so they exercise no routing worth covering.
+
+Such cases don't carry decoy coverage; the suite's other (harness-routed) cases provide it.
+
+A reverted handler (one that goes back to `resolveSoleConnection()`) trips the decoy's untouched assertion on every routed case, so the coverage is not vacuous.
 
 ## Test Server & Runtime Fixtures
 

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.test.ts
@@ -14,12 +14,12 @@ import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
 import {
   DEFAULT_CONNECTION_ID,
-  kafkaRuntime,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
 } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
@@ -154,30 +154,16 @@ describe("describe-consumer-group-handler.ts", () => {
   describe("handle()", () => {
     const handler = new DescribeConsumerGroupHandler();
 
-    it("should route only to its resolved connection in a multi-connection config", async () => {
-      const clientManager = getMockedClientManager();
-      const admin = await clientManager.getAdminClient();
-      admin.describeGroups.mockResolvedValue({
-        groups: [fakeGroupDescription({ groupId: "my-group" })],
-      });
-
-      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
-      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
-      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
-      // the provided args for handle(), then asserts the decoy's manager went
-      // untouched — so `args` deliberately omits connectionId here.
-      await assertHandleCase({
-        handler,
-        runtime: runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        ),
-        args: { groupId: "my-group" },
-        outcome: { resolves: 'Consumer group "my-group" is' },
+    // Every case runs through assertHandleCase against a decoy runtime: the
+    // harness injects connectionId for the real connection and asserts the
+    // decoy's manager stays untouched, so routing is exercised on every
+    // behaviour path rather than in a single bespoke test.
+    const decoyRuntime = (clientManager: MockedClientManager) =>
+      runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
         clientManager,
-      });
-    });
+      );
 
     it("should forward the single groupId as a one-element array to describeGroups", async () => {
       const clientManager = getMockedClientManager();
@@ -186,8 +172,12 @@ describe("describe-consumer-group-handler.ts", () => {
         groups: [fakeGroupDescription({ groupId: "my-group" })],
       });
 
-      await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "my-group",
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "my-group" },
+        outcome: { resolves: 'Consumer group "my-group" is' },
+        clientManager,
       });
 
       expect(admin.describeGroups).toHaveBeenCalledOnce();
@@ -236,12 +226,19 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "orders-consumer",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "orders-consumer" },
+        outcome: {
+          resolves:
+            'Consumer group "orders-consumer" is Stable with 2 member(s)',
+          isError: false,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         groupId: "orders-consumer",
         state: "Stable",
         type: "Consumer",
@@ -270,7 +267,7 @@ describe("describe-consumer-group-handler.ts", () => {
           },
         ],
       });
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "orders-consumer" is Stable with 2 member(s); coordinator b7.example.com:9092.',
       );
     });
@@ -288,15 +285,21 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "orphan",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "orphan" },
+        outcome: {
+          resolves: 'Consumer group "orphan" is Empty with 0 member(s)',
+          isError: false,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
       expect(
-        (result.structuredContent as { members: unknown[] }).members,
+        (result!.structuredContent as { members: unknown[] }).members,
       ).toEqual([]);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "orphan" is Empty with 0 member(s); coordinator broker.example.com:9092.',
       );
     });
@@ -306,12 +309,18 @@ describe("describe-consumer-group-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.describeGroups.mockRejectedValue(fakeNotFoundError());
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "no-such-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "no-such-group" },
+        outcome: {
+          resolves: 'Consumer group "no-such-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "no-such-group" not found on this cluster.',
       );
     });
@@ -328,12 +337,18 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "no-such-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "no-such-group" },
+        outcome: {
+          resolves: 'Consumer group "no-such-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "no-such-group" not found on this cluster.',
       );
     });
@@ -358,12 +373,18 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "alive-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "alive-group" },
+        outcome: {
+          resolves: 'Consumer group "alive-group" is Stable',
+          isError: false,
+        },
+        clientManager,
       });
 
-      expect(result.isError, textOf(result)).not.toBe(true);
-      expect(result.structuredContent).toMatchObject({
+      expect(result!.structuredContent).toMatchObject({
         groupId: "alive-group",
         state: "Stable",
       });
@@ -392,12 +413,18 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "no-such-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "no-such-group" },
+        outcome: {
+          resolves: 'Consumer group "no-such-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "no-such-group" not found on this cluster.',
       );
     });
@@ -421,15 +448,17 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "rip-old-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "rip-old-group" },
+        outcome: { resolves: '"rip-old-group" is Dead', isError: false },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect((result.structuredContent as { state: string }).state).toBe(
+      expect((result!.structuredContent as { state: string }).state).toBe(
         "Dead",
       );
-      expect(textOf(result)).toContain('"rip-old-group" is Dead');
     });
 
     it("should translate a GroupDescription.error with any other code into a tool-level error citing the broker message verbatim", async () => {
@@ -447,12 +476,18 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: {
+          resolves: "Broker: Group authorization failed",
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe("Broker: Group authorization failed");
+      expect(textOf(result!)).toBe("Broker: Group authorization failed");
     });
 
     it("should let a non-not-found describeGroups rejection propagate without try/catch swallow", async () => {
@@ -460,9 +495,12 @@ describe("describe-consumer-group-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.describeGroups.mockRejectedValue(new Error("network unreachable"));
 
-      await expect(
-        handler.handle(kafkaRuntime(clientManager), { groupId: "g" }),
-      ).rejects.toThrow("network unreachable");
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { throws: "network unreachable" },
+      });
     });
 
     it("should include groupInstanceId per member only when the upstream payload sets it (static membership)", async () => {
@@ -488,12 +526,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "mixed-membership",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "mixed-membership" },
+        outcome: { resolves: 'Consumer group "mixed-membership" is' },
+        clientManager,
       });
 
       const members = (
-        result.structuredContent as {
+        result!.structuredContent as {
           members: Array<Record<string, unknown>>;
         }
       ).members;
@@ -528,12 +570,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "fanout",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "fanout" },
+        outcome: { resolves: 'Consumer group "fanout" is' },
+        clientManager,
       });
 
       const members = (
-        result.structuredContent as {
+        result!.structuredContent as {
           members: Array<{ assignment: Array<{ topic: string }> }>;
         }
       ).members;
@@ -570,12 +616,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is' },
+        clientManager,
       });
 
       const assignment = (
-        result.structuredContent as {
+        result!.structuredContent as {
           members: Array<{ assignment: Array<Record<string, unknown>> }>;
         }
       ).members[0]!.assignment;
@@ -614,12 +664,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is' },
+        clientManager,
       });
 
       const member = (
-        result.structuredContent as {
+        result!.structuredContent as {
           members: Array<{
             assignment: Array<{ topic: string; partition: number }>;
           }>;
@@ -653,13 +707,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is', isError: false },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
       const member = (
-        result.structuredContent as {
+        result!.structuredContent as {
           members: Array<{ assignment: unknown[] }>;
         }
       ).members[0]!;
@@ -678,12 +735,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is' },
+        clientManager,
       });
 
       const member = (
-        result.structuredContent as {
+        result!.structuredContent as {
           members: Array<Record<string, unknown>>;
         }
       ).members[0]!;
@@ -702,12 +763,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is' },
+        clientManager,
       });
 
       expect(
-        (result.structuredContent as { coordinator: Record<string, unknown> })
+        (result!.structuredContent as { coordinator: Record<string, unknown> })
           .coordinator,
       ).toEqual({
         id: 0,
@@ -728,12 +793,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is' },
+        clientManager,
       });
 
       const coordinator = (
-        result.structuredContent as { coordinator: Record<string, unknown> }
+        result!.structuredContent as { coordinator: Record<string, unknown> }
       ).coordinator;
       expect("rack" in coordinator).toBe(false);
     });
@@ -749,12 +818,16 @@ describe("describe-consumer-group-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g" },
+        outcome: { resolves: 'Consumer group "g" is' },
+        clientManager,
       });
 
       expect(
-        (result.structuredContent as { partitionAssignor: string })
+        (result!.structuredContent as { partitionAssignor: string })
           .partitionAssignor,
       ).toBe("cooperative-sticky");
     });
@@ -764,12 +837,18 @@ describe("describe-consumer-group-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.describeGroups.mockResolvedValue({ groups: [] });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "no-such-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "no-such-group" },
+        outcome: {
+          resolves: 'Consumer group "no-such-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "no-such-group" not found on this cluster.',
       );
     });

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
 } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
@@ -209,36 +210,19 @@ describe("get-consumer-group-lag-handler.ts", () => {
   describe("handle()", () => {
     const handler = new GetConsumerGroupLagHandler();
 
-    it("should route only to its resolved connection in a multi-connection config", async () => {
-      const clientManager = getMockedClientManager();
-      const admin = await clientManager.getAdminClient();
-      admin.fetchOffsets.mockResolvedValue([
-        {
-          topic: "orders",
-          partitions: [fakeFetchedPartition({ partition: 0, offset: "80" })],
-        },
-      ]);
-      admin.fetchTopicOffsets.mockResolvedValue([
-        fakeWatermark({ partition: 0, low: "0", high: "100" }),
-      ]);
-
-      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
-      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
-      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
-      // the provided args for handle(), then asserts the decoy's manager went
-      // untouched — so `args` deliberately omits connectionId here.
-      await assertHandleCase({
-        handler,
-        runtime: runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        ),
-        args: { groupId: "g1" },
-        outcome: { resolves: 'Consumer group "g1" has' },
+    // Connection-reaching behaviour cases run through assertHandleCase against a
+    // decoy runtime: the harness injects connectionId for the real connection and
+    // asserts the decoy's manager stays untouched, so routing is exercised on
+    // every such path. (The three throw-shape cases below pin librdkafka
+    // code/errno/origin on the thrown error via .rejects.toMatchObject, which the
+    // harness's message-only throws matcher can't express, so they stay as direct
+    // handle() calls.)
+    const decoyRuntime = (clientManager: MockedClientManager) =>
+      runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
         clientManager,
-      });
-    });
+      );
 
     it("should forward groupId verbatim to admin.fetchOffsets and not pass a topics field when the filter is omitted", async () => {
       const clientManager = getMockedClientManager();
@@ -250,7 +234,13 @@ describe("get-consumer-group-lag-handler.ts", () => {
         groups: [fakeRealGroup("g1")],
       });
 
-      await handler.handle(kafkaRuntime(clientManager), { groupId: "g1" });
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
+      });
 
       expect(admin.fetchOffsets).toHaveBeenCalledOnce();
       expect(admin.fetchOffsets).toHaveBeenCalledWith({ groupId: "g1" });
@@ -275,9 +265,12 @@ describe("get-consumer-group-lag-handler.ts", () => {
         })),
       }));
 
-      await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["orders", "shipments"],
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["orders", "shipments"] },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
       expect(admin.fetchOffsets).toHaveBeenCalledOnce();
@@ -304,12 +297,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 1, low: "0", high: "200" }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has', isError: false },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         groupId: "g1",
         topics: [
           {
@@ -361,12 +357,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         throw new Error(`unexpected topic ${topic}`);
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has', isError: false },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       expect(payload.totalLag).toBe(25);
       expect(payload.topics.map((t) => t.topic)).toEqual([
         "orders",
@@ -391,11 +390,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 1, low: "0", high: "999" }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       expect(payload.topics[0]!.partitions[1]).toEqual({
         partition: 1,
         committedOffset: null,
@@ -436,12 +439,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 0, low: "0", high: "100" }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has', isError: false },
+        clientManager,
       });
 
-      expect(result.isError, textOf(result)).not.toBe(true);
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       expect(payload.topics[0]!.partitions[0]).toEqual({
         partition: 0,
         committedOffset: "80",
@@ -487,11 +493,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 1, high: "200" }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       const partitions = payload.topics[0]!.partitions;
       expect(partitions[1]).toEqual({
         partition: 1,
@@ -522,11 +532,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 0, low: "0", high: "100" }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       expect(payload.topics[0]!.partitions[0]!.lag).toBe(-5);
       // Negative lag IS included in totalLag — clamping to zero would
       // hide the rebalance-race state the diagnostic is there to expose.
@@ -553,12 +567,16 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 0, high: "100" }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
       const partition = (
-        result.structuredContent as GetConsumerGroupLagResponse
+        result!.structuredContent as GetConsumerGroupLagResponse
       ).topics[0]!.partitions[0]!;
       expect(partition.metadata).toBe("checkpoint-A");
       expect(partition.leaderEpoch).toBe(7);
@@ -587,7 +605,13 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 2, high: "100" }),
       ]);
 
-      await handler.handle(kafkaRuntime(clientManager), { groupId: "g1" });
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
+      });
 
       expect(admin.fetchTopicOffsets).toHaveBeenCalledOnce();
       expect(admin.fetchTopicOffsets).toHaveBeenCalledWith("orders");
@@ -598,12 +622,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.fetchOffsets.mockRejectedValue(fakeNotFoundError());
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "ghost-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "ghost-group" },
+        outcome: {
+          resolves: 'Consumer group "ghost-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "ghost-group" not found on this cluster.',
       );
     });
@@ -637,12 +667,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         groups: [fakeRealGroup("g1")],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has', isError: false },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         groupId: "g1",
         topics: [],
         totalLag: 0,
@@ -667,12 +700,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         groups: [fakeUnknownGroupTombstone("ghost-group")],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "ghost-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "ghost-group" },
+        outcome: {
+          resolves: 'Consumer group "ghost-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "ghost-group" not found on this cluster.',
       );
     });
@@ -683,12 +722,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
       admin.fetchOffsets.mockResolvedValue([]);
       admin.describeGroups.mockRejectedValue(fakeNotFoundError());
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "ghost-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "ghost-group" },
+        outcome: {
+          resolves: 'Consumer group "ghost-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "ghost-group" not found on this cluster.',
       );
     });
@@ -706,12 +751,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "ghost-group",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "ghost-group" },
+        outcome: {
+          resolves: 'Consumer group "ghost-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "ghost-group" not found on this cluster.',
       );
     });
@@ -731,7 +782,13 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 0, high: "30" }),
       ]);
 
-      await handler.handle(kafkaRuntime(clientManager), { groupId: "g1" });
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
+      });
 
       expect(admin.describeGroups).not.toHaveBeenCalled();
     });
@@ -748,13 +805,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         groups: [fakeUnknownGroupTombstone("ghost-group")],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "ghost-group",
-        topics: ["does-not-exist"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "ghost-group", topics: ["does-not-exist"] },
+        outcome: {
+          resolves: 'Consumer group "ghost-group" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Consumer group "ghost-group" not found on this cluster.',
       );
       // The topic-existence path (via the watermark cache) never fires
@@ -846,11 +908,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         fakeWatermark({ partition: 1, low: "0", high: maxSafe }),
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       // Per-partition lag stays precise (each is in-range).
       expect(payload.topics[0]!.partitions[0]!.lag).toBe(
         Number.MAX_SAFE_INTEGER,
@@ -889,12 +955,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         topics: [{ name: "shipments", partitions: [] }],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["orders", "shipments"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["orders", "shipments"] },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       const shipments = payload.topics.find((t) => t.topic === "shipments");
       expect(shipments).toEqual({ topic: "shipments", partitions: [] });
       // The orders topic still has its lag computed.
@@ -923,13 +992,15 @@ describe("get-consumer-group-lag-handler.ts", () => {
         { name: "shipments", partitions: [] },
       ] as unknown as Awaited<ReturnType<typeof admin.fetchTopicMetadata>>);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["shipments"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["shipments"] },
+        outcome: { resolves: 'Consumer group "g1" has', isError: false },
+        clientManager,
       });
 
-      expect(result.isError, textOf(result)).not.toBe(true);
-      const payload = result.structuredContent as GetConsumerGroupLagResponse;
+      const payload = result!.structuredContent as GetConsumerGroupLagResponse;
       expect(payload.topics).toEqual([{ topic: "shipments", partitions: [] }]);
     });
 
@@ -952,9 +1023,12 @@ describe("get-consumer-group-lag-handler.ts", () => {
         ],
       });
 
-      await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["alpha", "bravo", "charlie"],
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["alpha", "bravo", "charlie"] },
+        outcome: { resolves: 'Consumer group "g1" has' },
+        clientManager,
       });
 
       expect(admin.fetchTopicMetadata).toHaveBeenCalledOnce();
@@ -982,13 +1056,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["alpha", "bravo"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["alpha", "bravo"] },
+        outcome: {
+          resolves: "Topic not found in [alpha, bravo] on this cluster.",
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         "Topic not found in [alpha, bravo] on this cluster.",
       );
       // The simplification deletes the per-topic-probe fallback path:
@@ -1020,12 +1099,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: {
+          resolves: 'Topic "deleted-since-commit" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Topic "deleted-since-commit" not found on this cluster.',
       );
     });
@@ -1048,13 +1133,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["does-not-exist"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["does-not-exist"] },
+        outcome: {
+          resolves: 'Topic "does-not-exist" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Topic "does-not-exist" not found on this cluster.',
       );
     });
@@ -1077,13 +1167,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["mystery-topic"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["mystery-topic"] },
+        outcome: {
+          resolves: 'Topic "mystery-topic" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Topic "mystery-topic" not found on this cluster.',
       );
     });
@@ -1102,13 +1197,18 @@ describe("get-consumer-group-lag-handler.ts", () => {
       });
       admin.fetchTopicMetadata.mockResolvedValue({ topics: [] });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
-        topics: ["silently-omitted-topic"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1", topics: ["silently-omitted-topic"] },
+        outcome: {
+          resolves: 'Topic "silently-omitted-topic" not found on this cluster.',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toBe(
+      expect(textOf(result!)).toBe(
         'Topic "silently-omitted-topic" not found on this cluster.',
       );
     });
@@ -1133,13 +1233,16 @@ describe("get-consumer-group-lag-handler.ts", () => {
         return [fakeWatermark({ partition: 0, high: "5" })];
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        groupId: "g1",
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { groupId: "g1" },
+        outcome: {
+          resolves:
+            'Consumer group "g1" has 25 message(s) of lag across 2 topic(s).',
+        },
+        clientManager,
       });
-
-      expect(textOf(result)).toContain(
-        'Consumer group "g1" has 25 message(s) of lag across 2 topic(s).',
-      );
     });
   });
 });

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
 } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 
@@ -33,30 +34,17 @@ describe("get-partition-offsets-handler.ts", () => {
   describe("handle()", () => {
     const handler = new GetPartitionOffsetsHandler();
 
-    it("should route only to its resolved connection in a multi-connection config", async () => {
-      const clientManager = getMockedClientManager();
-      const admin = await clientManager.getAdminClient();
-      admin.fetchTopicOffsets.mockResolvedValue([
-        { partition: 0, low: "0", high: "100", offset: "100" },
-      ]);
-
-      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
-      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
-      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
-      // the provided args for handle(), then asserts the decoy's manager went
-      // untouched — so `args` deliberately omits connectionId here.
-      await assertHandleCase({
-        handler,
-        runtime: runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        ),
-        args: { topicName: "orders" },
-        outcome: { resolves: 'Partition offsets for "orders"' },
+    // Connection-reaching behaviour cases run through assertHandleCase against a
+    // decoy runtime: the harness injects connectionId for the real connection and
+    // asserts the decoy's manager stays untouched, so routing is exercised on
+    // every such path. (The Zod-boundary cases below throw before connection
+    // resolution, so they stay as direct handle() calls — see their note.)
+    const decoyRuntime = (clientManager: MockedClientManager) =>
+      runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
         clientManager,
-      });
-    });
+      );
 
     it("should return a structured payload with low/highWatermark as strings and computed messageCount for every partition", async () => {
       const clientManager = getMockedClientManager();
@@ -67,15 +55,20 @@ describe("get-partition-offsets-handler.ts", () => {
         { partition: 2, low: "0", high: "0", offset: "0" },
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "orders",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "orders" },
+        outcome: {
+          resolves: 'Partition offsets for "orders" (3 partition(s))',
+          isError: false,
+        },
+        clientManager,
       });
 
       expect(admin.fetchTopicOffsets).toHaveBeenCalledOnce();
       expect(admin.fetchTopicOffsets).toHaveBeenCalledWith("orders");
-
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         topicName: "orders",
         partitions: [
           {
@@ -98,9 +91,6 @@ describe("get-partition-offsets-handler.ts", () => {
           },
         ],
       });
-      expect(textOf(result)).toContain(
-        'Partition offsets for "orders" (3 partition(s))',
-      );
     });
 
     it("should restrict the response to a single partition when the `partition` arg is supplied", async () => {
@@ -112,13 +102,18 @@ describe("get-partition-offsets-handler.ts", () => {
         { partition: 2, low: "10", high: "20", offset: "20" },
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "orders",
-        partition: 1,
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "orders", partition: 1 },
+        outcome: {
+          resolves: 'Partition offsets for "orders" (1 partition(s))',
+          isError: false,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         topicName: "orders",
         partitions: [
           {
@@ -129,9 +124,6 @@ describe("get-partition-offsets-handler.ts", () => {
           },
         ],
       });
-      expect(textOf(result)).toContain(
-        'Partition offsets for "orders" (1 partition(s))',
-      );
     });
 
     it("should return messageCount: 0 for an empty partition (low === high) without any special-case branch", async () => {
@@ -141,12 +133,18 @@ describe("get-partition-offsets-handler.ts", () => {
         { partition: 0, low: "42", high: "42", offset: "42" },
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "empty-topic",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "empty-topic" },
+        outcome: {
+          resolves: 'Partition offsets for "empty-topic"',
+          isError: false,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         topicName: "empty-topic",
         partitions: [
           {
@@ -174,12 +172,18 @@ describe("get-partition-offsets-handler.ts", () => {
         },
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "bigint-topic",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "bigint-topic" },
+        outcome: {
+          resolves: 'Partition offsets for "bigint-topic"',
+          isError: false,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         topicName: "bigint-topic",
         partitions: [
           {
@@ -197,14 +201,16 @@ describe("get-partition-offsets-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.fetchTopicOffsets.mockResolvedValue([]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "no-such-topic",
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "no-such-topic" },
+        outcome: {
+          resolves: 'Topic "no-such-topic" not found on this cluster',
+          isError: true,
+        },
+        clientManager,
       });
-
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain(
-        'Topic "no-such-topic" not found on this cluster',
-      );
     });
 
     it("should surface a clean 'topic not found' error for a KafkaJSError carrying ERR_UNKNOWN_TOPIC_OR_PART (broker-issued unknown-topic code)", async () => {
@@ -216,17 +222,20 @@ describe("get-partition-offsets-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "no-such-topic",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "no-such-topic" },
+        outcome: {
+          resolves: 'Topic "no-such-topic" not found on this cluster',
+          isError: true,
+        },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain(
-        'Topic "no-such-topic" not found on this cluster',
-      );
       // The friendly path replaces the librdkafka text entirely; the broker
       // wording must not leak through as the headline.
-      expect(textOf(result)).not.toContain(
+      expect(textOf(result!)).not.toContain(
         "Broker: Unknown topic or partition",
       );
     });
@@ -245,14 +254,16 @@ describe("get-partition-offsets-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "no-such-topic",
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "no-such-topic" },
+        outcome: {
+          resolves: 'Topic "no-such-topic" not found on this cluster',
+          isError: true,
+        },
+        clientManager,
       });
-
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain(
-        'Topic "no-such-topic" not found on this cluster',
-      );
     });
 
     it("should surface the real Kafka error (NOT 'topic not found') when fetchTopicOffsets rejects with a connection/auth/timeout failure", async () => {
@@ -270,13 +281,15 @@ describe("get-partition-offsets-handler.ts", () => {
         }),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "orders",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "orders" },
+        outcome: { resolves: "broker unreachable: ETIMEDOUT", isError: true },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain("broker unreachable: ETIMEDOUT");
-      expect(textOf(result)).not.toContain("not found on this cluster");
+      expect(textOf(result!)).not.toContain("not found on this cluster");
     });
 
     it("should surface the underlying message (NOT 'topic not found') when fetchTopicOffsets rejects with a non-Kafka error shape", async () => {
@@ -291,13 +304,15 @@ describe("get-partition-offsets-handler.ts", () => {
         new Error("unexpected library failure"),
       );
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "orders",
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "orders" },
+        outcome: { resolves: "unexpected library failure", isError: true },
+        clientManager,
       });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain("unexpected library failure");
-      expect(textOf(result)).not.toContain("not found on this cluster");
+      expect(textOf(result!)).not.toContain("not found on this cluster");
     });
 
     it("should surface a clean out-of-range error citing the actual partition span when a `partition` arg is past the topic's range", async () => {
@@ -309,15 +324,17 @@ describe("get-partition-offsets-handler.ts", () => {
         { partition: 2, low: "0", high: "30", offset: "30" },
       ]);
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        topicName: "orders",
-        partition: 5,
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { topicName: "orders", partition: 5 },
+        outcome: {
+          resolves:
+            'Topic "orders" has 3 partition(s) (0..2); requested partition 5 is out of range',
+          isError: true,
+        },
+        clientManager,
       });
-
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain(
-        'Topic "orders" has 3 partition(s) (0..2); requested partition 5 is out of range',
-      );
     });
 
     it("should reject a missing topicName at the Zod boundary", async () => {

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.test.ts
@@ -9,12 +9,12 @@ import { textOf } from "@tests/call-tool-result.js";
 import { fakeLibrdKafkaError } from "@tests/factories/librdkafka.js";
 import {
   DEFAULT_CONNECTION_ID,
-  kafkaRuntime,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,
   getMockedClientManager,
+  type MockedClientManager,
 } from "@tests/stubs/index.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
@@ -96,42 +96,33 @@ describe("list-consumer-groups-handler.ts", () => {
   describe("handle()", () => {
     const handler = new ListConsumerGroupsHandler();
 
-    it("should route only to its resolved connection in a multi-connection config", async () => {
-      const clientManager = getMockedClientManager();
-      const admin = await clientManager.getAdminClient();
-      admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
-
-      // runtimeWithDecoy gives a two-connection runtime (the DEFAULT_CONNECTION_ID
-      // real connection + a decoy keyed DECOY_CONNECTION_ID). assertHandleCase
-      // detects the decoy and injects `connectionId: DEFAULT_CONNECTION_ID` into
-      // the provided args for handle(), then asserts the decoy's manager went
-      // untouched — so `args` deliberately omits connectionId here.
-      await assertHandleCase({
-        handler,
-        runtime: runtimeWithDecoy(
-          { kafka: { bootstrap_servers: "broker:9092" } },
-          DEFAULT_CONNECTION_ID,
-          clientManager,
-        ),
-        args: {},
-        outcome: { resolves: "Found 0 consumer groups." },
+    // Every case runs through assertHandleCase against a decoy runtime: the
+    // harness injects connectionId for the real connection and asserts the
+    // decoy's manager stays untouched, so routing is exercised on every
+    // behaviour path rather than in a single bespoke test.
+    const decoyRuntime = (clientManager: MockedClientManager) =>
+      runtimeWithDecoy(
+        { kafka: { bootstrap_servers: "broker:9092" } },
+        DEFAULT_CONNECTION_ID,
         clientManager,
-      });
-    });
+      );
 
     it("should return an empty structured payload and 'Found 0 consumer groups.' when listGroups returns nothing", async () => {
       const clientManager = getMockedClientManager();
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {});
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        outcome: { resolves: "Found 0 consumer groups.", isError: false },
+        clientManager,
+      });
 
       expect(admin.listGroups).toHaveBeenCalledOnce();
       expect(admin.listGroups).toHaveBeenCalledWith({});
-
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({ groups: [], errors: [] });
-      expect(textOf(result)).toBe("Found 0 consumer groups.");
+      expect(result!.structuredContent).toEqual({ groups: [], errors: [] });
+      expect(textOf(result!)).toBe("Found 0 consumer groups.");
     });
 
     it("should map numeric librdkafka state/type enums to TitleCase strings on the response", async () => {
@@ -164,7 +155,12 @@ describe("list-consumer-groups-handler.ts", () => {
         errors: [],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {});
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        outcome: { resolves: "Found 3 consumer groups:", isError: false },
+        clientManager,
+      });
 
       const expectedPayload = {
         groups: [
@@ -192,12 +188,11 @@ describe("list-consumer-groups-handler.ts", () => {
         ],
         errors: [],
       };
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual(expectedPayload);
-      expect(textOf(result)).toBe(
+      expect(result!.structuredContent).toEqual(expectedPayload);
+      expect(textOf(result!)).toBe(
         `Found 3 consumer groups:\n${JSON.stringify(expectedPayload, null, 2)}`,
       );
-      expect(textOf(result)).toContain('"groupId": "live"');
+      expect(textOf(result!)).toContain('"groupId": "live"');
     });
 
     it("should forward matchStates to listGroups as the corresponding numeric enum values", async () => {
@@ -205,8 +200,12 @@ describe("list-consumer-groups-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
 
-      await handler.handle(kafkaRuntime(clientManager), {
-        matchStates: ["Stable", "Empty"],
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { matchStates: ["Stable", "Empty"] },
+        outcome: { resolves: "consumer groups" },
+        clientManager,
       });
 
       expect(admin.listGroups).toHaveBeenCalledOnce();
@@ -223,8 +222,12 @@ describe("list-consumer-groups-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
 
-      await handler.handle(kafkaRuntime(clientManager), {
-        matchType: "Consumer",
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { matchType: "Consumer" },
+        outcome: { resolves: "consumer groups" },
+        clientManager,
       });
 
       expect(admin.listGroups).toHaveBeenCalledOnce();
@@ -238,9 +241,12 @@ describe("list-consumer-groups-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockResolvedValue({ groups: [], errors: [] });
 
-      await handler.handle(kafkaRuntime(clientManager), {
-        matchStates: ["Stable"],
-        matchType: "Classic",
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { matchStates: ["Stable"], matchType: "Classic" },
+        outcome: { resolves: "consumer groups" },
+        clientManager,
       });
 
       expect(admin.listGroups).toHaveBeenCalledOnce();
@@ -258,11 +264,15 @@ describe("list-consumer-groups-handler.ts", () => {
         errors: [],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {
-        matchStates: ["Stable"],
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        args: { matchStates: ["Stable"] },
+        outcome: { resolves: "Found 2 consumer groups (filtered):" },
+        clientManager,
       });
 
-      expect(textOf(result)).toMatch(
+      expect(textOf(result!)).toMatch(
         /^Found 2 consumer groups \(filtered\):\n/,
       );
     });
@@ -278,10 +288,14 @@ describe("list-consumer-groups-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {});
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        outcome: { resolves: "Found 1 consumer group:", isError: false },
+        clientManager,
+      });
 
-      expect(result.isError).toBe(false);
-      expect(result.structuredContent).toEqual({
+      expect(result!.structuredContent).toEqual({
         groups: [
           {
             groupId: "g1",
@@ -309,10 +323,14 @@ describe("list-consumer-groups-handler.ts", () => {
         ],
       });
 
-      const result = await handler.handle(kafkaRuntime(clientManager), {});
+      const result = await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        outcome: { resolves: "all brokers down", isError: true },
+        clientManager,
+      });
 
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain("all brokers down");
+      expect(textOf(result!)).toContain("all brokers down");
     });
 
     it("should let listGroups rejections propagate without try/catch swallow", async () => {
@@ -320,9 +338,11 @@ describe("list-consumer-groups-handler.ts", () => {
       const admin = await clientManager.getAdminClient();
       admin.listGroups.mockRejectedValue(new Error("network unreachable"));
 
-      await expect(
-        handler.handle(kafkaRuntime(clientManager), {}),
-      ).rejects.toThrow("network unreachable");
+      await assertHandleCase({
+        handler,
+        runtime: decoyRuntime(clientManager),
+        outcome: { throws: "network unreachable" },
+      });
     });
   });
 });

--- a/tests/stubs/handler.ts
+++ b/tests/stubs/handler.ts
@@ -97,6 +97,10 @@ export function classifyThrown(label: string, thrown: unknown): string {
  *   before touching the client.
  * @param name - Label prepended to assertion failure messages and used in
  *   discovery-sentinel output. Defaults to `"(handler)"`.
+ * @returns The resolved {@link CallToolResult} when the handler resolved, or
+ *   `undefined` when it threw — so callers needing to pin exact
+ *   `structuredContent` / `textOf` beyond the `resolves` substring can assert on
+ *   the result after the harness call.
  *
  * When the runtime carries a {@link DECOY_CONNECTION_ID} connection (built via
  * `runtimeWithDecoy`), this also routes the call to the real connection — by
@@ -115,7 +119,7 @@ export async function assertHandleCase(options: {
   outcome: HandleOutcome;
   clientManager?: MockedClientManager;
   name?: string;
-}): Promise<void> {
+}): Promise<CallToolResult | undefined> {
   const {
     handler,
     runtime,
@@ -262,4 +266,6 @@ export async function assertHandleCase(options: {
       `${name}: unexpected error — update outcome with actual`,
     ).toContain((outcome as Throws).throws);
   }
+
+  return result;
 }


### PR DESCRIPTION
## Uniform handler-test shape across the Kafka surface

Almost every handler `handle()` suite runs its cases through `assertHandleCase` against a `runtimeWithDecoy` runtime. Four Kafka suites were the holdouts — `list-consumer-groups`, `describe-consumer-group`, `get-consumer-group-lag`, `get-partition-offsets` — driving `handle()` directly in their behaviour tests and bolting on a single bespoke routing test each. This PR routes their behaviour cases through the harness too, so the four now read like every other suite and the four bespoke routing tests are deleted. A reader moving between the Kafka, Flink, and Tableflow suites sees one idiom instead of two.

A few cases stay as direct `handle()` calls, because the harness's outcome matchers can't express what they pin — and these are the same principled exceptions any suite would carry:

- `get-consumer-group-lag` keeps three cases that assert `code` / `errno` / `origin` on a thrown librdkafka error via `.rejects.toMatchObject`; the harness's `{ throws }` matcher only sees the message.
- `get-partition-offsets` keeps three Zod-boundary cases that pin `issues[].path` / `issues[].code`; `classifyThrown` collapses every `ZodError` to `"ZodError"`, and these throw before connection resolution anyway.

## Routing coverage improves as a side benefit

Each suite previously proved routing in exactly one test while its other behaviour cases asserted nothing about which connection was hit. Now every routed case asserts the decoy connection's client manager stayed untouched, so a handler that routed to the wrong connection on any path fails — not just on the one bespoke test. The tripwire proves it isn't vacuous: reverting `ListConsumerGroupsHandler` to grab the first enabled connection turns 9 converted cases red on the decoy-untouched assertion.

## `assertHandleCase` hands back the result

`assertHandleCase` now returns the resolved `CallToolResult` (`undefined` if the handler threw), so the converted cases that pin an exact `structuredContent` shape or an exact/regex `textOf` capture the return and assert after the harness call — the `resolves` substring alone is too coarse for these suites. Existing callers that ignore the return are unaffected.

The routing section of `.claude/rules/unit-tests.md` is updated to match: the harness is the one way to get routing coverage, the consumer-group/offsets suites are no longer the direct-call exemplar, and the two case kinds that stay direct are spelled out.

## Relationships

Closes #565. Member of under epic #532.