### PR TITLE
fix(pnpm): move overrides/onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ web_modules/
 !/config.example.yaml
 !/config.oauth.example.yaml
 !/pnpm-lock.yaml
+!/pnpm-workspace.yaml
 !/docker-compose.yml
 !/service.yml
 

--- a/.semaphore/npm-audit.yml
+++ b/.semaphore/npm-audit.yml
@@ -36,16 +36,17 @@ blocks:
         - name: "Run audit and create/update PR"
           commands:
             - pnpm install --frozen-lockfile
-            # `pnpm audit --fix` writes `pnpm.overrides` entries pinning vulnerable
-            # transitive deps to fixed versions; a follow-up install applies those
-            # overrides to pnpm-lock.yaml. Unlike `npm audit fix`, it does not bump
-            # the dependency tree directly, so review the generated overrides.
+            # `pnpm audit --fix` writes `overrides` entries (to pnpm-workspace.yaml
+            # under pnpm 10+) pinning vulnerable transitive deps to fixed versions;
+            # a follow-up install applies those overrides to pnpm-lock.yaml. Unlike
+            # `npm audit fix`, it does not bump the dependency tree directly, so
+            # review the generated overrides.
             # ( || true to avoid exiting non-zero on unfixable advisories that
             # require manual, possibly-breaking changes to package.json)
             - pnpm audit --fix || true
             - pnpm install --no-frozen-lockfile
             - |
-              if git diff --quiet -- package.json pnpm-lock.yaml; then
+              if git diff --quiet -- package.json pnpm-workspace.yaml pnpm-lock.yaml; then
                 echo "No changes after pnpm audit --fix; nothing to do."
                 exit 0
               fi
@@ -59,7 +60,7 @@ blocks:
               TITLE="[${TARGET_BRANCH}] chore(deps): pnpm audit fix"
 
               git checkout -b "$BRANCH"
-              git add package.json pnpm-lock.yaml
+              git add package.json pnpm-workspace.yaml pnpm-lock.yaml
               git commit -m "$TITLE"
               git push --force -u origin "$BRANCH"
 
@@ -70,5 +71,5 @@ blocks:
                   --base "$TARGET_BRANCH" \
                   --head "$BRANCH" \
                   --title "$TITLE" \
-                  --body "Automated security update produced by \`pnpm audit --fix\` on \`${TARGET_BRANCH}\`. Please review the generated \`pnpm.overrides\` in \`package.json\` and the \`pnpm-lock.yaml\` changes before merging. Note: \`pnpm audit --fix\` pins vulnerable transitive deps via overrides rather than bumping the dependency tree, so each override should be re-evaluated as upstream fixes land. This PR is created/updated via the [\`scheduled-npm-audit\`](https://github.com/confluentinc/mcp-confluent/blob/${TARGET_BRANCH}/.semaphore/npm-audit.yml) Semaphore task."
+                  --body "Automated security update produced by \`pnpm audit --fix\` on \`${TARGET_BRANCH}\`. Please review the generated \`overrides\` in \`pnpm-workspace.yaml\` and the \`pnpm-lock.yaml\` changes before merging. Note: \`pnpm audit --fix\` pins vulnerable transitive deps via overrides rather than bumping the dependency tree, so each override should be re-evaluated as upstream fixes land. This PR is created/updated via the [\`scheduled-npm-audit\`](https://github.com/confluentinc/mcp-confluent/blob/${TARGET_BRANCH}/.semaphore/npm-audit.yml) Semaphore task."
               fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,10 @@ library's core.
 
 ### Building and Running
 
+This project uses [pnpm](https://pnpm.io/installation) (Node.js 22+).
+If you don't have pnpm yet, install it once -- `brew install pnpm` on macOS, or any [other method](https://pnpm.io/installation) on other platforms.
+The exact pnpm version is pinned in the `packageManager` field of `package.json` and pnpm switches to it automatically, so a recent pnpm install is all you need -- no separate Corepack setup required.
+
 1. **Install Dependencies:**
 
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ library's core.
 
 This project uses [pnpm](https://pnpm.io/installation) (Node.js 22+).
 If you don't have pnpm yet, install it once -- `brew install pnpm` on macOS, or any [other method](https://pnpm.io/installation) on other platforms.
-The exact pnpm version is pinned in the `packageManager` field of `package.json` and pnpm switches to it automatically, so a recent pnpm install is all you need -- no separate Corepack setup required.
+The exact pnpm version is pinned in the `packageManager` field of `package.json`, and pnpm automatically runs that pinned version (via its built-in package-manager version management), so a recent pnpm install is all you need -- no separate Corepack setup required.
 
 1. **Install Dependencies:**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ FROM ${NODE_IMAGE} AS builder
 WORKDIR /app
 
 
-COPY package.json pnpm-lock.yaml ./
+# pnpm-workspace.yaml carries `overrides` and `onlyBuiltDependencies`; without it
+# the install would skip the native build scripts for @confluentinc/kafka-javascript
+# (and others), producing an image whose native addon never gets compiled.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # corepack activates the pnpm version pinned in package.json's
 # `packageManager` field, matching CI and local dev.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The tests skip cleanly when those env vars are unset, so `pnpm run test:unit` an
   npm install -g pnpm
   ```
   See pnpm's [installation guide](https://pnpm.io/installation) for other options.
-  The exact pnpm version is pinned in the `packageManager` field of `package.json` and pnpm switches to it automatically, so a recent pnpm install is all you need -- no separate Corepack setup required.
+  The exact pnpm version is pinned in the `packageManager` field of `package.json`, and pnpm automatically runs that pinned version (via its built-in package-manager version management), so a recent pnpm install is all you need -- no separate Corepack setup required.
 - A local environment with Kafka or Schema Registry running, or a **Confluent Cloud** account with appropriate API keys or login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
 
 ### General Setup Steps

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ The tests skip cleanly when those env vars are unset, so `pnpm run test:unit` an
   nvm install 22
   nvm use 22
   ```
+- **[pnpm](https://pnpm.io/installation)** -- only needed to build from source (the `npx` quick start above does not require it).
+  On macOS the simplest install is Homebrew; `npm` works cross-platform:
+  ```bash
+  brew install pnpm        # macOS
+  # or, cross-platform:
+  npm install -g pnpm
+  ```
+  See pnpm's [installation guide](https://pnpm.io/installation) for other options.
+  The exact pnpm version is pinned in the `packageManager` field of `package.json` and pnpm switches to it automatically, so a recent pnpm install is all you need -- no separate Corepack setup required.
 - A local environment with Kafka or Schema Registry running, or a **Confluent Cloud** account with appropriate API keys or login credentials if [using OAuth to authenticate](#oauth-authentication-for-confluent-cloud).
 
 ### General Setup Steps

--- a/package.json
+++ b/package.json
@@ -97,23 +97,6 @@
     "yaml": "^2.8.3",
     "zod": "^4.0"
   },
-  "pnpm": {
-    "overrides": {
-      "zod": "^4.0",
-      "shell-quote@>=1.1.0 <=1.8.3": ">=1.8.4",
-      "protobufjs@<=7.6.2": ">=7.6.3",
-      "form-data@>=4.0.0 <4.0.6": ">=4.0.6",
-      "tar@<=7.5.15": ">=7.5.16",
-      "vite@>=8.0.0 <=8.0.15": ">=8.0.16",
-      "js-yaml@<=4.1.1": ">=4.2.0",
-      "protobufjs@<=7.6.0": ">=7.6.1"
-    },
-    "onlyBuiltDependencies": [
-      "@confluentinc/kafka-javascript",
-      "fsevents",
-      "protobufjs"
-    ]
-  },
   "files": [
     "dist",
     "config.example.yaml",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,17 @@
+# pnpm reads project settings like `overrides` and `onlyBuiltDependencies` from
+# this file, not the `pnpm` field in package.json. Recent pnpm versions ignore
+# that field (and warn that it "is no longer read"), so keep these settings here.
+# See https://pnpm.io/settings.
+overrides:
+  zod: ^4.0
+  shell-quote@>=1.1.0 <=1.8.3: ">=1.8.4"
+  protobufjs@<=7.6.2: ">=7.6.3"
+  form-data@>=4.0.0 <4.0.6: ">=4.0.6"
+  tar@<=7.5.15: ">=7.5.16"
+  vite@>=8.0.0 <=8.0.15: ">=8.0.16"
+  js-yaml@<=4.1.1: ">=4.2.0"
+  protobufjs@<=7.6.0: ">=7.6.1"
+onlyBuiltDependencies:
+  - "@confluentinc/kafka-javascript"
+  - fsevents
+  - protobufjs


### PR DESCRIPTION
## Summary

Fixes two regressions reported after #583 (the npm → pnpm migration):

1. **The `pnpm` field in `package.json` is no longer read by pnpm.** Newer pnpm versions emit
   `The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides", "pnpm.onlyBuiltDependencies"`
   and, critically, **stop applying those settings** — silently dropping our security `overrides`
   and the native-build `onlyBuiltDependencies` allowlist. The settings' canonical home as of
   pnpm 10 is `pnpm-workspace.yaml` ([docs](https://pnpm.io/settings)).
2. **No pnpm install guidance existed.** Contributors were told to run `pnpm install` with no
   word on how to obtain pnpm — the source of the "surprised I had to install a new package
   manager" friction.

## What changed

- **`pnpm-workspace.yaml` (new):** holds `overrides` + `onlyBuiltDependencies`, moved verbatim
  from the now-removed `package.json` `pnpm` field.
- **`Dockerfile`:** copy `pnpm-workspace.yaml` into the builder stage.
- **`.semaphore/npm-audit.yml`:** track `pnpm-workspace.yaml` in the audit-fix change-detection
  and commit, and update stale comments/PR-body text.
- **`.gitignore`:** `!/pnpm-workspace.yaml` exception (root `*.yaml` is blanket-ignored as a
  credential guard; this follows the documented pattern already used for `config.example.yaml`).
- **`README.md` / `CONTRIBUTING.md`:** add pnpm install guidance (`brew`/`npm`; the exact version
  is pinned via `packageManager` and pnpm switches to it automatically).

## Why these are the right changes — and why they're safe

- **The migration is provably resolution-neutral.** The `overrides` and `onlyBuiltDependencies`
  values are moved byte-for-byte, and `pnpm install --frozen-lockfile` passes with **zero
  lockfile churn**, so the dependency graph is unchanged — same CVE-mitigation overrides, same
  native-build allowlist. A non-frozen re-resolve confirmed pnpm now sources the settings from
  `pnpm-workspace.yaml` (removing the file drops the `overrides:` block from the lockfile;
  keeping it leaves the lockfile identical). `pnpm-workspace.yaml` is the correct home even for a
  single-package (non-monorepo) repo and needs no `packages:` key.
- **The Dockerfile fix prevents a real image regression.** pnpm 10 blocks dependency build
  scripts unless allowlisted via `onlyBuiltDependencies`. That allowlist used to live in
  `package.json` (which the builder copies); moving it to `pnpm-workspace.yaml` without copying
  that file would leave `@confluentinc/kafka-javascript`'s native addon uncompiled — a runtime
  failure that only surfaces when the container starts. Copying the file restores the previous
  behavior.
- **The npm-audit fix closes the same failure mode this PR is about.** `pnpm audit --fix` writes
  overrides to `pnpm-workspace.yaml` under pnpm 10; without tracking that file the bot would
  generate a `pnpm-lock.yaml` it can't reproduce from the committed manifests.
- **`.npmrc` is deliberately untouched.** It points at the public npm registry so this public
  OSS repo builds for contributors without Confluent CodeArtifact access. (The CodeArtifact 401
  in the original report was an expired-token issue on a Confluent machine whose _global_ npm
  config routes to CodeArtifact — not a repo defect; project-level `.npmrc` already overrides it
  to public npm, and pinning the registry here would fight employees' internal routing while
  adding nothing for outsiders.)

## Validation

- `pnpm install --frozen-lockfile` — clean, no lockfile changes.
- A/B re-resolve test confirms `pnpm-workspace.yaml` is the active settings source.
- `pnpm-workspace.yaml` and `.semaphore/npm-audit.yml` parse as valid YAML.
- `prettier --check` passes on all touched files; pre-commit (prettier + eslint) and pre-push
  (lint + typecheck) hooks ran clean.

## Follow-up (not in this PR)

Removing the CI/Docker dependence on Corepack (replacing `corepack enable` with an explicit pnpm
install + pnpm's self-management) will be a separate PR — it touches the Dockerfile and 4
Semaphore pipelines and warrants its own `docker build` + green-pipeline validation.
