### PR TITLE
Per-connection-id disabled tool explanations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this MCP server will be documented in this file.
 #### New Tools / Tool Features
 
 - **`create-schema` tool.** Registers a schema (or a new version) under a subject in the Schema Registry, peer to `list-schemas` and `delete-schema`.
+- **`explain-disabled-tools` now reports per connection.** The "why is this tool missing?" report is split into one section per configured connection, each with its own disabled-tool buckets and counts — so a tool live on one connection and dark on another surfaces under exactly the connection that gates it, rather than being flattened to a single server-wide verdict.
 - **`list-configured-connections` tool.** Read-only, always-enabled discovery tool describing configured connections (including read-only-ness) and the connection-routable tools and enabled for each.
 - **`describe-configured-connection` tool.** Read-only, always-enabled discovery tool that, given one connection id, reports its non-secret config (never credentials), read-only-ness, and the tools enabled on it alongside the reason each disabled tool is gated off.
 - **`produce-message` improvements:**

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -251,9 +251,9 @@ describe("explain-disabled-tools-handler.ts", () => {
         );
       });
 
-      it("should render a single 'all tools enabled' summary when nothing is disabled", () => {
+      it("should render a single 'all tools advertised' summary when nothing is disabled", () => {
         // A no-tool registry-thunk makes every tool trivially absent from the
-        // disabled set; the all-enabled branch fires even though the runtime
+        // disabled set; the all-advertised branch fires even though the runtime
         // has a connection.
         const empty = new ExplainDisabledToolsHandler(() => []);
         const text = getText(empty.handle(bareRuntime(), undefined));
@@ -262,7 +262,7 @@ describe("explain-disabled-tools-handler.ts", () => {
         );
       });
 
-      it("should render the 'all tools enabled' summary on a zero-connection config when nothing is disabled", () => {
+      it("should render the 'all tools advertised' summary on a zero-connection config when nothing is disabled", () => {
         // No connections AND no disabled tools (empty registry) takes the
         // all-advertised branch ahead of the no-connections summary — there is
         // genuinely nothing connection-gated to report.

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -2,10 +2,15 @@ import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolCategory } from "@src/confluent/tools/base-tools.js";
 import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
 import { ExplainDisabledToolsHandler } from "@src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.js";
-import type { ToolGatingReport } from "@src/confluent/tools/tool-availability.js";
+import type {
+  ConnectionGatingSection,
+  DisabledToolGroup,
+  ToolGatingReport,
+} from "@src/confluent/tools/tool-availability.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import {
+  FLINK_CONN,
   KAFKA_CONN,
   bareRuntime,
   ccloudOAuthRuntime,
@@ -34,6 +39,30 @@ function getReport(result: CallToolResult): ToolGatingReport {
   return meta as unknown as ToolGatingReport;
 }
 
+function sectionFor(
+  report: ToolGatingReport,
+  connectionId: string,
+): ConnectionGatingSection {
+  const section = report.connections.find(
+    (s) => s.connectionId === connectionId,
+  );
+  if (section === undefined) {
+    throw new Error(`expected a section for connection '${connectionId}'`);
+  }
+  return section;
+}
+
+function groupByReason(
+  section: ConnectionGatingSection,
+  reason: ToolDisabledReason,
+): DisabledToolGroup | undefined {
+  return section.disabledGroups.find(
+    (g) => "reason" in g && g.reason === reason,
+  );
+}
+
+const totalRegistered = Array.from(ToolHandlerRegistry.allHandlers()).length;
+
 describe("explain-disabled-tools-handler.ts", () => {
   describe("ExplainDisabledToolsHandler", () => {
     const handler = new ExplainDisabledToolsHandler(() =>
@@ -52,131 +81,180 @@ describe("explain-disabled-tools-handler.ts", () => {
     });
 
     describe("handle()", () => {
-      it("should report kafka-gated tools under MissingKafkaBlock when run against a bare runtime", async () => {
-        const result = handler.handle(bareRuntime(), undefined);
-        const report = getReport(result);
+      it("should report kafka-gated tools under MissingKafkaBlock in the lone connection's section against a bare runtime", () => {
+        const report = getReport(handler.handle(bareRuntime(), undefined));
 
-        const kafkaGroup = report.disabledGroups.find(
-          (g) =>
-            "reason" in g && g.reason === ToolDisabledReason.MissingKafkaBlock,
+        const section = sectionFor(report, "default");
+        const kafkaGroup = groupByReason(
+          section,
+          ToolDisabledReason.MissingKafkaBlock,
         );
         expect(
           kafkaGroup,
-          "expected a disabledGroups entry for MissingKafkaBlock against a bare runtime",
+          "expected a MissingKafkaBlock bucket in the default section against a bare runtime",
         ).toBeDefined();
         expect(kafkaGroup!.tools).toContain(ToolName.LIST_TOPICS);
         expect(kafkaGroup!.tools).toContain(ToolName.PRODUCE_MESSAGE);
-        expect(report.disabledCount).toBeGreaterThan(0);
+        expect(section.disabledCount).toBeGreaterThan(0);
       });
 
-      it("should not list alwaysEnabled tools (search-product-docs, get-product-doc-page, explain-disabled-tools) under any disabled group", async () => {
-        const result = handler.handle(bareRuntime(), undefined);
-        const report = getReport(result);
+      it("should not list alwaysEnabled tools (search-product-docs, get-product-doc-page, explain-disabled-tools) in any section", () => {
+        const report = getReport(handler.handle(bareRuntime(), undefined));
 
-        const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
-        expect(allDisabledTools).not.toContain(ToolName.SEARCH_PRODUCT_DOCS);
-        expect(allDisabledTools).not.toContain(ToolName.GET_PRODUCT_DOC_PAGE);
-        expect(allDisabledTools).not.toContain(ToolName.EXPLAIN_DISABLED_TOOLS);
+        const allSectionTools = report.connections.flatMap((s) =>
+          s.disabledGroups.flatMap((g) => g.tools),
+        );
+        for (const independent of [
+          ToolName.SEARCH_PRODUCT_DOCS,
+          ToolName.GET_PRODUCT_DOC_PAGE,
+          ToolName.EXPLAIN_DISABLED_TOOLS,
+        ]) {
+          expect(allSectionTools).not.toContain(independent);
+        }
       });
 
-      it("should remove kafka tools from disabledGroups when the connection carries a kafka block", async () => {
-        const result = handler.handle(runtimeWith(KAFKA_CONN), undefined);
-        const report = getReport(result);
+      it("should drop kafka tools from the section and keep flink tools disabled when the connection carries a kafka block", () => {
+        const report = getReport(
+          handler.handle(runtimeWith(KAFKA_CONN), undefined),
+        );
 
-        const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
-        expect(allDisabledTools).not.toContain(ToolName.LIST_TOPICS);
-        expect(allDisabledTools).not.toContain(ToolName.PRODUCE_MESSAGE);
+        const section = sectionFor(report, "default");
+        const allDisabled = section.disabledGroups.flatMap((g) => g.tools);
+        expect(allDisabled).not.toContain(ToolName.LIST_TOPICS);
+        expect(allDisabled).not.toContain(ToolName.PRODUCE_MESSAGE);
 
-        const flinkGroup = report.disabledGroups.find(
-          (g) =>
-            "reason" in g && g.reason === ToolDisabledReason.MissingFlinkBlock,
+        const flinkGroup = groupByReason(
+          section,
+          ToolDisabledReason.MissingFlinkBlock,
         );
         expect(flinkGroup).toBeDefined();
         expect(flinkGroup!.tools).toContain(ToolName.LIST_FLINK_STATEMENTS);
       });
 
-      it("should report OAuthNoServiceBlocks against an OAuth-typed connection for tools that need a service block", async () => {
-        const result = handler.handle(ccloudOAuthRuntime(), undefined);
-        const report = getReport(result);
+      it("should report OAuthNoServiceBlocks in the OAuth connection's section for tools that need a service block", () => {
+        const report = getReport(
+          handler.handle(ccloudOAuthRuntime(), undefined),
+        );
 
-        const oauthGroup = report.disabledGroups.find(
-          (g) =>
-            "reason" in g &&
-            g.reason === ToolDisabledReason.OAuthNoServiceBlocks,
+        const oauthGroup = groupByReason(
+          sectionFor(report, "default"),
+          ToolDisabledReason.OAuthNoServiceBlocks,
         );
         expect(oauthGroup).toBeDefined();
         expect(oauthGroup!.tools).toContain(ToolName.LIST_FLINK_STATEMENTS);
       });
 
-      it("should keep connection-independent tools enabled and bucket every other tool under NoConnectionsConfigured on a zero-connection config", async () => {
-        const result = handler.handle(runtimeWithConnections({}), undefined);
-        const report = getReport(result);
-
-        const allDisabledTools = report.disabledGroups.flatMap((g) => g.tools);
-        // The alwaysEnabled tools stay enabled with no connections at all.
-        expect(allDisabledTools).not.toContain(ToolName.SEARCH_PRODUCT_DOCS);
-        expect(allDisabledTools).not.toContain(ToolName.EXPLAIN_DISABLED_TOOLS);
-
-        // Every connection-dependent tool collapses into a single group: there
-        // is no connection to attribute a per-service reason to.
-        expect(report.disabledGroups).toHaveLength(1);
-        expect(report.disabledGroups[0]).toHaveProperty(
-          "reason",
-          ToolDisabledReason.NoConnectionsConfigured,
+      it("should split a tool across the per-connection sections of a flink+kafka pair of connections", () => {
+        const report = getReport(
+          handler.handle(
+            runtimeWithConnections({
+              "ccloud-flink": FLINK_CONN,
+              "local-kafka": KAFKA_CONN,
+            }),
+            undefined,
+          ),
         );
-        expect(report.disabledGroups[0]!.tools).toContain(ToolName.LIST_TOPICS);
-        expect(report.enabledCount + report.disabledCount).toBe(
-          Array.from(ToolHandlerRegistry.allHandlers()).length,
-        );
+
+        // Sections come back lex-sorted by id.
+        expect(report.connections.map((s) => s.connectionId)).toEqual([
+          "ccloud-flink",
+          "local-kafka",
+        ]);
+
+        // The flink-only connection lacks Kafka, so list-topics is disabled
+        // there but absent from the kafka connection's section (enabled there).
+        const flinkSection = sectionFor(report, "ccloud-flink");
+        expect(
+          groupByReason(flinkSection, ToolDisabledReason.MissingKafkaBlock)!
+            .tools,
+        ).toContain(ToolName.LIST_TOPICS);
+        const kafkaSection = sectionFor(report, "local-kafka");
+        expect(
+          kafkaSection.disabledGroups.flatMap((g) => g.tools),
+        ).not.toContain(ToolName.LIST_TOPICS);
+
+        // ...and symmetrically, the kafka-only connection lacks Flink, so
+        // list-flink-statements is disabled there but enabled on the flink one.
+        expect(
+          groupByReason(kafkaSection, ToolDisabledReason.MissingFlinkBlock)!
+            .tools,
+        ).toContain(ToolName.LIST_FLINK_STATEMENTS);
+        expect(
+          flinkSection.disabledGroups.flatMap((g) => g.tools),
+        ).not.toContain(ToolName.LIST_FLINK_STATEMENTS);
       });
 
-      it("should account for every registered tool in the enabled and disabled counts (no double-counting, no skips)", async () => {
-        const result = handler.handle(bareRuntime(), undefined);
-        const report = getReport(result);
+      it("should keep connection-independent tools enabled and report no sections on a zero-connection config", () => {
+        const report = getReport(
+          handler.handle(runtimeWithConnections({}), undefined),
+        );
 
-        const totalRegistered = Array.from(
-          ToolHandlerRegistry.allHandlers(),
-        ).length;
+        expect(report.connections).toEqual([]);
+        // The alwaysEnabled tools stay enabled with no connections at all;
+        // every connection-dependent tool is dark.
+        expect(report.enabledCount).toBeGreaterThan(0);
+        expect(report.disabledCount).toBeGreaterThan(0);
         expect(report.enabledCount + report.disabledCount).toBe(
           totalRegistered,
         );
-        const flatDisabledCount = report.disabledGroups.reduce(
-          (sum, g) => sum + g.tools.length,
-          0,
-        );
-        expect(flatDisabledCount).toBe(report.disabledCount);
       });
 
-      it("should render the disabled-count summary header with both totals", async () => {
-        const text = getText(handler.handle(bareRuntime(), undefined));
-        const totalRegistered = Array.from(
-          ToolHandlerRegistry.allHandlers(),
-        ).length;
-        expect(text).toMatch(
-          new RegExp(
-            String.raw`^\d+ of ${totalRegistered} tools disabled for the following reasons:`,
-          ),
+      it("should account for every registered tool in the enabled and disabled counts (no double-counting, no skips)", () => {
+        const report = getReport(handler.handle(bareRuntime(), undefined));
+        expect(report.enabledCount + report.disabledCount).toBe(
+          totalRegistered,
         );
       });
 
-      it("should render each disabled group as a header line plus indented '    - <tool>' bullets", async () => {
-        const text = getText(handler.handle(bareRuntime(), undefined));
-        // Pin the specific kafka group: header ends with `(<n>):` (no inline
-        // tool list), and each tool lives on its own bullet line indented
-        // four spaces. A future regression that reverts to the old
-        // comma-joined form fails on the bullet expectation.
-        expect(text).toMatch(
-          new RegExp(
-            String.raw`\n  ${escapeForRegex(ToolDisabledReason.MissingKafkaBlock)} \(\d+\):\n`,
+      it("should render a section header per connection on a flink+kafka pair", () => {
+        const text = getText(
+          handler.handle(
+            runtimeWithConnections({
+              "ccloud-flink": FLINK_CONN,
+              "local-kafka": KAFKA_CONN,
+            }),
+            undefined,
           ),
         );
-        expect(text).toContain("\n    - list-topics\n");
+
+        expect(text).toContain("Per-connection tool gating (by reason):");
+        expect(text).toContain("Connection 'ccloud-flink' —");
+        expect(text).toContain("Connection 'local-kafka' —");
+        // list-topics is disabled on the flink-only connection; its bullet
+        // sits under that connection's MissingKafkaBlock bucket.
+        expect(text).toContain("\n      - list-topics\n");
         expect(text).toContain("tools advertised via tools/list.");
       });
 
-      it("should render a single 'all tools enabled' summary when nothing is disabled", async () => {
-        // Build a no-tool registry-thunk so every tool is trivially absent
-        // from the disabled set; the flat-summary branch fires.
+      it("should render a connection header, an indented reason bucket, and six-space tool bullets against a bare runtime", () => {
+        const text = getText(handler.handle(bareRuntime(), undefined));
+        expect(text).toContain("Connection 'default' —");
+        // Bucket header is indented four spaces under the connection; tool
+        // bullets sit six spaces in, one per line. A regression to a
+        // comma-joined inline list fails the bullet expectation.
+        expect(text).toMatch(
+          new RegExp(
+            String.raw`\n    ${escapeForRegex(ToolDisabledReason.MissingKafkaBlock)} \(\d+\):\n`,
+          ),
+        );
+        expect(text).toContain("\n      - list-topics\n");
+      });
+
+      it("should render the dedicated no-connections summary on a zero-connection config", () => {
+        const text = getText(
+          handler.handle(runtimeWithConnections({}), undefined),
+        );
+        expect(text).toMatch(
+          new RegExp(
+            String.raw`^No connections are configured — \d+ of ${totalRegistered} tools are connection-gated and unavailable;`,
+          ),
+        );
+      });
+
+      it("should render a single 'all tools enabled' summary when nothing is disabled", () => {
+        // A no-tool registry-thunk makes every tool trivially absent from the
+        // disabled set; the all-enabled branch fires even though the runtime
+        // has a connection.
         const empty = new ExplainDisabledToolsHandler(() => []);
         const text = getText(empty.handle(bareRuntime(), undefined));
         expect(text).toBe(
@@ -184,65 +262,67 @@ describe("explain-disabled-tools-handler.ts", () => {
         );
       });
 
+      it("should render the 'all tools enabled' summary on a zero-connection config when nothing is disabled", () => {
+        // No connections AND no disabled tools (empty registry) takes the
+        // all-advertised branch ahead of the no-connections summary — there is
+        // genuinely nothing connection-gated to report.
+        const empty = new ExplainDisabledToolsHandler(() => []);
+        const text = getText(
+          empty.handle(runtimeWithConnections({}), undefined),
+        );
+        expect(text).toBe(
+          "All 0 registered tools are advertised via tools/list.",
+        );
+      });
+
       describe('group_by: "category"', () => {
-        it('should bucket disabled tools by handler.category and tag the report with groupBy="category"', async () => {
-          const result = handler.handle(bareRuntime(), {
-            group_by: "category",
-          });
-          const report = getReport(result);
+        it('should bucket disabled tools by handler.category within each section and tag the report with groupBy="category"', () => {
+          const report = getReport(
+            handler.handle(bareRuntime(), { group_by: "category" }),
+          );
 
           expect(report.groupBy).toBe("category");
 
           // Bare runtime → every block-gated tool is disabled. Kafka tools
           // bucket under ToolCategory.Kafka regardless of the specific
           // ToolDisabledReason they each emit.
-          const kafkaGroup = report.disabledGroups.find(
+          const section = sectionFor(report, "default");
+          const kafkaGroup = section.disabledGroups.find(
             (g) => "category" in g && g.category === ToolCategory.Kafka,
           );
           expect(
             kafkaGroup,
-            "expected a ToolCategory.Kafka bucket against a bare runtime",
+            "expected a ToolCategory.Kafka bucket in the default section",
           ).toBeDefined();
           expect(kafkaGroup!.tools).toContain(ToolName.LIST_TOPICS);
           expect(kafkaGroup!.tools).toContain(ToolName.PRODUCE_MESSAGE);
         });
 
-        it("should render the heading with 'across the following categories' under group_by='category'", async () => {
+        it("should render the heading with '(by category)' under group_by='category'", () => {
           const text = getText(
             handler.handle(bareRuntime(), { group_by: "category" }),
           );
-          const totalRegistered = Array.from(
-            ToolHandlerRegistry.allHandlers(),
-          ).length;
-          expect(text).toMatch(
-            new RegExp(
-              String.raw`^\d+ of ${totalRegistered} tools disabled across the following categories:`,
-            ),
-          );
+          expect(text).toContain("Per-connection tool gating (by category):");
           // A ToolCategory.Kafka bucket renders its kebab-case enum value as
-          // the group header — pins the renderer reading from
-          // `disabledToolGroupKey` rather than the legacy `group.reason`.
+          // the bucket header — pins the renderer reading from
+          // `disabledToolGroupKey` rather than a legacy `group.reason`.
           expect(text).toMatch(
-            new RegExp(String.raw`\n  ${ToolCategory.Kafka} \(\d+\):\n`),
+            new RegExp(String.raw`\n    ${ToolCategory.Kafka} \(\d+\):\n`),
           );
         });
 
-        it("should render category sections lex-sorted by kebab-case enum value", () => {
+        it("should render category buckets lex-sorted by kebab-case enum value within the section", () => {
           // Belt-and-suspenders against a regression that bypasses the
-          // localeCompare in tool-availability.ts and renders categories
-          // in (e.g.) handler-iteration or enum-declaration order. The
-          // data-shape test in tool-availability.test.ts pins the sorted
-          // disabledGroups; this one pins that the renderer doesn't
-          // re-order between data and text. Search for the `"  <name> ("`
-          // header prefix (two-space indent + name + count-paren) — that's
-          // unique to bucket headers and won't collide with tool-name
-          // bullets, which use a four-space `"    - "` prefix.
+          // localeCompare in tool-availability.ts and renders categories in
+          // (e.g.) handler-iteration order. Search for the four-space bucket
+          // header prefix; tool bullets use a six-space `"      - "` prefix so
+          // they won't collide.
           const text = getText(
             handler.handle(bareRuntime(), { group_by: "category" }),
           );
-          const billingAt = text.indexOf("  billing (");
-          const kafkaAt = text.indexOf("  kafka (");
-          const tableflowAt = text.indexOf("  tableflow (");
+          const billingAt = text.indexOf("    billing (");
+          const kafkaAt = text.indexOf("    kafka (");
+          const tableflowAt = text.indexOf("    tableflow (");
           expect(billingAt, "billing header not found").toBeGreaterThan(-1);
           expect(kafkaAt, "kafka header not found").toBeGreaterThan(-1);
           expect(tableflowAt, "tableflow header not found").toBeGreaterThan(-1);
@@ -250,7 +330,7 @@ describe("explain-disabled-tools-handler.ts", () => {
           expect(kafkaAt).toBeLessThan(tableflowAt);
         });
 
-        it("should treat group_by as optional and default to 'reason' when absent", async () => {
+        it("should treat group_by as optional and default to 'reason' when absent", () => {
           // Schema default makes an undefined arg equivalent to passing
           // group_by="reason" — pins the back-compat path so existing
           // callers (no args) see no behaviour change.
@@ -276,10 +356,6 @@ describe("explain-disabled-tools-handler.ts", () => {
           expect(issues).toHaveLength(1);
           // Path pins the offending field; code pins the validator class
           // (Zod v4 collapses enum/literal mismatches under `invalid_value`).
-          // A future regression that loosened the schema in a different
-          // place — say, dropping the enum constraint entirely — would
-          // fail either by not throwing at all or by emitting a different
-          // path, both of which this assertion catches.
           expect(issues[0]).toMatchObject({
             path: ["group_by"],
             code: "invalid_value",

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
@@ -7,6 +7,7 @@ import {
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import {
   buildToolGatingReport,
+  type ConnectionGatingSection,
   type DisabledToolGroup,
   disabledToolGroupKey,
   type ToolGatingReport,
@@ -21,35 +22,26 @@ const explainDisabledToolsArguments = z.object({
     .enum(["reason", "category"])
     .default("reason")
     .describe(
-      'Axis to bucket disabled tools by. "reason" (default) answers "what config piece would unlock these?" — each bucket is a ToolDisabledReason (MissingKafkaBlock, MissingFlinkBlock, …). "category" answers "which functional area is offline?" — each bucket is a ToolCategory (kafka, flink, schema-registry, …). Flip to "category" when triaging a misconfigured connection by functional area instead of by missing config piece.',
+      'Axis to bucket each connection\'s disabled tools by. "reason" (default) answers "what config piece would unlock these?" — each bucket is a ToolDisabledReason (MissingKafkaBlock, MissingFlinkBlock, …). "category" answers "which functional area is offline?" — each bucket is a ToolCategory (kafka, flink, schema-registry, …). Flip to "category" when triaging a misconfigured connection by functional area instead of by missing config piece.',
     ),
 });
 
 /**
- * Diagnostic tool that surfaces *why* tools are absent from `tools/list`.
+ * Diagnostic tool that surfaces *why* tools are absent from `tools/list` or
+ * unavailable on a given connection.
  *
- * The MCP protocol already advertises the enabled tool set via `tools/list`;
- * what it does not surface is the predicate-driven decision behind every
- * absence — which config piece is missing, and which tools each gap would
- * unlock. This handler returns that view.
+ * `tools/list` advertises the enabled tool set but not the predicate-driven
+ * decision behind every absence. This handler returns that view, shaped around
+ * connections: one section per configured connection listing the tools
+ * disabled on it (bucketed by the missing config piece, or by functional area
+ * under `group_by="category"`). A tool enabled on one connection and disabled
+ * on another shows up in the latter's section, so the cross-connection
+ * asymmetry is readable by comparing sections. A zero-connection config
+ * collapses to a dedicated summary; a single-connection config is simply one
+ * section. Connection-independent tools are advertised everywhere and never
+ * appear in a section.
  *
- * Current shape: a flat list of disabled tools grouped by the missing config
- * piece (kafka block, flink block, schema registry block, …), or by
- * `NoConnectionsConfigured` when the config has no connections at all. Tools
- * enabled on any connection are intentionally absent — `tools/list` already
- * advertises them.
- *
- * The flatten is *lossy* on a multi-connection config: a tool enabled on at
- * least one connection is reported as enabled (and omitted from
- * `disabledGroups` entirely), and a tool disabled on several connections with
- * different reasons is bucketed under the first disabled verdict its iteration
- * produces — the cross-connection asymmetry vanishes from the output.
- *
- * #559 regrows the output around connections: one block per connection
- * (header + per-connection gaps) plus a `Cross-connection deltas` section
- * surfacing tools enabled on some connections but not others — the canonical
- * "what does connection B need to reach parity with connection A?" view. The
- * structured `_meta` shape mirrors that change; see the
+ * The structured `_meta` mirrors the rendered text; see the
  * {@linkcode ToolGatingReport} JSDoc in `tool-availability.ts`.
  *
  * Always enabled (predicate is `alwaysEnabled`) so an operator can call it
@@ -78,7 +70,7 @@ export class ExplainDisabledToolsHandler extends ToolMetadataHandler {
     return {
       name: ToolName.EXPLAIN_DISABLED_TOOLS,
       description:
-        'Call when the user asks why a tool is missing or unavailable (e.g., "why can\'t I list Kafka topics?", "where are the Flink tools?"). Returns disabled tools grouped by the config gap each one is waiting on, so you can tell the user the exact YAML block or field to add. Pass group_by="category" to regroup by functional area (kafka, flink, schema-registry, …) when the user\'s question is framed by what\'s offline rather than by what\'s missing from config. Prefer this over guessing about credentials, network, or auth.',
+        'Call when the user asks why a tool is missing or unavailable (e.g., "why can\'t I list Kafka topics?", "where are the Flink tools?"). Returns disabled tools organized per connection — each connection\'s gaps bucketed by the config piece each tool is waiting on, so you can tell the user the exact YAML block or field to add (and, with more than one connection, which connection needs it). Pass group_by="category" to bucket each connection\'s gaps by functional area (kafka, flink, schema-registry, …) instead of by missing config piece. Prefer this over guessing about credentials, network, or auth.',
       inputSchema: explainDisabledToolsArguments.shape,
       annotations: READ_ONLY,
     };
@@ -93,58 +85,61 @@ export class ExplainDisabledToolsHandler extends ToolMetadataHandler {
  * the tool's response. Format is stable — handler tests pin specific
  * substrings so the AI/script-facing structure does not drift silently.
  *
- * The heading line varies by `report.groupBy`:
+ * Three shapes:
+ *   - nothing disabled anywhere → a one-line "all advertised" summary;
+ *   - no connections configured → a one-line no-connections summary;
+ *   - otherwise → a `Per-connection tool gating (by {axis}):` heading, one
+ *     section per connection that has gaps, and a closing advertised-count line.
  *
- *   - `"reason"`: "{disabled} of {total} tools disabled for the following reasons:"
- *   - `"category"`: "{disabled} of {total} tools disabled across the following categories:"
+ * Section layout (two-space connection header, four-space bucket header,
+ * six-space bullets):
  *
- * Body shape is identical for both axes — one header line per bucket
- * followed by indented `- {tool}` bullets, separated by a blank line:
+ *   Per-connection tool gating (by reason):
  *
- *   {disabled} of {total} tools disabled for the following reasons:
- *
- *     {reason or category} ({n}):
- *       - {tool}
- *       - {tool}
- *       …
- *
- *     {next bucket} ({n}):
- *       - {tool}
- *       …
+ *     Connection 'local-kafka' — 3 of 40 tools disabled:
+ *       {reason or category} ({n}):
+ *         - {tool}
+ *         …
  *
  *   {enabled} tools advertised via tools/list.
- *
- * Two-space indent on the bucket header, four-space indent on the bullets.
- *
- * v2 (#559, multi-connection): grow a per-connection section (header +
- * per-connection gaps) plus an optional `Cross-connection deltas` section.
- * See the handler's class JSDoc for the migration sketch.
  */
 function renderReport(report: ToolGatingReport): string {
   const total = report.enabledCount + report.disabledCount;
-  if (report.disabledCount === 0) {
+
+  if (report.connections.length === 0) {
+    if (report.disabledCount === 0) {
+      return `All ${total} registered tools are advertised via tools/list.`;
+    }
+    return `No connections are configured — ${report.disabledCount} of ${total} tools are connection-gated and unavailable; ${report.enabledCount} connection-independent tools remain available.`;
+  }
+
+  const gappedSections = report.connections.filter(
+    (section) => section.disabledCount > 0,
+  );
+  if (gappedSections.length === 0) {
     return `All ${total} registered tools are advertised via tools/list.`;
   }
 
-  const headingTail =
-    report.groupBy === "reason"
-      ? "for the following reasons"
-      : "across the following categories";
-
-  // Each group's render contains its own header line + indented bullets;
-  // joining with a blank line separates groups visually so long bullet
-  // lists from one group don't bleed into the next.
-  return [
-    `${report.disabledCount} of ${total} tools disabled ${headingTail}:`,
-    "",
-    report.disabledGroups.map(renderGroup).join("\n\n"),
-    "",
+  // Blocks are joined with a blank line so adjacent sections and the footer
+  // stay visually separate.
+  const blocks: string[] = [
+    `Per-connection tool gating (by ${report.groupBy}):`,
+    ...gappedSections.map((section) => renderConnectionSection(section, total)),
     `${report.enabledCount} tools advertised via tools/list.`,
-  ].join("\n");
+  ];
+  return blocks.join("\n\n");
+}
+
+function renderConnectionSection(
+  section: ConnectionGatingSection,
+  total: number,
+): string {
+  const header = `  Connection '${section.connectionId}' — ${section.disabledCount} of ${total} tools disabled:`;
+  return [header, ...section.disabledGroups.map(renderGroup)].join("\n");
 }
 
 function renderGroup(group: DisabledToolGroup): string {
-  const header = `  ${disabledToolGroupKey(group)} (${group.tools.length}):`;
-  const bullets = group.tools.map((tool) => `    - ${tool}`);
+  const header = `    ${disabledToolGroupKey(group)} (${group.tools.length}):`;
+  const bullets = group.tools.map((tool) => `      - ${tool}`);
   return [header, ...bullets].join("\n");
 }

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -183,31 +183,45 @@ describe("tool-availability.ts", () => {
   });
 
   describe("buildToolGatingReport()", () => {
-    it("should produce an empty report with zero counts when no tools are passed", () => {
+    it("should emit one empty section per configured connection with zero counts when no tools are passed", () => {
       const report = buildToolGatingReport([], runtimeWith({}, "default"));
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [],
+        connections: [
+          {
+            connectionId: "default",
+            disabledGroups: [],
+            enabledCount: 0,
+            disabledCount: 0,
+          },
+        ],
         enabledCount: 0,
         disabledCount: 0,
       });
     });
 
-    it("should report each tool as enabled and emit no disabledGroups when every tool passes its predicate", () => {
+    it("should count a connection-independent tool as enabled and place it in no section bucket or delta", () => {
       const handler = stubWithPredicate(alwaysEnabled);
       const report = buildToolGatingReport(
-        [[ToolName.LIST_TOPICS, handler]],
+        [[ToolName.SEARCH_PRODUCT_DOCS, handler]],
         runtimeWith(KAFKA_CONN),
       );
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [],
+        connections: [
+          {
+            connectionId: "default",
+            disabledGroups: [],
+            enabledCount: 1,
+            disabledCount: 0,
+          },
+        ],
         enabledCount: 1,
         disabledCount: 0,
       });
     });
 
-    it("should group fully-disabled tools by reason, sorted lex by reason", () => {
+    it("should bucket fully-disabled tools within the connection's section, sorted lex by reason", () => {
       const kafkaTool = stubWithPredicate(disabledForKafka);
       const otherKafkaTool = stubWithPredicate(disabledForKafka);
       const flinkTool = stubWithPredicate(disabledForFlink);
@@ -221,14 +235,21 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [
+        connections: [
           {
-            reason: ToolDisabledReason.MissingFlinkBlock,
-            tools: [ToolName.LIST_FLINK_STATEMENTS],
-          },
-          {
-            reason: ToolDisabledReason.MissingKafkaBlock,
-            tools: [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+            connectionId: "default",
+            disabledGroups: [
+              {
+                reason: ToolDisabledReason.MissingFlinkBlock,
+                tools: [ToolName.LIST_FLINK_STATEMENTS],
+              },
+              {
+                reason: ToolDisabledReason.MissingKafkaBlock,
+                tools: [ToolName.LIST_TOPICS, ToolName.CREATE_TOPICS],
+              },
+            ],
+            enabledCount: 0,
+            disabledCount: 3,
           },
         ],
         enabledCount: 0,
@@ -236,13 +257,12 @@ describe("tool-availability.ts", () => {
       });
     });
 
-    it("should classify a tool as enabled when at least one configured connection passes its predicate, omitting it from disabledGroups (lossy flatten)", () => {
-      // Pins the lossy flatten against a multi-connection runtime: a tool
-      // enabled on `with-kafka` and disabled on `without-kafka` is reported as
-      // enabled overall, with no entry in `disabledGroups`. The asymmetry is
-      // dropped — the per-connection / cross-connection-deltas shape (#559, see
-      // ToolGatingReport JSDoc) is the proper fix. This test exists so the
-      // lossy aggregation is documented in code rather than implied by prose.
+    it("should split a mixed tool across per-connection sections, disabled on the connection that lacks its block", () => {
+      // The crux of #559: a tool enabled on one connection and disabled on
+      // another no longer flattens to "enabled". It is absent from the
+      // satisfied connection's section (so enabled there) and bucketed in the
+      // other's section under the reason that connection falls short — the
+      // cross-connection asymmetry is readable by comparing the two sections.
       const handler = stubWithPredicate(hasKafka);
       const runtime = runtimeWithConnections({
         "with-kafka": KAFKA_CONN,
@@ -256,16 +276,89 @@ describe("tool-availability.ts", () => {
 
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [],
+        connections: [
+          {
+            connectionId: "with-kafka",
+            disabledGroups: [],
+            enabledCount: 1,
+            disabledCount: 0,
+          },
+          {
+            connectionId: "without-kafka",
+            disabledGroups: [
+              {
+                reason: ToolDisabledReason.MissingKafkaBlock,
+                tools: [ToolName.LIST_TOPICS],
+              },
+            ],
+            enabledCount: 0,
+            disabledCount: 1,
+          },
+        ],
         enabledCount: 1,
         disabledCount: 0,
       });
     });
 
-    it("should report a read_only-suppressed mutating tool under the ReadOnlyConnection reason bucket", () => {
+    it("should list a tool dark on every connection in each connection's section and count it once", () => {
+      const handler = stubWithPredicate(disabledForKafka);
+      const runtime = runtimeWithConnections({ alpha: {}, bravo: {} });
+
+      const report = buildToolGatingReport(
+        [[ToolName.LIST_TOPICS, handler]],
+        runtime,
+      );
+
+      expect(report).toEqual({
+        groupBy: "reason",
+        connections: [
+          {
+            connectionId: "alpha",
+            disabledGroups: [
+              {
+                reason: ToolDisabledReason.MissingKafkaBlock,
+                tools: [ToolName.LIST_TOPICS],
+              },
+            ],
+            enabledCount: 0,
+            disabledCount: 1,
+          },
+          {
+            connectionId: "bravo",
+            disabledGroups: [
+              {
+                reason: ToolDisabledReason.MissingKafkaBlock,
+                tools: [ToolName.LIST_TOPICS],
+              },
+            ],
+            enabledCount: 0,
+            disabledCount: 1,
+          },
+        ],
+        enabledCount: 0,
+        disabledCount: 1,
+      });
+    });
+
+    it("should order connection sections lex by connectionId, regardless of insertion order", () => {
+      const handler = stubWithPredicate(disabledForKafka);
+      const runtime = runtimeWithConnections({ zeta: {}, alpha: {} });
+
+      const report = buildToolGatingReport(
+        [[ToolName.LIST_TOPICS, handler]],
+        runtime,
+      );
+
+      expect(report.connections.map((c) => c.connectionId)).toEqual([
+        "alpha",
+        "zeta",
+      ]);
+    });
+
+    it("should bucket a read_only-suppressed mutating tool under ReadOnlyConnection in its connection section", () => {
       // The predicate (hasKafka) passes, so the only thing disabling this write
-      // tool is the read-only overlay — it lands in disabledGroups under
-      // ReadOnlyConnection, the "flip the flag and these return" set.
+      // tool is the read-only overlay — it lands in the connection's section
+      // under ReadOnlyConnection, the "flip the flag and these return" set.
       const mutatingTool = new StubHandler({
         predicate: hasKafka,
         annotations: CREATE_UPDATE,
@@ -276,10 +369,17 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [
+        connections: [
           {
-            reason: ToolDisabledReason.ReadOnlyConnection,
-            tools: [ToolName.CREATE_TOPICS],
+            connectionId: "default",
+            disabledGroups: [
+              {
+                reason: ToolDisabledReason.ReadOnlyConnection,
+                tools: [ToolName.CREATE_TOPICS],
+              },
+            ],
+            enabledCount: 0,
+            disabledCount: 1,
           },
         ],
         enabledCount: 0,
@@ -287,7 +387,7 @@ describe("tool-availability.ts", () => {
       });
     });
 
-    it("should bucket a connection-dependent tool under NoConnectionsConfigured on a zero-connection runtime", () => {
+    it("should count a connection-dependent tool as disabled with no section on a zero-connection runtime", () => {
       const handler = stubWithPredicate(hasKafka);
       const report = buildToolGatingReport(
         [[ToolName.LIST_TOPICS, handler]],
@@ -295,18 +395,13 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [
-          {
-            reason: ToolDisabledReason.NoConnectionsConfigured,
-            tools: [ToolName.LIST_TOPICS],
-          },
-        ],
+        connections: [],
         enabledCount: 0,
         disabledCount: 1,
       });
     });
 
-    it("should report a connection-independent tool as enabled on a zero-connection runtime", () => {
+    it("should count a connection-independent tool as enabled on a zero-connection runtime", () => {
       const handler = stubWithPredicate(alwaysEnabled);
       const report = buildToolGatingReport(
         [[ToolName.SEARCH_PRODUCT_DOCS, handler]],
@@ -314,13 +409,13 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
-        disabledGroups: [],
+        connections: [],
         enabledCount: 1,
         disabledCount: 0,
       });
     });
 
-    it("should preserve handler iteration order for tools within a single reason group", () => {
+    it("should preserve handler iteration order for tools within a single connection's reason bucket", () => {
       // Insertion order matters for the rendered text: handlers iterate in
       // registry-declaration order, and the diagnostic surface should show
       // tools in that same order so adjacent tools (e.g. all kafka tools)
@@ -336,7 +431,7 @@ describe("tool-availability.ts", () => {
         ],
         runtimeWith({}, "default"),
       );
-      expect(report.disabledGroups).toEqual([
+      expect(report.connections[0]!.disabledGroups).toEqual([
         {
           reason: ToolDisabledReason.MissingKafkaBlock,
           tools: [
@@ -354,7 +449,7 @@ describe("tool-availability.ts", () => {
       // Under the default "reason" axis they'd split into two buckets;
       // the "category" axis merges them — proving the bucket key really
       // is the category, not the reason.
-      it('should merge same-category disabled tools under one bucket when groupBy is "category"', () => {
+      it('should merge same-category disabled tools under one bucket within the connection section when groupBy is "category"', () => {
         const sameCategoryKafkaReasonStub = stubWithPredicate(disabledForKafka);
         const sameCategoryFlinkReasonStub = stubWithPredicate(disabledForFlink);
         const report = buildToolGatingReport(
@@ -367,10 +462,17 @@ describe("tool-availability.ts", () => {
         );
         expect(report).toEqual({
           groupBy: "category",
-          disabledGroups: [
+          connections: [
             {
-              category: ToolCategory.Kafka,
-              tools: [ToolName.LIST_TOPICS, ToolName.LIST_FLINK_STATEMENTS],
+              connectionId: "default",
+              disabledGroups: [
+                {
+                  category: ToolCategory.Kafka,
+                  tools: [ToolName.LIST_TOPICS, ToolName.LIST_FLINK_STATEMENTS],
+                },
+              ],
+              enabledCount: 0,
+              disabledCount: 2,
             },
           ],
           enabledCount: 0,
@@ -378,7 +480,7 @@ describe("tool-availability.ts", () => {
         });
       });
 
-      it("should sort category-keyed groups lex by category", () => {
+      it("should sort category-keyed buckets lex by category within a section", () => {
         // Two stubs with the same predicate (so reasons are identical
         // and the only differentiator is category) but distinct categories —
         // insertion order Tableflow-then-Billing, expected output
@@ -405,7 +507,9 @@ describe("tool-availability.ts", () => {
         // before `tableflow` lexicographically regardless of insertion
         // order.
         expect(
-          report.disabledGroups.map((g) => disabledToolGroupKey(g)),
+          report.connections[0]!.disabledGroups.map((g) =>
+            disabledToolGroupKey(g),
+          ),
         ).toEqual([ToolCategory.Billing, ToolCategory.Tableflow]);
       });
     });

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -152,61 +152,33 @@ export function buildToolGatingReport(
   // Per-connection accumulator: connectionId -> (bucketKey -> tools). Both
   // axes' keys (ToolDisabledReason / ToolCategory values) are string enums at
   // runtime, so a single string-keyed inner Map drives both code paths.
-  const sectionBuckets = new Map<string, Map<string, ToolName[]>>(
+  const sectionBuckets: SectionBuckets = new Map(
     connectionIds.map((id) => [id, new Map<string, ToolName[]>()]),
   );
   let enabledCount = 0;
   let disabledCount = 0;
 
   for (const [toolName, handler] of handlers) {
-    if (handler.isConnectionIndependent) {
+    if (
+      classifyAndBucketHandler(
+        toolName,
+        handler,
+        runtime,
+        groupBy,
+        sectionBuckets,
+      )
+    ) {
       enabledCount += 1;
-      continue;
-    }
-    const verdicts = handler.connectionVerdicts(runtime);
-    if (verdicts.size === 0) {
-      // No connections configured: nothing to attribute a per-connection
-      // verdict to, so the tool is dark with no section.
+    } else {
       disabledCount += 1;
-      continue;
     }
-
-    let anyEnabled = false;
-    for (const [connectionId, verdict] of verdicts) {
-      if (verdict.enabled) {
-        anyEnabled = true;
-        continue;
-      }
-      const key = groupBy === "reason" ? verdict.reason : handler.category;
-      const buckets = sectionBuckets.get(connectionId)!;
-      let bucket = buckets.get(key);
-      bucket ??= [];
-      buckets.set(key, bucket);
-      bucket.push(toolName);
-    }
-
-    if (anyEnabled) enabledCount += 1;
-    else disabledCount += 1;
   }
 
   const totalRegistered = enabledCount + disabledCount;
-  const connections: ConnectionGatingSection[] = connectionIds
-    .map((connectionId): ConnectionGatingSection => {
-      const disabledGroups = bucketsToGroups(
-        sectionBuckets.get(connectionId)!,
-        groupBy,
-      );
-      const sectionDisabled = disabledGroups.reduce(
-        (sum, group) => sum + group.tools.length,
-        0,
-      );
-      return {
-        connectionId,
-        disabledGroups,
-        enabledCount: totalRegistered - sectionDisabled,
-        disabledCount: sectionDisabled,
-      };
-    })
+  const connections = connectionIds
+    .map((id) =>
+      buildSection(id, sectionBuckets.get(id)!, groupBy, totalRegistered),
+    )
     .sort((a, b) => a.connectionId.localeCompare(b.connectionId));
 
   return {
@@ -214,6 +186,81 @@ export function buildToolGatingReport(
     connections,
     enabledCount,
     disabledCount,
+  };
+}
+
+/**
+ * Per-connection bucket accumulator: connectionId → (bucketKey → tools), where
+ * the bucket key is a {@linkcode ToolDisabledReason} or {@linkcode ToolCategory}
+ * string value depending on the report's axis.
+ */
+type SectionBuckets = Map<string, Map<string, ToolName[]>>;
+
+/**
+ * Classify one handler for the report and, as a side effect, bucket its tool
+ * into the section of every connection that disables it. Returns `true` when
+ * the tool is advertised (connection-independent, or enabled on at least one
+ * connection) — i.e. when it counts toward `enabledCount` rather than
+ * `disabledCount`. A connection-dependent tool on a zero-connection config is
+ * dark with no section to attribute it to.
+ */
+function classifyAndBucketHandler(
+  toolName: ToolName,
+  handler: ToolHandler,
+  runtime: ServerRuntime,
+  groupBy: "reason" | "category",
+  sectionBuckets: SectionBuckets,
+): boolean {
+  if (handler.isConnectionIndependent) return true;
+  const verdicts = handler.connectionVerdicts(runtime);
+  if (verdicts.size === 0) return false;
+
+  let anyEnabled = false;
+  for (const [connectionId, verdict] of verdicts) {
+    if (verdict.enabled) {
+      anyEnabled = true;
+      continue;
+    }
+    const key = groupBy === "reason" ? verdict.reason : handler.category;
+    pushToBucket(sectionBuckets.get(connectionId)!, key, toolName);
+  }
+  return anyEnabled;
+}
+
+/** Append `toolName` to `buckets[key]`, creating the bucket array on first use. */
+function pushToBucket(
+  buckets: Map<string, ToolName[]>,
+  key: string,
+  toolName: ToolName,
+): void {
+  let bucket = buckets.get(key);
+  bucket ??= [];
+  buckets.set(key, bucket);
+  bucket.push(toolName);
+}
+
+/**
+ * Assemble one connection's {@linkcode ConnectionGatingSection} from its bucket
+ * accumulator. `enabledCount` is the complement of this connection's disabled
+ * tally against the whole registered set, so connection-independent tools count
+ * as enabled here.
+ */
+function buildSection(
+  connectionId: string,
+  buckets: Map<string, ToolName[]>,
+  groupBy: "reason" | "category",
+  totalRegistered: number,
+): ConnectionGatingSection {
+  const disabledGroups = bucketsToGroups(buckets, groupBy);
+  const sectionDisabled = disabledGroups.reduce(
+    (sum, group) => sum + group.tools.length,
+    0,
+  );
+  return {
+    connectionId,
+    disabledGroups,
+    enabledCount: totalRegistered - sectionDisabled,
+    disabledCount: sectionDisabled,
   };
 }
 

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -1,8 +1,5 @@
 import { ToolCategory, ToolHandler } from "@src/confluent/tools/base-tools.js";
-import {
-  PredicateResult,
-  ToolDisabledReason,
-} from "@src/confluent/tools/connection-predicates.js";
+import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 
@@ -28,24 +25,43 @@ export function disabledToolGroupKey(group: DisabledToolGroup): string {
 }
 
 /**
+ * One configured connection's view of the gating report: the tools disabled
+ * *on this connection*, bucketed by the report's chosen axis, plus the
+ * connection's own enabled/disabled tallies. A tool enabled on this connection
+ * never appears in `disabledGroups` here; a tool enabled on a sibling
+ * connection but disabled on this one shows up in this section's buckets, so
+ * the cross-connection asymmetry is readable by comparing sections.
+ */
+export interface ConnectionGatingSection {
+  readonly connectionId: string;
+  readonly disabledGroups: readonly DisabledToolGroup[];
+  /** Tools advertisable on this connection: `totalRegistered - disabledCount`. */
+  readonly enabledCount: number;
+  /** Tools disabled on this connection: the sum of `disabledGroups[].tools.length`. */
+  readonly disabledCount: number;
+}
+
+/**
  * Output of {@linkcode buildToolGatingReport}; drives the
- * `explain-disabled-tools` diagnostic tool. Tools advertised via
- * `tools/list` are intentionally absent — the report carries the
- * negative signal only.
+ * `explain-disabled-tools` diagnostic tool.
  *
- * `groupBy` records which axis the bucket discriminators carry so
- * consumers (renderer, MCP-client UIs) can pick the right framing.
+ * The report is connection-shaped: one {@linkcode ConnectionGatingSection} per
+ * configured connection, each carrying that connection's disabled-tool buckets.
+ * A single-connection config yields exactly one section — there is one shape
+ * regardless of connection count.
  *
- * This is a flat report: each tool counts once as enabled or disabled across
- * the whole config, with no per-connection breakdown. On a multi-connection
- * config that flatten is lossy (a tool enabled on one connection and disabled
- * on another reads as simply enabled). #559 regrows the shape around
- * connections — per-connection sections plus a cross-connection-deltas section
- * calling out tools enabled on some connections but not others.
+ * `groupBy` records which axis the section buckets carry so consumers
+ * (renderer, MCP-client UIs) can pick the right framing.
+ *
+ * The top-level `enabledCount` / `disabledCount` are whole-server rollups: a
+ * tool counts as enabled if it is connection-independent or enabled on at
+ * least one connection, and disabled only when it is connection-dependent and
+ * dark on every connection (or there are no connections at all).
  */
 export interface ToolGatingReport {
   readonly groupBy: "reason" | "category";
-  readonly disabledGroups: readonly DisabledToolGroup[];
+  /** One section per configured connection, lex-sorted by id; empty iff no connections are configured. */
+  readonly connections: readonly ConnectionGatingSection[];
   readonly enabledCount: number;
   readonly disabledCount: number;
 }
@@ -110,48 +126,106 @@ export function groupDisabledToolsByReason(
 }
 
 /**
- * Assemble a {@linkcode ToolGatingReport} for the given handler set against the
- * configured connections.
+ * Assemble a connection-shaped {@linkcode ToolGatingReport} for the given
+ * handler set against the configured connections.
  *
- * - `disabledGroups` is sorted lex by reason; tools within a group follow
- *   handler iteration order.
- * - Each tool contributes once to `enabledCount` *or* `disabledCount`, via
- *   {@linkcode classifyHandler}: connection-independent tools count as enabled;
- *   a connection-dependent tool enabled on at least one connection counts as
- *   enabled (and is omitted from `disabledGroups`); otherwise it counts as
- *   disabled and lands under either the first disabled verdict's reason or
- *   {@linkcode ToolDisabledReason.NoConnectionsConfigured} when the config has
- *   no connections at all. The single-connection-vs-multi flatten is lossy —
- *   see {@linkcode ToolGatingReport} and #559.
+ * One pass over the handlers:
+ * - connection-independent tools count as enabled and appear in no section
+ *   (they are enabled on every connection);
+ * - a connection-dependent tool on a zero-connection config counts as disabled
+ *   with no section to attribute it to;
+ * - otherwise each connection that disables it gets the tool added to its
+ *   section bucket (keyed by reason, or by {@linkcode ToolHandler.category}
+ *   under `groupBy: "category"`), and the tool counts as enabled iff at least
+ *   one connection enables it.
+ *
+ * Sections are lex-sorted by `connectionId` and buckets lex by
+ * {@linkcode disabledToolGroupKey}. Tools within a bucket follow handler
+ * iteration order.
  */
 export function buildToolGatingReport(
   handlers: Iterable<readonly [ToolName, ToolHandler]>,
   runtime: ServerRuntime,
   groupBy: "reason" | "category" = "reason",
 ): ToolGatingReport {
-  // Both axes' keys (ToolDisabledReason values, ToolCategory values) are
-  // string enums at runtime, so a single string-keyed Map drives both code
-  // paths. The discriminator on the emitted DisabledToolGroup is what
-  // tells the consumer which axis it's reading.
-  const groups = new Map<string, ToolName[]>();
+  const connectionIds = runtime.config.getConnectionIds();
+  // Per-connection accumulator: connectionId -> (bucketKey -> tools). Both
+  // axes' keys (ToolDisabledReason / ToolCategory values) are string enums at
+  // runtime, so a single string-keyed inner Map drives both code paths.
+  const sectionBuckets = new Map<string, Map<string, ToolName[]>>(
+    connectionIds.map((id) => [id, new Map<string, ToolName[]>()]),
+  );
   let enabledCount = 0;
   let disabledCount = 0;
 
   for (const [toolName, handler] of handlers) {
-    const classification = classifyHandler(handler, runtime);
-    if (classification.kind === "enabled") {
+    if (handler.isConnectionIndependent) {
       enabledCount += 1;
       continue;
     }
-    disabledCount += 1;
-    const key = groupBy === "reason" ? classification.reason : handler.category;
-    let bucket = groups.get(key);
-    bucket ??= [];
-    groups.set(key, bucket);
-    bucket.push(toolName);
+    const verdicts = handler.connectionVerdicts(runtime);
+    if (verdicts.size === 0) {
+      // No connections configured: nothing to attribute a per-connection
+      // verdict to, so the tool is dark with no section.
+      disabledCount += 1;
+      continue;
+    }
+
+    let anyEnabled = false;
+    for (const [connectionId, verdict] of verdicts) {
+      if (verdict.enabled) {
+        anyEnabled = true;
+        continue;
+      }
+      const key = groupBy === "reason" ? verdict.reason : handler.category;
+      const buckets = sectionBuckets.get(connectionId)!;
+      let bucket = buckets.get(key);
+      bucket ??= [];
+      buckets.set(key, bucket);
+      bucket.push(toolName);
+    }
+
+    if (anyEnabled) enabledCount += 1;
+    else disabledCount += 1;
   }
 
-  const disabledGroups: DisabledToolGroup[] = Array.from(groups.entries())
+  const totalRegistered = enabledCount + disabledCount;
+  const connections: ConnectionGatingSection[] = connectionIds
+    .map((connectionId): ConnectionGatingSection => {
+      const disabledGroups = bucketsToGroups(
+        sectionBuckets.get(connectionId)!,
+        groupBy,
+      );
+      const sectionDisabled = disabledGroups.reduce(
+        (sum, group) => sum + group.tools.length,
+        0,
+      );
+      return {
+        connectionId,
+        disabledGroups,
+        enabledCount: totalRegistered - sectionDisabled,
+        disabledCount: sectionDisabled,
+      };
+    })
+    .sort((a, b) => a.connectionId.localeCompare(b.connectionId));
+
+  return {
+    groupBy,
+    connections,
+    enabledCount,
+    disabledCount,
+  };
+}
+
+/**
+ * Project one connection's `(bucketKey -> tools)` accumulator into the
+ * discriminated {@linkcode DisabledToolGroup} array, lex-sorted by bucket key.
+ */
+function bucketsToGroups(
+  buckets: Map<string, ToolName[]>,
+  groupBy: "reason" | "category",
+): DisabledToolGroup[] {
+  return Array.from(buckets.entries())
     .map(
       ([key, tools]): DisabledToolGroup =>
         groupBy === "reason"
@@ -161,56 +235,4 @@ export function buildToolGatingReport(
     .sort((a, b) =>
       disabledToolGroupKey(a).localeCompare(disabledToolGroupKey(b)),
     );
-
-  return { groupBy, disabledGroups, enabledCount, disabledCount };
-}
-
-type ToolClassification =
-  | { kind: "enabled" }
-  | { kind: "disabled"; reason: ToolDisabledReason };
-
-/**
- * Classify a single handler for the flat gating report. Three cases, in order:
- * a connection-independent tool is enabled regardless of how many connections
- * exist; a connection-dependent tool on a zero-connection config is disabled
- * under {@linkcode ToolDisabledReason.NoConnectionsConfigured} (there is no
- * per-connection verdict to attribute a reason to); otherwise the per-connection
- * verdicts decide via {@linkcode classifyVerdicts}.
- */
-function classifyHandler(
-  handler: ToolHandler,
-  runtime: ServerRuntime,
-): ToolClassification {
-  if (handler.isConnectionIndependent) return { kind: "enabled" };
-  const verdicts = handler.connectionVerdicts(runtime);
-  if (verdicts.size === 0) {
-    return {
-      kind: "disabled",
-      reason: ToolDisabledReason.NoConnectionsConfigured,
-    };
-  }
-  return classifyVerdicts(verdicts);
-}
-
-/**
- * Reduce a non-empty per-connection verdict map to a single classification for
- * the flat report: "enabled on at least one connection" wins, otherwise the
- * first disabled verdict's reason. This flatten is lossy on a multi-connection
- * runtime — see {@linkcode ToolGatingReport} for the consequences and #559 for
- * the per-connection shape that replaces it.
- *
- * {@linkcode classifyHandler} handles the connection-independent and
- * zero-connection cases, so the map handed here is always non-empty and there
- * is always a verdict to read.
- */
-function classifyVerdicts(
-  verdicts: Map<string, PredicateResult>,
-): ToolClassification {
-  let firstDisabledReason: ToolDisabledReason | undefined;
-  for (const verdict of verdicts.values()) {
-    if (verdict.enabled) return { kind: "enabled" };
-    firstDisabledReason ??= verdict.reason;
-  }
-  // Non-empty map with no enabled verdict, so a disabled reason was recorded.
-  return { kind: "disabled", reason: firstDisabledReason! };
 }

--- a/src/confluent/tools/tool-registry.test.ts
+++ b/src/confluent/tools/tool-registry.test.ts
@@ -565,7 +565,7 @@ describe("tool-registry.ts", () => {
       [ToolName.GET_PRODUCT_DOC_PAGE]: { outcome: { throws: "ZodError" } },
       // Diagnostics — no client calls; the handler walks the registry's
       // own predicate map. Against `allServicesRuntime` every gate passes
-      // and the handler emits its all-enabled summary.
+      // and the handler emits its all-advertised summary.
       [ToolName.EXPLAIN_DISABLED_TOOLS]: {
         outcome: { resolves: "registered tools are advertised via tools/list" },
         bypassesClientLayer: true,


### PR DESCRIPTION
## explain-disabled-tools, regrown around connections

`explain-disabled-tools` answers "why is tool X missing from `tools/list`?". Its report used to flatten the per-connection verdict map to one classification per tool — enabled-on-any wins, and a tool disabled on several connections collapsed under the first disabled verdict the iteration happened to see. That was correct while a server held at most one connection, but lossy the moment epic #532 lets a Confluent Cloud OAuth connection and a local Kafka broker coexist: the cross-connection asymmetry (a tool live on A, dark on B) vanished from both the text body and the structured `_meta`.

- **`ToolGatingReport` is now connection-shaped.** It carries one `ConnectionGatingSection` per configured connection — its own disabled-tool buckets and enabled/disabled counts. A tool enabled on one connection and disabled on another lands in the latter's section, so the cross-connection asymmetry is recoverable by comparing sections rather than being flattened away. The single-connection case is just one section, so there is one code path and one `_meta` shape regardless of connection count.
- **`buildToolGatingReport` makes one per-connection partition pass.** For each connection-dependent tool it drops the tool into each disabled connection's bucket (keyed by reason or, under `group_by="category"`, by category) and counts it as advertised iff at least one connection enables it. Connection-independent tools stay advertised and never appear in a section. The retired flat-flatten helpers (`classifyHandler` / `classifyVerdicts`) are gone.
- **The renderer grows per-connection sections.** Each connection gets a header line and its gap buckets; the zero-connection and all-enabled cases keep dedicated one-line summaries. New tests pin the section headers, the per-connection split of a tool across a flink+kafka pair, and that the `category` axis still buckets within each connection section.

## Sample structured output (`_meta`)

A single-connection config (kafka block only) yields one section — the common case stays simple:

```json
{
  "groupBy": "reason",
  "connections": [
    {
      "connectionId": "default",
      "disabledGroups": [
        {
          "reason": "no 'flink' block in connection config",
          "tools": ["list-flink-statements", "..."]
        },
        {
          "reason": "no 'schema_registry' block in connection config",
          "tools": ["list-schemas", "..."]
        }
      ],
      "enabledCount": 22,
      "disabledCount": 18
    }
  ],
  "enabledCount": 22,
  "disabledCount": 18
}
```

A two-connection config — a Flink-only `ccloud-flink` alongside a Kafka-only `local-kafka` — is where the new shape earns its keep. Each connection reports its own gaps; tools dark on _both_ (schema-registry, tableflow, billing, …) show up in both sections, while a tool live on one and dark on the other (`list-topics`, `list-flink-statements`) appears only in the section that lacks it:

```json
{
  "groupBy": "reason",
  "connections": [
    {
      "connectionId": "ccloud-flink",
      "disabledGroups": [
        {
          "reason": "no 'kafka' block in connection config",
          "tools": ["list-topics", "produce-message", "..."]
        },
        {
          "reason": "no 'schema_registry' block in connection config",
          "tools": ["list-schemas", "..."]
        }
      ],
      "enabledCount": 14,
      "disabledCount": 26
    },
    {
      "connectionId": "local-kafka",
      "disabledGroups": [
        {
          "reason": "no 'flink' block in connection config",
          "tools": ["list-flink-statements", "..."]
        },
        {
          "reason": "no 'schema_registry' block in connection config",
          "tools": ["list-schemas", "..."]
        }
      ],
      "enabledCount": 22,
      "disabledCount": 18
    }
  ],
  "enabledCount": 30,
  "disabledCount": 10
}
```

The top-level `disabledCount` (10) counts only tools dark on _every_ connection; `list-topics` and `list-flink-statements` are advertised (each enabled somewhere), so they're counted in `enabledCount` and surface only inside the one section that disables them — `list-topics` under `ccloud-flink`, `list-flink-statements` under `local-kafka`.

## Relationships

- Closes #559.
- Child of #532 (multi-connection support).

<img width="1116" height="996" alt="image" src="https://github.com/user-attachments/assets/49381260-6114-4839-bc2a-645497576be7" />

