### PR TITLE
Additional ListSchemasHandler.handle() tests.

### DIFF
--- a/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
@@ -92,6 +92,23 @@ describe(
           const parsed = JSON.parse(textContent(result));
           expect(parsed).toHaveProperty(subject);
         });
+
+        it("should return an array of every version for the subject when latestOnly is false", async () => {
+          const result = await server.client.callTool({
+            name: ToolName.LIST_SCHEMAS,
+            arguments: { subjectPrefix: subject, latestOnly: false },
+          });
+
+          expect(result.isError, textContent(result)).not.toBe(true);
+          // with latestOnly:false the handler walks getAllVersions + getSchemaMetadata per
+          // version, so each subject maps to an array rather than a single metadata object
+          const parsed = JSON.parse(textContent(result));
+          expect(Array.isArray(parsed[subject])).toBe(true);
+          // the seeded subject has exactly one registered version; SR numbers versions from 1
+          expect(parsed[subject]).toHaveLength(1);
+          expect(parsed[subject][0].version).toBe(1);
+          expect(typeof parsed[subject][0].id).toBe("number");
+        });
       });
     });
 

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -1,5 +1,8 @@
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
@@ -121,9 +124,277 @@ describe("list-schemas-handler.ts", () => {
           args: {},
           outcome: {
             resolves: "Failed to list schemas: registry unreachable",
+            isError: true,
           },
           clientManager,
         });
+      });
+
+      it("should record a per-subject error entry (not fail the whole call) when getLatestSchemaMetadata rejects for one subject", async () => {
+        sr.getAllSubjects.mockResolvedValue(["healthy", "broken"]);
+        sr.getLatestSchemaMetadata.mockImplementation(
+          async (subject: string) => {
+            if (subject === "broken") {
+              throw new Error("subject broken has no schema");
+            }
+            return {
+              version: 3,
+              id: 7,
+              schemaType: "AVRO",
+              schema: '{"name":"healthy"}',
+            };
+          },
+        );
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: { resolves: '"broken":{"error":', isError: false },
+          clientManager,
+        });
+
+        expect(JSON.parse(textOf(result!))).toEqual({
+          healthy: {
+            version: 3,
+            id: 7,
+            schemaType: "AVRO",
+            schema: '{"name":"healthy"}',
+          },
+          broken: { error: "subject broken has no schema" },
+        });
+      });
+
+      it("should return an array of every version per subject when latestOnly is false", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getAllVersions.mockResolvedValue([1, 2]);
+        sr.getSchemaMetadata.mockImplementation(
+          async (subject: string, version: number) => ({
+            version,
+            id: 100 + version,
+            schemaType: "AVRO",
+            schema: `{"v":${version}}`,
+          }),
+        );
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { latestOnly: false },
+          outcome: { resolves: '"orders":[', isError: false },
+          clientManager,
+        });
+
+        expect(sr.getLatestSchemaMetadata).not.toHaveBeenCalled();
+        expect(sr.getAllVersions).toHaveBeenCalledWith("orders");
+        // deleted defaults to false when the arg is omitted
+        expect(sr.getSchemaMetadata).toHaveBeenCalledWith("orders", 1, false);
+        expect(sr.getSchemaMetadata).toHaveBeenCalledWith("orders", 2, false);
+
+        // versions are fetched via Promise.all, so push order is not guaranteed
+        const parsed = JSON.parse(textOf(result!)) as Record<string, unknown[]>;
+        expect(parsed.orders).toEqual(
+          expect.arrayContaining([
+            { version: 1, id: 101, schemaType: "AVRO", schema: '{"v":1}' },
+            { version: 2, id: 102, schemaType: "AVRO", schema: '{"v":2}' },
+          ]),
+        );
+        expect(parsed.orders).toHaveLength(2);
+      });
+
+      it("should forward deleted=true to getSchemaMetadata when latestOnly is false", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getAllVersions.mockResolvedValue([5]);
+        sr.getSchemaMetadata.mockResolvedValue({
+          version: 5,
+          id: 50,
+          schemaType: "AVRO",
+          schema: "{}",
+        });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { latestOnly: false, deleted: true },
+          outcome: { resolves: '"orders":[', isError: false },
+          clientManager,
+        });
+
+        expect(sr.getSchemaMetadata).toHaveBeenCalledWith("orders", 5, true);
+      });
+
+      it("should record a per-version error entry when getSchemaMetadata rejects for one version (latestOnly false)", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getAllVersions.mockResolvedValue([1, 2]);
+        sr.getSchemaMetadata.mockImplementation(
+          async (subject: string, version: number) => {
+            if (version === 2) {
+              throw new Error("version 2 was hard-deleted");
+            }
+            return {
+              version,
+              id: 100 + version,
+              schemaType: "AVRO",
+              schema: `{"v":${version}}`,
+            };
+          },
+        );
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { latestOnly: false },
+          outcome: { resolves: "version 2 was hard-deleted", isError: false },
+          clientManager,
+        });
+
+        const parsed = JSON.parse(textOf(result!)) as Record<string, unknown[]>;
+        expect(parsed.orders).toEqual(
+          expect.arrayContaining([
+            { version: 1, id: 101, schemaType: "AVRO", schema: '{"v":1}' },
+            { version: 2, error: "version 2 was hard-deleted" },
+          ]),
+        );
+        expect(parsed.orders).toHaveLength(2);
+      });
+
+      it("should record a per-subject error entry when getAllVersions rejects (latestOnly false)", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getAllVersions.mockRejectedValue(
+          new Error("subject orders not found"),
+        );
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { latestOnly: false },
+          outcome: { resolves: '"orders":{"error":', isError: false },
+          clientManager,
+        });
+
+        expect(sr.getSchemaMetadata).not.toHaveBeenCalled();
+        expect(JSON.parse(textOf(result!))).toEqual({
+          orders: { error: "subject orders not found" },
+        });
+      });
+
+      // The handler narrows every rejection with `err instanceof Error ? err.message : ...`.
+      // The SR SDK can reject with a non-Error value, so the four cases below pin the
+      // fallback arm of each catch block (String(err) inside the loops, JSON.stringify at
+      // the top level) rather than letting it rot as untested defensive code.
+
+      it("should JSON.stringify a non-Error rejection from getAllSubjects in the top-level catch", async () => {
+        sr.getAllSubjects.mockRejectedValue({ code: 503 });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: {
+            resolves: 'Failed to list schemas: {"code":503}',
+            isError: true,
+          },
+          clientManager,
+        });
+      });
+
+      it("should String()-coerce a non-Error rejection from getLatestSchemaMetadata into the per-subject error entry", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getLatestSchemaMetadata.mockRejectedValue("registry exploded");
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: { resolves: '"orders":{"error":', isError: false },
+          clientManager,
+        });
+
+        expect(JSON.parse(textOf(result!))).toEqual({
+          orders: { error: "registry exploded" },
+        });
+      });
+
+      it("should String()-coerce a non-Error rejection from getSchemaMetadata into the per-version error entry", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getAllVersions.mockResolvedValue([1]);
+        sr.getSchemaMetadata.mockRejectedValue("version exploded");
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { latestOnly: false },
+          outcome: { resolves: "version exploded", isError: false },
+          clientManager,
+        });
+
+        expect(JSON.parse(textOf(result!))).toEqual({
+          orders: [{ version: 1, error: "version exploded" }],
+        });
+      });
+
+      it("should String()-coerce a non-Error rejection from getAllVersions into the per-subject error entry", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getAllVersions.mockRejectedValue("versions exploded");
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { latestOnly: false },
+          outcome: { resolves: '"orders":{"error":', isError: false },
+          clientManager,
+        });
+
+        expect(JSON.parse(textOf(result!))).toEqual({
+          orders: { error: "versions exploded" },
+        });
+      });
+    });
+
+    describe("getToolConfig()", () => {
+      it("should expose the expected name, READ_ONLY annotations, and input schema fields", () => {
+        const config = handler.getToolConfig();
+        expect(config.name).toBe(ToolName.LIST_SCHEMAS);
+        expect(config.annotations).toBe(READ_ONLY);
+        expect(
+          Object.keys(config.inputSchema).sort((a, b) => a.localeCompare(b)),
+        ).toEqual(["deleted", "environment_id", "latestOnly", "subjectPrefix"]);
       });
     });
   });


### PR DESCRIPTION
# Targeted tests for `ListSchemasHandler.handle()`


## Unit coverage

`ListSchemasHandler.handle()` previously had only the `latestOnly=true` happy path, the prefix filter, `environment_id` wiring, and the top-level `getAllSubjects`-rejects case under test — 58% line / 25% branch. The handler's `latestOnly=false` versions branch and every per-item error sub-branch were untested, and `getToolConfig()` had no test at all.

- **`latestOnly=false` versions branch.** New cases prove each subject maps to an array built from `getAllVersions` + per-version `getSchemaMetadata`, that `getLatestSchemaMetadata` is never consulted, and that `deleted` defaults to `false (and forwards `true` when supplied) into `getSchemaMetadata`.
- **Per-item error resilience.** Separate cases pin that a rejection from `getLatestSchemaMetadata` (latest mode), from `getSchemaMetadata` (one version), or from `getAllVersions` (whole subject) is captured as a per-subject / per-version `{ error }` entry rather than failing the whole call — asserting the exact error string and surrounding shape.
- **Non-`Error` rejection fallbacks.** The SR SDK can reject with a non-`Error` value; four cases drive each `catch` block's `err instanceof Error ? … : …` fallback arm (`String(err)` inside the loops, `JSON.stringify` at the top level), closing the branch gap to 100%.
- **`getToolConfig()`.** Pins the tool name, `READ_ONLY` annotations by identity, and the four input-schema field names.

Result: 100% statement / branch / line / function coverage on the handler.

## Integration coverage

The integration suite previously exercised only the default `latestOnly=true` path end-to-end. Added a direct-connection case calling with `latestOnly: false`, asserting the seeded subject maps to a one-element version
array (version 1, numeric id) — driving the server-side `getAllVersions` + per-version `getSchemaMetadata` branch against a live registry.

## Relationships

Backfills missing coverage for `ListSchemasHandler` — no issue tie.
