### PR TITLE
Configured connections have IDs, not names. Align all terminology.

### DIFF
--- a/.claude/rules/connection-nomenclature.md
+++ b/.claude/rules/connection-nomenclature.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - src/config/**/*.ts
+  - src/confluent/tools/**/*.ts
+  - tests/harness/**
+  - tests/factories/**
+---
+
+# Connection nomenclature: configured connections have IDs, not names
+
+A configured connection is addressed by its **id**.
+The id is the key under the `connections:` map in YAML, and it is the same value a caller passes as the `connectionId` tool argument to route a call — the map key and the routing id are one and the same thing.
+There is no separate "connection name" concept; do not introduce one.
+
+## The rule
+
+Every identifier, constant, method, parameter, Zod message, docstring, test title, log line, and user-facing string that refers to a configured connection's key must say **id**, never **name**.
+Concretely: `connectionId` (camelCase parameters/fields), `*ConnectionId` / `ConnectionId` (types), `*_CONNECTION_ID` (SCREAMING_CASE constants), `getConnectionIds()` (accessors), and "connection id" in prose.
+
+This was decided in #556: a survey found `id`-form identifiers outnumbered `name`-form ones roughly 225 to 22, and — more decisively — the user-facing surface already speaks `id` (the injected `connectionId` tool argument, `MCPServerConfiguration.getConnectionConfig(connectionId)`, `getConnectionIds()`, and the README's "connection id").
+`name` lost; do not reintroduce it.
+
+## The one legitimate "connection_name"
+
+`connection_name` in the generated `src/confluent/openapi-schema.d.ts` is the **Flink SQL `CONNECTION` object** — a distinct Confluent domain concept that has nothing to do with the MCP server's connection keys.
+Leave it alone, never hand-edit generated types, and never conflate a Flink `CONNECTION` with an MCP connection id.
+
+## When you add or rename
+
+Name any new connection-key identifier, constant, argument, message, or doc with `id` from the start.
+Before claiming a connection rename or addition is complete, sweep case-insensitively — `grep -rin "connection name"` plus a `CONNECTION_NAME` / `connectionName` identifier grep — because a case-sensitive camelCase grep silently misses `SCREAMING_CASE` constants and space-separated prose.
+
+If two modules legitimately need same-named connection-id constants with different values (e.g. the production env-var synthesis id `"_default"` in `src/config/env-config.ts` versus the test-fixture id `"default"` in `tests/factories/runtime.ts`), state the distinction in both docstrings and cross-reference them so the collision reads as deliberate rather than as a trap.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -102,7 +102,7 @@ connections:
     telemetry: { ... }
 ```
 
-The connection name (`staging` above) is freeform.
+The connection id (`staging` above) is freeform.
 Either connection flavor also accepts an optional `description` — a free-text label echoed back by the `list-configured-connections` tool so an agent can tell your connections apart.
 A blank or whitespace-only `description` is treated as no description.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -66,7 +66,7 @@ server:
     # disabled: true
 
 connections:
-  # Connection name is freeform. A config may define several named connections
+  # Connection id is freeform. A config may define several connections
   # and route each tool call to one by id — and may mix api-key (`direct`)
   # connections with at most one browser-login (`oauth`) connection. See the
   # commented-out OAuth connection at the end of this file.

--- a/config.oauth.example.yaml
+++ b/config.oauth.example.yaml
@@ -32,7 +32,7 @@
 #     # disabled: true
 
 connections:
-  # Connection name is freeform. The `type: oauth` declaration is the only
+  # Connection id is freeform. The `type: oauth` declaration is the only
   # required field.
   ccloud-oauth:
     type: oauth

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -1,6 +1,6 @@
 import {
   buildConfigFromEnvAndCli,
-  DEFAULT_CONNECTION_NAME,
+  DEFAULT_CONNECTION_ID,
 } from "@src/config/env-config.js";
 import { describe, expect, it } from "vitest";
 
@@ -69,13 +69,13 @@ describe("config/env-config.ts", () => {
         expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       });
 
-      it("should use the default connection name", () => {
+      it("should use the default connection id", () => {
         const config = buildConfigFromEnvAndCli(
           envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
         );
 
         expect(Object.keys(config.connections)).toEqual([
-          DEFAULT_CONNECTION_NAME,
+          DEFAULT_CONNECTION_ID,
         ]);
       });
 

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -10,8 +10,14 @@ import type { Environment } from "@src/env.js";
 import { type KeyValuePairObject } from "properties-file";
 
 /**
- * Connection name synthesized by the env-var path. Chosen as `"_default"` so
- * the YAML loader can reuse the same name as the zero-config fallback.
+ * Connection id synthesized by the env-var path. The leading underscore marks
+ * it as machine-synthesized rather than user-chosen; it is the canonical
+ * zero-config id the YAML loader must adopt when the env-var path is retired.
+ *
+ * Distinct from the test factories' {@link DEFAULT_CONNECTION_ID} (`"default"`,
+ * exported from `tests/factories/runtime.ts`): same constant name, different
+ * value, different world. This one is the production env-var synthesis; that
+ * one is an arbitrary fixture id. The values differ on purpose — do not unify.
  *
  * Fallback contract: with no CLI args and no env vars, this module produces
  * `connections: { _default: { type: "direct" } }` alongside the
@@ -19,10 +25,10 @@ import { type KeyValuePairObject } from "properties-file";
  * blocks, so only connection-agnostic tools are enabled. When the env-var
  * path is retired, the YAML loader must preserve this connection shape.
  */
-export const DEFAULT_CONNECTION_NAME = "_default";
+export const DEFAULT_CONNECTION_ID = "_default";
 
 /** The manufactured document path prefix for the single connection configured from env vars. */
-const CONN = `connections.${DEFAULT_CONNECTION_NAME}`;
+const CONN = `connections.${DEFAULT_CONNECTION_ID}`;
 
 /**
  * Maps each environment variable in type Environment (and handled by buildConfigFromEnvAndCli)
@@ -100,7 +106,7 @@ function buildConfigFromEnv(
   if (oauth) {
     const rawDocument: Record<string, unknown> = {
       connections: {
-        [DEFAULT_CONNECTION_NAME]: {
+        [DEFAULT_CONNECTION_ID]: {
           type: "oauth",
           ...(oauth.ccloudEnv && {
             ccloud_env: oauth.ccloudEnv,
@@ -156,7 +162,7 @@ function buildConfigFromEnv(
   // authOverrides are folded in here so Zod validates the final combined state,
   // including the disabled+api_key mutual exclusion refine.
   const rawDocument: Record<string, unknown> = {
-    connections: { [DEFAULT_CONNECTION_NAME]: connection },
+    connections: { [DEFAULT_CONNECTION_ID]: connection },
     ...buildServerBlock(env, authOverrides),
   };
 

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -218,7 +218,7 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      expect(config.getConnectionNames()).toEqual([]);
+      expect(config.getConnectionIds()).toEqual([]);
     });
 
     it("should accept more than one connection", () => {
@@ -235,7 +235,7 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      expect(config.getConnectionNames()).toEqual(["local", "staging"]);
+      expect(config.getConnectionIds()).toEqual(["local", "staging"]);
       const local = config.getConnectionConfig("local");
       const staging = config.getConnectionConfig("staging");
       // Each connection keeps its own blocks — they don't collapse into one.
@@ -247,7 +247,7 @@ describe("config/index.ts", () => {
       ).toBe("staging:9092");
     });
 
-    it("should throw error when connection name is whitespace-only", () => {
+    it("should throw error when connection id is whitespace-only", () => {
       const yamlContent = `connections:
   " ":
     type: "direct"

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONNECTION_NAME } from "@src/config/env-config.js";
+import { DEFAULT_CONNECTION_ID } from "@src/config/env-config.js";
 import type { DirectConnectionConfig } from "@src/config/models.js";
 import {
   KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
@@ -679,13 +679,13 @@ describe("config/models.ts", () => {
   });
 
   describe("MCPServerConfiguration", () => {
-    describe("getConnectionNames", () => {
-      it("should return connection names sorted alphabetically", () => {
+    describe("getConnectionIds", () => {
+      it("should return connection ids sorted alphabetically", () => {
         const config = new MCPServerConfiguration({
           connections: { staging: directConnection, local: directConnection },
         });
 
-        expect(config.getConnectionNames()).toEqual(["local", "staging"]);
+        expect(config.getConnectionIds()).toEqual(["local", "staging"]);
       });
     });
 
@@ -737,7 +737,7 @@ describe("config/models.ts", () => {
       it("should throw when the sole connection is OAuth-typed", () => {
         const config = new MCPServerConfiguration({
           connections: {
-            [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "devel" },
+            [DEFAULT_CONNECTION_ID]: { type: "oauth", ccloud_env: "devel" },
           },
         });
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -212,18 +212,18 @@ export class MCPServerConfiguration {
    * @throws Error if 0 or more than 1 connection is defined.
    */
   getSoleConnection(): ConnectionConfig {
-    const connectionNames = Object.keys(this.connections);
-    if (connectionNames.length === 0) {
+    const connectionIds = Object.keys(this.connections);
+    if (connectionIds.length === 0) {
       throw new Error("No connections defined in configuration");
     }
-    if (connectionNames.length > 1) {
+    if (connectionIds.length > 1) {
       throw new Error(
         "Multiple connections defined in configuration; only one is supported currently",
       );
     }
 
     // must be exactly one connection at this point, so return it.
-    return this.connections[connectionNames[0]!]!;
+    return this.connections[connectionIds[0]!]!;
   }
 
   /**
@@ -255,14 +255,14 @@ export class MCPServerConfiguration {
     if (conn === undefined) {
       throw new Error(
         `Unknown connection id "${connectionId}"; defined connections: ${
-          quoteJoinIds(this.getConnectionNames()) || "none"
+          quoteJoinIds(this.getConnectionIds()) || "none"
         }`,
       );
     }
     return conn;
   }
 
-  getConnectionNames(): string[] {
+  getConnectionIds(): string[] {
     return Object.keys(this.connections).sort((a, b) => a.localeCompare(b));
   }
 }
@@ -680,7 +680,7 @@ export const DEFAULT_SERVER_CONFIG = serverConfigSchema.parse({});
 export const mcpConfigSchema = z
   .object({
     connections: z.record(
-      z.string().trim().min(1, "Connection name cannot be empty"),
+      z.string().trim().min(1, "Connection id cannot be empty"),
       connectionConfigSchema,
     ),
     server: serverConfigSchema.default(() => DEFAULT_SERVER_CONFIG),

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -240,7 +240,7 @@ export abstract class BaseToolHandler implements ToolHandler {
     // which connection a call routes to, so the call auto-routes with no extra
     // argument. The zero-connection case also covers the `--list-tools` runtime,
     // which wants the unaugmented view.
-    if (runtime.config.getConnectionNames().length <= 1)
+    if (runtime.config.getConnectionIds().length <= 1)
       return config.inputSchema;
 
     const ids = this.enabledConnectionIds(runtime);

--- a/src/confluent/tools/cluster-arg-resolvers.test.ts
+++ b/src/confluent/tools/cluster-arg-resolvers.test.ts
@@ -1,5 +1,5 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
-import { DEFAULT_CONNECTION_NAME } from "@src/config/env-config.js";
+import { DEFAULT_CONNECTION_ID } from "@src/config/env-config.js";
 import { MCPServerConfiguration } from "@src/config/index.js";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import {
@@ -14,7 +14,7 @@ import { ServerRuntime } from "@src/server-runtime.js";
 import { createMockInstance } from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 
-const CONN_ID = DEFAULT_CONNECTION_NAME;
+const CONN_ID = DEFAULT_CONNECTION_ID;
 
 function directRuntime(
   connOverrides: Record<string, unknown> = {},

--- a/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.integration.test.ts
@@ -1,7 +1,7 @@
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
+  integrationConnectionId,
   integrationConnectionLoaded,
-  integrationConnectionName,
 } from "@tests/harness/runtime.js";
 import {
   startServer,
@@ -24,7 +24,7 @@ describe("describe-configured-connection", { tags: [Tag.SMOKE] }, () => {
     return;
   }
 
-  const connectionId = integrationConnectionName();
+  const connectionId = integrationConnectionId();
 
   describe.each(activeTransports)("via %s transport", (transport) => {
     let server: StartedServer;

--- a/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.ts
@@ -74,7 +74,7 @@ export class DescribeConfiguredConnectionHandler extends ToolMetadataHandler {
     if (conn === undefined) {
       return this.createResponse(
         `Unknown connection id "${connectionId}". Configured connections: ${
-          quoteJoinIds(runtime.config.getConnectionNames()) || "none"
+          quoteJoinIds(runtime.config.getConnectionIds()) || "none"
         }.`,
         true,
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -412,7 +412,7 @@ async function main() {
     const telemetry = TelemetryService.getInstance();
 
     logger.info(
-      `${mcpConfig.getConnectionNames().length} connections loaded successfully`,
+      `${mcpConfig.getConnectionIds().length} connections loaded successfully`,
     );
 
     const runtime = ServerRuntime.fromConfig(mcpConfig, allowedToolNames);

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONNECTION_NAME } from "@src/config/env-config.js";
+import { DEFAULT_CONNECTION_ID } from "@src/config/env-config.js";
 import { type DirectConnectionConfig } from "@src/config/index.js";
 import { MCPServerConfiguration } from "@src/config/models.js";
 import {
@@ -315,7 +315,7 @@ describe("ServerRuntime", () => {
     it("should leave oauthHolder undefined when the config has no ccloud-oauth", () => {
       const noOauthConfig = new MCPServerConfiguration({
         connections: {
-          [DEFAULT_CONNECTION_NAME]: connWith({
+          [DEFAULT_CONNECTION_ID]: connWith({
             kafka: { bootstrap_servers: "broker:9092" },
           }),
         },
@@ -327,7 +327,7 @@ describe("ServerRuntime", () => {
     it("should construct an OAuthHolder when a connection has type 'oauth'", () => {
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "devel" },
+          [DEFAULT_CONNECTION_ID]: { type: "oauth", ccloud_env: "devel" },
         },
       });
 
@@ -341,13 +341,13 @@ describe("ServerRuntime", () => {
     it("should construct an OAuthClientManager for an oauth connection", () => {
       const oauthConfig = new MCPServerConfiguration({
         connections: {
-          [DEFAULT_CONNECTION_NAME]: { type: "oauth", ccloud_env: "stag" },
+          [DEFAULT_CONNECTION_ID]: { type: "oauth", ccloud_env: "stag" },
         },
       });
 
       const runtime = ServerRuntime.fromConfig(oauthConfig);
 
-      expect(runtime.clientManagers[DEFAULT_CONNECTION_NAME]).toBeInstanceOf(
+      expect(runtime.clientManagers[DEFAULT_CONNECTION_ID]).toBeInstanceOf(
         OAuthClientManager,
       );
     });

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -16,7 +16,13 @@ import {
 import { fileURLToPath } from "node:url";
 import type { Mocked } from "vitest";
 
-/** Connection ID used by the named runtime factories and their default single-connection runtimes. */
+/**
+ * Connection id used by the named runtime factories and their default
+ * single-connection runtimes. An arbitrary fixture id — distinct from the
+ * production env-var synthesis constant of the same name (`"_default"`,
+ * exported from `@src/config/env-config.js`); the differing values are
+ * intentional.
+ */
 export const DEFAULT_CONNECTION_ID = "default";
 
 const CCLOUD_OAUTH_FIXTURE = fileURLToPath(

--- a/tests/harness/cp-runtime.ts
+++ b/tests/harness/cp-runtime.ts
@@ -23,8 +23,8 @@ const CP_FIXTURE_PATH = resolve(
   "test-fixtures/yaml_configs/integration.cp.yaml",
 );
 
-/** The connection name the CP fixture gives its single connection. */
-const CP_CONNECTION_NAME = "cp";
+/** The connection id the CP fixture gives its single connection. */
+const CP_CONNECTION_ID = "cp";
 
 /**
  * The {@linkcode ServerRuntime} the spawned MCP server would see when using
@@ -64,7 +64,7 @@ export function cpIntegrationConnection(): ConnectionConfig {
   } catch {
     return { type: "direct" };
   }
-  return config.getConnectionConfig(CP_CONNECTION_NAME);
+  return config.getConnectionConfig(CP_CONNECTION_ID);
 }
 
 export interface CpSpawnConfigOptions {

--- a/tests/harness/runtime.ts
+++ b/tests/harness/runtime.ts
@@ -70,7 +70,7 @@ export function integrationRuntime(
 
 /**
  * The {@link ConnectionConfig} the spawned MCP server would see, looked up by
- * the fixture's connection name (see {@linkcode FIXTURE_CONNECTION_NAME}) in the
+ * the fixture's connection id (see {@linkcode FIXTURE_CONNECTION_ID}) in the
  * same fixture {@linkcode integrationRuntime} loads. Integration fixtures hold
  * exactly one connection, so this single connection is the right-sized input for
  * a {@linkcode ConnectionPredicate} gate: `handler.predicate(integrationConnection())`
@@ -83,7 +83,7 @@ export function integrationRuntime(
  * On load failure (a required `${VAR}` missing — creds absent) returns an empty
  * `direct` connection, so every block-based predicate yields a clean disabled
  * verdict and the gate skips. A fixture that loads but lacks the expected
- * connection name is fixture drift, not a creds-skip — {@linkcode MCPServerConfiguration.getConnectionConfig}
+ * connection id is fixture drift, not a creds-skip — {@linkcode MCPServerConfiguration.getConnectionConfig}
  * throws loudly rather than letting the whole suite silently skip.
  */
 export function integrationConnection(
@@ -93,16 +93,16 @@ export function integrationConnection(
   // Fixture failed to load (a required `${VAR}` missing — i.e. creds absent):
   // an empty direct connection yields a clean disabled verdict, so the gate skips.
   if (config === undefined) return { type: "direct" };
-  // Fixture loaded: resolve the expected connection by name. A miss here is
+  // Fixture loaded: resolve the expected connection by id. A miss here is
   // fixture drift (renamed/removed connection), not a credential-skip case, so
   // let getConnectionConfig throw loudly rather than silently skipping the whole suite.
   return config.getConnectionConfig(
-    FIXTURE_CONNECTION_NAME[options.oauth ? "oauth" : "direct"],
+    FIXTURE_CONNECTION_ID[options.oauth ? "oauth" : "direct"],
   );
 }
 
 /**
- * The fixture connection's name — its key in the `connections` map, which is
+ * The fixture connection's id — its key in the `connections` map, which is
  * also the value a test passes as the `connectionId` argument to a
  * connection-addressed tool (e.g. `describe-configured-connection`); the map key
  * and the routing id are one and the same. A constant rather than a
@@ -110,10 +110,10 @@ export function integrationConnection(
  * multi-connection fixtures #543 introduces, and so a fixture rename surfaces
  * here rather than as a mysterious "unknown connection id" at call time.
  */
-export function integrationConnectionName(
+export function integrationConnectionId(
   options: { oauth?: boolean } = {},
 ): string {
-  return FIXTURE_CONNECTION_NAME[options.oauth ? "oauth" : "direct"];
+  return FIXTURE_CONNECTION_ID[options.oauth ? "oauth" : "direct"];
 }
 
 /**
@@ -214,12 +214,12 @@ const OAUTH_FIXTURE_PATH = resolve(
 );
 
 /**
- * The connection name each integration fixture gives its single connection.
+ * The connection id each integration fixture gives its single connection.
  * {@linkcode integrationConnection} looks the connection up by this key rather
  * than via `getSoleConnection()`, which the #532 epic is removing repo-wide
  * (it encodes the single-connection assumption and throws once two exist).
  */
-const FIXTURE_CONNECTION_NAME: Record<"direct" | "oauth", string> = {
+const FIXTURE_CONNECTION_ID: Record<"direct" | "oauth", string> = {
   direct: "integration",
   oauth: "integration-oauth",
 };


### PR DESCRIPTION
## Align connection-key nomenclature on `id`

- A survey of how the codebase refers to the keys of the `connections:` map settled the `name` vs `id` question decisively in favor of `id`: ~225 `id`-form identifiers against a couple dozen `name`-form holdouts, and — more tellingly — the user-facing surface already speaks `id`. The routing parameter every multi-connection tool injects is `connectionId`, the by-key accessor is `getConnectionConfig(connectionId)`, the join helper is `quoteJoinIds`, and the README already says "the connection id". The map key you write under `connections:` and the value you hand a tool to route a call are one and the same noun, so the codebase should use one word for it.
- Renamed `MCPServerConfiguration.getConnectionNames()` to `getConnectionIds()` (the issue's headline) and updated its three callers in `index.ts`, `base-tools.ts`, and the `describe-configured-connection` handler. The method returns exactly the set of legal `connectionId` values, so its old name was the most conspicuous outlier.
- Swept the remaining `name`-flavored holdouts into the same alignment: the `getSoleConnection()` local var, the integration harness's `integrationConnectionName()` → `integrationConnectionId()` and `FIXTURE_CONNECTION_NAME` → `FIXTURE_CONNECTION_ID` (plus their docstrings), and the user-facing "Connection name is freeform" prose in `CONFIGURATION.md` and both example YAMLs, which now matches the README's existing "connection id".
- Renamed two `SCREAMING_CASE` connection-key constants a case-sensitive `connectionName` grep had hidden: `DEFAULT_CONNECTION_NAME` → `DEFAULT_CONNECTION_ID` (the env-var path's synthesized id, 15 call sites across 5 files) and the CP harness's `CP_CONNECTION_NAME` → `CP_CONNECTION_ID`. Also reworded the schema's `"Connection name cannot be empty"` Zod message to `"Connection id cannot be empty"` and two `"...connection name..."` test titles.
- Reconciled the `DEFAULT_CONNECTION_ID` name collision rather than papering over it. After the rename, `@src/config/env-config.ts` (`"_default"`) and `tests/factories/runtime.ts` (`"default"`) export same-named constants with different values. The split is intentional: `"_default"` is the production zero-config id the YAML loader must adopt when the env-var path retires (a forward contract), while `"default"` is an arbitrary test fixture id. Both docstrings now state the distinction and cross-reference each other so the collision reads as deliberate, not as a trap. The values are deliberately left un-unified.
- Noted but did not test the Zod message reword: Zod discards a record-key schema's custom `.min(1, ...)` message and surfaces `"Invalid key in record"` instead (verified empirically), so `"Connection id cannot be empty"` is dead text that never reaches a user. The existing whitespace-key test correctly pins the real `/Invalid key in record/`; the reword is for source consistency only, and no test can guard an unreachable string.
- Left `connection_name` in the generated `openapi-schema.d.ts` untouched: that is the Flink SQL `CONNECTION` object — a different Confluent domain concept that has nothing to do with the MCP server's connection keys.
- Added `.claude/rules/connection-nomenclature.md` to keep the convention from drifting back: it states that configured connections are addressed by `id` (never `name`), records the #556 survey verdict, carves out the one legitimate `connection_name` (the generated Flink `CONNECTION` object), and prescribes the case-insensitive sweep that this PR's own first pass skipped. Auto-loads when editing config, tool, or harness/factory files.
- This is a behavior-preserving rename. The existing config and harness tests are the regression net (renamed call sites assert the new contract), and `tsc --noEmit` mechanically catches any missed caller; `lint`, `typecheck`, and the full unit suite stay green.

## Relationships

- Closes #556.
- Child of #532 (Epic: Multi-connection support).
