### PR TITLE
Properly round-trip multi-valued Kafka message headers.

### DIFF
--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -355,6 +355,62 @@ describe(
             });
           }
         });
+
+        it("should preserve a repeated-key header through the broker as a string array, not a comma-joined scalar", async () => {
+          // The bug behind #597: a record carrying the same header key twice
+          // (`trace: ["x", "y"]`) used to come back comma-joined as the
+          // scalar `"x,y"`, losing multiplicity. Seed such a record, consume
+          // it through the tool, and assert the array survives in the echoed
+          // JSON — the round-trip the produce suite's raw-consumer read-back
+          // can't prove, because only this tool does the header echoing.
+          const headerTopic = uniqueName("consume-mvh");
+          const markerValue = `mvh-${transport}`;
+          await admin.createTopics({
+            topics: [{ topic: headerTopic, numPartitions: 1 }],
+          });
+          try {
+            await producer.send({
+              topic: headerTopic,
+              messages: [
+                {
+                  value: markerValue,
+                  headers: { trace: ["x", "y"], source: "clusterA" },
+                },
+              ],
+            });
+
+            const result = await server.client.callTool({
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [{ name: headerTopic }],
+                maxMessages: 1,
+                timeoutMs: 15_000,
+                valueFormat: { disableSchemaRegistry: true },
+              },
+            });
+
+            const text = textContent(result);
+            // Guard against the regression directly: the lossy form would
+            // surface the joined scalar in the echoed JSON.
+            expect(text).not.toContain('"trace": "x,y"');
+
+            const consumed = JSON.parse(text.slice(text.indexOf("["))) as {
+              value: string;
+              headers?: Record<string, unknown>;
+            }[];
+            const record = consumed.find((m) => m.value === markerValue);
+            expect(record, text).toBeDefined();
+            expect(record!.headers).toEqual({
+              trace: ["x", "y"],
+              source: "clusterA",
+            });
+          } finally {
+            await admin.deleteTopics({ topics: [headerTopic] }).catch(() => {
+              // teardown-only; a cleanup failure shouldn't fail an
+              // already-asserted test
+            });
+          }
+        });
       });
     });
 

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -1680,6 +1680,54 @@ describe("consume-kafka-messages-handler.ts", () => {
         });
       });
 
+      it("should preserve a repeated-key header as a string array rather than comma-joining it", async () => {
+        // Kafka headers are an ordered list where keys may repeat, so the
+        // client surfaces a repeated key as an array. Stringifying the whole
+        // array (Array.prototype.toString) would collapse ["x", "y"] to the
+        // lossy "x,y" — indistinguishable from a single value containing a
+        // comma. Map per element so multiplicity survives (#597).
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage({ headers: { trace: ["x", "y"] } }),
+          undefined,
+          { disableSchemaRegistry: true },
+          { disableSchemaRegistry: true },
+        );
+        expect(result.headers).toEqual({ trace: ["x", "y"] });
+      });
+
+      it("should stringify each Buffer element of a repeated-key header independently", async () => {
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage({
+            headers: { trace: [Buffer.from("x"), Buffer.from("y")] },
+          }),
+          undefined,
+          { disableSchemaRegistry: true },
+          { disableSchemaRegistry: true },
+        );
+        expect(result.headers).toEqual({ trace: ["x", "y"] });
+      });
+
+      it("should keep scalar headers scalar while preserving sibling array headers", async () => {
+        const result = await handler.processMessage(
+          "topic-x",
+          0,
+          fakeMessage({
+            headers: { source: Buffer.from("clusterA"), trace: ["x", "y"] },
+          }),
+          undefined,
+          { disableSchemaRegistry: true },
+          { disableSchemaRegistry: true },
+        );
+        expect(result.headers).toEqual({
+          source: "clusterA",
+          trace: ["x", "y"],
+        });
+      });
+
       describe("schema-id header echo (always kept, decoded to GUID)", () => {
         // Per Stefan's #607 review: the __value_schema_id / __key_schema_id
         // headers identify the key/value schema by GUID, mirroring the CCloud

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -236,7 +236,15 @@ export interface ProcessedMessage {
    */
   timestamp: string;
   offset: string;
-  headers?: Record<string, string>;
+  /**
+   * Record headers echoed back to the caller. Kafka headers are an ordered
+   * list whose keys may repeat, so a repeated key is preserved as a
+   * `string[]` (multiplicity intact) while a single-occurrence key stays a
+   * scalar `string` — mirroring the per-key shape the underlying client
+   * surfaces. The schema-id headers decode to their GUID; every other value
+   * is stringified element-wise (see {@link echoHeaderValue}).
+   */
+  headers?: Record<string, string | string[]>;
   topic: string;
   partition: number;
 }
@@ -262,16 +270,34 @@ const SCHEMA_ID_HEADER_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Render a record header for the echoed consume response. The schema-id
- * headers (__value_schema_id / __key_schema_id) carry the schema GUID as raw
- * bytes; decode them to the canonical GUID string so callers see the same
- * schema identifier the CCloud UI and VS Code extension surface. Every other
- * header — and any schema-id header whose bytes don't decode to a GUID — is
- * stringified as-is.
+ * Render a record header for the echoed consume response, preserving
+ * multiplicity: a repeated-key header (surfaced by the client as an array)
+ * maps element-wise to a `string[]`, while a single-occurrence header stays a
+ * scalar `string`. Joining the array via `Array.prototype.toString` would
+ * collapse `["a", "b"]` to the lossy `"a,b"` — indistinguishable from a
+ * single value literally containing a comma (#597).
  */
 function echoHeaderValue(
   key: string,
   value: Buffer | string | (Buffer | string)[] | undefined,
+): string | string[] {
+  if (Array.isArray(value)) {
+    return value.map((element) => echoSingleHeaderValue(key, element));
+  }
+  return echoSingleHeaderValue(key, value);
+}
+
+/**
+ * Stringify one header occurrence. The schema-id headers
+ * (__value_schema_id / __key_schema_id) carry the schema GUID as raw bytes;
+ * decode them to the canonical GUID string so callers see the same schema
+ * identifier the CCloud UI and VS Code extension surface. Every other
+ * value — and any schema-id header whose bytes don't decode to a GUID — is
+ * stringified as-is.
+ */
+function echoSingleHeaderValue(
+  key: string,
+  value: Buffer | string | undefined,
 ): string {
   if (SCHEMA_ID_HEADER_KEYS.has(key) && Buffer.isBuffer(value)) {
     const guid = schemaRegistryHelper.decodeSchemaGuidHeader(value);


### PR DESCRIPTION
# Preserve multi-valued Kafka headers in `consume-messages`

## Multi-valued header fidelity

- Kafka record headers are an ordered list of key/value pairs where keys may repeat, so the `@confluentinc/kafka-javascript` client surfaces a repeated key as an array (`IHeaders` values are `Buffer | string | (Buffer | string)[]`). The consume handler stringified the whole value with `value?.toString()`, so a repeated-key header `["x", "y"]` collapsed to the scalar `"x,y"` — indistinguishable from a single value literally containing a comma, and lossy for `Buffer` arrays.
- `echoHeaderValue` now maps element-wise: a repeated-key header is preserved as a `string[]`, while a single-occurrence header stays a scalar `string`, mirroring the per-key shape the client delivers. The schema-id GUID decode (`__value_schema_id` / `__key_schema_id`) moves to a per-element helper, `echoSingleHeaderValue`, with byte-identical scalar behavior — those headers are never multi-valued.
- `ProcessedMessage.headers` widens from `Record<string, string>` to `Record<string, string | string[]>` so the type can express the preserved multiplicity. The only consumer is the response's `JSON.stringify`, which serializes either shape cleanly.
- Unit tests pin the contract: a repeated-key header round-trips as `["x", "y"]` (not `"x,y"`), each `Buffer` element of an array is stringified independently, and scalar headers stay scalar alongside sibling array headers. The first of these reproduced the bug before the fix.
- A consume integration test seeds a record carrying a repeated header key, consumes it through the tool, and asserts the array survives in the echoed JSON — the round-trip the produce suite's raw-consumer read-back can't prove, because only this tool does the header echoing.

## Relationships

- Closes #597.
- Builds on #588 (produce-side header support), which landed the multi-valued header input this round-trips against.
