### PR TITLE
Fix serialization of AVRO toplevel primitives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this MCP server will be documented in this file.
 - **Per-connection `description` field.** Optional free-text label on any connection, echoed back by `list-configured-connections`.
 - **Per-connection `read_only` flag.** Set `read_only: true` on a connection to auto-disable every state-mutating tool for it, leaving only read-only tools enabled.
 
+### Fixed
+
+- `produce-message` can now produce primitive key and value payloads (numbers, booleans, strings) against top-level primitive Schema Registry schemas such as Avro `long`; previously the serializer rejected anything but an object.
+
 ## 1.4.0
 
 ### Added

--- a/src/confluent/schema-registry-helper.test.ts
+++ b/src/confluent/schema-registry-helper.test.ts
@@ -1,5 +1,9 @@
 import { SerdeType } from "@confluentinc/schemaregistry";
-import { checkSchemaNeeded } from "@src/confluent/schema-registry-helper.js";
+import {
+  checkSchemaNeeded,
+  deserializeMessage,
+  serializeMessage,
+} from "@src/confluent/schema-registry-helper.js";
 import { getMockedSchemaRegistry } from "@tests/stubs/index.js";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -98,5 +102,104 @@ describe("schema-registry-helper.ts", () => {
         expect(result).toEqual({ type: "no-schema", subject: expected });
       },
     );
+  });
+
+  describe("serializeMessage()", () => {
+    let registry: ReturnType<typeof getMockedSchemaRegistry>;
+
+    beforeEach(() => {
+      registry = getMockedSchemaRegistry();
+    });
+
+    describe("without schema registry", () => {
+      it("should pass a string payload through unchanged", async () => {
+        const result = await serializeMessage(
+          "orders",
+          { message: "raw", useSchemaRegistry: false },
+          SerdeType.VALUE,
+          undefined,
+        );
+        expect(result).toBe("raw");
+      });
+
+      it.each([
+        { name: "number", message: 123, expected: "123" },
+        { name: "boolean", message: true, expected: "true" },
+        { name: "object", message: { x: 1 }, expected: '{"x":1}' },
+      ])(
+        "should JSON-encode a $name payload",
+        async ({ message, expected }) => {
+          const result = await serializeMessage(
+            "orders",
+            { message, useSchemaRegistry: false },
+            SerdeType.VALUE,
+            undefined,
+          );
+          expect(result).toBe(expected);
+        },
+      );
+    });
+
+    describe("with schema registry and a primitive top-level schema", () => {
+      it.each([
+        { name: "Avro long", message: 123, schema: '"long"' },
+        { name: "Avro boolean", message: true, schema: '"boolean"' },
+        { name: "Avro string", message: "hello", schema: '"string"' },
+      ])(
+        "should serialize a $name primitive and round-trip it back to the value",
+        async ({ message, schema }) => {
+          // No subject association registered → the serializer falls back to
+          // the {topic}-value naming strategy rather than throwing.
+          registry.getAssociationsByResourceName.mockResolvedValue([]);
+          // The latest-registered schema drives serialization; the same schema,
+          // resolved by id, drives the deserialize round-trip.
+          registry.getLatestSchemaMetadata.mockResolvedValue({
+            id: 1,
+            version: 1,
+            subject: "orders-value",
+            schema,
+            schemaType: "AVRO",
+          });
+          registry.getBySubjectAndId.mockResolvedValue({
+            schema,
+            schemaType: "AVRO",
+          });
+
+          const serialized = await serializeMessage(
+            "orders",
+            { message, useSchemaRegistry: true, schemaType: "AVRO" },
+            SerdeType.VALUE,
+            registry,
+          );
+
+          expect(Buffer.isBuffer(serialized)).toBe(true);
+          const roundTripped = await deserializeMessage(
+            "orders",
+            serialized as Buffer,
+            "AVRO",
+            registry,
+            SerdeType.VALUE,
+          );
+          expect(roundTripped).toBe(message);
+        },
+      );
+
+      it("should reject a null payload with a non-null-required message", async () => {
+        await expect(
+          serializeMessage(
+            "orders",
+            {
+              message: null as unknown as object,
+              useSchemaRegistry: true,
+              schemaType: "AVRO",
+            },
+            SerdeType.VALUE,
+            registry,
+          ),
+        ).rejects.toThrow(
+          "When using schema registry, a non-null message payload is required.",
+        );
+      });
+    });
   });
 });

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -45,7 +45,7 @@ export interface SchemaRegistryOptions {
  * Includes the message payload and schema registry configuration.
  */
 export type MessageOptions = {
-  message: Buffer | object | string;
+  message: Buffer | object | string | number | boolean;
   useSchemaRegistry?: boolean;
   schemaType?: SchemaType;
   schema?: string;
@@ -254,10 +254,13 @@ export async function serializeMessage(
       );
     }
   }
-  // Validate message type
-  if (typeof options.message !== "object" || options.message === null) {
+  // Primitives (number/boolean/string) are valid payloads for top-level
+  // primitive schemas (e.g. Avro "long"); only null/undefined is rejected here
+  // because the serializer refuses it with a cryptic "message is empty". Every
+  // other shape is validated against the actual schema by the serializer.
+  if (options.message === null || options.message === undefined) {
     throw new Error(
-      "When using schema registry, message must be an object matching the schema.",
+      "When using schema registry, a non-null message payload is required.",
     );
   }
   let serializer: Serializer;

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -22,6 +22,7 @@ import {
   stopOAuthServer,
 } from "@tests/harness/oauth-flow.js";
 import { integrationConnection } from "@tests/harness/runtime.js";
+import { withSharedSrClient } from "@tests/harness/schema-registry.js";
 import { skipIfDisabled } from "@tests/harness/skip-gate.js";
 import {
   startServer,
@@ -172,6 +173,78 @@ describe(
                 value: { message: `hello from oauth ${transport}` },
                 cluster_id: clusterId,
                 environment_id: environmentId,
+              },
+            });
+
+            const text = textContent(result);
+            expect(text).toMatch(/Message produced successfully to \[Topic: /);
+            expect(text).toContain(topic);
+          });
+        });
+      },
+    );
+
+    describe(
+      "with a top-level Avro primitive value schema",
+      { tags: [Tag.REQUIRES_SCHEMA_REGISTRY_CONFIG] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+          it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
+          return;
+        }
+        // kafka gate (handler predicate), then a schema-registry gate so a
+        // fixture carrying kafka but no schema_registry block skips cleanly
+        // rather than failing when the produce call reaches for an SR client.
+        if (skipIfDisabled(handler, integrationConnection())) {
+          return;
+        }
+        const connection = integrationConnection();
+        if (connection.type !== "direct" || !connection.schema_registry) {
+          it.skip("requires schema_registry config", () => {});
+          return;
+        }
+
+        let admin: KafkaJS.Admin;
+        const topic = uniqueName("produce-avro-long");
+        // shared SR client only for subject cleanup; the produce call itself
+        // registers the schema via its `schema` argument
+        const { createdSubjects } = withSharedSrClient();
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
+        });
+
+        afterAll(async () => {
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect();
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startServer({ transport });
+          });
+
+          afterAll(async () => {
+            await server?.stop();
+          });
+
+          it("should serialize and produce a numeric long value against a primitive schema", async () => {
+            createdSubjects.push(`${topic}-value`);
+            const result = await server.client.callTool({
+              name: ToolName.PRODUCE_MESSAGE,
+              arguments: {
+                topicName: topic,
+                value: {
+                  message: 123,
+                  useSchemaRegistry: true,
+                  schemaType: "AVRO",
+                  schema: '"long"',
+                },
               },
             });
 

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.test.ts
@@ -93,6 +93,55 @@ describe("produce-kafka-message-handler.ts", () => {
         });
       });
 
+      it("should serialize a numeric Avro value and send the buffer to the producer", async () => {
+        const clientManager = getMockedClientManager();
+        const producer = await clientManager.getProducer();
+        producer.send.mockResolvedValue([
+          { topicName: "smoke", partition: 0, offset: "5", errorCode: 0 },
+        ]);
+        // Latest registered value schema is a top-level Avro long, so the
+        // numeric payload serializes against it rather than tripping the old
+        // object-only guard.
+        const registry = clientManager.getSchemaRegistryClient();
+        registry.getAssociationsByResourceName.mockResolvedValue([]);
+        registry.getLatestSchemaMetadata.mockResolvedValue({
+          id: 1,
+          version: 1,
+          subject: "smoke-value",
+          schema: '"long"',
+          schemaType: "AVRO",
+        });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            { kafka: { bootstrap_servers: "broker:9092" } },
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {
+            topicName: "smoke",
+            value: {
+              message: 123,
+              useSchemaRegistry: true,
+              schemaType: "AVRO",
+            },
+          },
+          outcome: {
+            resolves: "Message produced successfully to [Topic: smoke",
+          },
+          clientManager,
+        });
+
+        // Confluent wire format: magic byte 0x00, 4-byte big-endian schema id
+        // (1), then the Avro long zigzag-varint encoding of 123 (0xF6 0x01).
+        // No key entry, since the args carry only a value.
+        expect(producer.send).toHaveBeenCalledWith({
+          topic: "smoke",
+          messages: [{ value: Buffer.from([0, 0, 0, 0, 1, 0xf6, 0x01]) }],
+        });
+      });
+
       it("should call getSchemaRegistrySdkClient with the resolved envId when value.useSchemaRegistry is true", async () => {
         // Pin the SR-under-OAuth wiring at the handler-test layer. Under
         // direct-mode runtime, `resolveKafkaClusterArgs` returns

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -25,9 +25,9 @@ import { z } from "zod";
 
 const messageOptions = z.object({
   message: z
-    .union([z.object({}).passthrough(), z.string()])
+    .union([z.object({}).passthrough(), z.string(), z.number(), z.boolean()])
     .describe(
-      "The payload to produce. If using schema registry, this should be an object matching the schema. Otherwise, a string.",
+      "The payload to produce. When using schema registry, this should match the schema: an object for record schemas, or a primitive (string/number/boolean) for top-level primitive schemas such as Avro long. Without schema registry, a string is sent raw and anything else is JSON-encoded.",
     ),
   useSchemaRegistry: z
     .boolean()


### PR DESCRIPTION
# produce-message: primitive key/value payloads for Schema Registry

## Primitive payloads on the produce path

- `produce-message` could only accept an object or a string payload for a key or value. Schemas whose top-level type is an Avro (or JSON Schema) primitive — `long`, `int`, `double`, `boolean`, `string` — had no way to be produced faithfully. This widens the accepted payload to also include `number` and `boolean`, so a record keyed or valued by a primitive schema can be produced as the AI assistant naturally represents it.
- Two gates rejected primitives, and a primitive tripped both:
  - The handler's Zod `message` schema was `union([object, string])`, rejecting `number`/`boolean` before `handle()` ran.
  - `serializeMessage` threw "message must be an object matching the schema" for any non-object on the Schema Registry path — which also meant a top-level `string` schema was broken there, not just numeric ones.
- The downstream `@confluentinc/schemaregistry` serializer already handles primitive-typed schemas (`avroType.toBuffer(value)`); the only thing standing in the way was our own pre-flight validation. The fix relaxes that guard to reject only a null/undefined payload (the one value the SDK itself refuses, with a cryptic "message is empty") and lets every concrete primitive through to be validated against the real schema.

### Scope notes

- Avro `long` values beyond JavaScript's 2^53 safe-integer range lose precision because tool arguments arrive as already-parsed JSON numbers. Faithfully round-tripping large longs would require accepting them as strings plus a custom avsc long type; that is left as a follow-up rather than folded in here.
- Top-level Avro `null` is intentionally not accepted — the serializer rejects a null payload outright, so advertising it would only bait a confusing failure.

## Tests

- `serializeMessage` gains its first unit coverage: an `it.each` produces `long`/`boolean`/`string` primitive payloads against a mocked registry and round-trips each back through `deserializeMessage` to the exact value, proving the primitive reaches the serializer and encodes faithfully. The non-Schema-Registry path is pinned too (`123` → `"123"`, `true` → `"true"`), and a negative case asserts the relaxed guard still rejects a null payload with the new "a non-null message payload is required" message.
- A `produce-message` handler case produces a numeric Avro value end-to-end through `runtimeWithDecoy`, asserting success and that the producer received the serialized buffer — red today on the Zod gate.
- An integration case registers a `"long"` value schema and produces a numeric record against live Schema Registry.


## Proof
A prompt like `Copy the most recent 10 messages from ccloud RealWorldData's WeatherData to the local WeatherData topic.` now works, where said source and dest topic have key schemas specifying AVRO primitive `long` values. Here is a screenshot of VS Code Extension's consume message of one of the copied messages showing that the key was indeed serialized using AVRO:

<img width="480" height="902" alt="image" src="https://github.com/user-attachments/assets/f225030d-d541-40b3-b499-600917279d37" />

## Relationships

Closes #587.


