### PR TITLE
More test coverage over environment tools branches.

### DIFF
--- a/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
@@ -105,20 +105,6 @@ describe("list-environments-handler.ts", () => {
         },
         {
           label:
-            "render a Pagination block with no link lines when metadata is present but empty",
-          args: {},
-          get: {
-            data: {
-              api_version: "org/v2",
-              kind: "EnvironmentList",
-              metadata: {},
-              data: [ENV_FIXTURE],
-            },
-          },
-          outcome: { resolves: "Pagination:" },
-        },
-        {
-          label:
             "resolve with a validation-error response when the API returns an unexpected payload",
           args: {},
           get: { data: { not: "an EnvironmentList" } },
@@ -160,6 +146,61 @@ describe("list-environments-handler.ts", () => {
           args,
           outcome,
           clientManager,
+        });
+      });
+
+      it("should render a Pagination header but no link lines when metadata is present but empty", async () => {
+        const clientManager = getMockedClientManager();
+        configureGet(clientManager, {
+          data: {
+            api_version: "org/v2",
+            kind: "EnvironmentList",
+            metadata: {},
+            data: [ENV_FIXTURE],
+          },
+        });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          outcome: { resolves: "Pagination:", isError: false },
+          clientManager,
+        });
+
+        // The outer `metadata ?` guard is true (header renders), but every
+        // inner link ternary takes its false arm — so no link line appears.
+        const text = textOf(result!);
+        expect(text).toContain("Pagination:");
+        expect(text).not.toContain("Total Environments:");
+        expect(text).not.toContain("First Page:");
+        expect(text).not.toContain("Last Page:");
+        expect(text).not.toContain("Previous Page:");
+        expect(text).not.toContain("Next Page:");
+
+        // _meta still carries a pagination object, with every link undefined.
+        expect(result!._meta).toEqual({
+          environments: [
+            {
+              id: "env-abc123",
+              name: "production",
+              created_at: "2024-01-01T00:00:00Z",
+              updated_at: "2024-01-02T00:00:00Z",
+              deleted_at: undefined,
+              resource_name: "crn://confluent.cloud/environment=env-abc123",
+              stream_governance: undefined,
+            },
+          ],
+          total: undefined,
+          pagination: {
+            first: undefined,
+            last: undefined,
+            prev: undefined,
+            next: undefined,
+          },
         });
       });
 
@@ -218,6 +259,9 @@ describe("list-environments-handler.ts", () => {
         expect(text).toContain("Deleted At: 2024-03-03T00:00:00Z");
         expect(text).toContain("Stream Governance Package: ADVANCED");
         expect(text).toContain("Total Environments: 7");
+        expect(text).toContain(`First Page: ${FULL_LIST_METADATA.first}`);
+        expect(text).toContain(`Last Page: ${FULL_LIST_METADATA.last}`);
+        expect(text).toContain(`Previous Page: ${FULL_LIST_METADATA.prev}`);
         expect(text).toContain(`Next Page: ${FULL_LIST_METADATA.next}`);
       });
     });

--- a/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
@@ -1,4 +1,5 @@
 import { ListEnvironmentsHandler } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   CCLOUD_CONN,
   DEFAULT_CONNECTION_ID,
@@ -9,7 +10,7 @@ import {
   getMockedClientManager,
   type HandleCase,
 } from "@tests/stubs/index.js";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const ENV_FIXTURE = {
   api_version: "org/v2",
@@ -24,6 +25,52 @@ const ENV_FIXTURE = {
   },
 };
 
+// A fully-populated environment exercising every optional rendering arm:
+// metadata.deleted_at and stream_governance_config.package.
+const RICH_ENV_FIXTURE = {
+  api_version: "org/v2",
+  kind: "Environment",
+  id: "env-rich9",
+  display_name: "staging",
+  metadata: {
+    self: "https://api.confluent.cloud/org/v2/environments/env-rich9",
+    resource_name: "crn://confluent.cloud/environment=env-rich9",
+    created_at: "2024-03-01T00:00:00Z",
+    updated_at: "2024-03-02T00:00:00Z",
+    deleted_at: "2024-03-03T00:00:00Z",
+  },
+  stream_governance_config: { package: "ADVANCED" },
+};
+
+// Every pagination link populated so the optional rendering arms all fire.
+const FULL_LIST_METADATA = {
+  total_size: 7,
+  first: "https://api.confluent.cloud/org/v2/environments?page_token=first",
+  last: "https://api.confluent.cloud/org/v2/environments?page_token=last",
+  prev: "https://api.confluent.cloud/org/v2/environments?page_token=prev",
+  next: "https://api.confluent.cloud/org/v2/environments?page_token=next",
+};
+
+// Mock behavior for the single GET the handler issues to /org/v2/environments.
+type GetBehavior =
+  | { data: unknown }
+  | { apiError: unknown }
+  | { rejects: unknown };
+
+function configureGet(
+  clientManager: ReturnType<typeof getMockedClientManager>,
+  get: GetBehavior,
+): void {
+  const restGet = clientManager.getConfluentCloudRestClient().GET;
+  if ("rejects" in get) {
+    restGet.mockRejectedValue(get.rejects);
+  } else if ("apiError" in get) {
+    restGet.mockResolvedValue({ error: get.apiError });
+  } else {
+    restGet.mockResolvedValue({ data: get.data });
+  }
+}
+
 describe("list-environments-handler.ts", () => {
   describe("ListEnvironmentsHandler", () => {
     const handler = new ListEnvironmentsHandler();
@@ -32,16 +79,14 @@ describe("list-environments-handler.ts", () => {
     // the real connection and asserts the decoy's client manager stays
     // untouched — making each a routing test for the resolveConnection port.
     describe("handle()", () => {
-      type EnvsCase = HandleCase & { cloudGetData: unknown };
+      type EnvsCase = HandleCase & { get: GetBehavior };
       const cases: EnvsCase[] = [
         {
           label:
             "resolve with 'retrieved 0 environments' when the API returns an empty list",
           args: {},
-          cloudGetData: {
-            api_version: "org/v2",
-            kind: "EnvironmentList",
-            data: [],
+          get: {
+            data: { api_version: "org/v2", kind: "EnvironmentList", data: [] },
           },
           outcome: { resolves: "Successfully retrieved 0 environments" },
         },
@@ -49,42 +94,132 @@ describe("list-environments-handler.ts", () => {
           label:
             "resolve with the environment's display name when the API returns one entry",
           args: {},
-          cloudGetData: {
-            api_version: "org/v2",
-            kind: "EnvironmentList",
-            data: [ENV_FIXTURE],
+          get: {
+            data: {
+              api_version: "org/v2",
+              kind: "EnvironmentList",
+              data: [ENV_FIXTURE],
+            },
           },
           outcome: { resolves: "production" },
         },
         {
           label:
+            "render a Pagination block with no link lines when metadata is present but empty",
+          args: {},
+          get: {
+            data: {
+              api_version: "org/v2",
+              kind: "EnvironmentList",
+              metadata: {},
+              data: [ENV_FIXTURE],
+            },
+          },
+          outcome: { resolves: "Pagination:" },
+        },
+        {
+          label:
             "resolve with a validation-error response when the API returns an unexpected payload",
           args: {},
-          cloudGetData: { not: "an EnvironmentList" },
+          get: { data: { not: "an EnvironmentList" } },
           outcome: { resolves: "Invalid environment list data", isError: true },
+        },
+        {
+          label:
+            "resolve with an error response when the API itself returns an error",
+          args: {},
+          get: { apiError: { message: "forbidden" } },
+          outcome: { resolves: "Failed to fetch environments", isError: true },
+        },
+        {
+          label:
+            "surface the underlying message when the GET rejects with an Error",
+          args: {},
+          get: { rejects: new Error("connection reset") },
+          outcome: { resolves: "connection reset", isError: true },
+        },
+        {
+          label:
+            "stringify the thrown value when the GET rejects with a non-Error",
+          args: {},
+          get: { rejects: "raw string failure" },
+          outcome: { resolves: "raw string failure", isError: true },
         },
       ];
 
-      it.each(cases)(
-        "should $label",
-        async ({ args, outcome, cloudGetData }) => {
-          const clientManager = getMockedClientManager();
-          clientManager
-            .getConfluentCloudRestClient()
-            .GET.mockResolvedValue({ data: cloudGetData });
-          await assertHandleCase({
-            handler,
-            runtime: runtimeWithDecoy(
-              CCLOUD_CONN,
-              DEFAULT_CONNECTION_ID,
-              clientManager,
-            ),
-            args,
-            outcome,
+      it.each(cases)("should $label", async ({ args, outcome, get }) => {
+        const clientManager = getMockedClientManager();
+        configureGet(clientManager, get);
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
             clientManager,
-          });
-        },
-      );
+          ),
+          args,
+          outcome,
+          clientManager,
+        });
+      });
+
+      it("should render deleted-at, stream-governance, and every pagination link for a fully-populated response", async () => {
+        const clientManager = getMockedClientManager();
+        configureGet(clientManager, {
+          data: {
+            api_version: "org/v2",
+            kind: "EnvironmentList",
+            metadata: FULL_LIST_METADATA,
+            data: [RICH_ENV_FIXTURE],
+          },
+        });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          // A pageToken arg exercises the query-param-provided path.
+          args: { pageToken: "page-token-xyz" },
+          outcome: { resolves: "staging", isError: false },
+          clientManager,
+        });
+
+        expect(
+          clientManager.getConfluentCloudRestClient().GET,
+        ).toHaveBeenCalledWith("/org/v2/environments", {
+          params: { query: { page_token: "page-token-xyz" } },
+        });
+
+        expect(result!._meta).toEqual({
+          environments: [
+            {
+              id: "env-rich9",
+              name: "staging",
+              created_at: "2024-03-01T00:00:00Z",
+              updated_at: "2024-03-02T00:00:00Z",
+              deleted_at: "2024-03-03T00:00:00Z",
+              resource_name: "crn://confluent.cloud/environment=env-rich9",
+              stream_governance: "ADVANCED",
+            },
+          ],
+          total: 7,
+          pagination: {
+            first: FULL_LIST_METADATA.first,
+            last: FULL_LIST_METADATA.last,
+            prev: FULL_LIST_METADATA.prev,
+            next: FULL_LIST_METADATA.next,
+          },
+        });
+
+        const text = textOf(result!);
+        expect(text).toContain("Deleted At: 2024-03-03T00:00:00Z");
+        expect(text).toContain("Stream Governance Package: ADVANCED");
+        expect(text).toContain("Total Environments: 7");
+        expect(text).toContain(`Next Page: ${FULL_LIST_METADATA.next}`);
+      });
     });
   });
 });

--- a/src/confluent/tools/handlers/environments/read-environment-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.test.ts
@@ -1,4 +1,5 @@
 import { ReadEnvironmentHandler } from "@src/confluent/tools/handlers/environments/read-environment-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   CCLOUD_CONN,
   DEFAULT_CONNECTION_ID,
@@ -9,7 +10,7 @@ import {
   getMockedClientManager,
   type HandleCase,
 } from "@tests/stubs/index.js";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const ENV_FIXTURE = {
   api_version: "org/v2",
@@ -24,6 +25,43 @@ const ENV_FIXTURE = {
   },
 };
 
+// A fully-populated environment exercising the optional rendering arms:
+// metadata.deleted_at and stream_governance_config.package.
+const RICH_ENV_FIXTURE = {
+  api_version: "org/v2",
+  kind: "Environment",
+  id: "env-rich9",
+  display_name: "staging",
+  metadata: {
+    self: "https://api.confluent.cloud/org/v2/environments/env-rich9",
+    resource_name: "crn://confluent.cloud/environment=env-rich9",
+    created_at: "2024-03-01T00:00:00Z",
+    updated_at: "2024-03-02T00:00:00Z",
+    deleted_at: "2024-03-03T00:00:00Z",
+  },
+  stream_governance_config: { package: "ADVANCED" },
+};
+
+// Mock behavior for the single GET the handler issues to /org/v2/environments/{id}.
+type GetBehavior =
+  | { data: unknown }
+  | { apiError: unknown }
+  | { rejects: unknown };
+
+function configureGet(
+  clientManager: ReturnType<typeof getMockedClientManager>,
+  get: GetBehavior,
+): void {
+  const restGet = clientManager.getConfluentCloudRestClient().GET;
+  if ("rejects" in get) {
+    restGet.mockRejectedValue(get.rejects);
+  } else if ("apiError" in get) {
+    restGet.mockResolvedValue({ error: get.apiError });
+  } else {
+    restGet.mockResolvedValue({ data: get.data });
+  }
+}
+
 describe("read-environment-handler.ts", () => {
   describe("ReadEnvironmentHandler", () => {
     const handler = new ReadEnvironmentHandler();
@@ -32,25 +70,39 @@ describe("read-environment-handler.ts", () => {
     // the real connection and asserts the decoy's client manager stays
     // untouched — making each a routing test for the resolveConnection port.
     describe("handle()", () => {
-      type ReadEnvCase = HandleCase & { cloudGetData?: unknown };
+      type ReadEnvCase = HandleCase & { get?: GetBehavior };
       const cases: ReadEnvCase[] = [
         {
           label: "resolve with the environment's display name on success",
           args: { environmentId: "env-abc123" },
-          cloudGetData: ENV_FIXTURE,
+          get: { data: ENV_FIXTURE },
           outcome: { resolves: "production" },
         },
         {
           label: "resolve with an error response when the API returns an error",
           args: { environmentId: "env-abc123" },
-          cloudGetData: undefined,
+          get: { apiError: { message: "not found" } },
           outcome: { resolves: "Failed to fetch environment", isError: true },
+        },
+        {
+          label:
+            "surface the underlying message when the GET rejects with an Error",
+          args: { environmentId: "env-abc123" },
+          get: { rejects: new Error("connection reset") },
+          outcome: { resolves: "connection reset", isError: true },
+        },
+        {
+          label:
+            "stringify the thrown value when the GET rejects with a non-Error",
+          args: { environmentId: "env-abc123" },
+          get: { rejects: "raw string failure" },
+          outcome: { resolves: "raw string failure", isError: true },
         },
         {
           label:
             "resolve with a validation-error response on an unexpected payload",
           args: { environmentId: "env-abc123" },
-          cloudGetData: { not: "an Environment" },
+          get: { data: { not: "an Environment" } },
           outcome: { resolves: "Invalid environment data", isError: true },
         },
         {
@@ -60,30 +112,62 @@ describe("read-environment-handler.ts", () => {
         },
       ];
 
-      it.each(cases)(
-        "should $label",
-        async ({ args, outcome, cloudGetData }) => {
-          const clientManager = getMockedClientManager();
-          clientManager
-            .getConfluentCloudRestClient()
-            .GET.mockResolvedValue(
-              cloudGetData === undefined
-                ? { error: { message: "not found" } }
-                : { data: cloudGetData },
-            );
-          await assertHandleCase({
-            handler,
-            runtime: runtimeWithDecoy(
-              CCLOUD_CONN,
-              DEFAULT_CONNECTION_ID,
-              clientManager,
-            ),
-            args,
-            outcome,
+      it.each(cases)("should $label", async ({ args, outcome, get }) => {
+        const clientManager = getMockedClientManager();
+        if (get) {
+          configureGet(clientManager, get);
+        }
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
             clientManager,
-          });
-        },
-      );
+          ),
+          args,
+          outcome,
+          // The ZodError case throws before reaching the client layer.
+          clientManager: get ? clientManager : undefined,
+        });
+      });
+
+      it("should render deleted-at and stream-governance for a fully-populated environment", async () => {
+        const clientManager = getMockedClientManager();
+        configureGet(clientManager, { data: RICH_ENV_FIXTURE });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: { environmentId: "env-rich9" },
+          outcome: { resolves: "staging", isError: false },
+          clientManager,
+        });
+
+        expect(result!._meta).toEqual({
+          environment: {
+            api_version: "org/v2",
+            kind: "Environment",
+            id: "env-rich9",
+            name: "staging",
+            metadata: {
+              created_at: "2024-03-01T00:00:00Z",
+              updated_at: "2024-03-02T00:00:00Z",
+              deleted_at: "2024-03-03T00:00:00Z",
+              resource_name: "crn://confluent.cloud/environment=env-rich9",
+              self: "https://api.confluent.cloud/org/v2/environments/env-rich9",
+            },
+            stream_governance_package: "ADVANCED",
+          },
+        });
+
+        const text = textOf(result!);
+        expect(text).toContain("Deleted At: 2024-03-03T00:00:00Z");
+        expect(text).toContain("Stream Governance Package: ADVANCED");
+      });
     });
   });
 });


### PR DESCRIPTION
## Environments handler branch coverage

The two environments tools shipped with happy-path-only unit tests: every fixture was a minimal environment with no optional fields and no pagination metadata, so most of each handler's rendering and failure logic was dark. Branch coverage sat at 23% for `list-environments-handler.ts` and 42% for `read-environment-handler.ts`.

- **`list-environments-handler.ts`** — added cases for the API-error path (`{ error }` from the REST client), a GET that rejects with an `Error` (asserting the underlying message surfaces), and a GET that rejects with a non-`Error` value (the `String(error)` fallback). A fully-populated fixture — `deleted_at`, `stream_governance_config.package`, and every pagination link (`total_size`/`first`/`last`/`prev`/`next`) plus a `pageToken` arg — exercises every optional rendering arm and the whole pagination block at once; it pins the exact `_meta` payload and the rendered optional-field lines. An empty-`metadata` fixture covers the false arms of the inner pagination ternaries while the outer `metadata ?` guard stays true. Branch coverage 23% → 96%, lines 100%.

- **`read-environment-handler.ts`** — added the two reject paths (Error and non-Error, mirroring list) and a fully-populated fixture covering `deleted_at` and `stream_governance_package`, pinning the exact `_meta.environment` payload and the rendered optional-field lines. Branch coverage 42% → 92%, lines 100%.

The lone uncovered branch left in each file is the `String(validationError)` false arm of `validationError instanceof Error ? … : …`. It is dead code: the only thing that reaches that `catch` is `schema.parse()`, which throws exclusively `ZodError` (an `Error`), so the false arm is unreachable without stubbing the schema to throw a non-`Error` — contortion for no real-world signal.

The shared test plumbing now routes the mocked REST GET through a small `configureGet` helper with a three-way `GetBehavior` discriminant (`data` / `apiError` / `rejects`), replacing the ad-hoc `cloudGetData === undefined` discriminator the read suite used.

## Relationships

Closes #620
