### PR TITLE
Remove the single-connection guard and allow multiple connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this MCP server will be documented in this file.
 - **Per-connection `description` field.** Optional free-text label on any connection, echoed back by `list-configured-connections`.
 - **Per-connection `read_only` flag.** Set `read_only: true` on a connection to auto-disable every state-mutating tool for it, leaving only read-only tools enabled.
 
+### Changed
+
+- **A YAML config may now define multiple connections — or none.** Point a single `config.yaml` at several clusters at once — for example a local Apache Kafka broker alongside Confluent Cloud — or run with no connection at all (documentation search and server-diagnostic tools still work). At most one of those connections may use OAuth to Confluent Cloud.
+
 ## 1.4.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this MCP server will be documented in this file.
 
 ### Changed
 
-- **Configuration**: _A YAML config may now define multiple connections — or none._ Point a single `config.yaml` at several clusters at once — for example a local Apache Kafka broker alongside Confluent Cloud — or run with no connection at all (documentation search and server-diagnostic tools still work). At most one of those connections may use OAuth to Confluent Cloud.
+- **Configuration**: _A YAML config may now define multiple connections — or none._ Point a single `config.yaml` at several clusters at once — for example a local Apache Kafka broker alongside Confluent Cloud — or run with no connection at all (documentation search and server-diagnostic tools still work). At most one of those connections may use OAuth to Confluent Cloud. See [CONFIGURATION.md → Multiple connections (and zero connections)](CONFIGURATION.md#multiple-connections-and-zero-connections).
 
 #### Added
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -363,11 +363,11 @@ To migrate, run `--init-config`, then translate each variable you currently set 
 For a side-by-side, every `${VAR:-...}` placeholder in `config.example.yaml` names the env var that field used to come from.
 You can keep secrets in your existing `.env` and reference them via `${VAR}` from the YAML — that is job 1 above, and is the recommended migration target.
 
-## Future plans
+## Multiple connections
 
-The configuration schema accepts multiple named entries under `connections:` and the YAML parser validates them, but today the server expects exactly one.
-Once the rest of the runtime catches up, a single `config.yaml` will be able to point at several Confluent Cloud or local clusters at the same time; you will not need to restructure existing configs for that to work.
-This capability will be YAML-only — the legacy env-var path has no way to express it.
+A single `config.yaml` may define several named entries under `connections:` — for example a Confluent Cloud connection alongside a local Apache Kafka broker — and each tool call routes to the connection you address.
+A config may also define no connections at all; the connection-independent tools (documentation search and the server-diagnostic tools) stay available regardless.
+This capability is YAML-only — the legacy env-var path can express only a single connection.
 
 ## Troubleshooting
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,13 +8,13 @@ It covers the YAML config file (`-c config.yaml`), the legacy env-var path (`-e 
 - [Two paths, one configuration](#two-paths-one-configuration)
 - [Quick start (YAML)](#quick-start-yaml)
 - [Anatomy of a YAML config](#anatomy-of-a-yaml-config)
+- [Multiple connections (and zero connections)](#multiple-connections-and-zero-connections)
 - [`${VAR}` interpolation](#var-interpolation)
 - [How env vars and `.env` files fit into the YAML world](#how-env-vars-and-env-files-fit-into-the-yaml-world)
 - [Authentication modes](#authentication-modes)
 - [HTTP/SSE transport security](#httpsse-transport-security)
 - [Tool enablement: which block lights up what](#tool-enablement-which-block-lights-up-what)
 - [Legacy env-var configuration (deprecated)](#legacy-env-var-configuration-deprecated)
-- [Future plans](#future-plans)
 - [Troubleshooting](#troubleshooting)
 
 ## Two paths, one configuration
@@ -54,7 +54,8 @@ The two flags are mutually exclusive.
 
 ## Anatomy of a YAML config
 
-A config picks one of two connection flavors — OAuth or direct — and optionally adds a top-level `server:` block for transport/security/logging settings.
+A config is a `connections:` map plus an optional top-level `server:` block for transport/security/logging settings.
+Each connection block is one of two types — OAuth or direct — taken in turn below; a single configuragion may hold several connections and mix their types (see [Multiple connections (and zero connections)](#multiple-connections-and-zero-connections)).
 The fully annotated reference is [`config.example.yaml`](config.example.yaml); per-field comments live there rather than being duplicated here.
 Compact examples for common local-Docker setups live in [`sample_configs/`](sample_configs/).
 
@@ -123,9 +124,9 @@ This is the recommended posture for handing an agent a staging or production con
 
 Field-level details, defaults, and which CLI/env-var each field replaces are in [`config.example.yaml`](config.example.yaml).
 
-### The common `server:` block
+### The top-level `server:` block
 
-Both connection flavors above accept the same top-level `server:` block.
+The top-level `server:` block sits beside `connections:` and applies to the whole config, regardless of which connection flavors you defined.
 It is entirely optional — omit it to accept the same defaults today's env-var users get.
 The fully annotated example is in [`config.example.yaml`](config.example.yaml); when present, it replaces these env vars:
 
@@ -144,6 +145,19 @@ The fully annotated example is in [`config.example.yaml`](config.example.yaml); 
 | `server.auth.disabled`             | `MCP_AUTH_DISABLED` / `--disable-auth`                                |
 
 `server.transports` and the `--transport` CLI flag are mutually exclusive — declare transports in YAML or on the command line, not both.
+
+## Multiple connections (and zero connections)
+
+A single `config.yaml` may define several named entries under `connections:` — for example a Confluent Cloud connection alongside a local Apache Kafka broker — and each tool call routes to the connection you address by id.
+There is no fixed ceiling on the number of connections.
+
+One rule constrains the mix: you may pair as many `type: direct` connections as you like, but **at most one** may be `type: oauth`.
+The shared Confluent Cloud sign-in owns a single browser session and identity, so a second OAuth connection is rejected at startup with `Multiple OAuth connections defined in configuration; only one is supported`.
+
+A config may also define **no connections at all**.
+The four connection-independent tools — `search-product-docs`, `get-product-doc-page`, `explain-disabled-tools`, and `list-configured-connections` — stay enabled regardless, so an empty config still gives you documentation search plus the server-diagnostic tools.
+
+This capability is YAML-only — the legacy env-var path can express only a single connection.
 
 ## `${VAR}` interpolation
 
@@ -225,6 +239,7 @@ connections:
 
 OAuth connections carry no service blocks.
 Resource IDs (cluster_id, environment_id, ...) that direct-mode connections pin in YAML instead flow in as tool arguments at call time.
+A server may define at most one OAuth connection, alongside any number of `type: direct` connections — see [Multiple connections (and zero connections)](#multiple-connections-and-zero-connections).
 Get a starter file via `--init-oauth-config`.
 
 **OAuth-eligible tools.** Not every tool has been migrated to OAuth yet — REST-only categories (Connect, Tableflow, Flink, Metrics, Catalog & Tags) still require `type: direct`.
@@ -339,7 +354,7 @@ Run the server without `-c` and these variables, read either from the parent she
 | FLINK_COMPUTE_POOL_ID         | Flink compute pool ID; must start with `lfcp-`.                                                                                                                                                                                 |                                         | For Flink tools                      |
 | FLINK_DATABASE_NAME           | Default Flink database, used as `sql.current-database`.                                                                                                                                                                         |                                         | No                                   |
 | FLINK_ENV_ID                  | Flink environment ID; must start with `env-`.                                                                                                                                                                                   |                                         | For Flink tools                      |
-| FLINK_ENV_NAME                | **Deprecated** (removed in v1.4.0). Use `FLINK_CATALOG_NAME` instead.                                                                                                                                                           |                                         | No                                   |
+| FLINK_ENV_NAME                | **Deprecated** alias, still accepted; rename to `FLINK_CATALOG_NAME` (removal tracked in [#598](https://github.com/confluentinc/mcp-confluent/issues/598)).                                                                     |                                         | No                                   |
 | FLINK_ORG_ID                  | Confluent Cloud organization ID.                                                                                                                                                                                                |                                         | For Flink tools                      |
 | FLINK_REST_ENDPOINT           | Base URL for Confluent Cloud's Flink REST API.                                                                                                                                                                                  |                                         | For Flink tools                      |
 | KAFKA_API_KEY                 | Kafka SASL username.                                                                                                                                                                                                            |                                         | For authenticated Kafka              |
@@ -362,12 +377,6 @@ Run the server without `-c` and these variables, read either from the parent she
 To migrate, run `--init-config`, then translate each variable you currently set into the matching block from [`config.example.yaml`](config.example.yaml).
 For a side-by-side, every `${VAR:-...}` placeholder in `config.example.yaml` names the env var that field used to come from.
 You can keep secrets in your existing `.env` and reference them via `${VAR}` from the YAML — that is job 1 above, and is the recommended migration target.
-
-## Multiple connections
-
-A single `config.yaml` may define several named entries under `connections:` — for example a Confluent Cloud connection alongside a local Apache Kafka broker — and each tool call routes to the connection you address.
-A config may also define no connections at all; the connection-independent tools (documentation search and the server-diagnostic tools) stay available regardless.
-This capability is YAML-only — the legacy env-var path can express only a single connection.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ The full configuration reference — YAML schema, every service block, env-var i
 
 > **Compatibility note.** This release ships full parity between YAML (`-c config.yaml`) and the legacy env-var path (`-e config.env`) for a single connection.
 > The env-var-only path will emit a startup warning in a near-future release and be removed a release or two later.
-> Multi-connection support (next release) will be YAML-only.
-> See [CONFIGURATION.md → Two paths, one configuration](CONFIGURATION.md#two-paths-one-configuration).
+> Defining multiple connections (or none) is YAML-only — the env-var path can express only a single connection.
+> See [CONFIGURATION.md → Two paths, one configuration](CONFIGURATION.md#two-paths-one-configuration) and [CONFIGURATION.md → Multiple connections (and zero connections)](CONFIGURATION.md#multiple-connections-and-zero-connections).
 
 ### Prerequisites & setup for Tableflow commands
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,9 +8,11 @@
 # rather than the YAML itself. Plain literal values are also fine when you do
 # not need interpolation.
 #
-# Each sub-block under `connections.<name>` is independently optional; remove
-# the ones you do not need. At least one of `kafka`, `schema_registry`,
-# `confluent_cloud`, `flink`, `tableflow`, or `telemetry` must remain.
+# Each service block under a `direct` connection (`kafka`, `schema_registry`,
+# `confluent_cloud`, `flink`, `tableflow`, `telemetry`) is independently
+# optional; remove the ones you do not need, but at least one must remain. An
+# `oauth` connection carries no service blocks — see the commented-out example
+# at the end of this file.
 
 # --- Server ---
 # MCP server transport, authentication, and logging settings.
@@ -64,10 +66,10 @@ server:
     # disabled: true
 
 connections:
-  # Connection name is freeform. Today exactly one connection is read at
-  # runtime; multi-connection support is the focus of the next release, and
-  # this plural structure is here so that landing it does not require any
-  # schema changes on your side.
+  # Connection name is freeform. A config may define several named connections
+  # and route each tool call to one by id — and may mix api-key (`direct`)
+  # connections with at most one browser-login (`oauth`) connection. See the
+  # commented-out OAuth connection at the end of this file.
   default:
     type: direct
 
@@ -160,3 +162,17 @@ connections:
     #     type: api_key
     #     key: "${TELEMETRY_API_KEY}"
     #     secret: "${TELEMETRY_API_SECRET}"
+
+  # --- OAuth connection (browser login instead of API keys) ---
+  # A config may pair any number of `direct` connections like the one above with
+  # at most one `oauth` connection. Uncomment to add one: on the first tool call
+  # needing Confluent Cloud access, the server opens the CCloud sign-in page
+  # (PKCE) and reuses that session for the rest of the process — no API keys to
+  # provision. OAuth connections carry no service blocks; resource IDs
+  # (cluster_id, environment_id, ...) are passed as tool arguments at call time.
+  # Not every tool is OAuth-eligible yet (see CONFIGURATION.md → Authentication
+  # modes). For an OAuth-only starter, run `--init-oauth-config` instead.
+  # ccloud:
+  #   type: oauth
+  #   description: "Confluent Cloud (OAuth login)"
+  #   # read_only: true

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -450,7 +450,7 @@ function buildFlinkBlock(env: Environment): {
  * `logger.warn` when only the legacy var is set so the deprecation lands in
  * server logs at startup.
  *
- * TODO: Remove FLINK_ENV_NAME support in v1.4.0. See issue #209.
+ * TODO: Remove FLINK_ENV_NAME support. See issue #598.
  */
 function resolveFlinkCatalogName(env: Environment): string | undefined {
   if (env.FLINK_CATALOG_NAME && env.FLINK_ENV_NAME) {
@@ -461,7 +461,7 @@ function resolveFlinkCatalogName(env: Environment): string | undefined {
   if (env.FLINK_CATALOG_NAME) return env.FLINK_CATALOG_NAME;
   if (env.FLINK_ENV_NAME) {
     logger.warn(
-      "FLINK_ENV_NAME is deprecated and will be removed in v1.4.0; rename to FLINK_CATALOG_NAME.",
+      "FLINK_ENV_NAME is deprecated (removal tracked in issue #598); rename to FLINK_CATALOG_NAME.",
     );
     return env.FLINK_ENV_NAME;
   }

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -212,19 +212,16 @@ describe("config/index.ts", () => {
       );
     });
 
-    it("should throw error when connections map is empty", () => {
+    it("should accept an empty connections map", () => {
       const yamlContent = `connections: {}
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /Configuration validation failed/,
-      );
-      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /Exactly one connection must be defined/,
-      );
+      const config = parseYamlConfiguration(yamlContent, {});
+
+      expect(config.getConnectionNames()).toEqual([]);
     });
 
-    it("should throw error when connections map has more than one entry", () => {
+    it("should accept more than one connection", () => {
       const yamlContent = `connections:
   local:
     type: "direct"
@@ -236,12 +233,18 @@ describe("config/index.ts", () => {
       bootstrap_servers: "staging:9092"
 `;
 
-      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /Configuration validation failed/,
+      const config = parseYamlConfiguration(yamlContent, {});
+
+      expect(config.getConnectionNames()).toEqual(["local", "staging"]);
+      const local = config.getConnectionConfig("local");
+      const staging = config.getConnectionConfig("staging");
+      // Each connection keeps its own blocks — they don't collapse into one.
+      expect(local.type === "direct" && local.kafka?.bootstrap_servers).toBe(
+        "localhost:9092",
       );
-      expect(() => parseYamlConfiguration(yamlContent, {})).toThrow(
-        /Exactly one connection must be defined/,
-      );
+      expect(
+        staging.type === "direct" && staging.kafka?.bootstrap_servers,
+      ).toBe("staging:9092");
     });
 
     it("should throw error when connection name is whitespace-only", () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -668,15 +668,10 @@ export const DEFAULT_SERVER_CONFIG = serverConfigSchema.parse({});
 
 export const mcpConfigSchema = z
   .object({
-    connections: z
-      .record(
-        z.string().trim().min(1, "Connection name cannot be empty"),
-        connectionConfigSchema,
-      )
-      .refine(
-        enforceSingleConnectionOnly,
-        "Exactly one connection must be defined (multiple connections not yet supported)",
-      ),
+    connections: z.record(
+      z.string().trim().min(1, "Connection name cannot be empty"),
+      connectionConfigSchema,
+    ),
     server: serverConfigSchema.default(() => DEFAULT_SERVER_CONFIG),
   })
   .strict();
@@ -689,11 +684,4 @@ export function formatZodIssues(issues: z.ZodError["issues"]): string {
       return path ? `  - ${path}: ${issue.message}` : `  - ${issue.message}`;
     })
     .join("\n");
-}
-
-// Temporary guard: remove when multi-connection support (#151) lands.
-function enforceSingleConnectionOnly(
-  connections: Record<string, unknown>,
-): boolean {
-  return Object.keys(connections).length === 1;
 }

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -513,6 +513,45 @@ describe("base-tools.ts", () => {
       });
     });
 
+    describe("resolvedTargetConnectionId()", () => {
+      const KAFKA = { kafka: { bootstrap_servers: "b:9092" } };
+
+      it("should return undefined for a connection-independent tool", () => {
+        const handler = new StubHandler({ enabled: true }); // predicate = alwaysEnabled
+        expect(
+          handler.resolvedTargetConnectionId(ccloudOAuthRuntime(), {}),
+        ).toBeUndefined();
+      });
+
+      it("should return the sole enabled connection id when connectionId is omitted", () => {
+        const handler = new StubHandler({ predicate: hasKafka });
+        const runtime = runtimeWithConnections({ a: KAFKA, b: {} });
+        expect(handler.resolvedTargetConnectionId(runtime, {})).toBe("a");
+      });
+
+      it("should return the explicitly requested connection id", () => {
+        const handler = new StubHandler({ predicate: hasKafka });
+        const runtime = runtimeWithConnections({ a: KAFKA, b: KAFKA });
+        expect(
+          handler.resolvedTargetConnectionId(runtime, { connectionId: "b" }),
+        ).toBe("b");
+      });
+
+      it("should return undefined when the call is ambiguous (multiple enabled, connectionId omitted)", () => {
+        const handler = new StubHandler({ predicate: hasKafka });
+        const runtime = runtimeWithConnections({ a: KAFKA, b: KAFKA });
+        expect(handler.resolvedTargetConnectionId(runtime, {})).toBeUndefined();
+      });
+
+      it("should return undefined when the requested connectionId is not an enabled connection", () => {
+        const handler = new StubHandler({ predicate: hasKafka });
+        const runtime = runtimeWithConnections({ a: KAFKA, b: {} });
+        expect(
+          handler.resolvedTargetConnectionId(runtime, { connectionId: "b" }),
+        ).toBeUndefined();
+      });
+    });
+
     describe("resolveDirectConnection()", () => {
       const KAFKA = { kafka: { bootstrap_servers: "b:9092" } };
 

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -537,18 +537,22 @@ describe("base-tools.ts", () => {
         ).toBe("b");
       });
 
-      it("should return undefined when the call is ambiguous (multiple enabled, connectionId omitted)", () => {
+      it("should throw a Wacky routing error when the call is ambiguous (multiple enabled, connectionId omitted)", () => {
         const handler = new StubHandler({ predicate: hasKafka });
         const runtime = runtimeWithConnections({ a: KAFKA, b: KAFKA });
-        expect(handler.resolvedTargetConnectionId(runtime, {})).toBeUndefined();
+        expect(() => handler.resolvedTargetConnectionId(runtime, {})).toThrow(
+          "Wacky -- connectionId omitted but this tool is enabled for 2 connections (a, b); cannot auto-route",
+        );
       });
 
-      it("should return undefined when the requested connectionId is not an enabled connection", () => {
+      it("should throw a Wacky routing error when the requested connectionId is not an enabled connection", () => {
         const handler = new StubHandler({ predicate: hasKafka });
         const runtime = runtimeWithConnections({ a: KAFKA, b: {} });
-        expect(
+        expect(() =>
           handler.resolvedTargetConnectionId(runtime, { connectionId: "b" }),
-        ).toBeUndefined();
+        ).toThrow(
+          'Wacky -- connection "b" is not an enabled connection for this tool; enabled: a',
+        );
       });
     });
 

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -123,6 +123,12 @@ export interface ToolHandler {
    * `describe-tool-availability` diagnostic tool.
    */
   connectionVerdicts(runtime: ServerRuntime): Map<string, PredicateResult>;
+
+  /**
+   * Whether this tool is enabled irrespective of the configured connections.
+   * See {@linkcode BaseToolHandler.isConnectionIndependent}.
+   */
+  readonly isConnectionIndependent: boolean;
 }
 
 export interface ToolConfig {
@@ -178,10 +184,10 @@ export abstract class BaseToolHandler implements ToolHandler {
   getRegisteredToolConfig(runtime: ServerRuntime): ToolConfig {
     const config = this.getToolConfig();
 
-    // alwaysEnabled is an identity-checked sentinel, so bail before the
-    // per-connection scan below: connection-agnostic tools (docs, diagnostics)
-    // never route to a connection and so never need a connectionId parameter.
-    if (this.predicate === alwaysEnabled) return config;
+    // Connection-independent tools (docs, diagnostics) never route to a
+    // connection and so never need a connectionId parameter; bail before the
+    // per-connection scan below.
+    if (this.isConnectionIndependent) return config;
 
     const ids = this.enabledConnectionIds(runtime);
 
@@ -280,6 +286,18 @@ export abstract class BaseToolHandler implements ToolHandler {
   }
 
   /**
+   * Whether this tool is enabled regardless of the configured connections —
+   * true exactly when its {@linkcode predicate} is `alwaysEnabled`, the only
+   * predicate that returns enabled without inspecting a connection. Such tools
+   * (docs lookup, server diagnostics) never route to a connection, so they
+   * register even on a zero-connection config, where the per-connection verdict
+   * map driving {@linkcode enabledConnectionIds} is empty.
+   */
+  get isConnectionIndependent(): boolean {
+    return this.predicate === alwaysEnabled;
+  }
+
+  /**
    * Per-connection verdict map for this tool — the single source of truth for
    * enablement. Each verdict composes the {@linkcode predicate} with the
    * read-only overlay (see {@linkcode connectionVerdict}). Powers grouped
@@ -323,14 +341,13 @@ export abstract class BaseToolHandler implements ToolHandler {
   }
 
   /**
-   * Resolves the single connection enabled for this tool, returning the
-   * connection id, its config, and the matching client manager. Designed
-   * for handlers that look up `runtime.clientManagers[connId]` (multi-
-   * connection-ready shape).
+   * Resolves the first connection enabled for this tool, returning the
+   * connection id, its config, and the matching client manager.
    *
-   * Selects `enabledConnectionIds(runtime)[0]` — current runtime is single-
-   * connection, so this is unambiguous; if multi-connection support lands
-   * later, handlers can switch to iterating ids.
+   * Selects `enabledConnectionIds(runtime)[0]`. On a multi-connection config
+   * that arbitrarily picks the first enabled connection, which is why handlers
+   * route via {@linkcode resolveConnection} instead. Single-connection
+   * scaffolding with no remaining production callers; deletion tracked in #554.
    */
   protected resolveSoleConnection(runtime: ServerRuntime): ResolvedConnection {
     const connId = this.enabledConnectionIds(runtime)[0]!;

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -311,12 +311,17 @@ export abstract class BaseToolHandler implements ToolHandler {
    * to launch the browser flow only when a call actually targets the OAuth
    * connection, not merely because one exists somewhere in the config.
    *
-   * Delegates to {@linkcode resolveConnection} so routing is decided in one
-   * place rather than duplicated in the gate. Returns `undefined` for a
-   * connection-independent tool (it routes to no connection) and for a call
-   * `resolveConnection` can't resolve unambiguously (e.g. a multi-connection
-   * tool invoked without a `connectionId`); in the latter case the gate declines
-   * to pre-launch a login and `handle()` reports the routing error to the caller.
+   * Returns `undefined` for a connection-independent tool — it routes to no
+   * connection, so there is nothing to pre-launch a login for.
+   *
+   * Otherwise delegates to {@linkcode resolveConnection} so routing is decided
+   * in one place rather than duplicated in the gate, and propagates its throw.
+   * Every throw path there is a `"Wacky --"` invariant violation: the injected
+   * schema (see {@linkcode getRegisteredToolConfig}) makes `connectionId`
+   * required for multi-connection tools and strips it for single-connection
+   * ones, so a call that can't resolve means that contract broke. Surfacing the
+   * error rather than swallowing it to `undefined` lets the broken invariant
+   * reach the caller instead of being silently re-discovered inside `handle()`.
    *
    * @final — concrete on `BaseToolHandler`; subclasses must not override.
    */
@@ -325,11 +330,7 @@ export abstract class BaseToolHandler implements ToolHandler {
     toolArguments: Record<string, unknown> | undefined,
   ): string | undefined {
     if (this.isConnectionIndependent) return undefined;
-    try {
-      return this.resolveConnection(runtime, toolArguments).connId;
-    } catch {
-      return undefined;
-    }
+    return this.resolveConnection(runtime, toolArguments).connId;
   }
 
   /**

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -129,6 +129,15 @@ export interface ToolHandler {
    * See {@linkcode BaseToolHandler.isConnectionIndependent}.
    */
   readonly isConnectionIndependent: boolean;
+
+  /**
+   * The connection id this invocation routes to, or `undefined` when it routes
+   * to none. See {@linkcode BaseToolHandler.resolvedTargetConnectionId}.
+   */
+  resolvedTargetConnectionId(
+    runtime: ServerRuntime,
+    toolArguments: Record<string, unknown> | undefined,
+  ): string | undefined;
 }
 
 export interface ToolConfig {
@@ -295,6 +304,32 @@ export abstract class BaseToolHandler implements ToolHandler {
    */
   get isConnectionIndependent(): boolean {
     return this.predicate === alwaysEnabled;
+  }
+
+  /**
+   * The connection id this invocation routes to — the OAuth-login gate uses it
+   * to launch the browser flow only when a call actually targets the OAuth
+   * connection, not merely because one exists somewhere in the config.
+   *
+   * Delegates to {@linkcode resolveConnection} so routing is decided in one
+   * place rather than duplicated in the gate. Returns `undefined` for a
+   * connection-independent tool (it routes to no connection) and for a call
+   * `resolveConnection` can't resolve unambiguously (e.g. a multi-connection
+   * tool invoked without a `connectionId`); in the latter case the gate declines
+   * to pre-launch a login and `handle()` reports the routing error to the caller.
+   *
+   * @final — concrete on `BaseToolHandler`; subclasses must not override.
+   */
+  resolvedTargetConnectionId(
+    runtime: ServerRuntime,
+    toolArguments: Record<string, unknown> | undefined,
+  ): string | undefined {
+    if (this.isConnectionIndependent) return undefined;
+    try {
+      return this.resolveConnection(runtime, toolArguments).connId;
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -134,7 +134,7 @@ export const hasConfluentCloudOrOAuth: ConnectionPredicate =
 /**
  * Block-level — verdict that holds only for direct connections carrying a
  * `confluent_cloud` block. Use this on handlers that are not yet OAuth-capable
- * and call `getSoleDirectConnection()` inside `handle()`. Once a handler
+ * and call `resolveDirectConnection()` inside `handle()`. Once a handler
  * widens to OAuth, switch its predicate to
  * {@linkcode hasConfluentCloudOrOAuth}.
  */
@@ -289,7 +289,7 @@ export const hasSchemaRegistryOrOAuth: ConnectionPredicate =
  * REST surface: requires both a `confluent_cloud` block (the `/connect/v1`
  * endpoint) and `kafka.auth` (the connector spec carries kafka API
  * credentials). Strict-direct — OAuth connections answer `OAuthNotDirectCapable`
- * because the handler calls `getSoleDirectConnection()`.
+ * because the handler calls `resolveDirectConnection()`.
  */
 export const canCreateDirectConnector: ConnectionPredicate = allOf(
   hasConfluentCloud,
@@ -316,10 +316,13 @@ export const flinkWithTelemetry: ConnectionPredicate = allOf(
  * missing from the connection config, or the policy it violates (not which
  * predicate or overlay emitted it — multiple sites may share a reason). Write
  * the value as a declarative phrase a misconfigured user could act on. Most
- * reasons originate in a predicate body; {@linkcode ReadOnlyConnection} is the
- * exception — it is produced by the read-only verdict overlay in
- * `BaseToolHandler`, which composes a tool's mutation posture with the
- * connection's `read_only` flag, a cross-cutting check no predicate can make.
+ * reasons originate in a predicate body; two are exceptions, produced outside
+ * any predicate because they describe a condition no per-connection check can
+ * see: {@linkcode ReadOnlyConnection} (the read-only verdict overlay in
+ * `BaseToolHandler`, composing a tool's mutation posture with the connection's
+ * `read_only` flag) and {@linkcode NoConnectionsConfigured} (assigned by
+ * `buildToolGatingReport` when there are no connections at all, so no
+ * connection-dependent tool has any verdict to report).
  */
 export enum ToolDisabledReason {
   MissingKafkaBlock = "no 'kafka' block in connection config",
@@ -335,4 +338,5 @@ export enum ToolDisabledReason {
   OAuthNoServiceBlocks = "OAuth connections carry no service blocks",
   OAuthNotDirectCapable = "OAuth connection cannot satisfy a direct-only requirement",
   ReadOnlyConnection = "connection is marked read_only; tools that mutate state are disabled",
+  NoConnectionsConfigured = "no connections are configured",
 }

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -10,6 +10,7 @@ import {
   bareRuntime,
   ccloudOAuthRuntime,
   runtimeWith,
+  runtimeWithConnections,
 } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
@@ -105,6 +106,28 @@ describe("explain-disabled-tools-handler.ts", () => {
         );
         expect(oauthGroup).toBeDefined();
         expect(oauthGroup!.tools).toContain(ToolName.LIST_FLINK_STATEMENTS);
+      });
+
+      it("should keep connection-independent tools enabled and bucket every other tool under NoConnectionsConfigured on a zero-connection config", async () => {
+        const result = handler.handle(runtimeWithConnections({}), undefined);
+        const report = getReport(result);
+
+        const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
+        // The alwaysEnabled tools stay enabled with no connections at all.
+        expect(allDisabledTools).not.toContain(ToolName.SEARCH_PRODUCT_DOCS);
+        expect(allDisabledTools).not.toContain(ToolName.EXPLAIN_DISABLED_TOOLS);
+
+        // Every connection-dependent tool collapses into a single group: there
+        // is no connection to attribute a per-service reason to.
+        expect(report.disabledGroups).toHaveLength(1);
+        expect(report.disabledGroups[0]).toHaveProperty(
+          "reason",
+          ToolDisabledReason.NoConnectionsConfigured,
+        );
+        expect(report.disabledGroups[0]!.tools).toContain(ToolName.LIST_TOPICS);
+        expect(report.enabledCount + report.disabledCount).toBe(
+          Array.from(ToolHandlerRegistry.allHandlers()).length,
+        );
       });
 
       it("should account for every registered tool in the enabled and disabled counts (no double-counting, no skips)", async () => {

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
@@ -33,32 +33,24 @@ const explainDisabledToolsArguments = z.object({
  * absence — which config piece is missing, and which tools each gap would
  * unlock. This handler returns that view.
  *
- * v1 scope (today's release): the server enforces a single configured
- * connection (see `enforceSingleConnectionOnly()` in
- * `src/config/models.ts`), so the output is a flat list of disabled tools
- * grouped by the missing config piece (kafka block, flink block, schema
- * registry block, …). Tools enabled on the active connection are
- * intentionally absent — `tools/list` already advertises them.
+ * Current shape: a flat list of disabled tools grouped by the missing config
+ * piece (kafka block, flink block, schema registry block, …), or by
+ * `NoConnectionsConfigured` when the config has no connections at all. Tools
+ * enabled on any connection are intentionally absent — `tools/list` already
+ * advertises them.
  *
- * v2 plan (#559, when multi-connection support lands under epic #532):
- * regrow output around connections. The text body becomes one block per
- * connection (header + per-connection gaps) plus a `Cross-connection
- * deltas` section that surfaces tools enabled on some connections but not
- * others — the canonical "what does connection B need to reach parity with
- * connection A?" view. The structured `_meta` shape mirrors that change;
- * see the {@linkcode ToolGatingReport} JSDoc in `tool-availability.ts` for
- * the exact target type.
+ * The flatten is *lossy* on a multi-connection config: a tool enabled on at
+ * least one connection is reported as enabled (and omitted from
+ * `disabledGroups` entirely), and a tool disabled on several connections with
+ * different reasons is bucketed under the first disabled verdict its iteration
+ * produces — the cross-connection asymmetry vanishes from the output.
  *
- * Until v2 lands, the helper accepts a multi-connection runtime without
- * crashing, but the v1 flatten is *lossy*: a tool whose predicate is
- * enabled on at least one configured connection is reported as enabled
- * (and therefore omitted from `disabledGroups` entirely), and a tool
- * disabled on multiple connections with different reasons is bucketed
- * under the first disabled verdict its iteration produces — the
- * cross-connection asymmetry vanishes from the output. Today's
- * single-connection invariant means neither lossy case can fire in
- * production; this paragraph exists so a future reader does not mistake
- * defensive iteration for parity reporting.
+ * #559 regrows the output around connections: one block per connection
+ * (header + per-connection gaps) plus a `Cross-connection deltas` section
+ * surfacing tools enabled on some connections but not others — the canonical
+ * "what does connection B need to reach parity with connection A?" view. The
+ * structured `_meta` shape mirrors that change; see the
+ * {@linkcode ToolGatingReport} JSDoc in `tool-availability.ts`.
  *
  * Always enabled (predicate is `alwaysEnabled`) so an operator can call it
  * to diagnose a config that left every other tool disabled.

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -5,7 +5,6 @@ import {
 } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectionPredicate,
-  PredicateResult,
   ToolDisabledReason,
   alwaysEnabled,
   hasKafka,
@@ -45,24 +44,6 @@ const disabledForFlink: ConnectionPredicate = () => ({
   enabled: false,
   reason: ToolDisabledReason.MissingFlinkBlock,
 });
-
-/**
- * Returns a {@linkcode ToolHandler} whose `connectionVerdicts()` resolves
- * to an empty map — the invariant-violation shape the diagnostic tool
- * guards against. `BaseToolHandler.connectionVerdicts` is documented as
- * `@final` but the test deliberately monkey-patches the instance method
- * to reach a branch that should be unreachable in production (every
- * runtime carries at least one connection by `enforceSingleConnectionOnly`).
- */
-function handlerWithEmptyVerdicts(): ToolHandler {
-  const handler = new StubHandler();
-  (
-    handler as unknown as {
-      connectionVerdicts: () => Map<string, PredicateResult>;
-    }
-  ).connectionVerdicts = () => new Map();
-  return handler;
-}
 
 describe("tool-availability.ts", () => {
   describe("groupDisabledToolsByReason()", () => {
@@ -255,15 +236,13 @@ describe("tool-availability.ts", () => {
       });
     });
 
-    it("should classify a tool as enabled when at least one configured connection passes its predicate, omitting it from disabledGroups (lossy v1 flatten)", () => {
-      // Pins the v1 single-connection-scope behaviour against a synthesised
-      // multi-connection runtime: a tool enabled on `with-kafka` and
-      // disabled on `without-kafka` is reported as enabled overall, with
-      // no entry in `disabledGroups`. The asymmetry is dropped — the v2
-      // per-connection / cross-connection-deltas shape (see
-      // ToolGatingReport JSDoc) is the proper fix for this. This test
-      // exists so the lossy aggregation is documented in code rather
-      // than implied by prose.
+    it("should classify a tool as enabled when at least one configured connection passes its predicate, omitting it from disabledGroups (lossy flatten)", () => {
+      // Pins the lossy flatten against a multi-connection runtime: a tool
+      // enabled on `with-kafka` and disabled on `without-kafka` is reported as
+      // enabled overall, with no entry in `disabledGroups`. The asymmetry is
+      // dropped — the per-connection / cross-connection-deltas shape (#559, see
+      // ToolGatingReport JSDoc) is the proper fix. This test exists so the
+      // lossy aggregation is documented in code rather than implied by prose.
       const handler = stubWithPredicate(hasKafka);
       const runtime = runtimeWithConnections({
         "with-kafka": KAFKA_CONN,
@@ -308,20 +287,37 @@ describe("tool-availability.ts", () => {
       });
     });
 
-    it("should throw a 'Wacky --' error when a handler returns an empty verdict map (invariant violation)", () => {
-      // The empty-verdict-map case means a tool's `connectionVerdicts()`
-      // returned no entries — which only happens if `runtime.config.connections`
-      // is empty, which `enforceSingleConnectionOnly()` should have prevented
-      // at bootstrap. The diagnostic tool fails loudly with a `Wacky --`
-      // message rather than fabricating a misleading reason (e.g. the
-      // never-applicable `OAuthNoServiceBlocks`) and shipping it in the
-      // operator-facing report.
-      expect(() =>
-        buildToolGatingReport(
-          [[ToolName.LIST_TOPICS, handlerWithEmptyVerdicts()]],
-          runtimeWith({}),
-        ),
-      ).toThrow(/Wacky --.*empty verdict map/i);
+    it("should bucket a connection-dependent tool under NoConnectionsConfigured on a zero-connection runtime", () => {
+      const handler = stubWithPredicate(hasKafka);
+      const report = buildToolGatingReport(
+        [[ToolName.LIST_TOPICS, handler]],
+        runtimeWithConnections({}),
+      );
+      expect(report).toEqual({
+        groupBy: "reason",
+        disabledGroups: [
+          {
+            reason: ToolDisabledReason.NoConnectionsConfigured,
+            tools: [ToolName.LIST_TOPICS],
+          },
+        ],
+        enabledCount: 0,
+        disabledCount: 1,
+      });
+    });
+
+    it("should report a connection-independent tool as enabled on a zero-connection runtime", () => {
+      const handler = stubWithPredicate(alwaysEnabled);
+      const report = buildToolGatingReport(
+        [[ToolName.SEARCH_PRODUCT_DOCS, handler]],
+        runtimeWithConnections({}),
+      );
+      expect(report).toEqual({
+        groupBy: "reason",
+        disabledGroups: [],
+        enabledCount: 1,
+        disabledCount: 0,
+      });
     });
 
     it("should preserve handler iteration order for tools within a single reason group", () => {

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -36,12 +36,12 @@ export function disabledToolGroupKey(group: DisabledToolGroup): string {
  * `groupBy` records which axis the bucket discriminators carry so
  * consumers (renderer, MCP-client UIs) can pick the right framing.
  *
- * Single-connection scope today (the server enforces one connection; see
- * `enforceSingleConnectionOnly()` in `src/config/models.ts`). When
- * multi-connection support lands as part of issue #151's follow-ups the
- * shape regrows around connections — per-connection sections plus a
- * cross-connection-deltas section calling out tools enabled on some
- * connections but not others.
+ * This is a flat report: each tool counts once as enabled or disabled across
+ * the whole config, with no per-connection breakdown. On a multi-connection
+ * config that flatten is lossy (a tool enabled on one connection and disabled
+ * on another reads as simply enabled). #559 regrows the shape around
+ * connections — per-connection sections plus a cross-connection-deltas section
+ * calling out tools enabled on some connections but not others.
  */
 export interface ToolGatingReport {
   readonly groupBy: "reason" | "category";
@@ -110,23 +110,19 @@ export function groupDisabledToolsByReason(
 }
 
 /**
- * Assemble a {@linkcode ToolGatingReport} for the given handler set against
- * the configured connection.
+ * Assemble a {@linkcode ToolGatingReport} for the given handler set against the
+ * configured connections.
  *
- * v1 (single-connection scope):
  * - `disabledGroups` is sorted lex by reason; tools within a group follow
  *   handler iteration order.
- * - Each tool contributes once to `enabledCount` *or* `disabledCount`:
- *   a tool whose predicate produces an `enabled: true` verdict on at
- *   least one configured connection counts as enabled (and is omitted
- *   from `disabledGroups`); otherwise it counts as disabled and lands
- *   under the first disabled verdict's reason. This flatten is lossy
- *   on a multi-connection runtime — see the handler module-doc for
- *   the consequences and the v2 (multi-connection) shape on
- *   {@linkcode ToolGatingReport}.
- * - Throws `Wacky -- ...` if any handler returns an empty verdict map
- *   (a runtime-shaped invariant violation rather than a tool-state
- *   condition; see `classifyTool` for the rationale).
+ * - Each tool contributes once to `enabledCount` *or* `disabledCount`, via
+ *   {@linkcode classifyHandler}: connection-independent tools count as enabled;
+ *   a connection-dependent tool enabled on at least one connection counts as
+ *   enabled (and is omitted from `disabledGroups`); otherwise it counts as
+ *   disabled and lands under either the first disabled verdict's reason or
+ *   {@linkcode ToolDisabledReason.NoConnectionsConfigured} when the config has
+ *   no connections at all. The single-connection-vs-multi flatten is lossy —
+ *   see {@linkcode ToolGatingReport} and #559.
  */
 export function buildToolGatingReport(
   handlers: Iterable<readonly [ToolName, ToolHandler]>,
@@ -142,7 +138,7 @@ export function buildToolGatingReport(
   let disabledCount = 0;
 
   for (const [toolName, handler] of handlers) {
-    const classification = classifyTool(handler.connectionVerdicts(runtime));
+    const classification = classifyHandler(handler, runtime);
     if (classification.kind === "enabled") {
       enabledCount += 1;
       continue;
@@ -169,44 +165,52 @@ export function buildToolGatingReport(
   return { groupBy, disabledGroups, enabledCount, disabledCount };
 }
 
+type ToolClassification =
+  | { kind: "enabled" }
+  | { kind: "disabled"; reason: ToolDisabledReason };
+
 /**
- * Reduce a tool's per-connection verdict map to a single classification for
- * the v1 flat report. Under the single-connection invariant the verdict map
- * has exactly one entry, so this is a pass-through; the implementation
- * tolerates multi-entry maps (test fixtures synthesise them) by treating
- * "enabled on at least one connection" as enabled and otherwise reporting
- * the first disabled verdict's reason.
- *
- * v2 multi-connection: drop this helper. The aggregation moves into the
- * caller, which builds per-connection rows and cross-connection deltas
- * directly from the verdict map.
+ * Classify a single handler for the flat gating report. Three cases, in order:
+ * a connection-independent tool is enabled regardless of how many connections
+ * exist; a connection-dependent tool on a zero-connection config is disabled
+ * under {@linkcode ToolDisabledReason.NoConnectionsConfigured} (there is no
+ * per-connection verdict to attribute a reason to); otherwise the per-connection
+ * verdicts decide via {@linkcode classifyVerdicts}.
  */
-function classifyTool(
+function classifyHandler(
+  handler: ToolHandler,
+  runtime: ServerRuntime,
+): ToolClassification {
+  if (handler.isConnectionIndependent) return { kind: "enabled" };
+  const verdicts = handler.connectionVerdicts(runtime);
+  if (verdicts.size === 0) {
+    return {
+      kind: "disabled",
+      reason: ToolDisabledReason.NoConnectionsConfigured,
+    };
+  }
+  return classifyVerdicts(verdicts);
+}
+
+/**
+ * Reduce a non-empty per-connection verdict map to a single classification for
+ * the flat report: "enabled on at least one connection" wins, otherwise the
+ * first disabled verdict's reason. This flatten is lossy on a multi-connection
+ * runtime — see {@linkcode ToolGatingReport} for the consequences and #559 for
+ * the per-connection shape that replaces it.
+ *
+ * {@linkcode classifyHandler} handles the connection-independent and
+ * zero-connection cases, so the map handed here is always non-empty and there
+ * is always a verdict to read.
+ */
+function classifyVerdicts(
   verdicts: Map<string, PredicateResult>,
-): { kind: "enabled" } | { kind: "disabled"; reason: ToolDisabledReason } {
+): ToolClassification {
   let firstDisabledReason: ToolDisabledReason | undefined;
   for (const verdict of verdicts.values()) {
     if (verdict.enabled) return { kind: "enabled" };
-    if (firstDisabledReason === undefined) {
-      firstDisabledReason = verdict.reason;
-    }
+    firstDisabledReason ??= verdict.reason;
   }
-  if (firstDisabledReason === undefined) {
-    // Wacky -- handler returned an empty verdict map. BaseToolHandler builds
-    // verdicts directly from `runtime.config.connections`, so an empty map
-    // means there are zero configured connections, which
-    // `enforceSingleConnectionOnly()` in `src/config/models.ts` should have
-    // prevented at bootstrap. Fail loudly rather than fabricate a
-    // misleading `ToolDisabledReason` and ship it in the operator-facing
-    // report — a wrong-by-name reason is harder to diagnose than a stack
-    // trace.
-    throw new Error(
-      "Wacky -- classifyTool received an empty verdict map: a handler's " +
-        "connectionVerdicts() returned no entries. BaseToolHandler derives " +
-        "verdicts from runtime.config.connections; an empty map implies zero " +
-        "configured connections, which enforceSingleConnectionOnly() in " +
-        "src/config/models.ts should have rejected at bootstrap.",
-    );
-  }
-  return { kind: "disabled", reason: firstDisabledReason };
+  // Non-empty map with no enabled verdict, so a disabled reason was recorded.
+  return { kind: "disabled", reason: firstDisabledReason! };
 }

--- a/src/env-schema.ts
+++ b/src/env-schema.ts
@@ -197,12 +197,12 @@ const configSchema = z
       )
       .trim()
       .min(1),
-    // TODO: Remove FLINK_ENV_NAME in v1.4.0 — kept as a deprecated alias of
-    // FLINK_CATALOG_NAME for one release cycle. See issue #209.
+    // Deprecated alias of FLINK_CATALOG_NAME, still accepted. Removal tracked
+    // in issue #598 (the v1.4.0 cutoff it originally targeted came and went).
     FLINK_ENV_NAME: z
       .string()
       .describe(
-        "DEPRECATED: rename to FLINK_CATALOG_NAME. Will be removed in v1.4.0. Same meaning — the Flink catalog name used as `sql.current-catalog`.",
+        "DEPRECATED: rename to FLINK_CATALOG_NAME (removal tracked in issue #598). Same meaning — the Flink catalog name used as `sql.current-catalog`.",
       )
       .trim()
       .min(1),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,7 @@ import {
   outputApiKey,
   outputInitConfig,
   outputToolList,
+  performCleanup,
   resolveAllowedToolNames,
   resolveTelemetryWriteKey,
 } from "@src/index.js";
@@ -832,6 +833,43 @@ describe("index.ts", () => {
       // "no key supplied" so the caller routes through TelemetryService's
       // falsy-writeKey disabled path rather than passing "" to Segment.
       expect(result).toBeFalsy();
+    });
+  });
+
+  describe("performCleanup()", () => {
+    function cleanupDeps() {
+      return {
+        telemetry: { shutdown: vi.fn().mockResolvedValue(undefined) },
+        transportManager: { stop: vi.fn().mockResolvedValue(undefined) },
+        runtime: { oauthHolder: undefined, disconnectAll: vi.fn() },
+      };
+    }
+
+    it("should run every shutdown step then exit 0", async () => {
+      const deps = cleanupDeps();
+      deps.runtime.disconnectAll.mockResolvedValue(undefined);
+      const exit = vi.fn();
+
+      await performCleanup(deps, exit);
+
+      expect(deps.telemetry.shutdown).toHaveBeenCalledOnce();
+      expect(deps.transportManager.stop).toHaveBeenCalledOnce();
+      expect(deps.runtime.disconnectAll).toHaveBeenCalledOnce();
+      expect(exit).toHaveBeenCalledOnce();
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    it("should still exit 0 when a shutdown step rejects", async () => {
+      const deps = cleanupDeps();
+      deps.runtime.disconnectAll.mockRejectedValue(
+        new Error("disconnect boom"),
+      );
+      const exit = vi.fn();
+
+      await performCleanup(deps, exit);
+
+      expect(exit).toHaveBeenCalledOnce();
+      expect(exit).toHaveBeenCalledWith(0);
     });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -22,7 +22,11 @@ import {
 } from "@src/index.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
-import { ccloudOAuthRuntime, runtimeWith } from "@tests/factories/runtime.js";
+import {
+  ccloudOAuthRuntime,
+  runtimeWith,
+  runtimeWithConnections,
+} from "@tests/factories/runtime.js";
 import { StubHandler } from "@tests/stubs/index.js";
 import {
   createFsWrappers,
@@ -234,6 +238,17 @@ describe("index.ts", () => {
 
       expect(result.has(ToolName.LIST_TOPICS)).toBe(true);
       expect(result.has(ToolName.CREATE_TOPICS)).toBe(false);
+    });
+
+    it("should register the connection-independent tools on a zero-connection config", () => {
+      const result = getToolHandlersToRegister(runtimeWithConnections({}));
+
+      expect(result.has(ToolName.SEARCH_PRODUCT_DOCS)).toBe(true);
+      expect(result.has(ToolName.GET_PRODUCT_DOC_PAGE)).toBe(true);
+      expect(result.has(ToolName.LIST_CONFIGURED_CONNECTIONS)).toBe(true);
+      expect(result.has(ToolName.EXPLAIN_DISABLED_TOOLS)).toBe(true);
+      // A connection-dependent tool has no connection to enable it.
+      expect(result.has(ToolName.LIST_TOPICS)).toBe(false);
     });
 
     it("should emit one grouped warn per (connectionId, reason) for fully-disabled tools", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,9 @@ export function getToolHandlersToRegister(
     candidates.push([toolName, ToolHandlerRegistry.getToolHandler(toolName)]);
   }
 
-  // Pass 2: register tools that are enabled on at least one connection.
+  // Pass 2: register tools that are enabled on at least one connection, plus
+  // connection-independent tools (docs, diagnostics), which carry no per-connection
+  // verdict and so stay available even on a zero-connection config.
   for (const [toolName, handler] of candidates) {
     const enabledIds = handler.enabledConnectionIds(runtime);
     const unknownIds = enabledIds.filter((id) => !knownIds.has(id));
@@ -75,7 +77,7 @@ export function getToolHandlersToRegister(
         `Tool ${toolName}: enabledConnectionIds() returned unknown connection ID(s): ${unknownIds.join(", ")}`,
       );
     }
-    if (enabledIds.length > 0) {
+    if (enabledIds.length > 0 || handler.isConnectionIndependent) {
       toolHandlersToRegister.set(toolName, handler);
       logger.info(`Tool ${toolName} enabled`);
     }
@@ -448,7 +450,7 @@ async function main() {
       await transportManager.stop();
       // shutdown() is race-safe with an in-flight bootstrap.
       runtime.oauthHolder?.shutdown();
-      await runtime.clientManager.disconnect();
+      await runtime.disconnectAll();
       process.exit(0);
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,6 +324,35 @@ function runOutputInitConfig(oauth: boolean): EarlyExitResult {
   }
 }
 
+/**
+ * Tear the server down on a shutdown signal, then exit. Every step runs inside
+ * a try/finally so a rejection from any one — most plausibly a client manager
+ * failing to disconnect — is logged but never strands the process: the exit
+ * always fires. `exit` is injected (defaulting to `process.exit`) so this
+ * guarantee is unit-testable without stubbing the global.
+ */
+export async function performCleanup(
+  deps: {
+    telemetry: Pick<TelemetryService, "shutdown">;
+    transportManager: Pick<TransportManager, "stop">;
+    runtime: Pick<ServerRuntime, "oauthHolder" | "disconnectAll">;
+  },
+  exit: (code: number) => void = (code) => process.exit(code),
+): Promise<void> {
+  logger.info("Shutting down...");
+  try {
+    await deps.telemetry.shutdown();
+    await deps.transportManager.stop();
+    // shutdown() is race-safe with an in-flight bootstrap.
+    deps.runtime.oauthHolder?.shutdown();
+    await deps.runtime.disconnectAll();
+  } catch (error) {
+    logger.error({ err: error }, "Error during shutdown");
+  } finally {
+    exit(0);
+  }
+}
+
 async function main() {
   try {
     // Parse command line arguments.(NO LONGER LOADS ENV VARS FROM -e file!)
@@ -444,20 +473,13 @@ async function main() {
     });
 
     // Set up cleanup handlers
-    const performCleanup = async () => {
-      logger.info("Shutting down...");
-      await telemetry.shutdown();
-      await transportManager.stop();
-      // shutdown() is race-safe with an in-flight bootstrap.
-      runtime.oauthHolder?.shutdown();
-      await runtime.disconnectAll();
-      process.exit(0);
-    };
+    const cleanup = () =>
+      performCleanup({ telemetry, transportManager, runtime });
 
-    process.on("SIGINT", performCleanup);
-    process.on("SIGTERM", performCleanup);
-    process.on("SIGQUIT", performCleanup);
-    process.on("SIGUSR2", performCleanup);
+    process.on("SIGINT", cleanup);
+    process.on("SIGTERM", cleanup);
+    process.on("SIGQUIT", cleanup);
+    process.on("SIGUSR2", cleanup);
   } catch (error) {
     if (error instanceof DisplayedCommandLineUsageError) {
       process.exit(0);

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -192,10 +192,15 @@ describe("MCP server tool-call gate", () => {
   });
 
   it("should be a no-op when runtime.oauthHolder is undefined (api_key path)", async () => {
-    const handler = new StubHandler({ enabled: false });
+    // A normally-enabled tool that routes cleanly to the sole connection; the
+    // gate must skip the OAuth branch purely because no holder exists.
+    const handler = new StubHandler({ predicate: hasKafka });
     const handleSpy = vi.spyOn(handler, "handle");
 
-    const client = await startWith(handler, runtimeWith()); // No oauthHolder.
+    const client = await startWith(
+      handler,
+      runtimeWith({ kafka: { bootstrap_servers: "b:9092" } }), // No oauthHolder.
+    );
     await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
 
     expect(handleSpy).toHaveBeenCalledOnce();

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -2,7 +2,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { hasKafka } from "@src/confluent/tools/connection-predicates.js";
+import {
+  hasKafka,
+  kafkaBootstrapOrOAuth,
+} from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
@@ -10,6 +13,7 @@ import { createMcpServer, type ToolCallProps } from "@src/mcp/server.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import {
   ccloudOAuthRuntime,
+  localPlusOAuthRuntime,
   runtimeWith,
   runtimeWithConnections,
 } from "@tests/factories/runtime.js";
@@ -118,20 +122,59 @@ describe("MCP server tool-call gate", () => {
     return client;
   }
 
-  // StubHandler({ enabled: false }) yields a predicate that's not
-  // `alwaysEnabled` (it returns a disabled-result), which is the condition
-  // the gate uses to decide to launch the OAuth login. The "tool disabled"
-  // semantics are incidental — the gate doesn't read the predicate's
-  // result, only its identity.
-  it("should call ensureLoggedIn() before handle() when an OAuth holder is present and predicate is not alwaysEnabled", async () => {
+  it("should call ensureLoggedIn() before handle() when the call routes to the OAuth connection", async () => {
     const holder = createMockInstance(OAuthHolder);
     holder.ensureLoggedIn.mockResolvedValue(undefined);
-    const handler = new StubHandler({ enabled: false });
+    // Enabled on the sole OAuth connection, so the call unambiguously routes there.
+    const handler = new StubHandler({ predicate: kafkaBootstrapOrOAuth });
 
     const client = await startWith(handler, ccloudOAuthRuntime(holder));
     await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
 
     expect(holder.ensureLoggedIn).toHaveBeenCalledOnce();
+  });
+
+  it("should NOT call ensureLoggedIn() when the call routes to a local direct connection in a mixed config", async () => {
+    // The bug: invoking a local-only tool in a local+OAuth config used to launch
+    // the browser anyway, because the old gate fired whenever an OAuth holder
+    // merely existed. A `hasKafka` tool is enabled only on the local connection,
+    // so the call routes to direct — no OAuth login is needed.
+    const holder = createMockInstance(OAuthHolder);
+    holder.ensureLoggedIn.mockResolvedValue(undefined);
+    const handler = new StubHandler({ predicate: hasKafka });
+
+    const client = await startWith(handler, localPlusOAuthRuntime(holder));
+    await client.callTool({ name: ToolName.LIST_TOPICS, arguments: {} });
+
+    expect(holder.ensureLoggedIn).not.toHaveBeenCalled();
+  });
+
+  it("should call ensureLoggedIn() when a both-connections tool is explicitly routed to the OAuth connection", async () => {
+    const holder = createMockInstance(OAuthHolder);
+    holder.ensureLoggedIn.mockResolvedValue(undefined);
+    const handler = new StubHandler({ predicate: kafkaBootstrapOrOAuth });
+
+    const client = await startWith(handler, localPlusOAuthRuntime(holder));
+    await client.callTool({
+      name: ToolName.LIST_TOPICS,
+      arguments: { connectionId: "ccloud-oauth" },
+    });
+
+    expect(holder.ensureLoggedIn).toHaveBeenCalledOnce();
+  });
+
+  it("should NOT call ensureLoggedIn() when a both-connections tool is explicitly routed to the local connection", async () => {
+    const holder = createMockInstance(OAuthHolder);
+    holder.ensureLoggedIn.mockResolvedValue(undefined);
+    const handler = new StubHandler({ predicate: kafkaBootstrapOrOAuth });
+
+    const client = await startWith(handler, localPlusOAuthRuntime(holder));
+    await client.callTool({
+      name: ToolName.LIST_TOPICS,
+      arguments: { connectionId: "local" },
+    });
+
+    expect(holder.ensureLoggedIn).not.toHaveBeenCalled();
   });
 
   it("should NOT call ensureLoggedIn() when handler.predicate is alwaysEnabled (e.g., docs lookups)", async () => {
@@ -163,7 +206,7 @@ describe("MCP server tool-call gate", () => {
     holder.ensureLoggedIn.mockRejectedValue(
       new Error("PKCE login timed out after 120000ms"),
     );
-    const handler = new StubHandler({ enabled: false });
+    const handler = new StubHandler({ predicate: kafkaBootstrapOrOAuth });
     const handleSpy = vi.spyOn(handler, "handle");
     const trackSpy = vi.fn();
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,6 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
@@ -64,11 +63,18 @@ export function createMcpServer({
           clientVersion: clientInfo?.version,
         };
         try {
-          // Gate launch of the browser OAuth login flow only on the
-          // first tool call that needs Confluent OAuth tokens.
+          // Launch the browser OAuth login flow only when this call actually
+          // routes to the OAuth connection — not merely because an OAuth
+          // connection exists somewhere in the config. A call targeting a
+          // local/direct connection in a mixed setup needs no login.
+          const targetConnectionId = handler.resolvedTargetConnectionId(
+            runtime,
+            args,
+          );
           if (
             runtime.oauthHolder !== undefined &&
-            handler.predicate !== alwaysEnabled
+            targetConnectionId !== undefined &&
+            runtime.config.connections[targetConnectionId]?.type === "oauth"
           ) {
             await runtime.oauthHolder.ensureLoggedIn();
           }

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -182,6 +182,19 @@ describe("ServerRuntime", () => {
     });
   });
 
+  describe("disconnectAll()", () => {
+    it("should disconnect every configured client manager", async () => {
+      const cm1 = createMockInstance(DirectClientManager);
+      const cm2 = createMockInstance(DirectClientManager);
+      const runtime = new ServerRuntime(config, { conn1: cm1, conn2: cm2 });
+
+      await runtime.disconnectAll();
+
+      expect(cm1.disconnect).toHaveBeenCalledOnce();
+      expect(cm2.disconnect).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("isToolAllowed()", () => {
     it("should return true for any tool when no allow/block list was configured", () => {
       const runtime = new ServerRuntime(config, {});
@@ -281,7 +294,7 @@ describe("ServerRuntime", () => {
       expect(runtime.oauthHolder?.getDataPlaneToken()).toBeUndefined();
     });
 
-    it("should construct OAuthClientManager instances for every connection when an oauth connection is present", () => {
+    it("should construct an OAuthClientManager for an oauth connection", () => {
       const oauthConfig = new MCPServerConfiguration({
         connections: {
           [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "stag" },
@@ -295,11 +308,28 @@ describe("ServerRuntime", () => {
       );
     });
 
+    it("should construct per-connection manager types for a mixed direct + oauth config", () => {
+      const mixedConfig = new MCPServerConfiguration({
+        connections: {
+          local: connWith({ kafka: { bootstrap_servers: "localhost:9092" } }),
+          cloud: { type: "oauth", ccloud_env: "devel" },
+        },
+      });
+
+      const runtime = ServerRuntime.fromConfig(mixedConfig);
+
+      expect(runtime.clientManagers["local"]).toBeInstanceOf(
+        DirectClientManager,
+      );
+      expect(runtime.clientManagers["cloud"]).toBeInstanceOf(
+        OAuthClientManager,
+      );
+      expect(runtime.oauthHolder).toBeInstanceOf(OAuthHolder);
+    });
+
     it("should throw when more than one OAuth connection is defined", () => {
-      // enforceSingleConnectionOnly() prevents multi-connection records today,
-      // so this case is reached only by callers that bypass the schema (tests
-      // constructing MCPServerConfiguration directly). The defensive throw
-      // becomes load-bearing when multi-connection support lands (#151).
+      // Only one OAuth connection is supported (single shared CCloud identity);
+      // fromConfig rejects a second one rather than silently dropping it.
       const multiOauthConfig = new MCPServerConfiguration({
         connections: {
           "oauth-1": { type: "oauth", ccloud_env: "devel" },

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -193,6 +193,50 @@ describe("ServerRuntime", () => {
       expect(cm1.disconnect).toHaveBeenCalledOnce();
       expect(cm2.disconnect).toHaveBeenCalledOnce();
     });
+
+    it("should await every disconnect even when one rejects, surfacing an AggregateError", async () => {
+      const cm1 = createMockInstance(DirectClientManager);
+      const cm2 = createMockInstance(DirectClientManager);
+      const boom = new Error("conn1 disconnect failed");
+      cm1.disconnect.mockRejectedValue(boom);
+      cm2.disconnect.mockResolvedValue(undefined);
+      const runtime = new ServerRuntime(config, { conn1: cm1, conn2: cm2 });
+
+      let caught: unknown;
+      await runtime.disconnectAll().catch((e) => {
+        caught = e;
+      });
+
+      expect(cm1.disconnect).toHaveBeenCalledOnce();
+      expect(cm2.disconnect).toHaveBeenCalledOnce();
+      expect(caught).toBeInstanceOf(AggregateError);
+      expect((caught as AggregateError).errors).toEqual([boom]);
+    });
+
+    it("should aggregate every failure when multiple managers fail to disconnect", async () => {
+      const cm1 = createMockInstance(DirectClientManager);
+      const cm2 = createMockInstance(DirectClientManager);
+      const cm3 = createMockInstance(DirectClientManager);
+      const boom1 = new Error("conn1 disconnect failed");
+      const boom2 = new Error("conn2 disconnect failed");
+      cm1.disconnect.mockRejectedValue(boom1);
+      cm2.disconnect.mockRejectedValue(boom2);
+      cm3.disconnect.mockResolvedValue(undefined);
+      const runtime = new ServerRuntime(config, {
+        conn1: cm1,
+        conn2: cm2,
+        conn3: cm3,
+      });
+
+      let caught: unknown;
+      await runtime.disconnectAll().catch((e) => {
+        caught = e;
+      });
+
+      expect(cm3.disconnect).toHaveBeenCalledOnce();
+      expect(caught).toBeInstanceOf(AggregateError);
+      expect((caught as AggregateError).errors).toEqual([boom1, boom2]);
+    });
   });
 
   describe("isToolAllowed()", () => {

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -85,9 +85,21 @@ export class ServerRuntime {
    * {@link clientManager} getter could only reach one.
    */
   async disconnectAll(): Promise<void> {
-    await Promise.all(
+    // allSettled, not all: a single manager's disconnect() rejection must not
+    // abandon its siblings mid-shutdown. Wait for every disconnect, then raise
+    // an AggregateError carrying all failures so no error is silently dropped.
+    const results = await Promise.allSettled(
       Object.values(this.clientManagers).map((manager) => manager.disconnect()),
     );
+    const failures = results
+      .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+      .map((r) => r.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `Failed to disconnect ${failures.length} of ${results.length} client manager(s)`,
+      );
+    }
   }
 
   static fromConfig(

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -58,8 +58,9 @@ export class ServerRuntime {
   }
 
   /**
-   * Convenience accessor for the single-connection period.
-   * Remove (or make multi-connection-aware) when issue #151 lands.
+   * Single-connection scaffolding: returns the sole client manager, throwing
+   * when zero or more than one connection is configured. Has no remaining
+   * callers; deletion tracked in #554.
    */
   get clientManager(): BaseClientManager {
     const managers = Object.values(this.clientManagers);
@@ -67,13 +68,26 @@ export class ServerRuntime {
       throw new Error("ServerRuntime has no client managers");
     }
     if (managers.length > 1) {
-      // enforceSingleConnectionOnly() in config/models.ts should prevent this at parse time;
-      // this guard is the runtime mirror of that constraint.
+      // This getter is the single-connection scaffolding; a config with more
+      // than one connection has no "sole" manager. Callers route by id via
+      // clientManagers[id]. Deletion of this getter tracked in #554.
       throw new Error(
         "ServerRuntime has multiple client managers; use clientManagers[id] directly",
       );
     }
     return managers[0]!;
+  }
+
+  /**
+   * Disconnect every per-connection client manager. The teardown counterpart
+   * to the per-connection construction in {@link fromConfig}; a multi-connection
+   * config tears all of its connections down, where the single-connection
+   * {@link clientManager} getter could only reach one.
+   */
+  async disconnectAll(): Promise<void> {
+    await Promise.all(
+      Object.values(this.clientManagers).map((manager) => manager.disconnect()),
+    );
   }
 
   static fromConfig(
@@ -84,9 +98,9 @@ export class ServerRuntime {
       (c): c is OAuthConnectionConfig => c.type === "oauth",
     );
     if (oauthConns.length > 1) {
-      // `enforceSingleConnectionOnly()` already prevents this today; keep the
-      // defensive check so that when multi-connection support lands (#151),
-      // multi-OAuth is rejected explicitly rather than silently picking one.
+      // Only one OAuth connection is supported (the shared OAuthHolder owns a
+      // single CCloud identity). Reject multi-OAuth explicitly rather than
+      // silently picking one.
       throw new Error(
         `Multiple OAuth connections defined in configuration; only one is supported`,
       );
@@ -96,27 +110,27 @@ export class ServerRuntime {
       ? new OAuthHolder(oauthConn.ccloud_env)
       : undefined;
 
-    // Construct a client manager for each connection in the config.
-    // (although currently there will only be one, see `enforceSingleConnectionOnly()`)
-    // When OAuth is in play, every connection's manager is bearer-auth-backed by
-    // the shared holder; otherwise, fall back to the per-connection direct factory.
+    // Construct a client manager per connection, keyed on the connection's own
+    // type — a direct connection always gets a DirectClientManager even when a
+    // sibling OAuth connection exists, so the epic's "OAuth Confluent Cloud +
+    // local Apache Kafka broker side by side" config wires each connection to a
+    // manager that can actually reach it.
     const clientManagers = Object.fromEntries(
       Object.entries(config.connections).map(([id, conn]) => {
-        if (oauthHolder && oauthConn) {
+        if (conn.type === "oauth") {
+          if (!oauthHolder) {
+            throw new Error(
+              `Wacky -- connection ${id} is oauth but no OAuthHolder was constructed`,
+            );
+          }
           return [
             id,
             new OAuthClientManager(
               oauthHolder,
-              oauthConn.ccloud_env,
-              oauthConn.kafka_debug,
+              conn.ccloud_env,
+              conn.kafka_debug,
             ),
           ] as const;
-        }
-        // No OAuth connection found, so every connection is direct.
-        if (conn.type !== "direct") {
-          throw new Error(
-            `Internal error: connection ${id} is not direct but no OAuth holder was constructed`,
-          );
         }
         return [id, constructDirectClientManager(conn)] as const;
       }),

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -296,3 +296,27 @@ export function ccloudOAuthRuntime(holder?: OAuthHolder): ServerRuntime {
     holder,
   );
 }
+
+/**
+ * Mixed runtime: a `local` direct connection (kafka block) alongside a
+ * `ccloud-oauth` OAuth connection, with a stub `OAuthClientManager` and a
+ * caller-supplied {@link OAuthHolder}. The shape the OAuth-login gate tests
+ * use to prove a local-routed call doesn't trigger the browser bounce while an
+ * OAuth-routed one does.
+ */
+export function localPlusOAuthRuntime(holder?: OAuthHolder): ServerRuntime {
+  const config = new MCPServerConfiguration({
+    connections: {
+      local: { type: "direct", kafka: { bootstrap_servers: "localhost:9092" } },
+      "ccloud-oauth": { type: "oauth", ccloud_env: "devel" },
+    },
+  });
+  return new ServerRuntime(
+    config,
+    {
+      local: createMockInstance(DirectClientManager),
+      "ccloud-oauth": createMockInstance(OAuthClientManager),
+    },
+    holder,
+  );
+}

--- a/tests/harness/runtime.test.ts
+++ b/tests/harness/runtime.test.ts
@@ -17,7 +17,7 @@ describe("runtime.ts", () => {
     // Regression guard for the multi-connection smoke-gate bug: the prior
     // implementation resolved the *sole* connection, so a loaded multi-connection
     // config threw and read as "not loaded" — wrongly skipping the transport
-    // smoke tests once #540 lifts the single-connection load guard.
+    // smoke tests now that multiple connections are allowed.
     it("should return true for a multi-connection config (the prior sole-connection check threw here)", () => {
       const multi = new MCPServerConfiguration({
         connections: { a: { type: "direct" }, b: { type: "direct" } },


### PR DESCRIPTION
# Remove the single-connection guard and allow multiple connections

## Guard removal

- Deleted `enforceSingleConnectionOnly()` from `src/config/models.ts` and its `.refine()` on the
  `connections` record. The guard is gone in both directions: a config may now define more than one
  connection, and it may define zero. There is no replacement `>= 1` refine — an empty `connections: {}`
  is a valid, bootable config (see "Connection-independent enablement" below for why that's useful).

## Per-connection client-manager construction

- `ServerRuntime.fromConfig()` previously handed _every_ connection an `OAuthClientManager` whenever
  _any_ connection was OAuth. In a mixed config (the epic's motivating "Confluent Cloud via OAuth +
  local Apache Kafka broker" case) the direct connection silently got an OAuth manager pointed at
  CCloud and could never reach its broker. The construction loop now branches per connection on
  `conn.type`: direct connections get `constructDirectClientManager(conn)`, the lone OAuth connection
  gets an `OAuthClientManager` backed by the shared `OAuthHolder`.
- Boot tests cover `direct + direct` and `direct + oauth`, asserting each connection's concrete
  manager type — so a regression back to the all-OAuth loop fails loudly rather than booting a
  broken mixed config.
- Server teardown disconnected only the _sole_ client manager via the singular
  `ServerRuntime.clientManager` getter, which throws on a multi-connection config — so a
  multi-connection server crashed at shutdown. Added `ServerRuntime.disconnectAll()` (disconnects
  every per-connection manager) and routed `performCleanup` through it. The singular getter now has
  no production callers; its deletion stays with #554.
- `disconnectAll()` uses `Promise.allSettled`, not `Promise.all`: one manager's `disconnect()`
  rejection must not abandon its siblings mid-shutdown. It waits for every disconnect, then throws an
  `AggregateError` carrying all failures so none is silently dropped. Tests assert both the
  single-failure and multi-failure aggregation shapes.
- `performCleanup` is now a module-scope, exported function that runs every teardown step inside a
  `try/catch/finally` and exits in the `finally`. A rejection from any step (most plausibly a manager
  failing to disconnect) is logged but never strands the process — the exit always fires. `exit` is
  injected (defaulting to `process.exit`) so the determinism guarantee is unit-testable without
  stubbing the global; tests cover both the clean path and a rejecting step.

## Connection-independent enablement

- Four tools carry the `alwaysEnabled` predicate and work without any connection: `search-product-docs`,
  `get-product-doc-page`, `list-configured-connections`, and `explain-disabled-tools`. Enablement was
  derived per-connection, so a zero-connection config left even these with no enabled connection IDs —
  the server registered nothing and refused to boot, and `explain-disabled-tools` would itself throw on
  an empty verdict map.
- `BaseToolHandler` now exposes `isConnectionIndependent` (≡ the predicate is `alwaysEnabled`, the only
  unconditional predicate). Registration enables a tool when it has at least one enabled connection
  **or** it is connection-independent, so an empty config boots with exactly those four tools available.
- Added `ToolDisabledReason.NoConnectionsConfigured`. On a zero-connection config, `explain-disabled-tools`
  buckets every connection-dependent tool under it instead of crashing. The report builder now classifies
  each handler in one place (`classifyHandler`): connection-independent → enabled, zero connections →
  `NoConnectionsConfigured`, otherwise the per-connection verdicts decide (`classifyVerdicts`, tightened to
  a non-empty-map contract). The old `Wacky --` empty-verdict-map guard is deleted — its justification
  ("`enforceSingleConnectionOnly` rejected zero connections at bootstrap") no longer exists, and the
  empty-map case is now a handled, legitimate state rather than an invariant violation.

## OAuth login deferred to first OAuth-routed call

- In a mixed `local + ccloud-oauth` config the browser OAuth bounce fired on the _first tool call
  of any kind_, including a purely-local Kafka call — the gate in `mcp/server.ts` keyed on "an
  OAuth connection exists in the config AND the tool isn't connection-independent," never on which
  connection the call actually targets.
- New `BaseToolHandler.resolvedTargetConnectionId(runtime, args)` reports the connection a call
  routes to. It delegates to `resolveConnection` so routing stays decided in one place rather than
  duplicated in the gate; it returns `undefined` for connection-independent tools and for
  unresolvable/ambiguous calls (which `handle()` then reports the routing error for). The gate now
  calls `ensureLoggedIn()` only when that target connection is OAuth-typed — so a local-routed call
  never launches the browser, and the bounce happens on the first call that genuinely targets the
  OAuth connection.
- Tests: the OAuth-login gate suite now drives real routing (local-routed → no login; OAuth-routed,
  both implicit-sole and explicit-`connectionId` → login), plus focused `resolvedTargetConnectionId`
  unit tests covering the connection-independent, sole-enabled, explicit, ambiguous, and
  unknown-id branches.

## Stale single-connection claims swept

- After fixing the teardown crash (which the issue had wrongly described as having "zero callers"),
  swept the codebase for other code or prose assuming exactly one connection/manager. The logic is
  clean: every connection/manager walk iterates the full record (`config-telemetry.ts` already emits
  an array of connection types; `server-runtime.ts`, `index.ts`, `base-tools.ts`, and
  `list-configured-connections-handler.ts` all use `Object.entries/values`), and the `getSole*` /
  `resolveSoleConnection` accessors have no production callers (they wait on #541/#554).
- One prose finding, fixed: two predicate docstrings in `connection-predicates.ts` (`hasConfluentCloud`,
  `canCreateDirectConnector`) still said handlers "call `getSoleDirectConnection()` inside `handle()`."
  #564 ported every connect handler to `resolveDirectConnection()`, so the docstrings now name that.

## Relationships

- Closes #540
- Child of #532 (Epic: Multi-connection support)
