### PR TITLE
More test coverage over low-coverage misc modules.

### DIFF
--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
@@ -1,4 +1,6 @@
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ListClustersHandler } from "@src/confluent/tools/handlers/clusters/list-clusters-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   CCLOUD_CONN,
   ccloudOAuthRuntime,
@@ -16,9 +18,86 @@ type EnvIdCase = HandleCaseWithConn & {
   expectedEnvId: string;
 };
 
+/**
+ * Shape the handler maps each validated CMK cluster down to, surfaced on
+ * `result._meta.clusters`. Mirrors the projection in `handle()`.
+ */
+type MappedCluster = {
+  id: string;
+  name: string;
+  availability: string;
+  cloud: string;
+  region: string;
+  environmentId: string;
+  status: string;
+  cku: number;
+  endpoints: { http: string; bootstrap: string };
+  config: { kind: string; zones: string[] };
+};
+
+/**
+ * Builds a CMK cluster payload satisfying `clusterSchema`. Overrides target the
+ * fields whose mapping has branching logic (the `status.cku ?? config.cku ?? 0`
+ * chain and the `zones ?? []` default); everything else is fixed boilerplate.
+ */
+function makeCluster(overrides?: {
+  statusCku?: number;
+  configCku?: number;
+  zones?: string[];
+}): unknown {
+  return {
+    api_version: "cmk/v2",
+    id: "lkc-abc123",
+    kind: "Cluster",
+    metadata: {
+      created_at: "2024-01-01T00:00:00Z",
+      resource_name: "crn://cluster",
+      self: "https://api.confluent.cloud/cmk/v2/clusters/lkc-abc123",
+      updated_at: "2024-01-02T00:00:00Z",
+    },
+    spec: {
+      api_endpoint: "https://pkac-xxxxx.us-east-1.aws.confluent.cloud",
+      availability: "SINGLE_ZONE",
+      cloud: "AWS",
+      config: {
+        kind: "Dedicated",
+        cku: overrides?.configCku,
+        zones: overrides?.zones,
+      },
+      display_name: "prod-cluster",
+      environment: {
+        id: "env-xyz",
+        related: "https://api.confluent.cloud/org/v2/environments/env-xyz",
+        resource_name: "crn://environment",
+      },
+      http_endpoint: "https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443",
+      kafka_bootstrap_endpoint:
+        "SASL_SSL://pkc-xxxxx.us-east-1.aws.confluent.cloud:9092",
+      region: "us-east-1",
+    },
+    status: {
+      phase: "PROVISIONED",
+      cku: overrides?.statusCku,
+    },
+  };
+}
+
 describe("list-clusters-handler.ts", () => {
   describe("ListClustersHandler", () => {
     const handler = new ListClustersHandler();
+
+    describe("getToolConfig()", () => {
+      it("should be a read-only tool named LIST_CLUSTERS exposing only environmentId", () => {
+        const config = handler.getToolConfig();
+
+        expect(config.name).toBe(ToolName.LIST_CLUSTERS);
+        expect(config.description).toBe(
+          "Get all clusters in the Confluent Cloud environment",
+        );
+        expect(Object.keys(config.inputSchema)).toEqual(["environmentId"]);
+        expect(config.annotations).toBe(READ_ONLY);
+      });
+    });
 
     describe("handle()", () => {
       const CCLOUD_WITH_KAFKA_CONN = {
@@ -97,6 +176,206 @@ describe("list-clusters-handler.ts", () => {
           runtime: ccloudOAuthRuntime(),
           args: {},
           outcome: { throws: "call list-environments" },
+        });
+      });
+
+      it("should surface an error response carrying the API error when the GET returns one", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudRestClient()
+          .GET.mockResolvedValue({ error: { message: "quota exceeded" } });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_WITH_KAFKA_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: {
+            resolves: 'Failed to fetch clusters: {"message":"quota exceeded"}',
+            isError: true,
+          },
+          clientManager,
+        });
+
+        expect(result?._meta).toEqual({ error: { message: "quota exceeded" } });
+      });
+
+      it.each([
+        { label: "null", body: { data: null } },
+        { label: "a non-object scalar", body: { data: 42 } },
+      ])(
+        "should reject when the response payload is $label",
+        async ({ body }) => {
+          const clientManager = getMockedClientManager();
+          clientManager
+            .getConfluentCloudRestClient()
+            .GET.mockResolvedValue(body);
+
+          await assertHandleCase({
+            handler,
+            runtime: runtimeWithDecoy(
+              CCLOUD_WITH_KAFKA_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args: {},
+            outcome: {
+              resolves: "Invalid response format: response is not an object",
+              isError: true,
+            },
+            clientManager,
+          });
+        },
+      );
+
+      it("should reject when the response data field is not an array", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudRestClient()
+          .GET.mockResolvedValue({ data: { data: { not: "an array" } } });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_WITH_KAFKA_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: {
+            resolves: "Invalid response format: missing or invalid data array",
+            isError: true,
+          },
+          clientManager,
+        });
+      });
+
+      it("should map a validated cluster to the summarized shape and render its detail block", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
+          data: {
+            data: [
+              makeCluster({ statusCku: 3, zones: ["use1-az1", "use1-az2"] }),
+            ],
+            metadata: { total_size: 1 },
+          },
+        });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_WITH_KAFKA_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: {
+            resolves: "Successfully retrieved 1 clusters",
+            isError: false,
+          },
+          clientManager,
+        });
+
+        const meta = result?._meta as {
+          clusters: MappedCluster[];
+          total: number;
+        };
+        expect(meta.clusters).toEqual([
+          {
+            id: "lkc-abc123",
+            name: "prod-cluster",
+            availability: "SINGLE_ZONE",
+            cloud: "AWS",
+            region: "us-east-1",
+            environmentId: "env-xyz",
+            status: "PROVISIONED",
+            cku: 3,
+            endpoints: {
+              http: "https://pkc-xxxxx.us-east-1.aws.confluent.cloud:443",
+              bootstrap:
+                "SASL_SSL://pkc-xxxxx.us-east-1.aws.confluent.cloud:9092",
+            },
+            config: { kind: "Dedicated", zones: ["use1-az1", "use1-az2"] },
+          },
+        ]);
+        expect(meta.total).toBe(1);
+
+        const text = result!.content
+          .map((c) => ("text" in c ? c.text : ""))
+          .join("");
+        expect(text).toContain("Cluster: prod-cluster");
+        expect(text).toContain("Zones: use1-az1, use1-az2");
+      });
+
+      it.each([
+        {
+          label: "status.cku when present (winning over config.cku)",
+          overrides: { statusCku: 3, configCku: 5, zones: ["z1"] },
+          expectedCku: 3,
+          expectedZones: ["z1"],
+        },
+        {
+          label: "config.cku when status.cku is absent",
+          overrides: { configCku: 5 },
+          expectedCku: 5,
+          expectedZones: [],
+        },
+        {
+          label: "0 when neither cku is present, defaulting zones to empty",
+          overrides: {},
+          expectedCku: 0,
+          expectedZones: [],
+        },
+      ])(
+        "should resolve cku to $label",
+        async ({ overrides, expectedCku, expectedZones }) => {
+          const clientManager = getMockedClientManager();
+          clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
+            data: { data: [makeCluster(overrides)] },
+          });
+
+          const result = await assertHandleCase({
+            handler,
+            runtime: runtimeWithDecoy(
+              CCLOUD_WITH_KAFKA_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args: {},
+            outcome: { resolves: "Successfully retrieved 1 clusters" },
+            clientManager,
+          });
+
+          const meta = result?._meta as { clusters: MappedCluster[] };
+          expect(meta.clusters).toHaveLength(1);
+          const cluster = meta.clusters[0]!;
+          expect(cluster.cku).toBe(expectedCku);
+          expect(cluster.config.zones).toEqual(expectedZones);
+        },
+      );
+
+      it("should return an error response when a returned cluster fails schema validation", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudRestClient()
+          .GET.mockResolvedValue({ data: { data: [{ id: "lkc-malformed" }] } });
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_WITH_KAFKA_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: {
+            resolves: "Failed to fetch clusters: Invalid cluster data:",
+            isError: true,
+          },
+          clientManager,
         });
       });
     });

--- a/src/mcp/transports/auth.test.ts
+++ b/src/mcp/transports/auth.test.ts
@@ -5,8 +5,8 @@ import {
   createAuthHook,
   generateApiKey,
 } from "@src/mcp/transports/auth.js";
-import { FastifyReply, FastifyRequest } from "fastify";
-import { Mock, describe, expect, it, vi } from "vitest";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { describe, expect, it, vi, type Mock } from "vitest";
 
 /**
  * Minimal stand-in for the slice of {@link FastifyReply} the auth hook touches:

--- a/src/mcp/transports/auth.test.ts
+++ b/src/mcp/transports/auth.test.ts
@@ -1,0 +1,173 @@
+import * as nodeDeps from "@src/confluent/node-deps.js";
+import {
+  AuthConfig,
+  CFLT_MCP_API_KEY_HEADER,
+  createAuthHook,
+  generateApiKey,
+} from "@src/mcp/transports/auth.js";
+import { FastifyReply, FastifyRequest } from "fastify";
+import { Mock, describe, expect, it, vi } from "vitest";
+
+/**
+ * Minimal stand-in for the slice of {@link FastifyReply} the auth hook touches:
+ * a chainable `status().send()` pair whose calls the tests assert against.
+ */
+interface StubReply {
+  status: Mock;
+  send: Mock;
+}
+
+function makeReply(): FastifyReply & StubReply {
+  const reply = {
+    status: vi.fn(),
+    send: vi.fn(),
+  };
+  reply.status.mockReturnValue(reply);
+  reply.send.mockReturnValue(reply);
+  return reply as unknown as FastifyReply & StubReply;
+}
+
+function makeRequest(
+  headers: Record<string, string | string[] | undefined>,
+): FastifyRequest {
+  return { headers } as unknown as FastifyRequest;
+}
+
+function expectPassed(reply: StubReply): void {
+  expect(reply.status).not.toHaveBeenCalled();
+  expect(reply.send).not.toHaveBeenCalled();
+}
+
+describe("generateApiKey()", () => {
+  it("should hex-encode 32 random bytes into a 64-character string", () => {
+    const randomBytes = vi
+      .spyOn(nodeDeps.nodeCrypto, "randomBytes")
+      .mockReturnValue(Buffer.alloc(32, 0xab));
+
+    const key = generateApiKey();
+
+    expect(randomBytes).toHaveBeenCalledWith(32);
+    expect(key).toBe("ab".repeat(32));
+    expect(key).toHaveLength(64);
+  });
+});
+
+describe("createAuthHook()", () => {
+  const API_KEY = "secret-key-aaaa";
+  const ALLOWED_HOSTS = ["localhost", "127.0.0.1:8080"] as const;
+
+  function authConfig(overrides: Partial<AuthConfig> = {}): AuthConfig {
+    return {
+      apiKey: API_KEY,
+      enabled: true,
+      allowedHosts: ALLOWED_HOSTS,
+      ...overrides,
+    };
+  }
+
+  describe("Host header validation (runs whether or not API key auth is enabled)", () => {
+    it.each([
+      { name: "missing Host header", host: undefined },
+      { name: "unparseable Host header", host: "host:999999" },
+      { name: "Host not in the allowed list", host: "evil.com:8080" },
+    ])("should reject a request with a $name (403)", async ({ host }) => {
+      const hook = createAuthHook(authConfig());
+      const reply = makeReply();
+
+      await hook(makeRequest({ host }), reply);
+
+      expect(reply.status).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Forbidden",
+        message: "Invalid Host header",
+      });
+    });
+
+    it.each([
+      {
+        name: "exact hostname match ignoring the port",
+        host: "localhost:9090",
+      },
+      {
+        name: "full host:port match against the allowed entry",
+        host: "127.0.0.1:8080",
+      },
+    ])("should accept a request whose Host is an $name", async ({ host }) => {
+      // auth disabled isolates this assertion to the Host check — a pass means
+      // status/send were never touched.
+      const hook = createAuthHook(authConfig({ enabled: false }));
+      const reply = makeReply();
+
+      await hook(makeRequest({ host }), reply);
+
+      expectPassed(reply);
+    });
+  });
+
+  describe("API key validation (enabled)", () => {
+    const VALID_HOST = "localhost";
+
+    it("should accept a request bearing the configured API key", async () => {
+      const hook = createAuthHook(authConfig());
+      const reply = makeReply();
+
+      await hook(
+        makeRequest({ host: VALID_HOST, [CFLT_MCP_API_KEY_HEADER]: API_KEY }),
+        reply,
+      );
+
+      expectPassed(reply);
+    });
+
+    it.each([
+      { name: "the API key header is absent", apiKey: undefined },
+      {
+        name: "the API key header is an array, not a string",
+        apiKey: [API_KEY, API_KEY],
+      },
+    ])("should reject when $name (401)", async ({ apiKey }) => {
+      const hook = createAuthHook(authConfig());
+      const reply = makeReply();
+
+      await hook(
+        makeRequest({ host: VALID_HOST, [CFLT_MCP_API_KEY_HEADER]: apiKey }),
+        reply,
+      );
+
+      expect(reply.status).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Unauthorized",
+        message: `Missing ${CFLT_MCP_API_KEY_HEADER} header`,
+      });
+    });
+
+    it.each([
+      { name: "same length but different content", apiKey: "secret-key-bbbb" },
+      { name: "a different length entirely", apiKey: "x" },
+    ])("should reject an API key of $name (401)", async ({ apiKey }) => {
+      const hook = createAuthHook(authConfig());
+      const reply = makeReply();
+
+      await hook(
+        makeRequest({ host: VALID_HOST, [CFLT_MCP_API_KEY_HEADER]: apiKey }),
+        reply,
+      );
+
+      expect(reply.status).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: "Unauthorized",
+        message: "Invalid API key",
+      });
+    });
+  });
+
+  it("should skip API key validation entirely when auth is disabled", async () => {
+    // A valid Host with no API key header must still pass when disabled.
+    const hook = createAuthHook(authConfig({ enabled: false }));
+    const reply = makeReply();
+
+    await hook(makeRequest({ host: "localhost" }), reply);
+
+    expectPassed(reply);
+  });
+});

--- a/src/mcp/transports/manager.test.ts
+++ b/src/mcp/transports/manager.test.ts
@@ -2,10 +2,40 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { CreateMcpServerOptions } from "@src/mcp/server.js";
-import { TransportManager } from "@src/mcp/transports/manager.js";
-import { TransportType } from "@src/mcp/transports/types.js";
+import { HttpTransport } from "@src/mcp/transports/http.js";
+import {
+  HttpStartOptions,
+  TransportManager,
+} from "@src/mcp/transports/manager.js";
+import { HttpServer } from "@src/mcp/transports/server.js";
+import { SseTransport } from "@src/mcp/transports/sse.js";
+import { Transport, TransportType } from "@src/mcp/transports/types.js";
 import { runtimeWith } from "@tests/factories/runtime.js";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const HTTP_OPTS: HttpStartOptions = {
+  port: 0,
+  host: "localhost",
+  mcpEndpointPath: "/mcp",
+  sseEndpointPath: "/sse",
+  sseMessageEndpointPath: "/messages",
+};
+
+function fakeHttpServer(): HttpServer {
+  return {
+    stop: vi.fn().mockResolvedValue(undefined),
+  } as unknown as HttpServer;
+}
+
+/**
+ * Transport stub exposing only the `disconnect` the manager's `stop()` calls,
+ * with a configurable rejection to drive the per-transport error-tolerance arm.
+ */
+function fakeTransport(
+  disconnect = vi.fn().mockResolvedValue(undefined),
+): Transport {
+  return { disconnect } as unknown as Transport;
+}
 
 describe("TransportManager", () => {
   let manager: TransportManager;
@@ -18,6 +48,87 @@ describe("TransportManager", () => {
       toolHandlers: new Map<ToolName, ToolHandler>(),
       runtime: runtimeWith(),
     };
+  });
+
+  describe("start()", () => {
+    it("should reject when HTTP/SSE is requested without `http` start options, and clean up", async () => {
+      await expect(
+        manager.start({ serverOptions, types: [TransportType.HTTP] }),
+      ).rejects.toThrow(
+        "HTTP/SSE transports require `http` start options (port, host)",
+      );
+
+      // the catch arm runs stop(); nothing was constructed, so the manager is left clean
+      expect(manager["transports"].size).toBe(0);
+      expect(manager["httpServer"]).toBeNull();
+    });
+
+    it("should reject when auth is enabled but no API key is configured", async () => {
+      // default config => auth enabled, apiKey undefined; `http` is supplied so the
+      // earlier http-options guard passes and we reach the API-key guard
+      await expect(
+        manager.start({
+          serverOptions,
+          types: [TransportType.HTTP],
+          http: HTTP_OPTS,
+        }),
+      ).rejects.toThrow(
+        "MCP_API_KEY is required when authentication is enabled for HTTP/SSE transports. " +
+          "Generate a key using: npx mcp-confluent --generate-key",
+      );
+
+      expect(manager["httpServer"]).toBeNull();
+    });
+  });
+
+  describe("stop()", () => {
+    it("should resolve as a no-op on a manager that was never started", async () => {
+      await expect(manager.stop()).resolves.toBeUndefined();
+
+      expect(manager["transports"].size).toBe(0);
+      expect(manager["httpServer"]).toBeNull();
+      expect(manager["stdioServer"]).toBeNull();
+    });
+
+    it("should stop the HTTP server, disconnect every transport, close the stdio server, and reset all state", async () => {
+      const httpServer = fakeHttpServer();
+      const httpTransport = fakeTransport();
+      const stdioTransport = fakeTransport();
+      const stdioServer = {
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as McpServer;
+
+      manager["httpServer"] = httpServer;
+      manager["stdioServer"] = stdioServer;
+      manager["transports"].set(TransportType.HTTP, httpTransport);
+      manager["transports"].set(TransportType.STDIO, stdioTransport);
+
+      await manager.stop();
+
+      expect(httpServer.stop).toHaveBeenCalledOnce();
+      expect(httpTransport.disconnect).toHaveBeenCalledOnce();
+      expect(stdioTransport.disconnect).toHaveBeenCalledOnce();
+      expect(stdioServer.close).toHaveBeenCalledOnce();
+
+      expect(manager["transports"].size).toBe(0);
+      expect(manager["httpServer"]).toBeNull();
+      expect(manager["stdioServer"]).toBeNull();
+    });
+
+    it("should disconnect remaining transports and finish cleanup even when one transport's disconnect rejects", async () => {
+      const failing = fakeTransport(
+        vi.fn().mockRejectedValue(new Error("disconnect boom")),
+      );
+      const healthy = fakeTransport();
+      manager["transports"].set(TransportType.HTTP, failing);
+      manager["transports"].set(TransportType.SSE, healthy);
+
+      await expect(manager.stop()).resolves.toBeUndefined();
+
+      expect(failing.disconnect).toHaveBeenCalledOnce();
+      expect(healthy.disconnect).toHaveBeenCalledOnce();
+      expect(manager["transports"].size).toBe(0);
+    });
   });
 
   describe("createTransport()", () => {
@@ -33,6 +144,49 @@ describe("TransportManager", () => {
 
       expect(cachedAfterFirst).toBeInstanceOf(McpServer);
       expect(cachedAfterSecond).toBe(cachedAfterFirst);
+    });
+
+    it.each([TransportType.HTTP, TransportType.SSE])(
+      "should throw when %s transport is created before the HTTP server is initialized",
+      (type) => {
+        expect(() =>
+          manager["createTransport"](type, serverOptions, HTTP_OPTS),
+        ).toThrow("HTTP server not initialized");
+      },
+    );
+
+    it("should construct an HttpTransport once the HTTP server is initialized", () => {
+      manager["httpServer"] = fakeHttpServer();
+
+      const transport = manager["createTransport"](
+        TransportType.HTTP,
+        serverOptions,
+        HTTP_OPTS,
+      );
+
+      expect(transport).toBeInstanceOf(HttpTransport);
+    });
+
+    it("should construct an SseTransport once the HTTP server is initialized", () => {
+      manager["httpServer"] = fakeHttpServer();
+
+      const transport = manager["createTransport"](
+        TransportType.SSE,
+        serverOptions,
+        HTTP_OPTS,
+      );
+
+      expect(transport).toBeInstanceOf(SseTransport);
+    });
+
+    it("should throw on an unsupported transport type", () => {
+      expect(() =>
+        manager["createTransport"](
+          "ftp" as TransportType,
+          serverOptions,
+          undefined,
+        ),
+      ).toThrow("Unsupported transport type: ftp");
     });
   });
 });

--- a/src/mcp/transports/server.test.ts
+++ b/src/mcp/transports/server.test.ts
@@ -1,5 +1,12 @@
+import { AuthConfig } from "@src/mcp/transports/auth.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const AUTH_CONFIG: AuthConfig = {
+  apiKey: "test-key",
+  enabled: true,
+  allowedHosts: ["localhost"],
+};
 
 describe("server.ts", () => {
   describe("HttpServer", () => {
@@ -21,6 +28,90 @@ describe("server.ts", () => {
         expect(spec.servers?.[0]?.url).toBe("http://test-host:9999");
 
         await fastify.close();
+      });
+
+      it("should register an onRequest auth hook when an auth config was supplied", async () => {
+        const httpServer = new HttpServer({ auth: AUTH_CONFIG });
+        const addHook = vi.spyOn(httpServer.getInstance(), "addHook");
+
+        await httpServer.prepare({ host: "test-host", port: 9999 });
+
+        expect(addHook).toHaveBeenCalledWith("onRequest", expect.any(Function));
+      });
+
+      it("should not register an auth hook when no auth config was supplied", async () => {
+        const httpServer = new HttpServer();
+        const addHook = vi.spyOn(httpServer.getInstance(), "addHook");
+
+        await httpServer.prepare({ host: "test-host", port: 9999 });
+
+        expect(addHook).not.toHaveBeenCalledWith(
+          "onRequest",
+          expect.any(Function),
+        );
+      });
+
+      it("should short-circuit a second prepare() without re-registering plugins", async () => {
+        const httpServer = new HttpServer();
+        await httpServer.prepare({ host: "test-host", port: 9999 });
+
+        const register = vi.spyOn(httpServer.getInstance(), "register");
+        await httpServer.prepare({ host: "test-host", port: 9999 });
+
+        expect(register).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("start()", () => {
+      it("should ready the instance then listen on the configured host and port", async () => {
+        const httpServer = new HttpServer();
+        const fastify = httpServer.getInstance();
+        const ready = vi.spyOn(fastify, "ready").mockResolvedValue(fastify);
+        // fastify's `listen` is overloaded; vi.spyOn resolves to the void-returning
+        // overload, so the resolved address value is irrelevant here — we assert the
+        // call arguments, not the return.
+        const listen = vi.spyOn(fastify, "listen").mockResolvedValue(undefined);
+
+        await httpServer.start({ host: "test-host", port: 9999 });
+
+        expect(ready).toHaveBeenCalledOnce();
+        expect(listen).toHaveBeenCalledWith({
+          port: 9999,
+          host: "test-host",
+        });
+      });
+
+      it("should rethrow when listen fails", async () => {
+        const httpServer = new HttpServer();
+        const fastify = httpServer.getInstance();
+        vi.spyOn(fastify, "ready").mockResolvedValue(fastify);
+        vi.spyOn(fastify, "listen").mockRejectedValue(new Error("listen boom"));
+
+        await expect(
+          httpServer.start({ host: "test-host", port: 9999 }),
+        ).rejects.toThrow("listen boom");
+      });
+    });
+
+    describe("stop()", () => {
+      it("should close the fastify instance", async () => {
+        const httpServer = new HttpServer();
+        const close = vi
+          .spyOn(httpServer.getInstance(), "close")
+          .mockResolvedValue(undefined);
+
+        await httpServer.stop();
+
+        expect(close).toHaveBeenCalledOnce();
+      });
+
+      it("should rethrow when close fails", async () => {
+        const httpServer = new HttpServer();
+        vi.spyOn(httpServer.getInstance(), "close").mockRejectedValue(
+          new Error("close boom"),
+        );
+
+        await expect(httpServer.stop()).rejects.toThrow("close boom");
       });
     });
   });

--- a/src/mcp/transports/server.test.ts
+++ b/src/mcp/transports/server.test.ts
@@ -1,6 +1,6 @@
 import { AuthConfig } from "@src/mcp/transports/auth.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const AUTH_CONFIG: AuthConfig = {
   apiKey: "test-key",
@@ -8,11 +8,41 @@ const AUTH_CONFIG: AuthConfig = {
   allowedHosts: ["localhost"],
 };
 
+const openServers: HttpServer[] = [];
+
+/**
+ * Register an HttpServer so its real Fastify instance is closed in afterEach.
+ * Each test constructs a live Fastify; closing it in teardown keeps the suite
+ * free of leaked handles even on the rejection-path tests that never reach an
+ * in-test close.
+ */
+function track(httpServer: HttpServer): HttpServer {
+  openServers.push(httpServer);
+  return httpServer;
+}
+
+afterEach(async () => {
+  // Restore per-test spies first so a stubbed close()/listen() doesn't
+  // intercept the real close below; `restoreMocks: true` only restores ahead
+  // of the *next* test, which is too late for this teardown.
+  vi.restoreAllMocks();
+  await Promise.all(
+    openServers.splice(0).map((httpServer) =>
+      httpServer
+        .getInstance()
+        .close()
+        .catch(() => {
+          // teardown-only; a close failure shouldn't fail an asserted test
+        }),
+    ),
+  );
+});
+
 describe("server.ts", () => {
   describe("HttpServer", () => {
     describe("prepare()", () => {
       it("should build the swagger servers[0].url from the passed ServerConfig", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         await httpServer.prepare({ host: "test-host", port: 9999 });
 
         // @fastify/swagger augments the FastifyInstance with .swagger() but
@@ -26,12 +56,10 @@ describe("server.ts", () => {
         ).swagger();
 
         expect(spec.servers?.[0]?.url).toBe("http://test-host:9999");
-
-        await fastify.close();
       });
 
       it("should register an onRequest auth hook when an auth config was supplied", async () => {
-        const httpServer = new HttpServer({ auth: AUTH_CONFIG });
+        const httpServer = track(new HttpServer({ auth: AUTH_CONFIG }));
         const addHook = vi.spyOn(httpServer.getInstance(), "addHook");
 
         await httpServer.prepare({ host: "test-host", port: 9999 });
@@ -40,7 +68,7 @@ describe("server.ts", () => {
       });
 
       it("should not register an auth hook when no auth config was supplied", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         const addHook = vi.spyOn(httpServer.getInstance(), "addHook");
 
         await httpServer.prepare({ host: "test-host", port: 9999 });
@@ -52,7 +80,7 @@ describe("server.ts", () => {
       });
 
       it("should short-circuit a second prepare() without re-registering plugins", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         await httpServer.prepare({ host: "test-host", port: 9999 });
 
         const register = vi.spyOn(httpServer.getInstance(), "register");
@@ -64,7 +92,7 @@ describe("server.ts", () => {
 
     describe("start()", () => {
       it("should ready the instance then listen on the configured host and port", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         const fastify = httpServer.getInstance();
         const ready = vi.spyOn(fastify, "ready").mockResolvedValue(fastify);
         // fastify's `listen` is overloaded; vi.spyOn resolves to the void-returning
@@ -82,7 +110,7 @@ describe("server.ts", () => {
       });
 
       it("should rethrow when listen fails", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         const fastify = httpServer.getInstance();
         vi.spyOn(fastify, "ready").mockResolvedValue(fastify);
         vi.spyOn(fastify, "listen").mockRejectedValue(new Error("listen boom"));
@@ -95,7 +123,7 @@ describe("server.ts", () => {
 
     describe("stop()", () => {
       it("should close the fastify instance", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         const close = vi
           .spyOn(httpServer.getInstance(), "close")
           .mockResolvedValue(undefined);
@@ -106,7 +134,7 @@ describe("server.ts", () => {
       });
 
       it("should rethrow when close fails", async () => {
-        const httpServer = new HttpServer();
+        const httpServer = track(new HttpServer());
         vi.spyOn(httpServer.getInstance(), "close").mockRejectedValue(
           new Error("close boom"),
         );

--- a/src/mcp/transports/stdio.test.ts
+++ b/src/mcp/transports/stdio.test.ts
@@ -1,0 +1,43 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StdioTransport } from "@src/mcp/transports/stdio.js";
+import { createMockInstance } from "@tests/stubs/index.js";
+import { describe, expect, it } from "vitest";
+
+describe("stdio.ts", () => {
+  describe("StdioTransport", () => {
+    describe("connect()", () => {
+      it("should connect the McpServer over a fresh StdioServerTransport", async () => {
+        const server = createMockInstance(McpServer);
+        server.connect.mockResolvedValue(undefined);
+        const transport = new StdioTransport(server);
+
+        await transport.connect();
+
+        expect(server.connect).toHaveBeenCalledOnce();
+        expect(server.connect).toHaveBeenCalledWith(
+          expect.any(StdioServerTransport),
+        );
+      });
+
+      it("should propagate a rejection from the server connect", async () => {
+        const server = createMockInstance(McpServer);
+        server.connect.mockRejectedValue(new Error("connect refused"));
+        const transport = new StdioTransport(server);
+
+        await expect(transport.connect()).rejects.toThrow("connect refused");
+      });
+    });
+
+    describe("disconnect()", () => {
+      it("should resolve without touching the server (stdio has nothing to tear down)", async () => {
+        const server = createMockInstance(McpServer);
+        const transport = new StdioTransport(server);
+
+        await expect(transport.disconnect()).resolves.toBeUndefined();
+
+        expect(server.connect).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,13 @@ export default defineConfig({
       reporter: coverageReporters,
       reportsDirectory: "coverage",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/*.d.ts",
+        // Build-time README doc generator, not shipped server code: a top-level
+        // console.log over the legacy env-var schema, never imported at runtime.
+        "src/print-md-schema.ts",
+      ],
     },
     // Pre-declare every handler-subdirectory tag so follow-up PRs can add integration
     // tests without touching this config. Values come from `tests/tags.ts` (the single


### PR DESCRIPTION
# Write unit tests over lowest hanging fruit uncovered / sparsely covered files

## HTTP auth hook unit coverage

`src/mcp/transports/auth.ts` was the highest bang-for-the-buck gap in the unit suite: 6.8% line / 0% branch coverage on security-critical code (DNS-rebinding Host validation + timing-safe API key comparison), with no colocated test at all. It's pure, synchronous hook logic that drives entirely off a fake `request`/`reply` pair — no server needed — so the whole file was reachable cheaply. This branch adds `auth.test.ts`, taking the file to 100% lines / branches / functions.

- `generateApiKey()` is pinned by stubbing `nodeCrypto.randomBytes` to a known buffer and asserting the 64-char hex encoding, rather than just checking the length of a random string.
- Host-header validation is covered both ways via `it.each`: rejection (missing header, a genuinely unparseable `host:999999`, and a host outside the allowlist) all return 403; acceptance covers the two distinct match branches — exact hostname match ignoring the port, and a full `host:port` match against the allowed entry.
- API-key validation covers the configured-key accept path plus every rejection branch: absent header (401 "Missing …"), array-valued header (401 "Missing …"), and — crucially for the timing-safe comparator's two branches — a wrong key of the _same_ length and a wrong key of a _different_ length (both 401 "Invalid API key").
- The `enabled: false` short-circuit is asserted to skip API-key validation entirely while still enforcing the Host check.

## Transport manager lifecycle coverage

`src/mcp/transports/manager.ts` was the next-largest gap at 12% line / 3% branch — only the stdio-caching branch of `createTransport()` had a test. The `start()` validation guards, all of `stop()`, and the remaining `createTransport()` arms are reachable without ESM-import stubbing or real I/O by driving the private method directly and injecting fakes via bracket-notation, which brings the file to 80% lines / 64% branches.

- `start()` now covers both fail-fast guards with their exact messages: HTTP/SSE requested without `http` options, and auth-enabled-without-API-key. Each also asserts the `catch` arm's `stop()` cleanup left the manager clean (no transports, null `httpServer`).
- `stop()` is covered three ways: a no-op on a never-started manager; the fully-populated path (HTTP server stopped, every transport disconnected, stdio server closed, all state reset); and the error-tolerance arm where one transport's `disconnect()` rejects yet the others still disconnect and the clear still completes.
- `createTransport()` adds the HTTP/SSE "server not initialized" guards (via `it.each`), the happy-path construction of `HttpTransport`/`SseTransport` once a server is present, and the unsupported-type default. The pre-existing stdio-caching test is retained.

The residual uncovered lines (72, 81–100) are the `start()` success path: constructing a real `HttpServer`, calling `prepare()`/`start()`, and `connect()`-ing live transports. Reaching it cheaply would require routing the internal constructors (`createMcpServer`, `HttpServer`, the transport classes) through a stubbable namespace seam — a source refactor deliberately left out of this coverage-only branch.

## List-clusters response handling coverage

`src/confluent/tools/handlers/clusters/list-clusters-handler.ts` was the lowest-covered directory at 58.6% — the existing test only exercised env-arg resolution and the two discovery-hint throws, always against an empty cluster list, so every response-handling branch past the GET was cold. This brings the handler to 100% line / function coverage (80.95% branches).

- Adds the three response-shape rejections the handler guards against: an API `error` from the GET (surfaced as an error response carrying `_meta.error`), a payload that isn't an object (`null` and a non-object scalar, via `it.each`), and a `data` field that isn't an array — each asserted on its exact message with `isError: true`.
- Covers the previously-untested happy path with an actual cluster: a full `clusterSchema`-valid fixture is mapped to the summarized shape (asserted by deep-equality on `_meta.clusters`, including `_meta.total` from `metadata.total_size`) and its rendered detail block is checked for the formatted cluster line and joined zones.
- Pins the `status.cku ?? config.cku ?? 0` precedence and the `zones ?? []` default with an `it.each` over the three cku states.
- Drives the validation-error path (a malformed cluster in the array) which exercises both the per-cluster `catch` that rethrows as `Invalid cluster data:` and the outer `catch` that turns it into an error response — one test, two cold `catch` blocks.
- Adds the missing `getToolConfig()` test (name, description, single `environmentId` input, `READ_ONLY` annotations by identity).
- All new response-path cases run through `runtimeWithDecoy`, so they double as routing tests for free.

The remaining uncovered branches are defensive `error instanceof Error ? … : String(error)` fallbacks and the `toolArguments ?? {}` guard — reachable only by contriving a non-`Error` throw, the low-value branches the coverage strategy says to leave.

## Coverage scope: exclude the README doc generator

`src/print-md-schema.ts` is excluded from coverage in `vitest.config.ts`. It is a build-time documentation generator — a top-level `console.log` that walks the legacy env-var schema to emit the README's environment-variable table — invoked only by the `print:schema` npm script and never imported by the server. Like other executable entry points it isn't a unit under test, and it can't even be imported in a test without firing its `console.log`; scoring it dragged the denominator down for code that isn't part of the shipped runtime. (It also documents the legacy env-var surface slated for retirement under #151, so it will be deleted rather than tested.)

## Stdio transport coverage

`src/mcp/transports/stdio.ts` (25%) had no colocated test — only the constructor was incidentally hit. `StdioTransport.connect()` builds a real `StdioServerTransport` and hands it to `McpServer.connect()`; the new `stdio.test.ts` drives this against a `createMockInstance(McpServer)` whose `connect` is stubbed, so no real stdin/stdout is touched (the SDK's `StdioServerTransport` only attaches process listeners in `start()`, which the stubbed `connect` never triggers). Covers the happy path (asserting the server is connected over an `expect.any(StdioServerTransport)`), the rejection-propagation path, and the no-op `disconnect()`. Takes the file to 100%.

## HTTP server lifecycle coverage

`src/mcp/transports/server.ts` (44%) had a single test exercising the no-auth `prepare()` swagger path; the constructor's auth branch, the auth-hook registration, the idempotent second-`prepare()` early return, and all of `start()` / `stop()` were cold. The additions spy on the private fastify via `getInstance()` so the lifecycle methods are exercised without binding a real port — `start()` asserts `ready()` then `listen({ port, host })` and rethrows a `listen` failure; `stop()` asserts `close()` and rethrows a `close` failure. `prepare()` gains the auth-hook-registered / not-registered pair and the short-circuit-on-second-call case. Takes the file to 100%.

## Deferred: `lazy.ts` needs fixing first

`src/lazy.ts` was the next coverage candidate, but it has correctness bugs that must be fixed before its tests can land. That work is tracked in #612.


## Results
This gets `src/` dir up to 76% coverage. The `lazy` work will then get it into the green above 80%! 
