### PR TITLE
Expose a connection's read-onlyness via  tool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this MCP server will be documented in this file.
 #### Configuration
 
 - **Per-connection `description` field.** Optional free-text label on any connection, echoed back by `list-configured-connections`.
-- **Per-connection `read_only` flag.** Set `read_only: true` on a connection to auto-disable every state-mutating tool for it, leaving only read-only tools enabled.
+- **Per-connection `read_only` flag.** Set `read_only: true` on a connection to auto-disable every state-mutating tool for it, leaving only read-only tools enabled. `list-configured-connections` reports each connection's read-onlyness.
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this MCP server will be documented in this file.
 #### Added
 
 - **Configuration**: _Per-connection `description` field._ Optional free-text label on any connection, echoed back by `list-configured-connections`.
-- **Configuration**: _Per-connection `read_only` flag._ Set `read_only: true` on a connection to auto-disable every state-mutating tool for it, leaving only read-only tools enabled. Defaults to `false` --- resources reachable by a connection may be mutated or deleted from.
+- **Configuration**: _Per-connection `read_only` flag._ Set `read_only: true` on a connection to auto-disable every state-mutating tool for it, leaving only read-only tools enabled. **Defaults to `false`** --- resources reachable by a connection may be mutated or deleted from. The `list-configured-connections` tool reports each connection's read-onlyness.
 
 #### New Tools / Tool Features
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -109,6 +109,7 @@ Either connection flavor also accepts an optional `read_only` flag (default `fal
 When set to `read_only: true`, every tool that mutates state is automatically disabled for that connection, leaving only the read-only tools enabled.
 A tool's mutation posture comes from its `readOnlyHint` annotation, so there is nothing to configure per-tool: reads stay available while writes — produce, create/alter/delete, and the like — can never fire against that connection.
 This is the recommended posture for handing an agent a staging or production connection while keeping full read/write on a throwaway dev cluster.
+The `list-configured-connections` tool reports each connection's read-onlyness, so an agent can see at a glance which connections are read-only or write-enabled.
 
 #### Service blocks
 

--- a/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.test.ts
@@ -68,8 +68,11 @@ describe("ListConfiguredConnectionsHandler", () => {
       // from both lists; "bare" therefore has no routable tools at all.
       expect(result.structuredContent).toEqual({
         connections: {
-          k: { enabledTools: [ToolName.CREATE_TOPICS, ToolName.LIST_TOPICS] },
-          bare: { enabledTools: [] },
+          k: {
+            readOnly: false,
+            enabledTools: [ToolName.CREATE_TOPICS, ToolName.LIST_TOPICS],
+          },
+          bare: { readOnly: false, enabledTools: [] },
         },
       });
       expect(result.isError).toBe(false);
@@ -91,8 +94,8 @@ describe("ListConfiguredConnectionsHandler", () => {
 
       expect(result.structuredContent).toEqual({
         connections: {
-          k: { enabledTools: [] },
-          other: { enabledTools: [] },
+          k: { readOnly: false, enabledTools: [] },
+          other: { readOnly: false, enabledTools: [] },
         },
       });
     });
@@ -110,7 +113,9 @@ describe("ListConfiguredConnectionsHandler", () => {
       const result = handlerWith(threeToolUniverse()).handle(runtime);
 
       expect(result.structuredContent).toEqual({
-        connections: { k: { enabledTools: [ToolName.LIST_TOPICS] } },
+        connections: {
+          k: { readOnly: false, enabledTools: [ToolName.LIST_TOPICS] },
+        },
       });
     });
 
@@ -124,7 +129,7 @@ describe("ListConfiguredConnectionsHandler", () => {
       ]).handle(runtime);
 
       expect(result.structuredContent).toEqual({
-        connections: { bare: { enabledTools: [] } },
+        connections: { bare: { readOnly: false, enabledTools: [] } },
       });
       expect(textOf(result)).toContain("bare (0 tools): (none)");
     });
@@ -140,6 +145,7 @@ describe("ListConfiguredConnectionsHandler", () => {
         connections: {
           k: {
             description: "Prod east",
+            readOnly: false,
             enabledTools: [ToolName.CREATE_TOPICS, ToolName.LIST_TOPICS],
           },
         },
@@ -194,10 +200,58 @@ describe("ListConfiguredConnectionsHandler", () => {
 
       expect(result.structuredContent).toEqual({
         connections: {
-          prod: { enabledTools: [ToolName.LIST_TOPICS] },
-          dev: { enabledTools: [ToolName.CREATE_TOPICS, ToolName.LIST_TOPICS] },
+          prod: { readOnly: true, enabledTools: [ToolName.LIST_TOPICS] },
+          dev: {
+            readOnly: false,
+            enabledTools: [ToolName.CREATE_TOPICS, ToolName.LIST_TOPICS],
+          },
         },
       });
+    });
+
+    it("should report each connection's read-only-ness as a boolean in the structured payload", () => {
+      const runtime = runtimeWithConnections({
+        prod: { read_only: true, ...KAFKA },
+        dev: KAFKA,
+      });
+
+      const result = handlerWith(threeToolUniverse()).handle(runtime);
+
+      const { connections } = result.structuredContent as {
+        connections: Record<string, { readOnly: boolean }>;
+      };
+      expect(connections.prod?.readOnly).toBe(true);
+      expect(connections.dev?.readOnly).toBe(false);
+    });
+
+    it("should report readOnly false for a connection that never set read_only", () => {
+      // The handler coerces an absent read_only to a definite false, so the
+      // payload always carries a boolean rather than leaking undefined.
+      const runtime = runtimeWithConnections({ k: KAFKA });
+
+      const result = handlerWith(threeToolUniverse()).handle(runtime);
+
+      const bucket = (
+        result.structuredContent as {
+          connections: Record<string, { readOnly: boolean }>;
+        }
+      ).connections.k;
+      expect(bucket?.readOnly).toBe(false);
+    });
+
+    it("should mark read-only connections in the text summary", () => {
+      const runtime = runtimeWithConnections({
+        prod: { read_only: true, ...KAFKA },
+        dev: KAFKA,
+      });
+
+      const result = handlerWith([
+        [ToolName.LIST_TOPICS, new StubHandler({ predicate: hasKafka })],
+      ]).handle(runtime);
+
+      expect(textOf(result)).toContain("prod [read-only] (1 tool):");
+      expect(textOf(result)).toContain("dev (1 tool):");
+      expect(textOf(result)).not.toContain("dev [read-only]");
     });
 
     it("should return an empty mapping with explanatory text when no connections are configured", () => {

--- a/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.ts
@@ -15,9 +15,11 @@ const listConfiguredConnectionsArguments = z.object({});
 /**
  * Per-connection entry in the `list-configured-connections` payload. `description` is the operator's
  * optional label from config, present only when the connection defined a non-blank one.
+ * `readOnly` is the connection's resolved `read_only` setting, always a definite boolean.
  */
 interface ConnectionListing {
   description?: string;
+  readOnly: boolean;
   enabledTools: ToolName[];
 }
 
@@ -46,13 +48,18 @@ export class ListConfiguredConnectionsHandler extends ToolMetadataHandler {
 
     const connections: Record<string, ConnectionListing> = {};
     for (const [connId, conn] of Object.entries(runtime.config.connections)) {
-      // Omit the key entirely when there is no description (a blank one coerces
+      // Coerce read_only to a definite boolean: the YAML path Zod-defaults it to
+      // false, but the field is optional on the type, so an absent value would
+      // otherwise leak undefined into the payload instead of the false the
+      // listing promises.
+      const readOnly = conn.read_only === true;
+      // Omit the description key entirely when there is none (a blank one coerces
       // to undefined at config-parse time), so the listing never carries an
       // empty-string label.
       connections[connId] =
         conn.description === undefined
-          ? { enabledTools: [] }
-          : { description: conn.description, enabledTools: [] };
+          ? { readOnly, enabledTools: [] }
+          : { description: conn.description, readOnly, enabledTools: [] };
     }
 
     // Single pass over the catalog: compute each tool's enabled connection ids
@@ -86,7 +93,7 @@ export class ListConfiguredConnectionsHandler extends ToolMetadataHandler {
     return {
       name: ToolName.LIST_CONFIGURED_CONNECTIONS,
       description:
-        "List every configured connection and the connection-routable tools you can invoke against each. The connection id (the map key) is the value to pass as the `connectionId` argument on tools that ask for one. Connection-agnostic tools (e.g. docs and diagnostics that take no `connectionId`) are always available and appear in `tools/list`, not here. Call this when a tool offers a choice of connections, or to discover which connection supports the capability you need.",
+        "List every configured connection and the connection-routable tools you can invoke against each. The connection id (the map key) is the value to pass as the `connectionId` argument on tools that ask for one. Each connection also reports `readOnly`: when true, the connection is marked read-only and exposes only non-mutating tools. Connection-agnostic tools (e.g. docs and diagnostics that take no `connectionId`) are always available and appear in `tools/list`, not here. Call this when a tool offers a choice of connections, or to discover which connection supports the capability you need.",
       inputSchema: listConfiguredConnectionsArguments.shape,
       annotations: READ_ONLY,
     };
@@ -106,14 +113,15 @@ function renderSummary(connections: Record<string, ConnectionListing>): string {
   if (entries.length === 0) {
     return "No connections are configured.";
   }
-  const lines = entries.map(([id, { description, enabledTools }]) => {
+  const lines = entries.map(([id, { description, readOnly, enabledTools }]) => {
     const count = enabledTools.length;
     const list = count > 0 ? enabledTools.join(", ") : "(none)";
     // JSON.stringify quotes and escapes the description so an embedded quote or
     // newline can't make the summary line ambiguous or wrap onto another line.
     const label =
       description === undefined ? id : `${id} — ${JSON.stringify(description)}`;
-    return `  ${label} (${count} tool${count === 1 ? "" : "s"}): ${list}`;
+    const marker = readOnly ? " [read-only]" : "";
+    return `  ${label}${marker} (${count} tool${count === 1 ? "" : "s"}): ${list}`;
   });
   return [
     `${entries.length} connection${entries.length === 1 ? "" : "s"} configured:`,


### PR DESCRIPTION
# Expose connection read-only-ness in `list-configured-connections`

## `list-configured-connections` reports read-only-ness

- Each connection entry in the tool's structured payload now carries a `readOnly` boolean, so an agent can tell at a glance which connections are write-protected without having to infer it from the absence of mutating tools. The value is the connection's resolved `read_only` setting, coerced to a definite `true`/`false` (the field is Zod-defaulted to `false` on the YAML path but optional on the type).
- The text summary marks read-only connections inline with a `[read-only]` tag (e.g. `prod [read-only] (1 tool): list-topics`), keeping the at-a-glance view in sync with the authoritative structured payload.
- The tool description now advertises the `readOnly` field so agents discover it from `tools/list`.
- New handler tests pin the true and false branches in the structured payload, the `undefined → false` coercion for a connection that never set `read_only`, and the `[read-only]` summary marker; the existing exact-match assertions were extended to include `readOnly`, so any future regression that drops the field fails loudly.

## Relationships

- Closes #589
- Child of #532 (Epic: Multi-connection support)
- Builds on #578, which introduced the per-connection `read_only` flag

<img width="951" height="466" alt="Screenshot 2026-06-12 at 9 38 46 PM" src="https://github.com/user-attachments/assets/6440647f-315d-493d-ae16-329e0328d4b5" />
