### PR TITLE
Fix `explain-disabled-tools` vs operator disabled tools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this MCP server will be documented in this file.
 ### Fixed
 
 - `produce-message` can now produce primitive key and value payloads (numbers, booleans, strings) against top-level primitive Schema Registry schemas such as Avro `long`; previously the serializer rejected anything but an object.
+- `explain-disabled-tools` now accounts for tools the operator excluded via `--allow-tools` / `--block-tools`; previously (since v1.3.0) such tools were ignored by the diagnostic, which either counted them as enabled — contradicting `tools/list` — or blamed a missing config block. They now appear in a dedicated server-wide block.
 
 ### Changed
 

--- a/src/confluent/tools/connection-predicates.ts
+++ b/src/confluent/tools/connection-predicates.ts
@@ -316,13 +316,16 @@ export const flinkWithTelemetry: ConnectionPredicate = allOf(
  * missing from the connection config, or the policy it violates (not which
  * predicate or overlay emitted it — multiple sites may share a reason). Write
  * the value as a declarative phrase a misconfigured user could act on. Most
- * reasons originate in a predicate body; two are exceptions, produced outside
- * any predicate because they describe a condition no per-connection check can
- * see: {@linkcode ReadOnlyConnection} (the read-only verdict overlay in
+ * reasons originate in a predicate body; three are exceptions, produced
+ * outside any predicate because they describe a condition no per-connection
+ * check can see: {@linkcode ReadOnlyConnection} (the read-only verdict overlay in
  * `BaseToolHandler`, composing a tool's mutation posture with the connection's
- * `read_only` flag) and {@linkcode NoConnectionsConfigured} (assigned by
+ * `read_only` flag), {@linkcode NoConnectionsConfigured} (assigned by
  * `buildToolGatingReport` when there are no connections at all, so no
- * connection-dependent tool has any verdict to report).
+ * connection-dependent tool has any verdict to report), and
+ * {@linkcode OperatorBlocked} (assigned by `buildToolGatingReport` when the
+ * operator's server-wide allow/block-list excludes a tool, ahead of and
+ * independent of any per-connection check).
  */
 export enum ToolDisabledReason {
   MissingKafkaBlock = "no 'kafka' block in connection config",
@@ -339,4 +342,5 @@ export enum ToolDisabledReason {
   OAuthNotDirectCapable = "OAuth connection cannot satisfy a direct-only requirement",
   ReadOnlyConnection = "connection is marked read_only; tools that mutate state are disabled",
   NoConnectionsConfigured = "no connections are configured",
+  OperatorBlocked = "excluded by the operator's allow/block-list",
 }

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -338,6 +338,37 @@ describe("explain-disabled-tools-handler.ts", () => {
           expect(text).toContain("\n  - list-topics");
           expect(text).not.toContain("registered tools are advertised");
         });
+
+        it("should exclude operator-blocked tools from per-connection section denominators", () => {
+          // Allow only create-topics (kafka tool) and list-flink-statements
+          // (flink tool), operator-blocking all others. On a kafka-only
+          // connection, create-topics is enabled and list-flink-statements is
+          // disabled. The per-connection header should say "1 of 2" (not "1 of
+          // ${totalRegistered}"), since only 2 tools survive the operator filter
+          // to be connection-routable.
+          const allowTwoTools: ReadonlySet<ToolName> = new Set([
+            ToolName.CREATE_TOPICS,
+            ToolName.LIST_FLINK_STATEMENTS,
+          ]);
+
+          const text = getText(
+            handler.handle(
+              runtimeWith(KAFKA_CONN, "default", undefined, allowTwoTools),
+              undefined,
+            ),
+          );
+
+          // Most tools are in the operator block (totalRegistered - 2).
+          const operatorBlockedCount = totalRegistered - 2;
+          expect(text).toContain(
+            `${ToolDisabledReason.OperatorBlocked} (${operatorBlockedCount}):`,
+          );
+          // Per-connection section header: 1 disabled out of 2 connection-routable
+          // tools (create-topics + list-flink-statements), not totalRegistered.
+          expect(text).toContain(
+            "Connection 'default' — 1 of 2 tools disabled:",
+          );
+        });
       });
 
       describe('group_by: "category"', () => {

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -275,6 +275,71 @@ describe("explain-disabled-tools-handler.ts", () => {
         );
       });
 
+      describe("operator allow/block-list", () => {
+        // Allow only a flink tool: it stays predicate-disabled on a kafka-only
+        // connection (a MissingFlinkBlock gap), while every other tool —
+        // including list-topics, which the kafka block would otherwise enable —
+        // is operator-blocked.
+        const onlyFlinkAllowed: ReadonlySet<ToolName> = new Set([
+          ToolName.LIST_FLINK_STATEMENTS,
+        ]);
+
+        it("should list an operator-blocked tool in operatorBlocked and in no connection section", () => {
+          const report = getReport(
+            handler.handle(
+              runtimeWith(KAFKA_CONN, "default", undefined, onlyFlinkAllowed),
+              undefined,
+            ),
+          );
+
+          expect(report.operatorBlocked).toContain(ToolName.LIST_TOPICS);
+          const allSectionTools = report.connections.flatMap((s) =>
+            s.disabledGroups.flatMap((g) => g.tools),
+          );
+          expect(allSectionTools).not.toContain(ToolName.LIST_TOPICS);
+        });
+
+        it("should render the operator-block as a server-wide block above the per-connection sections", () => {
+          const text = getText(
+            handler.handle(
+              runtimeWith(KAFKA_CONN, "default", undefined, onlyFlinkAllowed),
+              undefined,
+            ),
+          );
+
+          const blockHeader = `${ToolDisabledReason.OperatorBlocked} (`;
+          expect(text).toContain(blockHeader);
+          // Operator-blocked bullets sit two spaces in (top-level), distinct
+          // from the six-space per-connection section bullets.
+          expect(text).toContain("\n  - list-topics");
+          // The server-wide block precedes the per-connection heading.
+          expect(text.indexOf(blockHeader)).toBeLessThan(
+            text.indexOf("Per-connection tool gating (by reason):"),
+          );
+        });
+
+        it("should surface the operator-block instead of the all-advertised summary when no connection has a predicate gap", () => {
+          // Allow only a connection-independent tool: every connection-dependent
+          // tool is operator-blocked, so no section carries a predicate gap. The
+          // report must still report the blocked tools, never claim all advertised.
+          const text = getText(
+            handler.handle(
+              runtimeWith(
+                KAFKA_CONN,
+                "default",
+                undefined,
+                new Set([ToolName.SEARCH_PRODUCT_DOCS]),
+              ),
+              undefined,
+            ),
+          );
+
+          expect(text).toContain(`${ToolDisabledReason.OperatorBlocked} (`);
+          expect(text).toContain("\n  - list-topics");
+          expect(text).not.toContain("registered tools are advertised");
+        });
+      });
+
       describe('group_by: "category"', () => {
         it('should bucket disabled tools by handler.category within each section and tag the report with groupBy="category"', () => {
           const report = getReport(

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
@@ -161,9 +161,15 @@ function renderConnectionPart(
   );
   if (gappedSections.length === 0) return undefined;
 
+  // Per-connection section denominators exclude operator-blocked tools so the
+  // "X of Y" counts are self-consistent with what each section represents.
+  const connectionRoutableTotal = total - report.operatorBlocked.length;
+
   return [
     `Per-connection tool gating (by ${report.groupBy}):`,
-    ...gappedSections.map((section) => renderConnectionSection(section, total)),
+    ...gappedSections.map((section) =>
+      renderConnectionSection(section, connectionRoutableTotal),
+    ),
     `${report.enabledCount} tools advertised via tools/list.`,
   ].join("\n\n");
 }

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
@@ -4,7 +4,10 @@ import {
   ToolCategory,
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
-import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
+import {
+  alwaysEnabled,
+  ToolDisabledReason,
+} from "@src/confluent/tools/connection-predicates.js";
 import {
   buildToolGatingReport,
   type ConnectionGatingSection,
@@ -85,11 +88,23 @@ export class ExplainDisabledToolsHandler extends ToolMetadataHandler {
  * the tool's response. Format is stable — handler tests pin specific
  * substrings so the AI/script-facing structure does not drift silently.
  *
- * Three shapes:
- *   - nothing disabled anywhere → a one-line "all advertised" summary;
- *   - no connections configured → a one-line no-connections summary;
- *   - otherwise → a `Per-connection tool gating (by {axis}):` heading, one
- *     section per connection that has gaps, and a closing advertised-count line.
+ * Two orthogonal parts, each present only when it has something to say, joined
+ * by a blank line:
+ *   - the server-wide operator allow/block-list block, when any tool was
+ *     excluded by it (rendered first, since the operator filter is the
+ *     outermost gate);
+ *   - the connection-shaped part: a no-connections summary, or a
+ *     `Per-connection tool gating (by {axis}):` heading with one section per
+ *     gapped connection and a closing advertised-count line.
+ *
+ * When neither part has anything to report, a one-line "all advertised"
+ * summary stands in.
+ *
+ * Operator block (top-level header, two-space bullets):
+ *
+ *   excluded by the operator's allow/block-list (2):
+ *     - list-topics
+ *     - create-topics
  *
  * Section layout (two-space connection header, four-space bucket header,
  * six-space bullets):
@@ -106,28 +121,62 @@ export class ExplainDisabledToolsHandler extends ToolMetadataHandler {
 function renderReport(report: ToolGatingReport): string {
   const total = report.enabledCount + report.disabledCount;
 
+  const operatorBlock =
+    report.operatorBlocked.length > 0
+      ? renderOperatorBlock(report.operatorBlocked)
+      : undefined;
+  const connectionPart = renderConnectionPart(report, total);
+
+  if (operatorBlock === undefined && connectionPart === undefined) {
+    return `All ${total} registered tools are advertised via tools/list.`;
+  }
+
+  // Blank line between the two parts so they stay visually separate.
+  return [operatorBlock, connectionPart]
+    .filter((part): part is string => part !== undefined)
+    .join("\n\n");
+}
+
+/**
+ * The connection-shaped portion of the report, or `undefined` when there is
+ * nothing connection-side to say (a zero-connection config whose only disabled
+ * tools are operator-blocked, or a populated config with every
+ * connection-dependent tool advertised). The operator-blocked tally is
+ * excluded from the no-connections "connection-gated" count — those tools are
+ * already accounted for in the operator block.
+ */
+function renderConnectionPart(
+  report: ToolGatingReport,
+  total: number,
+): string | undefined {
   if (report.connections.length === 0) {
-    if (report.disabledCount === 0) {
-      return `All ${total} registered tools are advertised via tools/list.`;
-    }
-    return `No connections are configured — ${report.disabledCount} of ${total} tools are connection-gated and unavailable; ${report.enabledCount} connection-independent tools remain available.`;
+    const connectionGated =
+      report.disabledCount - report.operatorBlocked.length;
+    if (connectionGated === 0) return undefined;
+    return `No connections are configured — ${connectionGated} of ${total} tools are connection-gated and unavailable; ${report.enabledCount} connection-independent tools remain available.`;
   }
 
   const gappedSections = report.connections.filter(
     (section) => section.disabledCount > 0,
   );
-  if (gappedSections.length === 0) {
-    return `All ${total} registered tools are advertised via tools/list.`;
-  }
+  if (gappedSections.length === 0) return undefined;
 
-  // Blocks are joined with a blank line so adjacent sections and the footer
-  // stay visually separate.
-  const blocks: string[] = [
+  return [
     `Per-connection tool gating (by ${report.groupBy}):`,
     ...gappedSections.map((section) => renderConnectionSection(section, total)),
     `${report.enabledCount} tools advertised via tools/list.`,
-  ];
-  return blocks.join("\n\n");
+  ].join("\n\n");
+}
+
+/**
+ * Render the server-wide operator allow/block-list block: a header naming the
+ * reason and count, then one two-space bullet per excluded tool in handler
+ * iteration order.
+ */
+function renderOperatorBlock(blocked: readonly ToolName[]): string {
+  const header = `${ToolDisabledReason.OperatorBlocked} (${blocked.length}):`;
+  const bullets = blocked.map((tool) => `  - ${tool}`);
+  return [header, ...bullets].join("\n");
 }
 
 function renderConnectionSection(

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -187,6 +187,7 @@ describe("tool-availability.ts", () => {
       const report = buildToolGatingReport([], runtimeWith({}, "default"));
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [
           {
             connectionId: "default",
@@ -208,6 +209,7 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [
           {
             connectionId: "default",
@@ -235,6 +237,7 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [
           {
             connectionId: "default",
@@ -276,6 +279,7 @@ describe("tool-availability.ts", () => {
 
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [
           {
             connectionId: "with-kafka",
@@ -311,6 +315,7 @@ describe("tool-availability.ts", () => {
 
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [
           {
             connectionId: "alpha",
@@ -369,6 +374,7 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [
           {
             connectionId: "default",
@@ -395,6 +401,7 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [],
         enabledCount: 0,
         disabledCount: 1,
@@ -409,6 +416,7 @@ describe("tool-availability.ts", () => {
       );
       expect(report).toEqual({
         groupBy: "reason",
+        operatorBlocked: [],
         connections: [],
         enabledCount: 1,
         disabledCount: 0,
@@ -443,6 +451,162 @@ describe("tool-availability.ts", () => {
       ]);
     });
 
+    describe("operator allow/block-list (isToolAllowed)", () => {
+      // An allow-list that admits only LIST_FLINK_STATEMENTS — every other
+      // tool reads as operator-blocked through runtime.isToolAllowed.
+      const onlyFlinkAllowed: ReadonlySet<ToolName> = new Set([
+        ToolName.LIST_FLINK_STATEMENTS,
+      ]);
+
+      it("should report an operator-blocked tool whose predicate would pass as blocked, not enabled", () => {
+        // The contradiction-with-tools/list bug: hasKafka passes on a kafka
+        // connection, so pre-#558 this counted as enabled even though the
+        // operator dropped it from the advertised set. It must land in
+        // operatorBlocked and count as disabled.
+        const handler = stubWithPredicate(hasKafka);
+        const report = buildToolGatingReport(
+          [[ToolName.LIST_TOPICS, handler]],
+          runtimeWith(KAFKA_CONN, "default", undefined, onlyFlinkAllowed),
+        );
+        expect(report).toEqual({
+          groupBy: "reason",
+          operatorBlocked: [ToolName.LIST_TOPICS],
+          connections: [
+            {
+              connectionId: "default",
+              disabledGroups: [],
+              enabledCount: 0,
+              disabledCount: 0,
+            },
+          ],
+          enabledCount: 0,
+          disabledCount: 1,
+        });
+      });
+
+      it("should not blame a config reason for an operator-blocked tool whose predicate also fails", () => {
+        // hasKafka fails on a kafka-less connection, but the operator block is
+        // the real story — the tool must appear in operatorBlocked and NOT in
+        // the connection's MissingKafkaBlock bucket.
+        const handler = stubWithPredicate(hasKafka);
+        const report = buildToolGatingReport(
+          [[ToolName.LIST_TOPICS, handler]],
+          runtimeWith({}, "default", undefined, onlyFlinkAllowed),
+        );
+        expect(report).toEqual({
+          groupBy: "reason",
+          operatorBlocked: [ToolName.LIST_TOPICS],
+          connections: [
+            {
+              connectionId: "default",
+              disabledGroups: [],
+              enabledCount: 0,
+              disabledCount: 0,
+            },
+          ],
+          enabledCount: 0,
+          disabledCount: 1,
+        });
+      });
+
+      it("should block even a connection-independent tool when the operator excludes it", () => {
+        // alwaysEnabled would otherwise advertise this everywhere; the operator
+        // block is the outermost gate and overrides connection-independence.
+        const handler = stubWithPredicate(alwaysEnabled);
+        const report = buildToolGatingReport(
+          [[ToolName.SEARCH_PRODUCT_DOCS, handler]],
+          runtimeWith(KAFKA_CONN, "default", undefined, onlyFlinkAllowed),
+        );
+        expect(report).toEqual({
+          groupBy: "reason",
+          operatorBlocked: [ToolName.SEARCH_PRODUCT_DOCS],
+          connections: [
+            {
+              connectionId: "default",
+              disabledGroups: [],
+              enabledCount: 0,
+              disabledCount: 0,
+            },
+          ],
+          enabledCount: 0,
+          disabledCount: 1,
+        });
+      });
+
+      it("should subtract operator-blocked tools from each connection section's enabledCount", () => {
+        // One allowed+enabled tool, one operator-blocked tool. The section's
+        // enabledCount must count only the allowed one (1), never claiming the
+        // blocked tool as enabled-on-this-connection.
+        const allowedHandler = stubWithPredicate(hasKafka);
+        const blockedHandler = stubWithPredicate(hasKafka);
+        const report = buildToolGatingReport(
+          [
+            [ToolName.LIST_FLINK_STATEMENTS, allowedHandler],
+            [ToolName.LIST_TOPICS, blockedHandler],
+          ],
+          runtimeWith(KAFKA_CONN, "default", undefined, onlyFlinkAllowed),
+        );
+        expect(report).toEqual({
+          groupBy: "reason",
+          operatorBlocked: [ToolName.LIST_TOPICS],
+          connections: [
+            {
+              connectionId: "default",
+              disabledGroups: [],
+              enabledCount: 1,
+              disabledCount: 0,
+            },
+          ],
+          enabledCount: 1,
+          disabledCount: 1,
+        });
+      });
+
+      it("should leave operatorBlocked unchanged under groupBy=category", () => {
+        // The operator block is axis-independent: the same server-wide list
+        // appears whether bucketing by reason or by functional category.
+        const handler = stubWithPredicate(hasKafka);
+        const report = buildToolGatingReport(
+          [[ToolName.LIST_TOPICS, handler]],
+          runtimeWith({}, "default", undefined, onlyFlinkAllowed),
+          "category",
+        );
+        expect(report).toEqual({
+          groupBy: "category",
+          operatorBlocked: [ToolName.LIST_TOPICS],
+          connections: [
+            {
+              connectionId: "default",
+              disabledGroups: [],
+              enabledCount: 0,
+              disabledCount: 0,
+            },
+          ],
+          enabledCount: 0,
+          disabledCount: 1,
+        });
+      });
+
+      it("should preserve handler iteration order within operatorBlocked", () => {
+        const a = stubWithPredicate(hasKafka);
+        const b = stubWithPredicate(hasKafka);
+        const c = stubWithPredicate(hasKafka);
+        const report = buildToolGatingReport(
+          [
+            [ToolName.PRODUCE_MESSAGE, a],
+            [ToolName.LIST_TOPICS, b],
+            [ToolName.CREATE_TOPICS, c],
+          ],
+          runtimeWith(KAFKA_CONN, "default", undefined, new Set()),
+        );
+        expect(report.operatorBlocked).toEqual([
+          ToolName.PRODUCE_MESSAGE,
+          ToolName.LIST_TOPICS,
+          ToolName.CREATE_TOPICS,
+        ]);
+      });
+    });
+
     describe('groupBy: "category"', () => {
       // Both stubs land in ToolCategory.Kafka, but their predicates fail
       // for different reasons (MissingKafkaBlock vs MissingFlinkBlock).
@@ -462,6 +626,7 @@ describe("tool-availability.ts", () => {
         );
         expect(report).toEqual({
           groupBy: "category",
+          operatorBlocked: [],
           connections: [
             {
               connectionId: "default",

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -53,13 +53,23 @@ export interface ConnectionGatingSection {
  * `groupBy` records which axis the section buckets carry so consumers
  * (renderer, MCP-client UIs) can pick the right framing.
  *
+ * `operatorBlocked` is the server-wide allow/block-list verdict, held apart
+ * from the per-connection sections because the operator filter is the
+ * outermost gate: it excludes a tool from every connection at once and owes
+ * nothing to any connection's config. A blocked tool appears here and in no
+ * section's buckets, and is subtracted from each section's `enabledCount`.
+ *
  * The top-level `enabledCount` / `disabledCount` are whole-server rollups: a
- * tool counts as enabled if it is connection-independent or enabled on at
- * least one connection, and disabled only when it is connection-dependent and
- * dark on every connection (or there are no connections at all).
+ * tool counts as enabled if it survives the operator filter AND is
+ * connection-independent or enabled on at least one connection; it counts as
+ * disabled when the operator filter excludes it, or when it is
+ * connection-dependent and dark on every connection (or there are no
+ * connections at all).
  */
 export interface ToolGatingReport {
   readonly groupBy: "reason" | "category";
+  /** Tools the operator's allow/block-list excluded server-wide, in handler iteration order. */
+  readonly operatorBlocked: readonly ToolName[];
   /** One section per configured connection, lex-sorted by id; empty iff no connections are configured. */
   readonly connections: readonly ConnectionGatingSection[];
   readonly enabledCount: number;
@@ -130,6 +140,10 @@ export function groupDisabledToolsByReason(
  * handler set against the configured connections.
  *
  * One pass over the handlers:
+ * - a tool the operator's allow/block-list excludes (`!isToolAllowed`) is
+ *   recorded in `operatorBlocked` and counts as disabled, ahead of and
+ *   independent of its predicate verdict — the filter is the outermost gate,
+ *   so it never reaches a connection section;
  * - connection-independent tools count as enabled and appear in no section
  *   (they are enabled on every connection);
  * - a connection-dependent tool on a zero-connection config counts as disabled
@@ -140,8 +154,8 @@ export function groupDisabledToolsByReason(
  *   one connection enables it.
  *
  * Sections are lex-sorted by `connectionId` and buckets lex by
- * {@linkcode disabledToolGroupKey}. Tools within a bucket follow handler
- * iteration order.
+ * {@linkcode disabledToolGroupKey}. Tools within a bucket — and within
+ * `operatorBlocked` — follow handler iteration order.
  */
 export function buildToolGatingReport(
   handlers: Iterable<readonly [ToolName, ToolHandler]>,
@@ -155,10 +169,16 @@ export function buildToolGatingReport(
   const sectionBuckets: SectionBuckets = new Map(
     connectionIds.map((id) => [id, new Map<string, ToolName[]>()]),
   );
+  const operatorBlocked: ToolName[] = [];
   let enabledCount = 0;
   let disabledCount = 0;
 
   for (const [toolName, handler] of handlers) {
+    if (!runtime.isToolAllowed(toolName)) {
+      operatorBlocked.push(toolName);
+      disabledCount += 1;
+      continue;
+    }
     if (
       classifyAndBucketHandler(
         toolName,
@@ -177,12 +197,19 @@ export function buildToolGatingReport(
   const totalRegistered = enabledCount + disabledCount;
   const connections = connectionIds
     .map((id) =>
-      buildSection(id, sectionBuckets.get(id)!, groupBy, totalRegistered),
+      buildSection(
+        id,
+        sectionBuckets.get(id)!,
+        groupBy,
+        totalRegistered,
+        operatorBlocked.length,
+      ),
     )
     .sort((a, b) => a.connectionId.localeCompare(b.connectionId));
 
   return {
     groupBy,
+    operatorBlocked,
     connections,
     enabledCount,
     disabledCount,
@@ -241,15 +268,18 @@ function pushToBucket(
 
 /**
  * Assemble one connection's {@linkcode ConnectionGatingSection} from its bucket
- * accumulator. `enabledCount` is the complement of this connection's disabled
- * tally against the whole registered set, so connection-independent tools count
- * as enabled here.
+ * accumulator. `enabledCount` is what remains advertisable on this connection
+ * once both the operator-blocked tools (excluded server-wide, never in this
+ * section's buckets) and this connection's own predicate-disabled tools are
+ * removed from the whole registered set — so connection-independent tools count
+ * as enabled here, but operator-blocked ones never do.
  */
 function buildSection(
   connectionId: string,
   buckets: Map<string, ToolName[]>,
   groupBy: "reason" | "category",
   totalRegistered: number,
+  operatorBlockedCount: number,
 ): ConnectionGatingSection {
   const disabledGroups = bucketsToGroups(buckets, groupBy);
   const sectionDisabled = disabledGroups.reduce(
@@ -259,7 +289,7 @@ function buildSection(
   return {
     connectionId,
     disabledGroups,
-    enabledCount: totalRegistered - sectionDisabled,
+    enabledCount: totalRegistered - operatorBlockedCount - sectionDisabled,
     disabledCount: sectionDisabled,
   };
 }


### PR DESCRIPTION
## Operator-blocked tools in the disabled-tools report

- `explain-disabled-tools` iterates the full static tool registry, including tools the operator dropped via `--allow-tools` / `--block-tools` (or their `*-file` variants). It classified every tool purely by its connection predicate, so an operator-blocked tool was either mis-blamed on a missing config block (predicate fails) or — worse — counted as _enabled_, flatly contradicting `tools/list` (predicate passes). **This was a latent bug in the `explain-disabled-tools` tool when `--allow-tools` / `--block-tools` cmdline arguments were used**: the diagnostic has never consulted the operator filter since it first shipped (in v1.3.0, as `describe-tool-gating`), because the allow/block list was applied only at registration. It now consults `runtime.isToolAllowed(name)` as the outermost gate, ahead of the predicate verdict, so a blocked tool is reported as blocked regardless of its config posture.
- The allow/block-list is a server-wide operator decision, not a per-connection config gap, so it gets a server-wide home rather than being smeared across every connection section. `ToolGatingReport` grows a top-level `operatorBlocked: ToolName[]` list, rendered as a dedicated block above the per-connection sections and identical regardless of `group_by`. The new `ToolDisabledReason.OperatorBlocked` ("excluded by the operator's allow/block-list") names the bucket; the wording is source-neutral because `isToolAllowed` can't tell a CLI flag from a `--*-tools-file`.
- A blocked tool counts as disabled in the whole-server rollup and is subtracted from each connection section's `enabledCount`, so a section never claims an operator-blocked tool as enabled-on-this-connection.
- New `tool-availability.test.ts` cases pin the contradiction-with-`tools/list` fix (a blocked tool whose predicate _would_ pass lands in `operatorBlocked`, not enabled), the no-config-blame fix (a blocked tool whose predicate fails is not in a config-reason bucket), the per-section `enabledCount` correction, and axis-independence under `group_by="category"`. New handler tests pin the rendered server-wide block and its placement above the connection sections.

## `describe-configured-connection` was already correct

`DescribeConfiguredConnectionHandler` did not have this bug. It iterates via `this.connectionRoutableTools(runtime)`, a shared helper from `ToolMetadataHandler` that already filters out operator-blocked tools with `runtime.isToolAllowed(name)` before yielding each tool. An operator-blocked tool appears in **neither** the `enabledTools` nor `disabledTools` buckets — the correct behavior.

A pre-existing test in `describe-configured-connection-handler.test.ts` ()"should exclude tools blocked by the operator allow/block filter from both buckets") proves this works: it creates a runtime with `CREATE_TOPICS` blocked by the operator and asserts the tool appears in neither bucket, even though its predicate would have disabled it on the bare connection anyway.

The bug was specific to `explain-disabled-tools`, which was iterating the full static tool registry without consulting the operator filter. `ListConfiguredConnectionsHandler` also uses `connectionRoutableTools()`, so it was already correct too.

## Relationships

- Closes #558
- Child of #532
- Builds on #536 (relocated the resolved allow/block-list onto `ServerRuntime.isToolAllowed`)
- Related: #559 (regrew the report around connections; this builds on that shape)
