### PR TITLE
Delete the single-connection scaffolding accessors

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -393,7 +393,7 @@ A few case kinds legitimately stay as direct `handler.handle(...)` calls rather 
 
 Such cases don't carry decoy coverage; the suite's other (harness-routed) cases provide it.
 
-A reverted handler (one that goes back to `resolveSoleConnection()`) trips the decoy's untouched assertion on every routed case, so the coverage is not vacuous.
+A handler that resolves by grabbing `enabledConnectionIds[0]` instead of the caller's `connectionId` trips the decoy's untouched assertion on every routed case, so the coverage is not vacuous.
 
 ## Test Server & Runtime Fixtures
 

--- a/src/config/env-config.test.ts
+++ b/src/config/env-config.test.ts
@@ -2,6 +2,7 @@ import {
   buildConfigFromEnvAndCli,
   DEFAULT_CONNECTION_ID,
 } from "@src/config/env-config.js";
+import { directConnectionOf } from "@tests/factories/config.js";
 import { describe, expect, it } from "vitest";
 
 type EnvInput = Parameters<typeof buildConfigFromEnvAndCli>[0];
@@ -63,8 +64,7 @@ describe("config/env-config.ts", () => {
           }),
         );
 
-        const conn = config.getSoleDirectConnection();
-        expect(conn.type).toBe("direct");
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
         expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       });
@@ -84,7 +84,7 @@ describe("config/env-config.ts", () => {
           envWith({ BOOTSTRAP_SERVERS: "broker1:9092,broker2:9092" }),
         );
 
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.bootstrap_servers).toBe("broker1:9092,broker2:9092");
         expect(conn.schema_registry).toBeUndefined();
       });
@@ -94,7 +94,7 @@ describe("config/env-config.ts", () => {
           envWith({ SCHEMA_REGISTRY_ENDPOINT: "https://sr.example.com:8081" }),
         );
 
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.schema_registry?.endpoint).toBe(
           "https://sr.example.com:8081",
         );
@@ -103,7 +103,7 @@ describe("config/env-config.ts", () => {
 
       it("should build an empty direct connection when no service env vars are set (docs-only setup)", () => {
         const config = buildConfigFromEnvAndCli(envWith());
-        expect(config.getSoleDirectConnection()).toEqual({
+        expect(directConnectionOf(config, DEFAULT_CONNECTION_ID)).toEqual({
           type: "direct",
           read_only: false,
         });
@@ -134,7 +134,7 @@ describe("config/env-config.ts", () => {
             KAFKA_API_SECRET: "mysecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.auth).toEqual({
           type: "api_key",
           key: "mykey",
@@ -150,7 +150,7 @@ describe("config/env-config.ts", () => {
             SCHEMA_REGISTRY_API_SECRET: "srsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.schema_registry?.auth).toEqual({
           type: "api_key",
           key: "srkey",
@@ -169,7 +169,7 @@ describe("config/env-config.ts", () => {
             SCHEMA_REGISTRY_API_SECRET: "srsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.auth).toEqual({
           type: "api_key",
           key: "kafkakey",
@@ -273,7 +273,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.confluent_cloud?.auth).toEqual({
           type: "api_key",
           key: "cckey",
@@ -291,7 +291,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_REST_ENDPOINT: "https://custom.confluent.cloud",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.confluent_cloud).toBeUndefined();
       });
 
@@ -303,7 +303,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.confluent_cloud?.endpoint).toBe(
           "https://custom.confluent.cloud",
         );
@@ -322,7 +322,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_ORG_ID: "org-abc123",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.confluent_cloud?.organization_id).toBe("org-abc123");
       });
 
@@ -333,7 +333,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.confluent_cloud?.organization_id).toBeUndefined();
       });
 
@@ -344,7 +344,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.confluent_cloud?.auth).toBeDefined();
         expect(conn.kafka).toBeUndefined();
         expect(conn.schema_registry).toBeUndefined();
@@ -381,7 +381,7 @@ describe("config/env-config.ts", () => {
         const config = buildConfigFromEnvAndCli(
           envWith(allRequiredFlinkEnvVars),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.flink?.endpoint).toBe(
           "https://flink.us-east-1.aws.confluent.cloud",
         );
@@ -403,7 +403,7 @@ describe("config/env-config.ts", () => {
             FLINK_DATABASE_NAME: "my-cluster",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.flink?.catalog_name).toBe("my-environment");
         expect(conn.flink?.database_name).toBe("my-cluster");
       });
@@ -412,7 +412,7 @@ describe("config/env-config.ts", () => {
         const config = buildConfigFromEnvAndCli(
           envWith(allRequiredFlinkEnvVars),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.flink).toBeDefined();
         expect(conn.kafka).toBeUndefined();
         expect(conn.schema_registry).toBeUndefined();
@@ -460,7 +460,7 @@ describe("config/env-config.ts", () => {
               "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.rest_endpoint).toBe(
           "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
         );
@@ -473,7 +473,7 @@ describe("config/env-config.ts", () => {
             KAFKA_CLUSTER_ID: "lkc-abc123",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.cluster_id).toBe("lkc-abc123");
       });
 
@@ -484,7 +484,7 @@ describe("config/env-config.ts", () => {
             KAFKA_ENV_ID: "env-xyz789",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.env_id).toBe("env-xyz789");
       });
 
@@ -498,7 +498,7 @@ describe("config/env-config.ts", () => {
             KAFKA_ENV_ID: "env-xyz789",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.rest_endpoint).toBe(
           "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
         );
@@ -524,7 +524,7 @@ describe("config/env-config.ts", () => {
               "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.kafka?.rest_endpoint).toBe(
           "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
         );
@@ -540,7 +540,7 @@ describe("config/env-config.ts", () => {
             TABLEFLOW_API_SECRET: "tfsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.tableflow?.auth).toEqual({
           type: "api_key",
           key: "tfkey",
@@ -555,7 +555,7 @@ describe("config/env-config.ts", () => {
             TABLEFLOW_API_SECRET: "tfsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.tableflow?.auth).toBeDefined();
         expect(conn.kafka).toBeUndefined();
         expect(conn.schema_registry).toBeUndefined();
@@ -756,7 +756,7 @@ describe("config/env-config.ts", () => {
             TELEMETRY_API_SECRET: "telsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.telemetry).toEqual({
           endpoint: "https://custom.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "telkey", secret: "telsecret" },
@@ -770,7 +770,7 @@ describe("config/env-config.ts", () => {
             TELEMETRY_API_SECRET: "telsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.telemetry).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "telkey", secret: "telsecret" },
@@ -795,7 +795,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.telemetry).toEqual({
           endpoint: "https://custom.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "cckey", secret: "ccsecret" },
@@ -809,7 +809,7 @@ describe("config/env-config.ts", () => {
             CONFLUENT_CLOUD_API_SECRET: "ccsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.telemetry).toEqual({
           endpoint: "https://api.telemetry.confluent.cloud",
           auth: { type: "api_key", key: "cckey", secret: "ccsecret" },
@@ -823,7 +823,7 @@ describe("config/env-config.ts", () => {
             TELEMETRY_API_SECRET: "telsecret",
           }),
         );
-        const conn = config.getSoleDirectConnection();
+        const conn = directConnectionOf(config, DEFAULT_CONNECTION_ID);
         expect(conn.telemetry?.endpoint).toBe(
           "https://api.telemetry.confluent.cloud",
         );
@@ -879,9 +879,10 @@ describe("config/env-config.ts", () => {
         "localhost",
         "127.0.0.1",
       ]);
-      expect(config.getSoleDirectConnection().kafka?.bootstrap_servers).toBe(
-        "localhost:9092",
-      );
+      expect(
+        directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka
+          ?.bootstrap_servers,
+      ).toBe("localhost:9092");
     });
 
     it("should override server.auth.disabled when disableAuth: true is provided", () => {
@@ -916,7 +917,10 @@ describe("config/env-config.ts", () => {
         envWith({ BOOTSTRAP_SERVERS: "localhost:9092" }),
         { kafkaConfig: { "ssl.ca.location": "/etc/ssl/certs/ca.pem" } },
       );
-      expect(config.getSoleDirectConnection().kafka?.extra_properties).toEqual({
+      expect(
+        directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka
+          ?.extra_properties,
+      ).toEqual({
         "ssl.ca.location": "/etc/ssl/certs/ca.pem",
       });
     });
@@ -926,9 +930,10 @@ describe("config/env-config.ts", () => {
         envWith({ BOOTSTRAP_SERVERS: "original:9092" }),
         { kafkaConfig: { "bootstrap.servers": "override:9092" } },
       );
-      expect(config.getSoleDirectConnection().kafka?.bootstrap_servers).toBe(
-        "override:9092",
-      );
+      expect(
+        directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka
+          ?.bootstrap_servers,
+      ).toBe("override:9092");
     });
 
     it("should construct a kafka block when none existed and kafkaConfig provides bootstrap.servers", () => {
@@ -939,11 +944,13 @@ describe("config/env-config.ts", () => {
         }),
         { kafkaConfig: { "bootstrap.servers": "broker:9092" } },
       );
-      expect(config.getSoleDirectConnection().kafka?.bootstrap_servers).toBe(
-        "broker:9092",
-      );
       expect(
-        config.getSoleDirectConnection().kafka?.extra_properties,
+        directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka
+          ?.bootstrap_servers,
+      ).toBe("broker:9092");
+      expect(
+        directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka
+          ?.extra_properties,
       ).toBeUndefined();
     });
 
@@ -961,7 +968,7 @@ describe("config/env-config.ts", () => {
           },
         },
       );
-      const kafka = config.getSoleDirectConnection().kafka;
+      const kafka = directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka;
       expect(kafka?.bootstrap_servers).toBe("broker:9092");
       expect(kafka?.auth).toEqual({
         type: "api_key",
@@ -984,7 +991,7 @@ describe("config/env-config.ts", () => {
           },
         },
       );
-      const kafka = config.getSoleDirectConnection().kafka;
+      const kafka = directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka;
       expect(kafka?.bootstrap_servers).toBe("broker:9092");
       expect(kafka?.extra_properties).toEqual({ "socket.timeout.ms": "30000" });
     });
@@ -1003,7 +1010,7 @@ describe("config/env-config.ts", () => {
           },
         },
       );
-      const kafka = config.getSoleDirectConnection().kafka;
+      const kafka = directConnectionOf(config, DEFAULT_CONNECTION_ID).kafka;
       expect(kafka?.auth).toEqual({
         type: "api_key",
         key: "k-key",
@@ -1083,13 +1090,13 @@ describe("config/env-config.ts", () => {
           envWith({ BOOTSTRAP_SERVERS: "broker:9092" }),
           {},
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getConnectionConfig(DEFAULT_CONNECTION_ID);
         expect(conn.type).toBe("direct");
       });
 
       it("should produce an OAuth connection with ccloud_env=prod when --oauth is alone", () => {
         const config = buildConfigFromEnvAndCli(envWith({}), { oauth: true });
-        const conn = config.getSoleConnection();
+        const conn = config.getConnectionConfig(DEFAULT_CONNECTION_ID);
         expect(conn).toEqual({
           type: "oauth",
           ccloud_env: "prod",
@@ -1102,7 +1109,7 @@ describe("config/env-config.ts", () => {
           oauth: true,
           ccloudEnv: "stag",
         });
-        const conn = config.getSoleConnection();
+        const conn = config.getConnectionConfig(DEFAULT_CONNECTION_ID);
         expect(conn).toEqual({
           type: "oauth",
           ccloud_env: "stag",
@@ -1121,7 +1128,7 @@ describe("config/env-config.ts", () => {
           }),
           { oauth: true, ccloudEnv: "devel" },
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getConnectionConfig(DEFAULT_CONNECTION_ID);
         expect(conn).toEqual({
           type: "oauth",
           ccloud_env: "devel",
@@ -1134,7 +1141,7 @@ describe("config/env-config.ts", () => {
           envWith({ OAUTH_KAFKA_DEBUG: "security,broker" }),
           { oauth: true },
         );
-        const conn = config.getSoleConnection();
+        const conn = config.getConnectionConfig(DEFAULT_CONNECTION_ID);
         expect(conn).toEqual({
           type: "oauth",
           ccloud_env: "prod",
@@ -1145,7 +1152,7 @@ describe("config/env-config.ts", () => {
 
       it("should leave kafka_debug unset on the OAuth connection when OAUTH_KAFKA_DEBUG is absent", () => {
         const config = buildConfigFromEnvAndCli(envWith({}), { oauth: true });
-        const conn = config.getSoleConnection();
+        const conn = config.getConnectionConfig(DEFAULT_CONNECTION_ID);
         expect(conn).not.toHaveProperty("kafka_debug");
       });
 

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -3,6 +3,7 @@ import {
   loadConfigFromYaml,
   parseYamlConfiguration,
 } from "@src/config/index.js";
+import { directConnectionOf } from "@tests/factories/config.js";
 import {
   createFsWrappers,
   type MockedFsWrappers,
@@ -13,25 +14,21 @@ describe("config/index.ts", () => {
   describe("parseYamlConfiguration", () => {
     it("should successfully parse minimal valid config (kafka only)", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "localhost:9092"
 `;
 
-      const conn = parseYamlConfiguration(
-        yamlContent,
-        {},
-      ).getSoleDirectConnection();
+      const conn = directConnectionOf(parseYamlConfiguration(yamlContent, {}));
 
-      expect(conn.type).toBe("direct");
       expect(conn.kafka!.bootstrap_servers).toBe("localhost:9092");
       expect(conn.schema_registry).toBeUndefined();
     });
 
     it("should successfully parse full valid config (kafka + schema_registry)", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "localhost:9092"
@@ -39,10 +36,7 @@ describe("config/index.ts", () => {
       endpoint: "http://localhost:8081"
 `;
 
-      const conn = parseYamlConfiguration(
-        yamlContent,
-        {},
-      ).getSoleDirectConnection();
+      const conn = directConnectionOf(parseYamlConfiguration(yamlContent, {}));
 
       expect(conn.schema_registry).toBeDefined();
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
@@ -50,16 +44,13 @@ describe("config/index.ts", () => {
 
     it("should accept multiple bootstrap servers", () => {
       const yamlContent = `connections:
-  cluster:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "broker1:9092,broker2:9092,broker3:9092"
 `;
 
-      const conn = parseYamlConfiguration(
-        yamlContent,
-        {},
-      ).getSoleDirectConnection();
+      const conn = directConnectionOf(parseYamlConfiguration(yamlContent, {}));
 
       expect(conn.kafka!.bootstrap_servers).toBe(
         "broker1:9092,broker2:9092,broker3:9092",
@@ -126,12 +117,12 @@ describe("config/index.ts", () => {
 
     it("should accept a direct connection with no service blocks", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
 `;
 
       const config = parseYamlConfiguration(yamlContent, {});
-      expect(config.getSoleDirectConnection()).toEqual({
+      expect(directConnectionOf(config)).toEqual({
         type: "direct",
         read_only: false,
       });
@@ -265,7 +256,7 @@ describe("config/index.ts", () => {
 
     it("should accept https schema_registry endpoint", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "localhost:9092"
@@ -275,14 +266,14 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      expect(config.getSoleDirectConnection().schema_registry?.endpoint).toBe(
+      expect(directConnectionOf(config).schema_registry?.endpoint).toBe(
         "https://schema-registry.example.com:8081",
       );
     });
 
     it("should successfully parse config with schema_registry only (no kafka)", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     schema_registry:
       endpoint: "http://localhost:8081"
@@ -290,20 +281,20 @@ describe("config/index.ts", () => {
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       expect(conn.kafka).toBeUndefined();
     });
 
     it("should parse a minimal oauth connection and apply the prod default", () => {
       const yamlContent = `connections:
-  prod-oauth:
+  default:
     type: "oauth"
 `;
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      expect(config.getSoleConnection()).toEqual({
+      expect(config.getConnectionConfig("default")).toEqual({
         type: "oauth",
         ccloud_env: "prod",
         read_only: false,
@@ -312,14 +303,14 @@ describe("config/index.ts", () => {
 
     it("should parse an explicit oauth ccloud_env value", () => {
       const yamlContent = `connections:
-  stag-oauth:
+  default:
     type: "oauth"
     ccloud_env: "stag"
 `;
 
       const config = parseYamlConfiguration(yamlContent, {});
 
-      expect(config.getSoleConnection()).toEqual({
+      expect(config.getConnectionConfig("default")).toEqual({
         type: "oauth",
         ccloud_env: "stag",
         read_only: false,
@@ -340,7 +331,7 @@ describe("config/index.ts", () => {
 
     it("should interpolate ${VAR} references using provided env before Zod validation", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "\${BOOTSTRAP}"
@@ -353,7 +344,7 @@ describe("config/index.ts", () => {
         SR_URL: "http://localhost:8081",
       });
 
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka!.bootstrap_servers).toBe("broker1:9092");
       expect(conn.schema_registry!.endpoint).toBe("http://localhost:8081");
     });
@@ -462,7 +453,7 @@ describe("config/index.ts", () => {
 
     it("should successfully load and parse a valid config file", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "localhost:9092"
@@ -472,14 +463,14 @@ describe("config/index.ts", () => {
 
       const config = loadConfigFromYaml("/path/to/config.yaml", {});
 
-      expect(config.getSoleDirectConnection().kafka!.bootstrap_servers).toBe(
+      expect(directConnectionOf(config).kafka!.bootstrap_servers).toBe(
         "localhost:9092",
       );
     });
 
     it("should pass env argument to parseYamlConfiguration for variable interpolation", () => {
       const yamlContent = `connections:
-  local:
+  default:
     type: "direct"
     kafka:
       bootstrap_servers: "\${BOOTSTRAP_SERVERS}"
@@ -491,7 +482,7 @@ describe("config/index.ts", () => {
         BOOTSTRAP_SERVERS: "broker1:9092",
       });
 
-      expect(config.getSoleDirectConnection().kafka!.bootstrap_servers).toBe(
+      expect(directConnectionOf(config).kafka!.bootstrap_servers).toBe(
         "broker1:9092",
       );
     });

--- a/src/config/models.test.ts
+++ b/src/config/models.test.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_CONNECTION_ID } from "@src/config/env-config.js";
 import type { DirectConnectionConfig } from "@src/config/models.js";
 import {
   KAFKA_PROTECTED_EXTRA_PROPERTY_KEYS,
@@ -686,72 +685,6 @@ describe("config/models.ts", () => {
         });
 
         expect(config.getConnectionIds()).toEqual(["local", "staging"]);
-      });
-    });
-
-    describe("getSoleConnection", () => {
-      it("should return the single defined connection", () => {
-        const config = new MCPServerConfiguration({
-          connections: { local: directConnection },
-        });
-
-        expect(config.getSoleConnection()).toBe(directConnection);
-      });
-
-      it("should throw when no connections are defined", () => {
-        const config = new MCPServerConfiguration({ connections: {} });
-
-        expect(() => config.getSoleConnection()).toThrow(
-          /No connections defined/,
-        );
-      });
-
-      it("should throw when more than one connection is defined", () => {
-        const config = new MCPServerConfiguration({
-          connections: {
-            local: directConnection,
-            staging: {
-              type: "direct",
-              kafka: { bootstrap_servers: "staging:9092" },
-            },
-          },
-        });
-
-        expect(() => config.getSoleConnection()).toThrow(
-          /Multiple connections defined/,
-        );
-      });
-    });
-
-    describe("getSoleDirectConnection", () => {
-      it("should return the connection narrowed to direct when sole connection is direct", () => {
-        const config = new MCPServerConfiguration({
-          connections: { local: directConnection },
-        });
-
-        const conn = config.getSoleDirectConnection();
-        expect(conn).toBe(directConnection);
-        expect(conn.type).toBe("direct");
-      });
-
-      it("should throw when the sole connection is OAuth-typed", () => {
-        const config = new MCPServerConfiguration({
-          connections: {
-            [DEFAULT_CONNECTION_ID]: { type: "oauth", ccloud_env: "devel" },
-          },
-        });
-
-        expect(() => config.getSoleDirectConnection()).toThrow(
-          /Expected sole connection to be a direct connection; got type "oauth"/,
-        );
-      });
-
-      it("should propagate the underlying getSoleConnection throw on zero connections", () => {
-        const config = new MCPServerConfiguration({ connections: {} });
-
-        expect(() => config.getSoleDirectConnection()).toThrow(
-          /No connections defined/,
-        );
       });
     });
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -206,43 +206,6 @@ export class MCPServerConfiguration {
   }
 
   /**
-   * Returns the single defined connection in the configuration.
-   *
-   * @returns the single defined connection
-   * @throws Error if 0 or more than 1 connection is defined.
-   */
-  getSoleConnection(): ConnectionConfig {
-    const connectionIds = Object.keys(this.connections);
-    if (connectionIds.length === 0) {
-      throw new Error("No connections defined in configuration");
-    }
-    if (connectionIds.length > 1) {
-      throw new Error(
-        "Multiple connections defined in configuration; only one is supported currently",
-      );
-    }
-
-    // must be exactly one connection at this point, so return it.
-    return this.connections[connectionIds[0]!]!;
-  }
-
-  /**
-   * Returns the sole connection narrowed to {@link DirectConnectionConfig}, throwing
-   * if it is OAuth-typed. Use from callers that need to read service-block fields
-   * (e.g., `kafka.cluster_id`, `flink.environment_id`) — the throw replaces what
-   * would otherwise be a `conn.type === "direct"` guard at every read site.
-   */
-  getSoleDirectConnection(): DirectConnectionConfig {
-    const conn = this.getSoleConnection();
-    if (conn.type !== "direct") {
-      throw new Error(
-        `Expected sole connection to be a direct connection; got type "${conn.type}"`,
-      );
-    }
-    return conn;
-  }
-
-  /**
    * Returns the {@link ConnectionConfig} registered under `connectionId`,
    * throwing if no such connection is defined. The by-id accessor for the
    * multi-connection world: callers route to a known connection (a tool's

--- a/src/config/yaml-fixtures.test.ts
+++ b/src/config/yaml-fixtures.test.ts
@@ -1,5 +1,6 @@
 import { loadConfigFromYaml } from "@src/config/index.js";
 import { combinedSchema } from "@src/env-schema.js";
+import { directConnectionOf } from "@tests/factories/config.js";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,8 +23,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-only.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
-      expect(conn.type).toBe("direct");
+      const conn = directConnectionOf(config);
       expect(conn.description).toBe("Local dev broker");
       expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
       expect(conn.kafka?.auth).toBeUndefined();
@@ -35,8 +35,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/sr-only.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
-      expect(conn.type).toBe("direct");
+      const conn = directConnectionOf(config);
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
       expect(conn.schema_registry?.auth).toBeUndefined();
       expect(conn.kafka).toBeUndefined();
@@ -47,7 +46,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-and-sr.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka?.bootstrap_servers).toBe("localhost:9092");
       expect(conn.kafka?.auth).toBeUndefined();
       expect(conn.schema_registry?.endpoint).toBe("http://localhost:8081");
@@ -59,7 +58,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka?.auth).toEqual({
         type: "api_key",
         key: "mykafkakey",
@@ -73,7 +72,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/sr-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.schema_registry?.auth).toEqual({
         type: "api_key",
         key: "mysrkey",
@@ -87,7 +86,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-and-sr-both-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka?.auth).toEqual({
         type: "api_key",
         key: "mykafkakey",
@@ -105,7 +104,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-interpolated-auth.yaml"),
         { KAFKA_API_KEY: "envkey", KAFKA_API_SECRET: "envsecret" },
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka?.auth).toEqual({
         type: "api_key",
         key: "envkey",
@@ -120,7 +119,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.confluent_cloud?.auth).toEqual({
         type: "api_key",
         key: "mycloudkey",
@@ -139,7 +138,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-with-endpoint-and-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.confluent_cloud?.endpoint).toBe(
         "https://custom.confluent.cloud",
       );
@@ -155,7 +154,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/tableflow-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.tableflow?.auth).toEqual({
         type: "api_key",
         key: "mytableflowkey",
@@ -171,7 +170,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-and-tableflow-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.confluent_cloud?.endpoint).toBe(
         "https://api.confluent.cloud",
       );
@@ -194,7 +193,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-oauth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleConnection();
+      const conn = config.getConnectionConfig("default");
       expect(conn.type).toBe("oauth");
       // Narrow off the discriminant before reading ccloud_env so the assertion
       // also serves as a compile-time check on the OAuth arm of ConnectionConfig.
@@ -211,7 +210,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-extra-properties.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka?.bootstrap_servers).toBe("broker.confluent.cloud:9092");
       expect(conn.kafka?.extra_properties).toEqual({
         "socket.timeout.ms": "30000",
@@ -227,7 +226,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/kafka-with-rest-metadata.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.kafka?.bootstrap_servers).toBe("broker.confluent.cloud:9092");
       expect(conn.kafka?.rest_endpoint).toBe(
         "https://pkc-abc123.us-east-1.aws.confluent.cloud:443",
@@ -243,7 +242,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/flink-with-required-fields.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.flink?.auth).toEqual({
         type: "api_key",
         key: "myflinkkey",
@@ -268,7 +267,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/flink-with-all-fields.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.flink?.endpoint).toBe("https://flink.confluent.cloud");
       expect(conn.flink?.auth).toEqual({
         type: "api_key",
@@ -287,7 +286,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/ccloud-and-flink-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.confluent_cloud?.auth).toEqual({
         type: "api_key",
         key: "mycloudkey",
@@ -308,7 +307,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/telemetry-with-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.telemetry).toEqual({
         endpoint: "https://api.telemetry.confluent.cloud",
         auth: {
@@ -326,7 +325,7 @@ describe("config/yaml-fixtures.test.ts", () => {
         fixtureFile("valid/telemetry-with-endpoint-and-auth.yaml"),
         NO_ENV,
       );
-      const conn = config.getSoleDirectConnection();
+      const conn = directConnectionOf(config);
       expect(conn.telemetry?.endpoint).toBe(
         "https://api.telemetry.confluent.cloud",
       );

--- a/src/confluent/tools/base-tools.test.ts
+++ b/src/confluent/tools/base-tools.test.ts
@@ -13,7 +13,6 @@ import {
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {
   bareRuntime,
-  CCLOUD_CONN,
   ccloudOAuthRuntime,
   DEFAULT_CONNECTION_ID,
   kafkaRuntime,
@@ -447,25 +446,6 @@ describe("base-tools.ts", () => {
 
           expect(parsed.success).toBe(true);
         });
-      });
-    });
-
-    describe("resolveSoleConnection()", () => {
-      const resolveSoleConnection = handler["resolveSoleConnection"].bind(
-        handler,
-      ) as (typeof handler)["resolveSoleConnection"];
-
-      it("should return the sole direct connection's id, config, and client manager", () => {
-        const runtime = runtimeWith(CCLOUD_CONN);
-        const { connId, conn, clientManager } = resolveSoleConnection(runtime);
-        expect(connId).toBe(DEFAULT_CONNECTION_ID);
-        expect(conn.type).toBe("direct");
-        expect(clientManager).toBeDefined();
-      });
-
-      it("should return the sole OAuth connection without narrowing", () => {
-        const { conn } = resolveSoleConnection(ccloudOAuthRuntime());
-        expect(conn.type).toBe("oauth");
       });
     });
 

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -415,24 +415,6 @@ export abstract class BaseToolHandler implements ToolHandler {
   }
 
   /**
-   * Resolves the first connection enabled for this tool, returning the
-   * connection id, its config, and the matching client manager.
-   *
-   * Selects `enabledConnectionIds(runtime)[0]`. On a multi-connection config
-   * that arbitrarily picks the first enabled connection, which is why handlers
-   * route via {@linkcode resolveConnection} instead. Single-connection
-   * scaffolding with no remaining production callers; deletion tracked in #554.
-   */
-  protected resolveSoleConnection(runtime: ServerRuntime): ResolvedConnection {
-    const connId = this.enabledConnectionIds(runtime)[0]!;
-    return {
-      connId,
-      conn: runtime.config.connections[connId]!,
-      clientManager: runtime.clientManagers[connId]!,
-    };
-  }
-
-  /**
    * Resolves which connection a tool call targets: the explicit `connectionId`
    * argument when present, else the sole connection enabled for this tool.
    * Throws a listing error when the id is unknown/not-enabled, when it is

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@tests/harness/kafka-admin.js";
 import {
   integrationConnection,
-  integrationRuntime,
+  integrationDirectConnection,
 } from "@tests/harness/runtime.js";
 import {
   TEST_AVRO_SCHEMA,
@@ -27,7 +27,6 @@ import { wrapAsPathBasedClient } from "openapi-fetch";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new AddTagToTopicHandler();
-const runtime = integrationRuntime();
 
 describe(
   "add-tags-to-topic-handler",
@@ -45,7 +44,7 @@ describe(
     }
     // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
     // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
-    const conn = runtime.config.getSoleDirectConnection();
+    const conn = integrationDirectConnection();
     if (!conn.confluent_cloud) {
       it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
       return;

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@tests/harness/kafka-admin.js";
 import {
   integrationConnection,
-  integrationRuntime,
+  integrationDirectConnection,
 } from "@tests/harness/runtime.js";
 import {
   TEST_AVRO_SCHEMA,
@@ -27,7 +27,6 @@ import { wrapAsPathBasedClient } from "openapi-fetch";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new RemoveTagFromEntityHandler();
-const runtime = integrationRuntime();
 
 describe(
   "remove-tag-from-entity-handler",
@@ -45,7 +44,7 @@ describe(
     }
     // test-side deps beyond the handler predicate (kafka admin + SR cluster id discovery); gating
     // here keeps a missing field as a skip rather than a beforeAll throw that fails the suite
-    const conn = runtime.config.getSoleDirectConnection();
+    const conn = integrationDirectConnection();
     if (!conn.confluent_cloud) {
       it.skip("requires confluent_cloud config for SR cluster id discovery", () => {});
       return;

--- a/src/confluent/tools/handlers/connect/connect-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/connect-tool-handler.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
 import { ConnectToolHandler } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { directConnectionOf } from "@tests/factories/config.js";
 import { runtimeWith } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
 
@@ -37,7 +38,7 @@ describe("connect-tool-handler.ts", () => {
         handler["resolveConnectEnvAndClusterId"].bind(handler);
 
       it("should use arg values when both args and config are present", () => {
-        const conn = runtimeWith(CONNECT_CONN).config.getSoleDirectConnection();
+        const conn = directConnectionOf(runtimeWith(CONNECT_CONN).config);
         const result = resolveConnectEnvAndClusterId(
           conn,
           "env-from-arg",
@@ -48,7 +49,7 @@ describe("connect-tool-handler.ts", () => {
       });
 
       it("should fall back to config values when args are absent", () => {
-        const conn = runtimeWith(CONNECT_CONN).config.getSoleDirectConnection();
+        const conn = directConnectionOf(runtimeWith(CONNECT_CONN).config);
         const result = resolveConnectEnvAndClusterId(
           conn,
           undefined,
@@ -59,24 +60,28 @@ describe("connect-tool-handler.ts", () => {
       });
 
       it("should throw when environment_id is absent from both arg and config", () => {
-        const conn = runtimeWith({
-          kafka: {
-            cluster_id: "lkc-from-config",
-            rest_endpoint: "https://pkc-example.confluent.cloud:443",
-          },
-        }).config.getSoleDirectConnection();
+        const conn = directConnectionOf(
+          runtimeWith({
+            kafka: {
+              cluster_id: "lkc-from-config",
+              rest_endpoint: "https://pkc-example.confluent.cloud:443",
+            },
+          }).config,
+        );
         expect(() =>
           resolveConnectEnvAndClusterId(conn, undefined, "lkc-from-arg"),
         ).toThrow("Environment ID is required");
       });
 
       it("should throw when kafka_cluster_id is absent from both arg and config", () => {
-        const conn = runtimeWith({
-          kafka: {
-            env_id: "env-from-config",
-            rest_endpoint: "https://pkc-example.confluent.cloud:443",
-          },
-        }).config.getSoleDirectConnection();
+        const conn = directConnectionOf(
+          runtimeWith({
+            kafka: {
+              env_id: "env-from-config",
+              rest_endpoint: "https://pkc-example.confluent.cloud:443",
+            },
+          }).config,
+        );
         expect(() =>
           resolveConnectEnvAndClusterId(conn, "env-from-arg", undefined),
         ).toThrow("Kafka Cluster ID is required");

--- a/src/confluent/tools/handlers/connect/connector-lifecycle.integration.test.ts
+++ b/src/confluent/tools/handlers/connect/connector-lifecycle.integration.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@tests/harness/connect.js";
 import {
   integrationConnection,
-  integrationRuntime,
+  integrationDirectConnection,
 } from "@tests/harness/runtime.js";
 import { skipIfDisabled } from "@tests/harness/skip-gate.js";
 import {
@@ -24,7 +24,6 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // All four lifecycle handlers share the same `hasConfluentCloud` predicate via
 // ConnectToolHandler, so any one of them is representative for the predicate gate.
 const handler = new PauseConnectorHandler();
-const runtime = integrationRuntime();
 
 describe(
   "connector-lifecycle",
@@ -114,7 +113,7 @@ describe(
         // with `quickstart` flipped from "USERS" to "ORDERS"
         // asserting the response echoes the new value to prove the
         // round-trip applied.
-        const conn = runtime.config.getSoleDirectConnection();
+        const conn = integrationDirectConnection();
         const auth = conn.kafka?.auth;
         expect(
           auth,

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.integration.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@tests/harness/kafka-admin.js";
 import {
   integrationConnection,
-  integrationRuntime,
+  integrationDirectConnection,
 } from "@tests/harness/runtime.js";
 import { skipIfDisabled } from "@tests/harness/skip-gate.js";
 import {
@@ -25,7 +25,6 @@ import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new DescribeTableHandler();
-const runtime = integrationRuntime();
 
 describe(
   "describe-table-handler",
@@ -43,7 +42,7 @@ describe(
 
     // also provisions a kafka topic and addresses it by cluster id, so gate
     // explicitly on the kafka fields the flink predicate doesn't cover
-    const conn = runtime.config.getSoleDirectConnection();
+    const conn = integrationDirectConnection();
     if (
       !conn.kafka?.bootstrap_servers ||
       !conn.kafka.auth ||

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.integration.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@tests/harness/kafka-admin.js";
 import {
   integrationConnection,
-  integrationRuntime,
+  integrationDirectConnection,
 } from "@tests/harness/runtime.js";
 import { skipIfDisabled } from "@tests/harness/skip-gate.js";
 import {
@@ -25,7 +25,6 @@ import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const handler = new GetTableInfoHandler();
-const runtime = integrationRuntime();
 
 describe(
   "get-table-info-handler",
@@ -43,7 +42,7 @@ describe(
 
     // also provisions a kafka topic and addresses it by cluster id, so gate
     // explicitly on the kafka fields the flink predicate doesn't cover
-    const conn = runtime.config.getSoleDirectConnection();
+    const conn = integrationDirectConnection();
     if (
       !conn.kafka?.bootstrap_servers ||
       !conn.kafka.auth ||

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -158,30 +158,6 @@ describe("ServerRuntime", () => {
     });
   });
 
-  describe("get clientManager()", () => {
-    it("should return the sole client manager", () => {
-      const cm = createMockInstance(DirectClientManager);
-      const runtime = new ServerRuntime(config, { "test-conn": cm });
-      expect(runtime.clientManager).toBe(cm);
-    });
-
-    it("should throw when clientManagers is empty", () => {
-      const runtime = new ServerRuntime(config, {});
-      expect(() => runtime.clientManager).toThrow(
-        "ServerRuntime has no client managers",
-      );
-    });
-
-    it("should throw when clientManagers has more than one entry", () => {
-      const cm1 = createMockInstance(DirectClientManager);
-      const cm2 = createMockInstance(DirectClientManager);
-      const runtime = new ServerRuntime(config, { conn1: cm1, conn2: cm2 });
-      expect(() => runtime.clientManager).toThrow(
-        "ServerRuntime has multiple client managers",
-      );
-    });
-  });
-
   describe("disconnectAll()", () => {
     it("should disconnect every configured client manager", async () => {
       const cm1 = createMockInstance(DirectClientManager);

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -58,31 +58,8 @@ export class ServerRuntime {
   }
 
   /**
-   * Single-connection scaffolding: returns the sole client manager, throwing
-   * when zero or more than one connection is configured. Has no remaining
-   * callers; deletion tracked in #554.
-   */
-  get clientManager(): BaseClientManager {
-    const managers = Object.values(this.clientManagers);
-    if (managers.length === 0) {
-      throw new Error("ServerRuntime has no client managers");
-    }
-    if (managers.length > 1) {
-      // This getter is the single-connection scaffolding; a config with more
-      // than one connection has no "sole" manager. Callers route by id via
-      // clientManagers[id]. Deletion of this getter tracked in #554.
-      throw new Error(
-        "ServerRuntime has multiple client managers; use clientManagers[id] directly",
-      );
-    }
-    return managers[0]!;
-  }
-
-  /**
-   * Disconnect every per-connection client manager. The teardown counterpart
-   * to the per-connection construction in {@link fromConfig}; a multi-connection
-   * config tears all of its connections down, where the single-connection
-   * {@link clientManager} getter could only reach one.
+   * Disconnect every per-connection client manager — the teardown counterpart
+   * to the per-connection construction in {@link fromConfig}.
    */
   async disconnectAll(): Promise<void> {
     // allSettled, not all: a single manager's disconnect() rejection must not

--- a/test-fixtures/yaml_configs/valid/ccloud-and-flink-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-and-flink-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     confluent_cloud:
       endpoint: "https://api.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/ccloud-and-tableflow-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-and-tableflow-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     confluent_cloud:
       endpoint: "https://api.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/ccloud-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     confluent_cloud:
       auth:

--- a/test-fixtures/yaml_configs/valid/ccloud-with-endpoint-and-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/ccloud-with-endpoint-and-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     confluent_cloud:
       endpoint: "https://custom.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/flink-with-all-fields.yaml
+++ b/test-fixtures/yaml_configs/valid/flink-with-all-fields.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     flink:
       endpoint: "https://flink.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/flink-with-required-fields.yaml
+++ b/test-fixtures/yaml_configs/valid/flink-with-required-fields.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     flink:
       endpoint: "https://flink.us-east-1.aws.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/kafka-and-sr-both-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-and-sr-both-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "broker.confluent.cloud:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-and-sr.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-and-sr.yaml
@@ -1,5 +1,5 @@
 connections:
-  local:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "localhost:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-only.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-only.yaml
@@ -1,5 +1,5 @@
 connections:
-  local:
+  default:
     type: direct
     description: "Local dev broker"
     kafka:

--- a/test-fixtures/yaml_configs/valid/kafka-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "broker.confluent.cloud:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-with-extra-properties.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-extra-properties.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "broker.confluent.cloud:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-with-interpolated-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-interpolated-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "broker.confluent.cloud:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-with-rest-metadata.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-rest-metadata.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "broker.confluent.cloud:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-with-server-block.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-server-block.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "localhost:9092"

--- a/test-fixtures/yaml_configs/valid/kafka-with-server-transports.yaml
+++ b/test-fixtures/yaml_configs/valid/kafka-with-server-transports.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     kafka:
       bootstrap_servers: "localhost:9092"

--- a/test-fixtures/yaml_configs/valid/sr-only.yaml
+++ b/test-fixtures/yaml_configs/valid/sr-only.yaml
@@ -1,5 +1,5 @@
 connections:
-  local:
+  default:
     type: direct
     schema_registry:
       endpoint: "http://localhost:8081"

--- a/test-fixtures/yaml_configs/valid/sr-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/sr-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     schema_registry:
       endpoint: "https://sr.confluent.cloud"

--- a/test-fixtures/yaml_configs/valid/tableflow-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/tableflow-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     tableflow:
       auth:

--- a/test-fixtures/yaml_configs/valid/telemetry-with-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/telemetry-with-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     telemetry:
       auth:

--- a/test-fixtures/yaml_configs/valid/telemetry-with-endpoint-and-auth.yaml
+++ b/test-fixtures/yaml_configs/valid/telemetry-with-endpoint-and-auth.yaml
@@ -1,5 +1,5 @@
 connections:
-  production:
+  default:
     type: direct
     telemetry:
       endpoint: "https://api.telemetry.confluent.cloud"

--- a/tests/factories/config.ts
+++ b/tests/factories/config.ts
@@ -1,0 +1,30 @@
+import {
+  type DirectConnectionConfig,
+  MCPServerConfiguration,
+} from "@src/config/models.js";
+import { DEFAULT_CONNECTION_ID } from "@tests/factories/runtime.js";
+
+/**
+ * Reads the connection registered under `id` and narrows it to
+ * {@link DirectConnectionConfig}, throwing if it is OAuth-typed. The by-id,
+ * narrow-to-direct seam config-parser/builder tests use to read a fixture's
+ * connection: `getConnectionConfig` returns the `ConnectionConfig` union, but
+ * these tests assert on direct-only fields (`kafka`, `schema_registry`, …).
+ *
+ * `id` defaults to {@link DEFAULT_CONNECTION_ID} — the connection key the
+ * single-connection `valid/*.yaml` fixtures and `tests/factories/runtime.ts`
+ * both use. Pass an explicit id for synthesized configs that key on a different
+ * constant (e.g. the env-var path's `DEFAULT_CONNECTION_ID`, `"_default"`).
+ */
+export function directConnectionOf(
+  config: MCPServerConfiguration,
+  id = DEFAULT_CONNECTION_ID,
+): DirectConnectionConfig {
+  const conn = config.getConnectionConfig(id);
+  if (conn.type !== "direct") {
+    throw new Error(
+      `Expected connection "${id}" to be a direct connection; got type "${conn.type}"`,
+    );
+  }
+  return conn;
+}

--- a/tests/factories/runtime.ts
+++ b/tests/factories/runtime.ts
@@ -91,9 +91,9 @@ export function runtimeWith(
  * tools, with its own auto-minted client manager that correct routing must
  * never touch.
  *
- * The decoy is inserted FIRST, so a handler resolving via the legacy
- * sole-connection accessor (which grabs `enabledConnectionIds[0]`) routes to
- * the decoy and trips the test. {@link assertHandleCase} recognizes the decoy
+ * The decoy is inserted FIRST, so a handler that resolves by grabbing
+ * `enabledConnectionIds[0]` instead of routing by the caller's `connectionId`
+ * lands on the decoy and trips the test. {@link assertHandleCase} recognizes the decoy
  * (by {@link DECOY_CONNECTION_ID}) and, for any handle() test built on this
  * runtime, auto-routes to the real connection and asserts the decoy stayed
  * untouched — so swapping a suite's `runtimeWith` for this turns every existing

--- a/tests/harness/confluent-cloud.ts
+++ b/tests/harness/confluent-cloud.ts
@@ -1,10 +1,10 @@
 import type { paths } from "@src/confluent/openapi-schema.js";
 import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
-import { integrationRuntime } from "@tests/harness/runtime.js";
+import { integrationDirectConnection } from "@tests/harness/runtime.js";
 import createClient, { type Client } from "openapi-fetch";
 
 export function newTestCloudClient(): Client<paths> {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.confluent_cloud) {
     throw new Error(
       "test-side ccloud client requires confluent_cloud config in test-fixtures/yaml_configs/integration.yaml",
@@ -33,7 +33,7 @@ export function newTestCloudClient(): Client<paths> {
  * confusing downstream error.
  */
 export function getTestEnvironmentId(): string {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.kafka?.env_id) {
     throw new Error(
       "test-side env id requires kafka.env_id in test-fixtures/yaml_configs/integration.yaml",
@@ -49,7 +49,7 @@ export function getTestEnvironmentId(): string {
  * the same SR cluster the spawned MCP server is talking to.
  */
 export async function getSchemaRegistryClusterId(): Promise<string> {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   const envId = conn.kafka?.env_id;
   if (!envId) {
     throw new Error(

--- a/tests/harness/connect.ts
+++ b/tests/harness/connect.ts
@@ -1,5 +1,5 @@
 import { newTestCloudClient } from "@tests/harness/confluent-cloud.js";
-import { integrationRuntime } from "@tests/harness/runtime.js";
+import { integrationDirectConnection } from "@tests/harness/runtime.js";
 import { afterAll } from "vitest";
 
 interface ConnectScope {
@@ -10,7 +10,7 @@ interface ConnectScope {
 }
 
 function getConnectScope(): ConnectScope {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.kafka?.env_id || !conn.kafka.cluster_id || !conn.kafka.auth) {
     throw new Error(
       "test-side connect helpers require kafka.env_id + kafka.cluster_id + kafka.auth in test-fixtures/yaml_configs/integration.yaml",

--- a/tests/harness/cp-runtime.ts
+++ b/tests/harness/cp-runtime.ts
@@ -46,16 +46,16 @@ export function cpIntegrationRuntime(): ServerRuntime {
 }
 
 /**
- * The {@link ConnectionConfig} the spawned CP server would see, resolved by name
+ * The {@link ConnectionConfig} the spawned CP server would see, resolved by id
  * from the CP fixture. The CP-fixture peer of {@linkcode integrationConnection}
  * in runtime.ts: a single connection is the right-sized input for a
  * {@linkcode ConnectionPredicate} gate, with no ServerRuntime to build.
  *
- * Resolves by id via {@linkcode MCPServerConfiguration.getConnectionConfig} rather than
- * `getSoleConnection()` — the #532 epic is removing the sole-connection
- * accessors repo-wide (see #541's completion bar). On load failure (creds
- * absent) returns an empty `direct` connection so the gate skips cleanly; a
- * loaded fixture missing the `cp` connection is drift and throws loudly.
+ * Resolves by id via {@linkcode MCPServerConfiguration.getConnectionConfig}: a
+ * configured connection is addressed by its id, never by a count-dependent
+ * "sole" lookup. On load failure (creds absent) returns an empty `direct`
+ * connection so the gate skips cleanly; a loaded fixture missing the `cp`
+ * connection is drift and throws loudly.
  */
 export function cpIntegrationConnection(): ConnectionConfig {
   let config: MCPServerConfiguration;

--- a/tests/harness/flink.ts
+++ b/tests/harness/flink.ts
@@ -1,7 +1,7 @@
 import type { paths } from "@src/confluent/openapi-schema.js";
 import type { FlinkStatementMeta } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
-import { integrationRuntime } from "@tests/harness/runtime.js";
+import { integrationDirectConnection } from "@tests/harness/runtime.js";
 import type { CallToolResponse } from "@tests/harness/tool-results.js";
 import { setTimeout as sleep } from "node:timers/promises";
 import createClient, { type Client } from "openapi-fetch";
@@ -34,7 +34,7 @@ interface FlinkScope {
 }
 
 function getFlinkScope(): FlinkScope {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.flink) {
     throw new Error(
       "test-side flink helpers require flink config in test-fixtures/yaml_configs/integration.yaml",

--- a/tests/harness/kafka-admin.ts
+++ b/tests/harness/kafka-admin.ts
@@ -1,5 +1,5 @@
 import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
-import { integrationRuntime } from "@tests/harness/runtime.js";
+import { integrationDirectConnection } from "@tests/harness/runtime.js";
 import { afterAll, beforeAll } from "vitest";
 
 /**
@@ -69,7 +69,7 @@ export async function connectTestConsumer(
  * `undefined` and produce a confusing downstream error.
  */
 export function getTestClusterId(): string {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.kafka?.cluster_id) {
     throw new Error(
       "test-side cluster id requires kafka.cluster_id in test-fixtures/yaml_configs/integration.yaml",
@@ -130,7 +130,7 @@ function newKafkaClient(clientId: string): KafkaJS.Kafka {
 // resolve from the same YAML fixture the server reads, so the test-side admin and the MCP server
 // can never disagree on which cluster they're talking to
 function kafkaConfig(clientId: string): GlobalConfig {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.kafka?.bootstrap_servers || !conn.kafka.auth) {
     throw new Error(
       "test-side kafka admin requires kafka.bootstrap_servers + kafka.auth in test-fixtures/yaml_configs/integration.yaml",

--- a/tests/harness/runtime.ts
+++ b/tests/harness/runtime.ts
@@ -1,6 +1,7 @@
 import { loadConfigFromYaml } from "@src/config/index.js";
 import {
   type ConnectionConfig,
+  type DirectConnectionConfig,
   MCPServerConfiguration,
 } from "@src/config/models.js";
 import { TransportType } from "@src/mcp/transports/types.js";
@@ -76,9 +77,10 @@ export function integrationRuntime(
  * a {@linkcode ConnectionPredicate} gate: `handler.predicate(integrationConnection())`
  * answers "is this tool enabled?" without constructing a whole ServerRuntime.
  *
- * Resolves by id via {@linkcode MCPServerConfiguration.getConnectionConfig} rather than
- * `getSoleConnection()` — the #532 epic is removing the sole-connection accessors
- * repo-wide (see #541's completion bar), so new code must not depend on them.
+ * Resolves by id via {@linkcode MCPServerConfiguration.getConnectionConfig}: a
+ * configured connection is addressed by its id, never by a count-dependent
+ * "sole" lookup, so this stays correct for the multi-connection fixtures #543
+ * introduces.
  *
  * On load failure (a required `${VAR}` missing — creds absent) returns an empty
  * `direct` connection, so every block-based predicate yields a clean disabled
@@ -102,11 +104,28 @@ export function integrationConnection(
 }
 
 /**
+ * {@linkcode integrationConnection} narrowed to {@link DirectConnectionConfig},
+ * throwing if the fixture connection is OAuth-typed. The seeding helpers
+ * (kafka-admin, schema-registry, flink, connect, confluent-cloud) build their
+ * own api-key-authed clients from direct-only fields (`kafka.env_id`,
+ * `confluent_cloud.auth`, …), so they need the narrowing the union doesn't give.
+ */
+export function integrationDirectConnection(): DirectConnectionConfig {
+  const conn = integrationConnection();
+  if (conn.type !== "direct") {
+    throw new Error(
+      `Expected the integration fixture connection to be direct; got type "${conn.type}"`,
+    );
+  }
+  return conn;
+}
+
+/**
  * The fixture connection's id — its key in the `connections` map, which is
  * also the value a test passes as the `connectionId` argument to a
  * connection-addressed tool (e.g. `describe-configured-connection`); the map key
  * and the routing id are one and the same. A constant rather than a
- * `getSoleConnection()`-style lookup so it stays correct for the
+ * count-dependent "sole" lookup so it stays correct for the
  * multi-connection fixtures #543 introduces, and so a fixture rename surfaces
  * here rather than as a mysterious "unknown connection id" at call time.
  */
@@ -123,7 +142,7 @@ export function integrationConnectionId(
  *
  * Counts connections rather than resolving the sole one, so it stays correct for
  * the multi-connection fixtures #543 introduces: a count answers "did anything
- * load?", whereas `getSoleConnection()` throws (and would wrongly read as "not
+ * load?", whereas a sole-connection lookup would throw (and wrongly read as "not
  * loaded") on more than one.
  */
 export function integrationConnectionLoaded(
@@ -216,8 +235,8 @@ const OAUTH_FIXTURE_PATH = resolve(
 /**
  * The connection id each integration fixture gives its single connection.
  * {@linkcode integrationConnection} looks the connection up by this key rather
- * than via `getSoleConnection()`, which the #532 epic is removing repo-wide
- * (it encodes the single-connection assumption and throws once two exist).
+ * than by a count-dependent "sole" lookup, which would encode the
+ * single-connection assumption and break once a fixture defines two.
  */
 const FIXTURE_CONNECTION_ID: Record<"direct" | "oauth", string> = {
   direct: "integration",

--- a/tests/harness/schema-registry.ts
+++ b/tests/harness/schema-registry.ts
@@ -1,7 +1,7 @@
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import type { paths } from "@src/confluent/openapi-schema.js";
 import { createRetryOn429Middleware } from "@tests/harness/retry-on-429.js";
-import { integrationRuntime } from "@tests/harness/runtime.js";
+import { integrationDirectConnection } from "@tests/harness/runtime.js";
 import createClient, {
   type Client,
   wrapAsPathBasedClient,
@@ -14,7 +14,7 @@ import { afterAll, beforeAll } from "vitest";
  * client and server can never disagree on which registry they're talking to.
  */
 export function newTestSrClient(): SchemaRegistryClient {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.schema_registry?.endpoint || !conn.schema_registry.auth) {
     throw new Error(
       "test-side schema registry client requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml",
@@ -35,7 +35,7 @@ export function newTestSrClient(): SchemaRegistryClient {
  * {@link SchemaRegistryClient} doesn't expose (e.g. `/catalog/v1/...`).
  */
 export function newTestSrRestClient(): Client<paths> {
-  const conn = integrationRuntime().config.getSoleDirectConnection();
+  const conn = integrationDirectConnection();
   if (!conn.schema_registry?.endpoint || !conn.schema_registry.auth) {
     throw new Error(
       "test-side schema registry rest client requires schema_registry.endpoint + schema_registry.auth in test-fixtures/yaml_configs/integration.yaml",


### PR DESCRIPTION
## Delete the single-connection scaffolding accessors

- Removed the four "sole/singular" accessors that the multi-connection epic drove to zero production callers: `MCPServerConfiguration.getSoleConnection()` / `getSoleDirectConnection()`, `BaseToolHandler.resolveSoleConnection()`, and the singular `ServerRuntime.clientManager` getter. These encoded the "there is only one connection" assumption; #534/#538/#539/#541 routed every handler through explicit `connectionId` resolution and #540 dropped the parse-time guard, leaving these as dead code whose deletion this issue owns. Behavior-preserving: no runtime path changes.
- Migrated every remaining caller — all of them tests and harness helpers — off the deleted accessors. The replacements are uniformly **by-id addressing plus narrow-to-direct**, never "find the sole one", which is the whole point: a test fixture that holds one connection is addressed by that connection's known id, not by an accessor that assumes the count.

## Test/harness migration

- Standardized the single-connection fixtures onto a consistent `default` connection id — both the external `test-fixtures/yaml_configs/valid/*.yaml` files (a mix of `production` / `local`) and the inline single-connection YAML strings in `index.test.ts` — matching the id `tests/factories/runtime.ts` and the existing OAuth fixture already use. The config-parser/builder unit tests now read their one connection via `getConnectionConfig("default")` rather than a sole-lookup. The deliberate multi-connection / negative cases keep their distinct ids.
- Added `directConnectionOf(config, id)` (`tests/factories/config.ts`) and `integrationDirectConnection()` (`tests/harness/runtime.ts`) as the narrow-to-direct seam over `getConnectionConfig(id)`, which returns the `ConnectionConfig` union. These replace `getSoleDirectConnection()` at the config-test and integration-harness sites respectively. The `getSoleConnection()` (union) sites migrated straight to `getConnectionConfig(id)`. Migrating the integration tests off the accessor also orphaned their `const runtime = integrationRuntime()` locals (the accessor was their only consumer), so those and the now-unused `integrationRuntime` imports came out too.
- Deleted the now-orphaned tests that exercised the accessors directly (`getSoleConnection` / `getSoleDirectConnection` blocks in `models.test.ts`, `resolveSoleConnection()` in `base-tools.test.ts`, `get clientManager()` in `server-runtime.test.ts`). The surviving `getConnectionConfig` coverage is the by-id replacement.
- Swept the prose that narrated the deleted scaffolding as live: the `disconnectAll` docstring's back-reference to the singular getter, four `getSoleConnection()`-citing docstrings in the integration harness, the `runtimeWithDecoy` docstring and its `.claude/rules/unit-tests.md` echo (both described the failure mode as "the legacy sole-connection accessor" — now stated as the actual `enabledConnectionIds[0]` anti-pattern). Several "stale prose" targets the issue lists were already clean on this branch (the predicate docstrings, and server-runtime's `#151` / `enforceSingleConnectionOnly()` references).

## Relationships

- Closes #554.
- Child of #532 (Epic: Multi-connection support).
