### PR TITLE
Always require a connectionId param if server is configured with >1 connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this MCP server will be documented in this file.
 ### Changed
 
 - **Configuration**: _A YAML config may now define multiple connections — or none._ Point a single `config.yaml` at several clusters at once — for example a local Apache Kafka broker alongside Confluent Cloud — or run with no connection at all (documentation search and server-diagnostic tools still work). At most one of those connections may use OAuth to Confluent Cloud. See [CONFIGURATION.md → Multiple connections (and zero connections)](CONFIGURATION.md#multiple-connections-and-zero-connections).
+  - When multiple connections are enabled, all connection-oriented tools will be driven with the connection id the tool should be invoked against, even if said tool was only invokable against a single connection to improve clarity and consistency (such as would be the case for a mutating tool invocation when one connection is marked read_only and the other allows writes).
 
 #### Added
 

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -774,7 +774,7 @@ describe("config/models.ts", () => {
         });
 
         expect(() => config.getConnectionConfig("ghost")).toThrow(
-          'Unknown connection id "ghost"; defined connections: local, staging',
+          'Unknown connection id "ghost"; defined connections: "local", "staging"',
         );
       });
     });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,6 +1,7 @@
 import { validateBootstrapServers } from "@src/config/validation.js";
 import { logLevels } from "@src/logger.js";
 import { TransportType } from "@src/mcp/transports/types.js";
+import { quoteJoinIds } from "@src/utils/quote-join-ids.js";
 import { z } from "zod";
 
 // The following interfaces and types define subcomponents of class MCPServerConfiguration, which represents our entire server configuration.
@@ -254,7 +255,7 @@ export class MCPServerConfiguration {
     if (conn === undefined) {
       throw new Error(
         `Unknown connection id "${connectionId}"; defined connections: ${
-          this.getConnectionNames().join(", ") || "none"
+          quoteJoinIds(this.getConnectionNames()) || "none"
         }`,
       );
     }

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -178,17 +178,7 @@ describe("base-tools.ts", () => {
             }),
           ],
           [
-            "connection-centric tool, two connections but none viable",
-            () => ({
-              handler: new StubHandler({
-                predicate: hasKafka,
-                inputSchema: { topicName: z.string() },
-              }),
-              runtime: runtimeWithConnections({ a: {}, b: {} }),
-            }),
-          ],
-          [
-            "connection-centric tool, single viable connection",
+            "connection-centric tool, single-connection server",
             () => ({
               handler: new StubHandler({
                 predicate: hasKafka,
@@ -197,23 +187,13 @@ describe("base-tools.ts", () => {
               runtime: runtimeWithConnections({ a: KAFKA }),
             }),
           ],
-          [
-            "connection-centric tool, multiple connections but only one viable",
-            () => ({
-              handler: new StubHandler({
-                predicate: hasKafka,
-                inputSchema: { topicName: z.string() },
-              }),
-              runtime: runtimeWithConnections({ a: KAFKA, b: {} }),
-            }),
-          ],
         ])("should not inject connectionId for %s", (_label, build) => {
           const { handler, runtime } = build();
           const reg = handler.getRegisteredToolConfig(runtime);
 
-          expect(reg.inputSchema).not.toHaveProperty("connectionId");
+          expect(reg.inputSchema.shape).not.toHaveProperty("connectionId");
           // authored field(s) and metadata pass through unchanged
-          expect(Object.keys(reg.inputSchema)).toEqual(
+          expect(Object.keys(reg.inputSchema.shape)).toEqual(
             Object.keys(handler["getToolConfig"]().inputSchema),
           );
           expect(reg.name).toBe(ToolName.LIST_TOPICS);
@@ -235,7 +215,29 @@ describe("base-tools.ts", () => {
           );
 
           expect(scan).not.toHaveBeenCalled();
-          expect(reg.inputSchema).not.toHaveProperty("connectionId");
+          expect(reg.inputSchema.shape).not.toHaveProperty("connectionId");
+        });
+      });
+
+      describe("guards an impossible state", () => {
+        it("should throw a Wacky error for a connection-gated tool viable on no connection of a multi-connection server", () => {
+          // Unreachable in production: a tool enabled on zero connections is
+          // never registered (the enablement filter in index.ts drops it), so
+          // getRegisteredToolConfig() is never called for it. Constructing the
+          // impossible state directly proves the guard fires instead of building
+          // an illegal z.enum([]).
+          const handler = new StubHandler({
+            predicate: hasKafka,
+            inputSchema: { topicName: z.string() },
+          });
+
+          expect(() =>
+            handler.getRegisteredToolConfig(
+              runtimeWithConnections({ a: {}, b: {} }),
+            ),
+          ).toThrow(
+            `Wacky -- tool ${ToolName.LIST_TOPICS} resolved to zero enabled connections on a multi-connection server; it should never have been registered`,
+          );
         });
       });
 
@@ -256,7 +258,7 @@ describe("base-tools.ts", () => {
         ): z.ZodEnum {
           const connectionId =
             multiViableHandler().getRegisteredToolConfig(runtime).inputSchema
-              .connectionId;
+              .shape.connectionId;
           if (!(connectionId instanceof z.ZodEnum)) {
             throw new Error("connectionId should be a ZodEnum");
           }
@@ -276,12 +278,32 @@ describe("base-tools.ts", () => {
             }),
           );
 
-          const connectionId = reg.inputSchema.connectionId;
+          const connectionId = reg.inputSchema.shape.connectionId;
           expect(connectionId).toBeInstanceOf(z.ZodEnum);
           if (!(connectionId instanceof z.ZodEnum)) {
             throw new Error("connectionId should be a ZodEnum");
           }
           expect(connectionId.options).toEqual(["conn-z", "conn-a"]);
+        });
+
+        it("should inject a required single-id connectionId enum when the server is multi-connection but only one connection is viable", () => {
+          // #590: the trigger is the *server* having more than one connection,
+          // not the *tool* being viable on more than one. A tool viable on a
+          // single connection of a multi-connection server still gets a required
+          // connectionId — so an explicit request for a non-viable connection
+          // (e.g. a read_only one) is rejected by the enum rather than silently
+          // auto-routed to the lone viable connection.
+          const reg = multiViableHandler().getRegisteredToolConfig(
+            runtimeWithConnections({ a: KAFKA, b: {} }),
+          );
+
+          const connectionId = reg.inputSchema.shape.connectionId;
+          expect(connectionId).toBeInstanceOf(z.ZodEnum);
+          if (!(connectionId instanceof z.ZodEnum)) {
+            throw new Error("connectionId should be a ZodEnum");
+          }
+          expect(connectionId.options).toEqual(["a"]);
+          expect(connectionId.isOptional()).toBe(false);
         });
 
         it("should mark connectionId as required (not optional)", () => {
@@ -297,10 +319,12 @@ describe("base-tools.ts", () => {
             runtimeWithConnections({ a: KAFKA, b: KAFKA }),
           );
 
-          expect(connectionId.description).toContain("a, b");
+          // The quote-wrapping/escaping logic itself is proven directly in
+          // quote-join-ids.test.ts; here we only assert the description adopts it.
+          expect(connectionId.description).toContain('"a", "b"');
         });
 
-        const CONNECTION_ID_BASE = `${CONNECTION_ID_DESCRIPTION_PREFIX}a, b.`;
+        const CONNECTION_ID_BASE = `${CONNECTION_ID_DESCRIPTION_PREFIX}"a", "b".`;
 
         it("should append the list-configured-connections pointer single-spaced when list-configured-connections is allowed", () => {
           // No allow-list configured ⇒ every tool, including list-configured-connections, is allowed.
@@ -331,7 +355,7 @@ describe("base-tools.ts", () => {
             runtimeWithConnections({ a: KAFKA, b: KAFKA }),
           );
 
-          expect(Object.keys(reg.inputSchema)).toEqual([
+          expect(Object.keys(reg.inputSchema.shape)).toEqual([
             "topicName",
             "connectionId",
           ]);
@@ -362,6 +386,66 @@ describe("base-tools.ts", () => {
           expect(reg.name).toBe(ToolName.LIST_TOPICS);
           expect(reg.description).toBe("stub");
           expect(reg.annotations).toBe(READ_ONLY);
+        });
+      });
+
+      describe("wraps the registered schema in a strict object (#590, part 2)", () => {
+        function kafkaHandler(): StubHandler {
+          return new StubHandler({
+            predicate: hasKafka,
+            inputSchema: { topicName: z.string() },
+          });
+        }
+
+        it("should reject an unknown key when no connectionId is injected (single-connection server)", () => {
+          const reg = kafkaHandler().getRegisteredToolConfig(
+            runtimeWith(KAFKA),
+          );
+
+          const parsed = reg.inputSchema.safeParse({
+            topicName: "t",
+            bogus: "x",
+          });
+
+          expect(parsed.success).toBe(false);
+          if (parsed.success) throw new Error("expected a strict rejection");
+          expect(parsed.error.issues).toEqual([
+            expect.objectContaining({
+              code: "unrecognized_keys",
+              keys: ["bogus"],
+            }),
+          ]);
+        });
+
+        it("should reject an unknown key alongside a valid connectionId (multi-connection server)", () => {
+          const reg = kafkaHandler().getRegisteredToolConfig(
+            runtimeWithConnections({ a: KAFKA, b: KAFKA }),
+          );
+
+          const parsed = reg.inputSchema.safeParse({
+            topicName: "t",
+            connectionId: "a",
+            bogus: "x",
+          });
+
+          expect(parsed.success).toBe(false);
+          if (parsed.success) throw new Error("expected a strict rejection");
+          expect(parsed.error.issues).toEqual([
+            expect.objectContaining({
+              code: "unrecognized_keys",
+              keys: ["bogus"],
+            }),
+          ]);
+        });
+
+        it("should accept input carrying only declared keys", () => {
+          const reg = kafkaHandler().getRegisteredToolConfig(
+            runtimeWith(KAFKA),
+          );
+
+          const parsed = reg.inputSchema.safeParse({ topicName: "t" });
+
+          expect(parsed.success).toBe(true);
         });
       });
     });

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -14,6 +14,7 @@ import {
 } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
+import { quoteJoinIds } from "@src/utils/quote-join-ids.js";
 import { z, ZodRawShape } from "zod";
 
 /**
@@ -36,7 +37,8 @@ export const DESTRUCTIVE: ToolAnnotations = {
 
 /**
  * Opening clause of the injected `connectionId` parameter description, before the
- * comma-separated list of viable connection ids is appended.
+ * quoted, comma-separated list of viable connection ids (see
+ * {@linkcode quoteJoinIds}) is appended.
  */
 export const CONNECTION_ID_DESCRIPTION_PREFIX =
   "Which configured connection to target. One of: ";
@@ -78,15 +80,15 @@ export interface ToolHandler {
   ): Promise<CallToolResult> | CallToolResult;
 
   /**
-   * Produce the actual config registered with MCP for this tool, potentially
-   * injecting a required `connectionId` parameter when the tool can target more
-   * than one connection. See the method body for the rules.
+   * Produce the actual config registered with MCP for this tool, injecting a
+   * required `connectionId` parameter when the server holds more than one
+   * connection. See {@linkcode BaseToolHandler.getRegisteredToolConfig} for the
+   * rules.
    *
    * This method is called when setting up the MCP server, and we ourselves make
    * the downcall to the handler-authored `getToolConfig()`.
-   * {@linkcode BaseToolHandler.getRegisteredToolConfig} for the rules.
    */
-  getRegisteredToolConfig(runtime: ServerRuntime): ToolConfig;
+  getRegisteredToolConfig(runtime: ServerRuntime): RegisteredToolConfig;
 
   /**
    * The connection predicate that gates this tool's enablement. Lifted onto
@@ -133,6 +135,18 @@ export interface ToolConfig {
 }
 
 /**
+ * The config actually registered with MCP, produced by
+ * {@linkcode BaseToolHandler.getRegisteredToolConfig}. Differs from the
+ * handler-authored {@linkcode ToolConfig} in that `inputSchema` is a resolved,
+ * strict Zod object rather than a bare shape: strict so unknown parameters are
+ * rejected (not silently stripped) before `handle()` runs, and resolved because
+ * a multi-connection server injects the required `connectionId` enum into it.
+ */
+export interface RegisteredToolConfig extends Omit<ToolConfig, "inputSchema"> {
+  inputSchema: z.ZodObject;
+}
+
+/**
  * What the connection-resolution helpers hand back: the chosen connection id,
  * its resolved config, and the client manager bound to it.
  *
@@ -166,38 +180,66 @@ export abstract class BaseToolHandler implements ToolHandler {
   protected abstract getToolConfig(): ToolConfig;
 
   /**
-   * Produce the actual config registered with MCP for this tool, potentially
-   * injecting a required `connectionId` parameter when the tool can target more
-   * than one connection. See the method body for the rules.
+   * Produce the actual config registered with MCP for this tool.
    *
-   * This method is called when setting up the MCP server, and we ourselves make
-   * the downcall to the handler-authored `getToolConfig()`.
+   *   * If the tool is connection-oriented and the server is configured
+   *    with multiple connections, injects a required `connectionId` parameter
+   *    indicating which connection the tool call should route to.
+   *    See {@linkcode registeredInputShape} for more details.
+   *
+   *   * Wrap the input schema in `z.object(...).strict()` to uniformly reject
+   *     unknown parameters before `handle()` runs.
+   *
+   * This method is called for each active tool when setting up the MCP server.
    *
    * @final — concrete on `BaseToolHandler`; subclasses must not override.
    */
-  getRegisteredToolConfig(runtime: ServerRuntime): ToolConfig {
+  getRegisteredToolConfig(runtime: ServerRuntime): RegisteredToolConfig {
     const config = this.getToolConfig();
+    return {
+      ...config,
+      inputSchema: z
+        .object(this.registeredInputShape(config, runtime))
+        .strict(),
+    };
+  }
 
-    // alwaysEnabled is an identity-checked sentinel, so bail before the
-    // per-connection scan below: connection-agnostic tools (docs, diagnostics)
-    // never route to a connection and so never need a connectionId parameter.
-    if (this.predicate === alwaysEnabled) return config;
+  /**
+   * The input shape to register, before strict-wrapping: the authored shape,
+   * plus a required `connectionId` enum when the server holds more than one
+   * connection AND this tool is connection-oriented. A single-element enum (when
+   * only one connection is viable) is still injected on a multi-connection server,
+   * so that an explicit request for a non-viable connection (e.g. to a disabled
+   * tool because it is read_only) is rejected by the enum rather than silently
+   * auto-routed.
+   */
+  private registeredInputShape(
+    config: ToolConfig,
+    runtime: ServerRuntime,
+  ): ZodRawShape {
+    // alwaysEnabled is an identity-checked sentinel: connection-agnostic tools
+    // (docs, diagnostics) never route to a connection and so never need a
+    // connectionId parameter.
+    if (this.predicate === alwaysEnabled) return config.inputSchema;
+
+    // A single-connection (or zero-connection) server has no ambiguity as to
+    // which connection a call routes to, so the call auto-routes with no extra
+    // argument. The zero-connection case also covers the `--list-tools` runtime,
+    // which wants the unaugmented view.
+    if (runtime.config.getConnectionNames().length <= 1)
+      return config.inputSchema;
 
     const ids = this.enabledConnectionIds(runtime);
 
-    // A tool viable on a single connection has no ambiguity as to which
-    // connection it routes to, so return the tool's authored config verbatim.
-
-    // (We might find that in multi-connection configurations, we might
-    //  want to surface the `connectionId` parameter regardless but then
-    //  lock it to a single value with `z.enum([theSoleEnabledId])`. Will
-    //  have to get farther along epic #532 before we can make that
-    //  determination, though. We have enough information in serverRuntime
-    //  to be able to migrate, though, so is not a blocker at this time.)
-    if (ids.length <= 1) return config;
-
-    // Otherwise, inject a required connectionId parameter into the Zod
-    // inputSchema with an enum of the enabled connection IDs.
+    // A tool viable on no connection is never registered (the enablement filter
+    // in index.ts drops it), so this method is never called for one. Reaching
+    // here means the wiring is broken; bail loudly rather than build an illegal
+    // `z.enum([])`.
+    if (ids.length === 0) {
+      throw new Error(
+        `Wacky -- tool ${config.name} resolved to zero enabled connections on a multi-connection server; it should never have been registered`,
+      );
+    }
 
     // Point the agent at list-configured-connections so it can learn which
     // tools each connection supports — but only when that tool is itself
@@ -210,15 +252,12 @@ export abstract class BaseToolHandler implements ToolHandler {
       ? ` ${LIST_CONFIGURED_CONNECTIONS_POINTER}`
       : "";
     return {
-      ...config,
-      inputSchema: {
-        ...config.inputSchema,
-        connectionId: z
-          .enum(ids as [string, ...string[]])
-          .describe(
-            `${CONNECTION_ID_DESCRIPTION_PREFIX}${ids.join(", ")}.${listConfiguredConnectionsPointer}`,
-          ),
-      },
+      ...config.inputSchema,
+      connectionId: z
+        .enum(ids as [string, ...string[]])
+        .describe(
+          `${CONNECTION_ID_DESCRIPTION_PREFIX}${quoteJoinIds(ids)}.${listConfiguredConnectionsPointer}`,
+        ),
     };
   }
 
@@ -384,9 +423,9 @@ export abstract class BaseToolHandler implements ToolHandler {
       // Unreachable in normal operation: Zod has already validated `args`
       // against the registered schema before `handle()` runs, and that schema
       // either declares `connectionId` as a string enum (multi-connection
-      // tools — a non-string fails parsing) or omits it entirely (single-
-      // connection tools — an unknown key is stripped). Either way a non-string
-      // can't survive to reach this branch. It exists purely as a symmetric
+      // servers — a non-string fails parsing) or omits it entirely (single-
+      // connection servers — the strict schema rejects the unknown key). Either
+      // way a non-string can't survive to reach this branch. It exists purely as a symmetric
       // peer to the two backstops below, so a malformed value can never quietly
       // masquerade as an omission and auto-route.
       throw new Error(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -213,7 +213,7 @@ describe("index.ts", () => {
       expect(() =>
         getToolHandlersToRegister(runtimeAllowing(ToolName.LIST_TOPICS)),
       ).toThrow(
-        "Tool list-topics: enabledConnectionIds() returned unknown connection ID(s): nonexistent-connection",
+        "Wacky -- Tool list-topics: enabledConnectionIds() returned unknown connection ID(s): nonexistent-connection",
       );
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,10 +69,13 @@ export function getToolHandlersToRegister(
   // Pass 2: register tools that are enabled on at least one connection.
   for (const [toolName, handler] of candidates) {
     const enabledIds = handler.enabledConnectionIds(runtime);
+    // Unreachable: enabledConnectionIds() is derived by iterating
+    // runtime.config.connections, so every id it yields is already a known key.
+    // A non-empty unknownIds means that derivation has broken.
     const unknownIds = enabledIds.filter((id) => !knownIds.has(id));
     if (unknownIds.length > 0) {
       throw new Error(
-        `Tool ${toolName}: enabledConnectionIds() returned unknown connection ID(s): ${unknownIds.join(", ")}`,
+        `Wacky -- Tool ${toolName}: enabledConnectionIds() returned unknown connection ID(s): ${unknownIds.join(", ")}`,
       );
     }
     if (enabledIds.length > 0) {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -221,8 +221,8 @@ describe("createMcpServer registered schema", () => {
   }
 
   // Proves the registration path advertises getRegisteredToolConfig() — not the
-  // raw authored getToolConfig() — by exercising the one case where they differ:
-  // a connection-gated tool viable on more than one connection gains a routing
+  // raw authored getToolConfig() — by exercising the connectionId injection: a
+  // connection-gated tool viable on more than one connection gains a routing
   // connectionId enum.
   it("should advertise a required connectionId enum for a connection-gated tool viable on multiple connections", async () => {
     const client = await startWith(
@@ -274,5 +274,38 @@ describe("createMcpServer registered schema", () => {
     });
 
     expect(handleSpy).toHaveBeenCalledOnce();
+  });
+
+  // #590, part 2: the registered schema is strict, so an unknown parameter is
+  // rejected before handle() runs rather than silently stripped. A single-
+  // connection server (no connectionId injected) proves the strictness is a
+  // property of the registration boundary, not of the connectionId injection.
+  const oneKafka = () =>
+    runtimeWith({ kafka: { bootstrap_servers: "a:9092" } });
+
+  it("should reject an unknown parameter before handle() runs on a single-connection server", async () => {
+    const handler = new StubHandler({ predicate: hasKafka });
+    const handleSpy = vi.spyOn(handler, "handle");
+    const client = await startWith(handler, oneKafka());
+
+    const result = await client.callTool({
+      name: ToolName.LIST_TOPICS,
+      arguments: { bogusParam: "nope" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(handleSpy).not.toHaveBeenCalled();
+  });
+
+  it("should advertise additionalProperties:false on the registered input schema", async () => {
+    const client = await startWith(
+      new StubHandler({ predicate: hasKafka }),
+      oneKafka(),
+    );
+
+    const { tools } = await client.listTools();
+    const listTopics = tools.find((t) => t.name === ToolName.LIST_TOPICS);
+
+    expect(listTopics?.inputSchema?.additionalProperties).toBe(false);
   });
 });

--- a/src/utils/quote-join-ids.test.ts
+++ b/src/utils/quote-join-ids.test.ts
@@ -1,0 +1,34 @@
+import { quoteJoinIds } from "@src/utils/quote-join-ids.js";
+import { describe, expect, it } from "vitest";
+
+describe("quote-join-ids.ts", () => {
+  describe("quoteJoinIds()", () => {
+    it.each([
+      ["an empty list", [], ""],
+      ["a single id", ["a"], '"a"'],
+      ["a plain multi-id list", ["a", "b"], '"a", "b"'],
+      [
+        "an id containing a comma (wrapped so the comma stays inside the quotes)",
+        ["c,d"],
+        '"c,d"',
+      ],
+      [
+        "an id containing a double quote (backslash-escaped)",
+        ['a"b'],
+        '"a\\"b"',
+      ],
+      [
+        "multiple ids each carrying a comma or quote",
+        ['a"b', "c,d"],
+        '"a\\"b", "c,d"',
+      ],
+      ["an id that is only a double quote", ['"'], '"\\""'],
+    ])("should render %s", (_label, ids: string[], expected) => {
+      expect(quoteJoinIds(ids)).toBe(expected);
+    });
+
+    it("should preserve the caller's order rather than sorting", () => {
+      expect(quoteJoinIds(["z", "a", "m"])).toBe('"z", "a", "m"');
+    });
+  });
+});

--- a/src/utils/quote-join-ids.ts
+++ b/src/utils/quote-join-ids.ts
@@ -1,0 +1,10 @@
+/**
+ * Render a list of ids as a double-quoted, comma-separated string for prose
+ * (tool descriptions, error messages). The quoting keeps the list unambiguous
+ * when an id contains a comma; contained double quotes are backslash-escaped so
+ * the wrapping itself stays unambiguous. Returns "" for an empty list, so a
+ * caller wanting a placeholder can write `quoteJoinIds(ids) || "none"`.
+ */
+export function quoteJoinIds(ids: readonly string[]): string {
+  return ids.map((id) => `"${id.replaceAll('"', '\\"')}"`).join(", ");
+}


### PR DESCRIPTION
# Always require a `connectionId` tool param on multi-connection servers (for connection-oriented tools)

## connectionId gating keyed on the server, not the tool

- `getRegisteredToolConfig()` now injects the required `connectionId` enum whenever the **server** is configured with more than one connection — not only when a tool is viable on more than one. A connection-routed tool viable on a single connection still gets a (one-element) required `connectionId` enum. Single- and zero-connection servers, and `alwaysEnabled` tools, are untouched and continue to auto-route with no extra argument.
- Removes silent auto-routing at invocation time. If `create-topic` is viable only on `local` because `ccloud` is `read_only`, the enum is `["local"]`; an explicit request for `ccloud` is rejected by Zod before `handle()` runs rather than being quietly redirected to `local`. This is the behavior the issue's read-only example asks for.
- The injected enum stays the set of _viable_ connections (`enabledConnectionIds`), so a connection the tool's predicate or read-only overlay disables is never an accepted target.
- The `connectionId` description renders viable ids via a new `quoteJoinIds()` helper (`"a", "b"` rather than a bare `a, b`), quote-wrapping each id and backslash-escaping any contained quote so an id holding a comma or quote stays unambiguous. `getConnectionConfig()`'s "Unknown connection id" error reuses the same helper. `quoteJoinIds()` is a leaf utility in `src/utils/quote-join-ids.ts` (importable from every layer with no cycle risk), proven directly by `quote-join-ids.test.ts`.
- A connection-gated tool that resolves to zero viable connections on a multi-connection server now throws a `Wacky --` error in `getRegisteredToolConfig()` instead of falling back to the authored shape: such a tool is never registered (the enablement filter drops it), so reaching that branch means broken wiring, not a buildable `z.enum([])`. Likewise the unknown-connection-id guard in `getToolHandlersToRegister()` is now a `Wacky --` error — `enabledConnectionIds()` is derived by iterating `runtime.config.connections`, so it can never yield an unknown id unless that derivation breaks.

## While here: reject unknown parameters (strict schemas)

- Every registered tool's input schema is now a strict Zod object: unknown parameters are rejected before `handle()` runs (server-side `safeParseAsync`), and the advertised `tools/list` JSON schema carries `additionalProperties: false`. Catches hallucinated parameters instead of silently dropping them.
- Applies to all tools uniformly — including `alwaysEnabled` (docs/diagnostics) and single-connection servers — so the strictness is a property of the registration boundary, independent of whether `connectionId` was injected.

## Relationships

- Closes #590.
- Child of #532 (multi-connection support).
- Revises the gating decision originally made in #533 (`getRegisteredToolConfig()`).
