### PR TITLE
New multi-connection sample configurations and tests.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -151,6 +151,7 @@ The fully annotated example is in [`config.example.yaml`](config.example.yaml); 
 
 A single `config.yaml` may define several named entries under `connections:` — for example a Confluent Cloud connection alongside a local Apache Kafka broker — and each tool call routes to the connection you address by id.
 There is no fixed ceiling on the number of connections.
+Ready-to-use two-connection starters pairing a read/write local-Docker connection with a read-only Cloud or Confluent Platform connection — across OAuth, API-key, and CP auth — live in [`sample_configs/`](sample_configs/).
 
 One rule constrains the mix: you may pair as many `type: direct` connections as you like, but **at most one** may be `type: oauth`.
 The shared Confluent Cloud sign-in owns a single browser session and identity, so a second OAuth connection is rejected at startup with `Multiple OAuth connections defined in configuration; only one is supported`.

--- a/sample_configs/local-docker-kafka-and-sr-and-readonly-ccloud-via-api-keys.yaml
+++ b/sample_configs/local-docker-kafka-and-sr-and-readonly-ccloud-via-api-keys.yaml
@@ -1,0 +1,50 @@
+# Example MCP Confluent Server configuration — two connections.
+#
+# A read/write local (Docker) Kafka + Schema Registry connection paired with a
+# read-only Confluent Cloud connection authenticated by API keys.
+#
+# Local Docker: the Confluent for VS Code extension makes spinning up and
+# managing the local Kafka and Schema Registry Docker containers simple. Your
+# local Docker Kafka bootstrap server string and Schema Registry URL will vary —
+# adjust the localhost:9092 / http://localhost:8081 values below to match your
+# containers.
+
+connections:
+  # Read/write local development cluster (Docker).
+  local:
+    type: "direct"
+    description: "Local Docker Kafka + Schema Registry (read/write)"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "http://localhost:8081"
+
+  # Read-only Confluent Cloud via API keys. Secrets come from the environment
+  # through ${VAR} interpolation; the pkc-/psrc-/lkc-/env- hostnames and ids
+  # below are placeholders — replace them with your cluster's values.
+  # `read_only: true` auto-disables every mutating tool for this connection.
+  ccloud:
+    type: "direct"
+    description: "Confluent Cloud (API keys, read-only)"
+    read_only: true
+    kafka:
+      bootstrap_servers: "${CCLOUD_KAFKA_BOOTSTRAP_SERVERS:-pkc-xxxxx.us-east-1.aws.confluent.cloud:9092}"
+      auth:
+        type: "api_key"
+        key: "${CCLOUD_KAFKA_API_KEY}"
+        secret: "${CCLOUD_KAFKA_API_SECRET}"
+      rest_endpoint: "${CCLOUD_KAFKA_REST_ENDPOINT:-https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443}"
+      cluster_id: "${CCLOUD_KAFKA_CLUSTER_ID:-lkc-xxxxx}"
+      env_id: "${CCLOUD_KAFKA_ENV_ID:-env-xxxxx}"
+    schema_registry:
+      endpoint: "${CCLOUD_SCHEMA_REGISTRY_ENDPOINT:-https://psrc-xxxxx.us-east-2.aws.confluent.cloud}"
+      auth:
+        type: "api_key"
+        key: "${CCLOUD_SCHEMA_REGISTRY_API_KEY}"
+        secret: "${CCLOUD_SCHEMA_REGISTRY_API_SECRET}"
+    confluent_cloud:
+      endpoint: "${CONFLUENT_CLOUD_REST_ENDPOINT:-https://api.confluent.cloud}"
+      auth:
+        type: "api_key"
+        key: "${CONFLUENT_CLOUD_API_KEY}"
+        secret: "${CONFLUENT_CLOUD_API_SECRET}"

--- a/sample_configs/local-docker-kafka-and-sr-and-readonly-confluent-platform.yaml
+++ b/sample_configs/local-docker-kafka-and-sr-and-readonly-confluent-platform.yaml
@@ -1,0 +1,57 @@
+# Example MCP Confluent Server configuration — two connections.
+#
+# A read/write local (Docker) Kafka + Schema Registry connection paired with a
+# read-only self-managed Confluent Platform (CP) cluster.
+#
+# Local Docker: the Confluent for VS Code extension makes spinning up and
+# managing the local Kafka and Schema Registry Docker containers simple. Your
+# local Docker Kafka bootstrap server string and Schema Registry URL will vary —
+# adjust the localhost:9092 / http://localhost:8081 values below to match your
+# containers.
+
+connections:
+  # Read/write local development cluster (Docker).
+  local:
+    type: "direct"
+    description: "Local Docker Kafka + Schema Registry (read/write)"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "http://localhost:8081"
+
+  # Read-only Confluent Platform. CP is not a distinct mode — it is just a set
+  # of connection values the direct-connection code already accepts; the seven
+  # Kafka and Schema Registry tools register, and every Confluent Cloud tool
+  # (Flink, Tableflow, Billing, Metrics, ...) auto-disables.
+  #
+  # Auth assumption: PLAIN over SASL_SSL for Kafka, HTTP Basic for Schema
+  # Registry. If your CP cluster uses SCRAM, mTLS, or another mechanism,
+  # override security.protocol and sasl.mechanisms via kafka.extra_properties
+  # below.
+  #
+  # TLS trust: if your CP brokers or Schema Registry use an internal CA not in
+  # Node's default trust store, set NODE_EXTRA_CA_CERTS=/path/to/ca.pem in your
+  # environment.
+  #
+  # `read_only: true` auto-disables every mutating tool for this connection.
+  cp:
+    type: "direct"
+    description: "Confluent Platform (read-only)"
+    read_only: true
+    kafka:
+      bootstrap_servers: "cp-broker.internal:9092"
+      auth:
+        type: "api_key"
+        key: "${CP_KAFKA_API_KEY}"
+        secret: "${CP_KAFKA_API_SECRET}"
+      # extra_properties:
+      #   security.protocol: "SASL_SSL"
+      #   sasl.mechanisms: "PLAIN"
+      # # For SCRAM instead:
+      # #   sasl.mechanisms: "SCRAM-SHA-512"
+    schema_registry:
+      endpoint: "https://cp-sr.internal:8081"
+      auth:
+        type: "api_key"
+        key: "${CP_SCHEMA_REGISTRY_API_KEY}"
+        secret: "${CP_SCHEMA_REGISTRY_API_SECRET}"

--- a/sample_configs/local-docker-kafka-and-sr-and-readonly-oauth-ccloud.yaml
+++ b/sample_configs/local-docker-kafka-and-sr-and-readonly-oauth-ccloud.yaml
@@ -1,0 +1,32 @@
+# Example MCP Confluent Server configuration — two connections.
+#
+# A read/write local (Docker) Kafka + Schema Registry connection paired with a
+# read-only Confluent Cloud connection authenticated by OAuth: a browser PKCE
+# sign-in, with no API keys to provision.
+#
+# Local Docker: the Confluent for VS Code extension makes spinning up and
+# managing the local Kafka and Schema Registry Docker containers simple. Your
+# local Docker Kafka bootstrap server string and Schema Registry URL will vary —
+# adjust the localhost:9092 / http://localhost:8081 values below to match your
+# containers.
+
+connections:
+  # Read/write local development cluster (Docker).
+  local:
+    type: "direct"
+    description: "Local Docker Kafka + Schema Registry (read/write)"
+    kafka:
+      bootstrap_servers: "localhost:9092"
+    schema_registry:
+      endpoint: "http://localhost:8081"
+
+  # Read-only Confluent Cloud via OAuth. The browser sign-in (PKCE) opens on the
+  # first tool call that needs Cloud access; the resulting session is reused for
+  # the rest of the process. OAuth connections carry no service blocks —
+  # resource IDs (cluster_id, env_id, ...) are passed as tool arguments at call
+  # time. `read_only: true` auto-disables every mutating tool for this
+  # connection, leaving only read-only tools enabled.
+  ccloud:
+    type: "oauth"
+    description: "Confluent Cloud (OAuth login, read-only)"
+    read_only: true

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -1,9 +1,9 @@
 import { loadConfigFromYaml } from "@src/config/index.js";
 import { combinedSchema } from "@src/env-schema.js";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const FIXTURES_DIR = fileURLToPath(
   new URL("../../test-fixtures/yaml_configs", import.meta.url),
@@ -443,6 +443,42 @@ describe("config/yaml-fixtures.test.ts", () => {
       const knownKeys = new Set(Object.keys(combinedSchema.shape));
       const unknown = [...found].filter((name) => !knownKeys.has(name));
       expect(unknown).toEqual([]);
+    });
+  });
+
+  describe("sample_configs starters", () => {
+    // Every shipped sample_configs/*.yaml must still parse as the schema
+    // evolves — a starter that silently stops loading is worse than none.
+    // Discover the files at runtime so a newly added sample is covered without
+    // touching this test. Same rationale as the config.example.yaml test above.
+    const SAMPLE_DIR = fileURLToPath(
+      new URL("../../sample_configs", import.meta.url),
+    );
+
+    let sampleFiles: string[];
+
+    beforeEach(() => {
+      sampleFiles = readdirSync(SAMPLE_DIR).filter((name) =>
+        /\.ya?ml$/.test(name),
+      );
+    });
+
+    it("should parse every sample without throwing", () => {
+      expect(sampleFiles.length).toBeGreaterThan(0);
+      for (const name of sampleFiles) {
+        const filePath = path.join(SAMPLE_DIR, name);
+        // Feed a dummy value for each no-default ${VAR} placeholder so
+        // interpolation succeeds. Placeholders carrying a :-default are left to
+        // resolve their default — those defaults are crafted to satisfy
+        // field-shape constraints (e.g. the env- prefix on env_id) that a blind
+        // "dummy" would violate.
+        const raw = readFileSync(filePath, "utf-8");
+        const env: Record<string, string> = {};
+        for (const match of raw.matchAll(/\$\{([A-Za-z_]\w*)\}/g)) {
+          env[match[1]!] = "dummy";
+        }
+        expect(() => loadConfigFromYaml(filePath, env), name).not.toThrow();
+      }
     });
   });
 


### PR DESCRIPTION
# Sample configs for multiple connections

## Sample configs

The recent multi-connection work shipped without a copy-pasteable starter showing it off.
These three new `sample_configs/` files each pair a **read/write local (Docker) Kafka + Schema Registry** connection with a **read-only second connection**, one per Cloud/CP authentication flavor:

- `local-docker-kafka-and-sr-and-readonly-oauth-ccloud.yaml` — local dev alongside read-only Confluent Cloud via OAuth (browser PKCE, no API keys).
- `local-docker-kafka-and-sr-and-readonly-ccloud-via-api-keys.yaml` — local dev alongside read-only Confluent Cloud via API keys, exposing `kafka` + `schema_registry` + `confluent_cloud` blocks.
- `local-docker-kafka-and-sr-and-readonly-confluent-platform.yaml` — local dev alongside a read-only self-managed Confluent Platform cluster, modeled on the existing `confluent-platform.yaml` (PLAIN/SASL_SSL, the commented SCRAM/mTLS override, internal-CA `NODE_EXTRA_CA_CERTS` note).

Each file's header comment makes the local-Docker story explicit: the Confluent for VS Code extension makes managing the local Kafka + Schema Registry containers simple, and the `localhost:9092` / `http://localhost:8081` values will vary per setup.

## Validity guard

Added a `sample_configs starters` block to `src/config/yaml-fixtures.test.ts` that discovers every `sample_configs/*.yaml` at runtime and asserts each parses through `loadConfigFromYaml` without throwing.
A `beforeEach` reads the directory into a describe-level array; the single test loops it, feeding a dummy value for each no-default `${VAR}` placeholder (defaulted placeholders keep their defaults, which are crafted to satisfy field-shape constraints like the `env-` prefix).
This mirrors the pre-existing `config.example.yaml` parse test — a shipped starter that silently stops parsing as the schema evolves is worse than no starter.
Before this change no test exercised `sample_configs/` at all; the guard now covers all seven samples and auto-covers any future addition.

## Docs

Added one line to `CONFIGURATION.md`'s "Multiple connections" section pointing at the new two-connection starters; the existing generic `sample_configs/` pointers in `README.md` and elsewhere stay as-is.

## Relationships

* Closes #542.
* Child of #532 
* Builds on the multi-connection support landed in #592 (require `connectionId` when >1 connection) and #593 (per-connection read-only exposure).
