### PR TITLE
Increase branch/line coverage in .../handlers/flink/catalog/...

### DIFF
--- a/src/confluent/tools/handlers/flink/catalog/catalog-resolver.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/catalog-resolver.test.ts
@@ -1,8 +1,34 @@
 import {
+  getCatalogMapping,
+  getSchemaMapping,
   resolveCatalogName,
   resolveDatabaseName,
+  resolveToCatalogName,
+  resolveToSchemaName,
 } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
-import { describe, expect, it } from "vitest";
+import {
+  getMockedClientManager,
+  type MockedClientManager,
+  type MockedRestClient,
+} from "@tests/stubs/index.js";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const SQL_OPTIONS = {
+  organizationId: "org-1",
+  environmentId: "env-abc123",
+  computePoolId: "lfcp-1",
+};
+
+/**
+ * Builds the `{ status, results }` envelope that `executeFlinkSql` polls for,
+ * so a resolver lookup sees `rows` as its result data.
+ */
+function sqlResponse(rows: unknown[]) {
+  return {
+    status: { phase: "COMPLETED" },
+    results: { data: rows },
+  };
+}
 
 describe("catalog-resolver.ts", () => {
   describe("resolveCatalogName()", () => {
@@ -83,6 +109,186 @@ describe("catalog-resolver.ts", () => {
         kafka: { bootstrap_servers: "broker:9092", cluster_id: "   " },
       };
       expect(resolveDatabaseName(undefined, conn)).toBeUndefined();
+    });
+  });
+
+  describe("resolveToCatalogName()", () => {
+    const mappings = [
+      { catalogId: "env-abc123", catalogName: "production" },
+      { catalogId: "env-def456", catalogName: "staging" },
+    ];
+
+    it("should map an env ID to its friendly CATALOG_NAME", () => {
+      expect(resolveToCatalogName("env-abc123", mappings)).toBe("production");
+    });
+
+    it("should return the env ID unchanged when no mapping matches", () => {
+      expect(resolveToCatalogName("env-unknown", mappings)).toBe("env-unknown");
+    });
+
+    it("should pass a friendly name through unchanged", () => {
+      expect(resolveToCatalogName("production", mappings)).toBe("production");
+    });
+  });
+
+  describe("resolveToSchemaName()", () => {
+    const mappings = [
+      { schemaId: "lkc-abc123", schemaName: "orders_cluster" },
+      { schemaId: "lkc-def456", schemaName: "events_cluster" },
+    ];
+
+    it("should map a cluster ID to its friendly SCHEMA_NAME", () => {
+      expect(resolveToSchemaName("lkc-abc123", mappings)).toBe(
+        "orders_cluster",
+      );
+    });
+
+    it("should return the cluster ID unchanged when no mapping matches", () => {
+      expect(resolveToSchemaName("lkc-unknown", mappings)).toBe("lkc-unknown");
+    });
+
+    it("should pass a friendly name through unchanged", () => {
+      expect(resolveToSchemaName("orders_cluster", mappings)).toBe(
+        "orders_cluster",
+      );
+    });
+  });
+
+  describe("getCatalogMapping()", () => {
+    let clientManager: MockedClientManager;
+    let flinkRest: MockedRestClient;
+
+    beforeEach(() => {
+      clientManager = getMockedClientManager();
+      flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+    });
+
+    it("should map CATALOG_ID/CATALOG_NAME rows from INFORMATION_SCHEMA.CATALOGS", async () => {
+      const rows = [
+        { CATALOG_ID: "env-abc123", CATALOG_NAME: "production" },
+        { CATALOG_ID: "env-def456", CATALOG_NAME: "staging" },
+      ];
+      flinkRest.POST.mockResolvedValue({ data: sqlResponse(rows) });
+      flinkRest.GET.mockResolvedValue({ data: sqlResponse(rows) });
+
+      const result = await getCatalogMapping(
+        clientManager,
+        "env-abc123",
+        SQL_OPTIONS,
+      );
+
+      expect(result.mappings).toEqual([
+        { catalogId: "env-abc123", catalogName: "production" },
+        { catalogId: "env-def456", catalogName: "staging" },
+      ]);
+      expect(result.statementName).toMatch(/^mcp-query-/);
+    });
+
+    it("should drop rows whose CATALOG_ID or CATALOG_NAME is not a string", async () => {
+      const rows = [
+        { CATALOG_ID: "env-abc123", CATALOG_NAME: "production" },
+        { CATALOG_ID: 42, CATALOG_NAME: "numeric-id" },
+        { CATALOG_ID: "env-ghi789", CATALOG_NAME: null },
+      ];
+      flinkRest.POST.mockResolvedValue({ data: sqlResponse(rows) });
+      flinkRest.GET.mockResolvedValue({ data: sqlResponse(rows) });
+
+      const result = await getCatalogMapping(
+        clientManager,
+        "env-abc123",
+        SQL_OPTIONS,
+      );
+
+      expect(result.mappings).toEqual([
+        { catalogId: "env-abc123", catalogName: "production" },
+      ]);
+    });
+
+    it("should return no mappings but still surface the statement name when the query fails", async () => {
+      const failed = {
+        status: { phase: "FAILED", detail: "synthetic failure" },
+        results: { data: [] },
+      };
+      flinkRest.POST.mockResolvedValue({ data: failed });
+      flinkRest.GET.mockResolvedValue({ data: failed });
+
+      const result = await getCatalogMapping(
+        clientManager,
+        "env-abc123",
+        SQL_OPTIONS,
+      );
+
+      expect(result.mappings).toEqual([]);
+      expect(result.statementName).toMatch(/^mcp-query-/);
+    });
+  });
+
+  describe("getSchemaMapping()", () => {
+    let clientManager: MockedClientManager;
+    let flinkRest: MockedRestClient;
+
+    beforeEach(() => {
+      clientManager = getMockedClientManager();
+      flinkRest = clientManager.getConfluentCloudFlinkRestClient();
+    });
+
+    it("should map SCHEMA_ID/SCHEMA_NAME rows from INFORMATION_SCHEMA.SCHEMATA", async () => {
+      const rows = [
+        { SCHEMA_ID: "lkc-abc123", SCHEMA_NAME: "orders_cluster" },
+        { SCHEMA_ID: "lkc-def456", SCHEMA_NAME: "events_cluster" },
+      ];
+      flinkRest.POST.mockResolvedValue({ data: sqlResponse(rows) });
+      flinkRest.GET.mockResolvedValue({ data: sqlResponse(rows) });
+
+      const result = await getSchemaMapping(
+        clientManager,
+        "env-abc123",
+        SQL_OPTIONS,
+      );
+
+      expect(result.mappings).toEqual([
+        { schemaId: "lkc-abc123", schemaName: "orders_cluster" },
+        { schemaId: "lkc-def456", schemaName: "events_cluster" },
+      ]);
+      expect(result.statementName).toMatch(/^mcp-query-/);
+    });
+
+    it("should drop rows whose SCHEMA_ID or SCHEMA_NAME is not a string", async () => {
+      const rows = [
+        { SCHEMA_ID: "lkc-abc123", SCHEMA_NAME: "orders_cluster" },
+        { SCHEMA_ID: 7, SCHEMA_NAME: "numeric-id" },
+        { SCHEMA_ID: "lkc-ghi789", SCHEMA_NAME: undefined },
+      ];
+      flinkRest.POST.mockResolvedValue({ data: sqlResponse(rows) });
+      flinkRest.GET.mockResolvedValue({ data: sqlResponse(rows) });
+
+      const result = await getSchemaMapping(
+        clientManager,
+        "env-abc123",
+        SQL_OPTIONS,
+      );
+
+      expect(result.mappings).toEqual([
+        { schemaId: "lkc-abc123", schemaName: "orders_cluster" },
+      ]);
+    });
+
+    it("should return no mappings but still surface the statement name when the query fails", async () => {
+      const failed = {
+        status: { phase: "FAILED", detail: "synthetic failure" },
+        results: { data: [] },
+      };
+      flinkRest.POST.mockResolvedValue({ data: failed });
+      flinkRest.GET.mockResolvedValue({ data: failed });
+
+      const result = await getSchemaMapping(
+        clientManager,
+        "env-abc123",
+        SQL_OPTIONS,
+      );
+
+      expect(result.mappings).toEqual([]);
+      expect(result.statementName).toMatch(/^mcp-query-/);
     });
   });
 });

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
@@ -1,4 +1,5 @@
 import { DescribeTableHandler } from "@src/confluent/tools/handlers/flink/catalog/describe-table-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
@@ -103,6 +104,48 @@ describe("describe-table-handler.ts", () => {
         expect(result._meta?.flinkStatementsCreated).toEqual([
           expect.stringMatching(/^mcp-query-/),
         ]);
+      });
+
+      it("should return a config error when the environment_id is not an env-* catalog", async () => {
+        const conn = {
+          flink: { ...FLINK_CONN.flink, environment_id: "friendly-env" },
+        };
+        const result = await handler.handle(
+          runtimeWith(conn, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          "Catalog name could not be resolved. Pass catalogName or environmentId as env-xxxxx, or set flink.environment_id in config.",
+        );
+      });
+
+      it("should report a not-found error qualified by the database when one is resolved", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME, databaseName: "mydb" },
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          `Table '${FLINK_CONN.flink.environment_id}.mydb.${TABLE_NAME}' not found or has no columns.`,
+        );
+      });
+
+      it("should report a catalog-scoped not-found error when no database is resolved", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          `Table '${TABLE_NAME}' in catalog '${FLINK_CONN.flink.environment_id}' not found or has no columns.`,
+        );
       });
 
       it("should surface BOTH statement names when an lkc-* databaseName triggers the resolver lookup", async () => {

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
@@ -1,4 +1,5 @@
 import { GetTableInfoHandler } from "@src/confluent/tools/handlers/flink/catalog/get-table-info-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
@@ -103,6 +104,48 @@ describe("get-table-info-handler.ts", () => {
         expect(result._meta?.flinkStatementsCreated).toEqual([
           expect.stringMatching(/^mcp-query-/),
         ]);
+      });
+
+      it("should return a config error when the environment_id is not an env-* catalog", async () => {
+        const conn = {
+          flink: { ...FLINK_CONN.flink, environment_id: "friendly-env" },
+        };
+        const result = await handler.handle(
+          runtimeWith(conn, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          "Catalog name could not be resolved. Pass catalogName or environmentId as env-xxxxx, or set flink.environment_id in config.",
+        );
+      });
+
+      it("should report a not-found error qualified by the database when one is resolved", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME, databaseName: "mydb" },
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          `Table '${FLINK_CONN.flink.environment_id}.mydb.${TABLE_NAME}' not found.`,
+        );
+      });
+
+      it("should report a catalog-scoped not-found error when no database is resolved", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { tableName: TABLE_NAME },
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          `Table '${TABLE_NAME}' in catalog '${FLINK_CONN.flink.environment_id}' not found.`,
+        );
       });
 
       it("should surface BOTH statement names when an lkc-* databaseName triggers the resolver lookup", async () => {

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
@@ -1,4 +1,5 @@
 import { ListCatalogsHandler } from "@src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
@@ -81,6 +82,32 @@ describe("list-catalogs-handler.ts", () => {
         expect(result._meta?.flinkStatementsCreated).toEqual([
           expect.stringMatching(/^mcp-query-/),
         ]);
+      });
+
+      it("should return a config error when the environment_id is not an env-* catalog", async () => {
+        const conn = {
+          flink: { ...FLINK_CONN.flink, environment_id: "friendly-env" },
+        };
+        const result = await handler.handle(
+          runtimeWith(conn, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          "Catalog name could not be resolved. Pass catalogName or environmentId as env-xxxxx, or set flink.environment_id in config.",
+        );
+      });
+
+      it("should report 'No catalogs found.' when the query returns zero rows", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).not.toBe(true);
+        expect(textOf(result)).toBe("No catalogs found.");
       });
 
       it("should still surface the statement name via _meta on the error path", async () => {

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
@@ -1,4 +1,5 @@
 import { ListDatabasesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-databases-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
@@ -77,6 +78,32 @@ describe("list-databases-handler.ts", () => {
         expect(result._meta?.flinkStatementsCreated).toEqual([
           expect.stringMatching(/^mcp-query-/),
         ]);
+      });
+
+      it("should return a config error when the environment_id is not an env-* catalog", async () => {
+        const conn = {
+          flink: { ...FLINK_CONN.flink, environment_id: "friendly-env" },
+        };
+        const result = await handler.handle(
+          runtimeWith(conn, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          "Catalog name could not be resolved. Pass catalogName or environmentId as env-xxxxx, or set flink.environment_id in config.",
+        );
+      });
+
+      it("should report 'No databases found.' when the query returns zero rows", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).not.toBe(true);
+        expect(textOf(result)).toBe("No databases found.");
       });
 
       it("should still surface the statement name via _meta on the error path", async () => {

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
@@ -1,4 +1,5 @@
 import { ListTablesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-tables-handler.js";
+import { textOf } from "@tests/call-tool-result.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
@@ -79,6 +80,34 @@ describe("list-tables-handler.ts", () => {
         expect(result._meta?.flinkStatementsCreated).toEqual([
           expect.stringMatching(/^mcp-query-/),
         ]);
+      });
+
+      it("should return a config error when the environment_id is not an env-* catalog", async () => {
+        const conn = {
+          flink: { ...FLINK_CONN.flink, environment_id: "friendly-env" },
+        };
+        const result = await handler.handle(
+          runtimeWith(conn, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toBe(
+          "Catalog name could not be resolved. Pass catalogName or environmentId as env-xxxxx, or set flink.environment_id in config.",
+        );
+      });
+
+      it("should report no tables in the named catalog when the query returns zero rows", async () => {
+        flinkRest.GET.mockResolvedValue({
+          data: { ...SQL_RESPONSE, results: { data: [] } },
+        });
+        const result = await handler.handle(
+          runtimeWith(FLINK_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+        expect(result.isError).not.toBe(true);
+        expect(textOf(result)).toBe(
+          `No tables found in catalog '${FLINK_CONN.flink.environment_id}'.`,
+        );
       });
 
       it("should still surface the statement name via _meta on the error path", async () => {


### PR DESCRIPTION
## Flink catalog test coverage

Lifts the whole `src/confluent/tools/handlers/flink/catalog` directory above the 80% branch-coverage bar and brings `catalog-resolver.ts` from 50% to full line coverage. All changes are test-only; no handler behaviour moved.

- `catalog-resolver.ts` was the worst offender (50% lines, 53% branches): only the two `resolve*Name` argument-fallback helpers were exercised, while the four functions that actually talk to `INFORMATION_SCHEMA` — `getCatalogMapping`, `getSchemaMapping`, `resolveToCatalogName`, `resolveToSchemaName` — had zero tests. New cases cover each: the `env-`/`lkc-` prefix lookups (match, no-match, and pass-through), the `typeof === "string"` row filter that silently drops malformed rows, and the `!result.success` early return that still surfaces the minted statement name.
- All five handlers (`list-catalogs`, `list-databases`, `list-tables`, `describe-table`, `get-table-info`) gained a config-error test that drives a non-`env-*` `environment_id` through `resolveCatalogNameOrError`, covering the previously-untested error arm and pinning the exact "Catalog name could not be resolved…" guidance message.
- The three list handlers each gained an empty-result test pinning the exact "No … found" message, closing the `length === 0` branch the existing success+error tests skipped.
- `describe-table` and `get-table-info` gained empty-result tests covering both arms of the not-found `scope` ternary — with and without a resolved database name — so the fully-qualified-vs-bare table message is exercised.
- The directory now sits at ~88% branch (was below 80%); every file clears the bar. The handful of residual uncovered branches (`result.statementName ? … : []` and `result.data ?? []`) are defensively dead — `executeFlinkSql` always returns a statement name and, on the success path the handler reaches, always returns a data array — so no honest test can drive them without faking an impossible helper return.

## Relationships

Closes #622
