### PR TITLE
Fix half-implemented caching lifecycle in `Lazy` / `AsyncLazy`

### DIFF
--- a/.claude/rules/config-fields.md
+++ b/.claude/rules/config-fields.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - src/config/models.ts
+  - src/confluent/tools/handlers/diagnostics/describe-fields.ts
+---
+
+# Connection config fields must be classified for visibility
+
+The `describe-configured-connection` tool surfaces a connection's config in its response card.
+To guarantee no credential ever leaks and no new knob is silently ignored, every field of every connection arm and service block is classified in a visibility allow-list at `src/confluent/tools/handlers/diagnostics/describe-fields.ts`.
+
+When you add, rename, or remove a field on any connection arm (`DirectConnectionConfig`, `OAuthConnectionConfig`) or service block (`KafkaDirectConfig`, `SchemaRegistryDirectConfig`, `ConfluentCloudDirectConfig`, `TableflowDirectConfig`, `TelemetryDirectConfig`, `FlinkDirectConfig`) — in the TypeScript interface, the Zod schema, or both — you **must** classify the field in the matching `*_FIELD_VISIBILITY` map.
+
+This is not optional, and it is enforced two ways:
+
+- **Compile time.** Each map is typed `Readonly<Record<keyof T, FieldVisibility>>`, so a new field fails `tsc --noEmit` (which runs in the pre-push hook and CI) with `Property '<field>' is missing` until you add a row.
+- **Runtime.** `describe-fields.test.ts` asserts each map's keys equal the Zod schema's `.shape` keys, so a field added to the schema alone (not the interface) fails the drift test.
+
+## How to classify
+
+Pick the `FieldVisibility` that is literally true of the field:
+
+- `public` — a non-secret scalar safe to surface (endpoint, cluster/env/org id, compute pool, region, …).
+- `secret` — credential material. **All `auth` blocks are `secret`.** Never `public`.
+- `withheld` — non-secret but deliberately not surfaced: a structured/opaque value (`extra_properties`), or one the card surfaces by other means (`read_only`, echoed as the top-level `readOnly` boolean).
+- `block` — a nested service block, surfaced via its own map. Only valid at the connection level; a connection block classified `block` must also have an entry in `SERVICE_BLOCK_VISIBILITY`.
+
+When in doubt between `secret` and `withheld`, ask whether the value is credential material: if it could authenticate, it is `secret`. If you classify a field `public`, confirm it is safe to hand to an LLM and surface in tool output — there is no second gate downstream.

--- a/src/lazy.test.ts
+++ b/src/lazy.test.ts
@@ -77,6 +77,20 @@ describe("Lazy", () => {
     expect(lazy.get()).toBe(0);
     expect(supplier).toHaveBeenCalledOnce();
   });
+
+  it("should clear a falsy cached value (0) on close() so the next get() rebuilds", () => {
+    const closeHandler = vi.fn();
+    const supplier = vi.fn(() => 0);
+    const lazy = new Lazy(supplier, closeHandler);
+
+    lazy.get();
+    lazy.close();
+    lazy.get();
+
+    expect(closeHandler).toHaveBeenCalledOnce();
+    expect(closeHandler).toHaveBeenCalledWith(0);
+    expect(supplier).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("AsyncLazy", () => {
@@ -168,5 +182,19 @@ describe("AsyncLazy", () => {
     expect(await lazy.get()).toBe(0);
     expect(await lazy.get()).toBe(0);
     expect(supplier).toHaveBeenCalledOnce();
+  });
+
+  it("should clear a falsy cached value (0) on close() so the next get() rebuilds", async () => {
+    const closeHandler = vi.fn(async () => {});
+    const supplier = vi.fn(async () => 0);
+    const lazy = new AsyncLazy(supplier, closeHandler);
+
+    await lazy.get();
+    await lazy.close();
+    await lazy.get();
+
+    expect(closeHandler).toHaveBeenCalledOnce();
+    expect(closeHandler).toHaveBeenCalledWith(0);
+    expect(supplier).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lazy.test.ts
+++ b/src/lazy.test.ts
@@ -1,0 +1,172 @@
+import { AsyncLazy, Lazy } from "@src/lazy.js";
+import { describe, expect, it, vi } from "vitest";
+
+describe("Lazy", () => {
+  it("should invoke the supplier exactly once across repeated get() calls", () => {
+    const supplier = vi.fn(() => ({ id: 1 }));
+    const lazy = new Lazy(supplier);
+
+    const first = lazy.get();
+    const second = lazy.get();
+
+    expect(supplier).toHaveBeenCalledOnce();
+    expect(second).toBe(first);
+  });
+
+  it("should rebuild via a fresh supplier invocation on get() after close()", () => {
+    const supplier = vi.fn(() => ({ id: 1 }));
+    const lazy = new Lazy(supplier);
+
+    const first = lazy.get();
+    lazy.close();
+    const second = lazy.get();
+
+    expect(supplier).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(first);
+  });
+
+  it("should wrap a throwing supplier as 'Failed to initialize lazy instance'", () => {
+    const lazy = new Lazy(() => {
+      throw new Error("boom");
+    });
+
+    expect(() => lazy.get()).toThrowError(
+      "Failed to initialize lazy instance: Error: boom",
+    );
+  });
+
+  it("should invoke the closeHandler with the cached instance, then clear it", () => {
+    const instance = { id: 1 };
+    const closeHandler = vi.fn();
+    const supplier = vi.fn(() => instance);
+    const lazy = new Lazy(supplier, closeHandler);
+
+    lazy.get();
+    lazy.close();
+
+    expect(closeHandler).toHaveBeenCalledOnce();
+    expect(closeHandler).toHaveBeenCalledWith(instance);
+    expect(lazy["instance"]).toBeUndefined();
+  });
+
+  it("should be a no-op on close() when no instance was ever built", () => {
+    const closeHandler = vi.fn();
+    const lazy = new Lazy(() => ({ id: 1 }), closeHandler);
+
+    lazy.close();
+
+    expect(closeHandler).not.toHaveBeenCalled();
+  });
+
+  it("should clear the instance on close() even when no closeHandler was provided", () => {
+    const supplier = vi.fn(() => ({ id: 1 }));
+    const lazy = new Lazy(supplier);
+
+    lazy.get();
+    lazy.close();
+    lazy.get();
+
+    expect(supplier).toHaveBeenCalledTimes(2);
+  });
+
+  it("should cache a falsy value (0) rather than rebuild it", () => {
+    const supplier = vi.fn(() => 0);
+    const lazy = new Lazy(supplier);
+
+    expect(lazy.get()).toBe(0);
+    expect(lazy.get()).toBe(0);
+    expect(supplier).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AsyncLazy", () => {
+  it("should invoke the supplier exactly once across repeated awaited get() calls", async () => {
+    const supplier = vi.fn(async () => ({ id: 1 }));
+    const lazy = new AsyncLazy(supplier);
+
+    const first = await lazy.get();
+    const second = await lazy.get();
+
+    expect(supplier).toHaveBeenCalledOnce();
+    expect(second).toBe(first);
+  });
+
+  it("should dedupe concurrent get() calls to a single supplier invocation", async () => {
+    let resolveSupplier: (value: { id: number }) => void;
+    const supplier = vi.fn(
+      () =>
+        new Promise<{ id: number }>((resolve) => {
+          resolveSupplier = resolve;
+        }),
+    );
+    const lazy = new AsyncLazy(supplier);
+
+    const firstPromise = lazy.get();
+    const secondPromise = lazy.get();
+    resolveSupplier!({ id: 1 });
+
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    expect(supplier).toHaveBeenCalledOnce();
+    expect(second).toBe(first);
+  });
+
+  it("should rebuild via a fresh supplier invocation on get() after close()", async () => {
+    const supplier = vi.fn(async () => ({ id: 1 }));
+    const lazy = new AsyncLazy(supplier);
+
+    const first = await lazy.get();
+    await lazy.close();
+    const second = await lazy.get();
+
+    expect(supplier).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(first);
+  });
+
+  it("should retry the supplier on the next get() after a rejected initialization", async () => {
+    const supplier = vi
+      .fn<() => Promise<{ id: number }>>()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue({ id: 1 });
+    const lazy = new AsyncLazy(supplier);
+
+    await expect(lazy.get()).rejects.toThrowError("transient");
+
+    const recovered = await lazy.get();
+
+    expect(supplier).toHaveBeenCalledTimes(2);
+    expect(recovered).toEqual({ id: 1 });
+  });
+
+  it("should invoke the async closeHandler, then reset instance and initializationPromise", async () => {
+    const instance = { id: 1 };
+    const closeHandler = vi.fn(async () => {});
+    const lazy = new AsyncLazy(async () => instance, closeHandler);
+
+    await lazy.get();
+    await lazy.close();
+
+    expect(closeHandler).toHaveBeenCalledOnce();
+    expect(closeHandler).toHaveBeenCalledWith(instance);
+    expect(lazy["instance"]).toBeUndefined();
+    expect(lazy["initializationPromise"]).toBeNull();
+  });
+
+  it("should be a no-op on close() when no instance was ever built", async () => {
+    const closeHandler = vi.fn(async () => {});
+    const lazy = new AsyncLazy(async () => ({ id: 1 }), closeHandler);
+
+    await lazy.close();
+
+    expect(closeHandler).not.toHaveBeenCalled();
+  });
+
+  it("should cache a falsy value (0) rather than rebuild it", async () => {
+    const supplier = vi.fn(async () => 0);
+    const lazy = new AsyncLazy(supplier);
+
+    expect(await lazy.get()).toBe(0);
+    expect(await lazy.get()).toBe(0);
+    expect(supplier).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -32,13 +32,15 @@ export class Lazy<T> {
    * @throws If the supplier function fails to initialize the value
    */
   get(): T {
-    try {
-      this.instance = this.supplier();
-      logger.debug(
-        `Lazy instance created with type ${this.instance?.constructor.name || typeof this.instance}`,
-      );
-    } catch (error) {
-      throw new Error(`Failed to initialize lazy instance: ${error}`);
+    if (this.instance === undefined) {
+      try {
+        this.instance = this.supplier();
+        logger.debug(
+          `Lazy instance created with type ${this.instance?.constructor.name || typeof this.instance}`,
+        );
+      } catch (error) {
+        throw new Error(`Failed to initialize lazy instance: ${error}`);
+      }
     }
     return this.instance!;
   }
@@ -99,11 +101,19 @@ export class AsyncLazy<T> {
    * @throws If the supplier function fails to initialize the value
    */
   async get(): Promise<T> {
-    if (!this.instance) {
+    if (this.instance === undefined) {
       if (!this.initializationPromise) {
         this.initializationPromise = this.supplier();
       }
-      this.instance = await this.initializationPromise;
+      try {
+        this.instance = await this.initializationPromise;
+      } catch (error) {
+        // A rejected supplier must leave the wrapper retryable: clear the
+        // cached promise so the next get() re-invokes the supplier rather
+        // than re-awaiting the same rejection forever.
+        this.initializationPromise = null;
+        throw error;
+      }
     }
     logger.debug(
       `Async Lazy instance created with type ${this.instance?.constructor.name || typeof this.instance}`,
@@ -112,8 +122,10 @@ export class AsyncLazy<T> {
   }
 
   /**
-   * Closes and cleans up the lazy-loaded instance if it exists
-   * If a closeHandler was provided, it will be called with the instance
+   * Closes and cleans up the lazy-loaded instance if it exists.
+   * If a closeHandler was provided, it will be called with the instance.
+   * The instance and any cached initialization promise are reset afterward,
+   * so the next get() rebuilds.
    * @returns A promise that resolves when the cleanup is complete
    */
   async close(): Promise<void> {
@@ -125,6 +137,8 @@ export class AsyncLazy<T> {
         await this.closeHandler(this.instance);
         logger.debug(`Lazy instance closed with type ${typeof this.instance}`);
       }
+      this.instance = undefined;
+      this.initializationPromise = null;
     }
   }
 }

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -51,7 +51,7 @@ export class Lazy<T> {
    * The instance is set to undefined after cleanup.
    */
   close(): void {
-    if (this.instance) {
+    if (this.instance !== undefined) {
       if (this.closeHandler) {
         logger.debug(
           `Initiating close handler for lazy instance of type ${typeof this.instance}`,
@@ -129,7 +129,7 @@ export class AsyncLazy<T> {
    * @returns A promise that resolves when the cleanup is complete
    */
   async close(): Promise<void> {
-    if (this.instance) {
+    if (this.instance !== undefined) {
       if (this.closeHandler) {
         logger.debug(
           `Initiating close handler for lazy instance of type ${typeof this.instance}`,


### PR DESCRIPTION
# Fix half-implemented caching lifecycle in `Lazy` / `AsyncLazy`

## Lifecycle correctness

`src/lazy.ts` ships two memoization helpers that each promise "build once, cache, rebuild after close" — and each broke that promise in a different direction, the classic signature of a guard added to one method and forgotten on its sibling.
All three defects were invisible in production only because every caller wraps an effectively-stateless client; the helpers are generic, so the bugs were live the moment anyone leaned on the contract.

- **`Lazy.get()` never cached.** It assigned `this.instance = this.supplier()` unconditionally on every call, rebuilding the openapi-fetch client (and its auth middleware) from scratch each time a `BaseClientManager` getter ran. Added the `this.instance === undefined` guard so the supplier runs at most once per live instance, mirroring `AsyncLazy.get()`.
- **`AsyncLazy.close()` never reset.** It awaited the close handler but left `instance` and `initializationPromise` populated, so the next `await get()` handed back the just-closed instance and could never re-initialize. It now clears both, mirroring `Lazy.close()`, and the docstring no longer overstates what `close()` leaves behind.
- **`AsyncLazy.get()` poisoned itself on a rejected supplier.** A rejection left `instance` undefined but `initializationPromise` pointing at the rejected promise, so the `!this.initializationPromise` short-circuit re-awaited the same failure forever — a transient client-build blip permanently bricked the wrapper. `get()` now nulls `initializationPromise` on rejection and re-throws, keeping the wrapper retryable. The sync `Lazy` needs no equivalent fix: with no cached promise, a throwing supplier already leaves `instance` undefined and the next `get()` retries naturally.

Both `get()` guards test `=== undefined` rather than truthiness, so a legitimately falsy cached value (`0`, `""`, `false`) stays cached instead of triggering a rebuild.

`AsyncLazy.get()` keeps throwing the raw supplier error; only the sync `Lazy` wraps as `Failed to initialize lazy instance:`.
Adding the wrapper to the async side would change the thrown shape for existing callers, so that asymmetry is left as-is.

## Caller impact

- **The `Lazy` caching fix is a live win.** Every getter that wraps a `Lazy` — the seven REST / Schema Registry clients in `BaseClientManager` and `getKafkaClient()` in `DirectClientManager` — fires on essentially every tool invocation, and each call used to rebuild its client from scratch (re-running `createClient<paths>(...)` and re-attaching `client.use(createAuthMiddleware(...))`, or `new Kafka(...)`). They now build once per connection lifetime. This also retroactively makes the `getSchemaRegistrySdkClient` docstring honest: it already claimed "under direct... the existing single-instance Lazy is returned", which was a lie while the Lazy rebuilt on every call.
- **The `AsyncLazy` retry fix is a latent robustness win.** The `adminClient` and `producer` suppliers `await connect()` against Kafka. Before the fix, a single transient connect rejection (broker blip, SASL hiccup) pinned `initializationPromise` to the rejected promise forever, so every later `getAdminClient()` / `getProducer()` re-threw the cached failure with no retry — the Kafka tools stayed bricked until the process restarted. They now retry on the next call.
- **The `AsyncLazy.close()` reset is preventive.** `close()` runs only from `disconnectAll()` at shutdown, and nothing re-acquires a client afterward, so no caller hits the get-after-close path today. The fix removes the footgun for any future reconnect-in-place flow.

## Coverage backfill

These bugs slipped in because `src/lazy.ts` had no colocated test and sat near 44% line coverage.
Added `src/lazy.test.ts` covering both classes; the three caching assertions (sync caches, async rebuilds after close, async retries after a rejected init) fail against the pre-fix code and pass after.
`src/lazy.ts` now reaches 100% line and function coverage.


## While Here
Add in `.claude/rules/config-fields.md` which documents to Claude how all fields in a Connection structure must be either allow or deny listed, and describes the test which will fail if this step is missed. Missed adding this file in #605.

## Relationships

Closes #612.
