### PR TITLE
chore: drop Corepack, bootstrap pnpm via npm + self-management

### DIFF
--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -19,10 +19,11 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      # Install any recent pnpm; it reads package.json's `packageManager` field
-      # and self-switches to the pinned version (no version pin or Corepack needed).
-      - npm install --global pnpm
       - checkout
+      # Install any recent pnpm after checkout so the repo's `.npmrc` governs the
+      # install; pnpm reads package.json's `packageManager` field and self-switches
+      # to the pinned version (no version pin or Corepack needed).
+      - npm install --global pnpm
       - pnpm config set store-dir ~/.pnpm-store
       - cache restore pnpm-store-$(checksum pnpm-lock.yaml),pnpm-store-
       - pnpm install --frozen-lockfile

--- a/.semaphore/integration.yml
+++ b/.semaphore/integration.yml
@@ -19,7 +19,9 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      - corepack enable
+      # Install any recent pnpm; it reads package.json's `packageManager` field
+      # and self-switches to the pinned version (no version pin or Corepack needed).
+      - npm install --global pnpm
       - checkout
       - pnpm config set store-dir ~/.pnpm-store
       - cache restore pnpm-store-$(checksum pnpm-lock.yaml),pnpm-store-

--- a/.semaphore/npm-audit.yml
+++ b/.semaphore/npm-audit.yml
@@ -11,7 +11,9 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      - corepack enable
+      # Install any recent pnpm; it reads package.json's `packageManager` field
+      # and self-switches to the pinned version (no version pin or Corepack needed).
+      - npm install --global pnpm
       - checkout
       - . vault-setup --version v3 --role mcp-confluent
       - |

--- a/.semaphore/npm-audit.yml
+++ b/.semaphore/npm-audit.yml
@@ -11,10 +11,11 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      # Install any recent pnpm; it reads package.json's `packageManager` field
-      # and self-switches to the pinned version (no version pin or Corepack needed).
-      - npm install --global pnpm
       - checkout
+      # Install any recent pnpm after checkout so the repo's `.npmrc` governs the
+      # install; pnpm reads package.json's `packageManager` field and self-switches
+      # to the pinned version (no version pin or Corepack needed).
+      - npm install --global pnpm
       - . vault-setup --version v3 --role mcp-confluent
       - |
         TARGET_BRANCH="${TARGET_BRANCH:-main}"

--- a/.semaphore/release-version.yml
+++ b/.semaphore/release-version.yml
@@ -19,7 +19,9 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      - corepack enable
+      # Install any recent pnpm; it reads package.json's `packageManager` field
+      # and self-switches to the pinned version (no version pin or Corepack needed).
+      - npm install --global pnpm
       - checkout
       - |
         if [ -n "$TARGET_BRANCH" ]; then

--- a/.semaphore/release-version.yml
+++ b/.semaphore/release-version.yml
@@ -19,10 +19,11 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      # Install any recent pnpm; it reads package.json's `packageManager` field
-      # and self-switches to the pinned version (no version pin or Corepack needed).
-      - npm install --global pnpm
       - checkout
+      # Install any recent pnpm after checkout so the repo's `.npmrc` governs the
+      # install; pnpm reads package.json's `packageManager` field and self-switches
+      # to the pinned version (no version pin or Corepack needed).
+      - npm install --global pnpm
       - |
         if [ -n "$TARGET_BRANCH" ]; then
           git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,10 +19,10 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      # corepack ships with Node 22 and activates the pnpm version pinned in
-      # package.json's `packageManager` field, so the CLI version is the
-      # single source of truth shared with local dev.
-      - corepack enable
+      # Install any recent pnpm; it reads package.json's `packageManager` field
+      # and self-switches to the pinned version, keeping that field the single
+      # source of truth shared with local dev (no version pin or Corepack needed).
+      - npm install --global pnpm
       - checkout
       - pnpm config set store-dir ~/.pnpm-store
       # Fuzzy-match restore: an exact key hit (lockfile unchanged) skips all

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,11 +19,12 @@ global_job_config:
   prologue:
     commands:
       - sem-version node 22
-      # Install any recent pnpm; it reads package.json's `packageManager` field
-      # and self-switches to the pinned version, keeping that field the single
-      # source of truth shared with local dev (no version pin or Corepack needed).
-      - npm install --global pnpm
       - checkout
+      # Install any recent pnpm after checkout so the repo's `.npmrc` governs the
+      # install; pnpm reads package.json's `packageManager` field and self-switches
+      # to the pinned version, keeping that field the single source of truth shared
+      # with local dev (no version pin or Corepack needed).
+      - npm install --global pnpm
       - pnpm config set store-dir ~/.pnpm-store
       # Fuzzy-match restore: an exact key hit (lockfile unchanged) skips all
       # downloads; the bare `pnpm-store-` prefix lets a changed lockfile still

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ WORKDIR /app
 # (and others), producing an image whose native addon never gets compiled.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-# corepack activates the pnpm version pinned in package.json's
-# `packageManager` field, matching CI and local dev.
-RUN corepack enable && pnpm install --frozen-lockfile
+# Install any recent pnpm; it reads package.json's `packageManager` field and
+# self-switches to the pinned version, keeping that field the single source of
+# truth shared with CI and local dev (no version pin or Corepack needed).
+RUN npm install --global pnpm && pnpm install --frozen-lockfile
 
 COPY tsconfig.json tsconfig.build.json ./
 COPY src/ ./src/


### PR DESCRIPTION
## Summary

Follow-up to #602. Removes the dependence on Corepack for bootstrapping pnpm in CI and Docker.

`node:22` ships Corepack but not pnpm, so `corepack enable` was only there to fetch the
`packageManager`-pinned pnpm. **pnpm 10+ self-manages its version** from the `packageManager`
field — the path pnpm recommends over Corepack for v10+, and Corepack's bundling in Node is being
wound down. This replaces `corepack enable` with `npm install --global pnpm` in the `Dockerfile`
and all four Semaphore pipelines; pnpm then self-switches to the pinned `10.33.4`.

> Stacked on `fix/pnpm-workspace-settings-and-setup-docs` (#602) to avoid a `Dockerfile` conflict
> and because it reads as the natural sequel. **Merge #602 first**, then this re-targets `main`.

## Why this is the right change — and why it's safe

- **`packageManager` stays the single source of truth.** The pinned version lives in exactly one
  place (`package.json`); no version string is duplicated across CI files. Any recent pnpm,
  invoked in the repo, self-switches to `10.33.4`.
- **Verified end to end locally.** Installing the latest pnpm via npm (11.7.0 today) and invoking
  it in this repo runs `10.33.4` and completes `pnpm install --frozen-lockfile` cleanly
  (`Done … using pnpm v10.33.4`).
- **Alpine/musl-safe.** pnpm self-management fetches the platform-independent JS package (run by
  the image's own Node), not a native `@pnpm/exe` binary — so it behaves the same as Corepack did
  on `node:22-alpine`. The `docker-image-scan` pipeline (`docker build … .`) exercises this path
  on every PR.
- **No new auth/registry surface.** Corepack already fetched pnpm from the registry; the committed
  `.npmrc` points at public npm, so this works for external contributors with no CodeArtifact
  access.
- **Prologue ordering is correct.** In each pipeline the global install precedes `checkout`, and
  the first `pnpm` command runs after checkout (and after any branch/SHA switch), so
  self-management always resolves the target ref's pin.

## Considered alternative: pinning the bootstrap

The PR-review pass flagged that `npm install --global pnpm` is unpinned, so build determinism
rests on pnpm's self-management default staying enabled. The alternative is
`npm install --global pnpm@10.33.4`. We chose **not** to pin here: self-management overrides the
bootstrap to the pinned version regardless, so pinning would duplicate the version across six
files (re-introducing the drift this design avoids) without changing what actually runs. The
unpinned form is also pnpm's own recommended approach, and the marginal supply-chain delta over
Corepack — which likewise fetched pnpm from the registry — is negligible. Happy to revisit if
reviewers feel the determinism guarantee should be explicit rather than relying on the default.

## Validation

- Local: npm-installed latest pnpm self-manages to `10.33.4`; `pnpm install --frozen-lockfile` clean.
- All four Semaphore YAMLs parse; no `corepack enable` remains anywhere.
- Full alpine image build is validated by the `docker-image-scan` pipeline on this PR.
