### PR TITLE
Multi-connection integration tests.

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -257,6 +257,53 @@ blocks:
             - pnpm run test:harness
             - make test-integration TAGS=@smoke
 
+  # Multi-connection block (#543): boots a server holding two connections —
+  # `ccloud` (CCloud) and `cp` (the local Confluent Platform broker) — and
+  # proves per-connection routing against live infra. The ONLY block that stands
+  # up the docker-compose CP stack, so it carries a bespoke prologue/epilogue for
+  # that lifecycle rather than the shared *integration-prologue anchor (it also
+  # skips that anchor's chromium install, which only @oauth tests need — this
+  # suite is direct-only). Fires whenever the multi-connection fixture, harness,
+  # test, or the CP compose file changes.
+  #
+  # TEMPORARY per-PR placement: this lives here only to prove the suite green on
+  # the PR that introduces it. A follow-up moves it to the scheduled/manual
+  # integration.yml pipeline (gated on a @multi SERVICE_CONFIGS sentinel) and
+  # deletes this block, so the docker + two-cluster cost stays off every PR.
+  - name: "Integration Tests: multi"
+    dependencies: ["Build & Test"]
+    run:
+      when: "change_in(['/src/confluent/tools/multi-connection.integration.test.ts', '/tests/harness/multi-runtime.ts', '/tests/harness/multi-start-server.ts', '/tests/harness/multi-kafka-admin.ts', '/test-fixtures/yaml_configs/integration.multi.yaml', '/docker-compose.cp-test.yml'], { default_branch: 'main' })"
+    task:
+      env_vars:
+        # Static, non-secret CP broker creds (match docker-compose.cp-test.yml's
+        # JAAS user_mcp). `make setup-test-env` only writes Vault-backed secrets,
+        # so the `cp` connection's ${CP_KAFKA_*} interpolation is sourced here.
+        - name: CP_KAFKA_USERNAME
+          value: "mcp"
+        - name: CP_KAFKA_PASSWORD
+          value: "mcp-secret"
+      prologue:
+        commands:
+          - . vault-setup --version v3 --role mcp-confluent
+          - make setup-test-env
+          - pnpm run build
+          # amd64 agents ship docker-compose v1.29.2 (hyphenated, no `--wait`),
+          # so block on the broker + SR ports with dockerize.
+          - docker-compose -f docker-compose.cp-test.yml up -d
+          - dockerize -wait tcp://localhost:9092 -wait tcp://localhost:8081 -timeout 120s
+      epilogue:
+        always:
+          commands:
+            - docker-compose -f docker-compose.cp-test.yml down -v
+            - make remove-test-env
+            - test-results publish TEST-integration.xml --name "Integration (${SEMAPHORE_JOB_NAME})" --force || true
+      jobs:
+        - name: "@multi"
+          commands:
+            - pnpm run test:harness
+            - make test-integration TAGS=@multi
+
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -289,9 +289,10 @@ blocks:
           - make setup-test-env
           - pnpm run build
           # amd64 agents ship docker-compose v1.29.2 (hyphenated, no `--wait`),
-          # so block on the broker + SR ports with dockerize.
+          # so block on the broker port with dockerize. Only the `cp` broker is
+          # used (the suite wires no connection to the stack's local SR).
           - docker-compose -f docker-compose.cp-test.yml up -d
-          - dockerize -wait tcp://localhost:9092 -wait tcp://localhost:8081 -timeout 120s
+          - dockerize -wait tcp://localhost:9092 -timeout 120s
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -273,7 +273,7 @@ blocks:
   - name: "Integration Tests: multi"
     dependencies: ["Build & Test"]
     run:
-      when: "change_in(['/src/confluent/tools/multi-connection.integration.test.ts', '/tests/harness/multi-runtime.ts', '/tests/harness/multi-start-server.ts', '/tests/harness/multi-kafka-admin.ts', '/test-fixtures/yaml_configs/integration.multi.yaml', '/docker-compose.cp-test.yml'], { default_branch: 'main' })"
+      when: "change_in(['/src/confluent/tools/multi-connection.integration.test.ts', '/tests/harness/multi-runtime.ts', '/tests/harness/multi-start-server.ts', '/tests/harness/multi-kafka-admin.ts', '/test-fixtures/yaml_configs/integration.multi.yaml', '/docker-compose.cp-test.yml', '/tests/tags.ts'], { default_branch: 'main' })"
     task:
       env_vars:
         # Static, non-secret CP broker creds (match docker-compose.cp-test.yml's

--- a/docker-compose.cp-test.yml
+++ b/docker-compose.cp-test.yml
@@ -32,7 +32,17 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: "SASL_PLAINTEXT"
       KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG: >-
+      # cp-kafka's `configure` step runs `dub ensure KAFKA_OPTS` whenever SASL
+      # appears in the advertised listeners and aborts startup if it is unset.
+      # The JAAS login is supplied per-listener below, so this only needs to be
+      # a harmless non-empty JVM flag to satisfy that guard.
+      KAFKA_OPTS: "-Dmcp.cp.test=1"
+      # cp-docker translates env-var keys to properties with `_` -> `.` and
+      # `__` -> `_`. The listener is named SASL_PLAINTEXT (literal underscore),
+      # so its per-listener JAAS key must double the underscore between SASL and
+      # PLAINTEXT; a single underscore yields `listener.name.sasl.plaintext...`,
+      # which Kafka ignores, dropping back to a missing global JAAS file.
+      KAFKA_LISTENER_NAME_SASL__PLAINTEXT_PLAIN_SASL_JAAS_CONFIG: >-
         org.apache.kafka.common.security.plain.PlainLoginModule required
         username="admin" password="admin-secret"
         user_admin="admin-secret"

--- a/src/confluent/tools/multi-connection.integration.test.ts
+++ b/src/confluent/tools/multi-connection.integration.test.ts
@@ -1,0 +1,290 @@
+import { KafkaJS } from "@confluentinc/kafka-javascript";
+import {
+  type ConnectionConfig,
+  type DirectConnectionConfig,
+} from "@src/config/models.js";
+import { ListFlinkStatementsHandler } from "@src/confluent/tools/handlers/flink/list-flink-statements-handler.js";
+import { ListTopicsHandler } from "@src/confluent/tools/handlers/kafka/list-topics-handler.js";
+import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { connectAdminForConnection } from "@tests/harness/multi-kafka-admin.js";
+import {
+  CCLOUD_CONNECTION_ID,
+  CP_CONNECTION_ID,
+  multiIntegrationConnection,
+  multiIntegrationConnectionsLoaded,
+} from "@tests/harness/multi-runtime.js";
+import {
+  startMultiServer,
+  type StartedServer,
+} from "@tests/harness/multi-start-server.js";
+import { skipIfDisabled } from "@tests/harness/skip-gate.js";
+import { textContent } from "@tests/harness/tool-results.js";
+import { activeTransports } from "@tests/harness/transports.js";
+import { uniqueName } from "@tests/harness/unique-name.js";
+import { Tag } from "@tests/tags.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const listTopicsHandler = new ListTopicsHandler();
+const listFlinkStatementsHandler = new ListFlinkStatementsHandler();
+
+/** Narrows a fixture connection to direct for the test-side admin builder. */
+function asDirect(conn: ConnectionConfig): DirectConnectionConfig {
+  if (conn.type !== "direct") {
+    throw new Error(
+      `Expected multi-fixture connection to be direct; got "${conn.type}"`,
+    );
+  }
+  return conn;
+}
+
+/** The JSON-schema view of an injected `connectionId` param, as `tools/list` exposes it. */
+interface ConnectionIdSchema {
+  enum?: string[];
+  description?: string;
+}
+
+/**
+ * The #543 multi-connection suite: one server holding two `direct` connections —
+ * `ccloud` (the sole Flink-capable connection) and `cp` (the local Confluent
+ * Platform broker, kafka only). Proves, against live infrastructure, that tool
+ * calls route to the addressed connection and that per-tool connection
+ * candidacy is advertised and enforced correctly on a multi-connection server.
+ */
+describe("multi-connection routing", { tags: [Tag.MULTI] }, () => {
+  // Both connections must load (both clusters' creds present) before any test
+  // can spawn the two-connection server.
+  if (!multiIntegrationConnectionsLoaded()) {
+    it.skip("requires both ccloud and cp connections configured in integration.multi.yaml (CCloud creds + a running docker-compose.cp-test.yml stack)", () => {});
+    return;
+  }
+  // Each connection independently satisfies the predicate of the tool that
+  // routes to it; the Flink assertions additionally need ccloud's flink block.
+  if (
+    skipIfDisabled(
+      listTopicsHandler,
+      multiIntegrationConnection(CCLOUD_CONNECTION_ID),
+    )
+  ) {
+    return;
+  }
+  if (
+    skipIfDisabled(
+      listTopicsHandler,
+      multiIntegrationConnection(CP_CONNECTION_ID),
+    )
+  ) {
+    return;
+  }
+  if (
+    skipIfDisabled(
+      listFlinkStatementsHandler,
+      multiIntegrationConnection(CCLOUD_CONNECTION_ID),
+    )
+  ) {
+    return;
+  }
+
+  describe.each(activeTransports)("via %s transport", (transport) => {
+    let server: StartedServer;
+    let ccloudAdmin: KafkaJS.Admin;
+    let cpAdmin: KafkaJS.Admin;
+    const ccloudTopic = uniqueName("multi-ccloud");
+    const cpTopic = uniqueName("multi-cp");
+
+    beforeAll(async () => {
+      server = await startMultiServer({ transport });
+      ccloudAdmin = await connectAdminForConnection(
+        asDirect(multiIntegrationConnection(CCLOUD_CONNECTION_ID)),
+        "mcp-confluent-multi-it-ccloud",
+      );
+      cpAdmin = await connectAdminForConnection(
+        asDirect(multiIntegrationConnection(CP_CONNECTION_ID)),
+        "mcp-confluent-multi-it-cp",
+      );
+      // One distinct topic per cluster so the two list-topics responses are
+      // provably different sets, not just the same set fetched twice.
+      await ccloudAdmin.createTopics({
+        topics: [{ topic: ccloudTopic, numPartitions: 1 }],
+      });
+      await cpAdmin.createTopics({
+        topics: [{ topic: cpTopic, numPartitions: 1 }],
+      });
+    });
+
+    afterAll(async () => {
+      await ccloudAdmin
+        ?.deleteTopics({ topics: [ccloudTopic] })
+        .catch(() => {});
+      await cpAdmin?.deleteTopics({ topics: [cpTopic] }).catch(() => {});
+      await ccloudAdmin?.disconnect().catch(() => {});
+      await cpAdmin?.disconnect().catch(() => {});
+      await server?.stop();
+    });
+
+    /** Returns the error text of a tool call that must fail, whether it rejects (SDK input validation) or returns `isError` (handler). Fails loudly if the call unexpectedly succeeds. */
+    async function callToolError(
+      name: ToolName,
+      args: Record<string, unknown>,
+    ): Promise<string> {
+      let result;
+      try {
+        result = await server.client.callTool({ name, arguments: args });
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+      expect(
+        result.isError,
+        `expected ${name} to error; got: ${textContent(result)}`,
+      ).toBe(true);
+      return textContent(result);
+    }
+
+    /** The injected `connectionId` schema for `toolName` from `tools/list`, or undefined. */
+    async function connectionIdSchema(
+      toolName: ToolName,
+    ): Promise<ConnectionIdSchema | undefined> {
+      const { tools } = await server.client.listTools();
+      const tool = tools.find((t) => t.name === toolName);
+      const props = tool?.inputSchema?.properties as
+        | Record<string, ConnectionIdSchema>
+        | undefined;
+      return props?.connectionId;
+    }
+
+    /** Whether `tools/list` marks `connectionId` required on `toolName`. */
+    async function connectionIdRequired(toolName: ToolName): Promise<boolean> {
+      const { tools } = await server.client.listTools();
+      const tool = tools.find((t) => t.name === toolName);
+      const required = tool?.inputSchema?.required as string[] | undefined;
+      return required?.includes("connectionId") ?? false;
+    }
+
+    // --- Assertion 1: Kafka routing ---
+
+    it("should route list-topics to the addressed connection, with distinct topic sets per cluster", async () => {
+      const ccloudText = textContent(
+        await server.client.callTool({
+          name: ToolName.LIST_TOPICS,
+          arguments: { connectionId: CCLOUD_CONNECTION_ID },
+        }),
+      );
+      expect(ccloudText, ccloudText).toContain(ccloudTopic);
+      expect(ccloudText).not.toContain(cpTopic);
+
+      const cpText = textContent(
+        await server.client.callTool({
+          name: ToolName.LIST_TOPICS,
+          arguments: { connectionId: CP_CONNECTION_ID },
+        }),
+      );
+      expect(cpText, cpText).toContain(cpTopic);
+      expect(cpText).not.toContain(ccloudTopic);
+    });
+
+    it("should advertise both connections as list-topics candidates and require an explicit choice", async () => {
+      expect(await connectionIdRequired(ToolName.LIST_TOPICS)).toBe(true);
+      const schema = await connectionIdSchema(ToolName.LIST_TOPICS);
+      expect(schema?.enum?.slice().sort((a, b) => a.localeCompare(b))).toEqual([
+        CCLOUD_CONNECTION_ID,
+        CP_CONNECTION_ID,
+      ]);
+      // both candidate ids surface in the description that steers the agent
+      expect(schema?.description).toContain(CCLOUD_CONNECTION_ID);
+      expect(schema?.description).toContain(CP_CONNECTION_ID);
+    });
+
+    it("should reject list-topics when connectionId is omitted", async () => {
+      const message = await callToolError(ToolName.LIST_TOPICS, {});
+      expect(message).toContain("connectionId");
+    });
+
+    // --- Assertion 2 (reframed per #590): per-tool candidate narrowing ---
+    //
+    // #590 makes a multi-connection server inject a *required* connectionId enum
+    // narrowed to the tool's viable candidates. Flink's enum is ["ccloud"] only,
+    // so omitting it errors and "cp" is not an accepted value. Do NOT "fix" these
+    // to expect auto-routing — that pre-#590 behavior only holds on a
+    // single-connection server.
+
+    it("should narrow list-flink-statements' connectionId enum to the flink-capable connection only", async () => {
+      expect(await connectionIdRequired(ToolName.LIST_FLINK_STATEMENTS)).toBe(
+        true,
+      );
+      const schema = await connectionIdSchema(ToolName.LIST_FLINK_STATEMENTS);
+      expect(schema?.enum).toEqual([CCLOUD_CONNECTION_ID]);
+    });
+
+    it("should resolve list-flink-statements against the flink-capable connection", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_FLINK_STATEMENTS,
+        arguments: { connectionId: CCLOUD_CONNECTION_ID },
+      });
+      expect(result.isError, textContent(result)).not.toBe(true);
+    });
+
+    it("should reject list-flink-statements addressed to the non-flink connection", async () => {
+      const message = await callToolError(ToolName.LIST_FLINK_STATEMENTS, {
+        connectionId: CP_CONNECTION_ID,
+      });
+      // Zod v4's invalid_value issue names the *accepted* value, never the
+      // rejected input, so the message can't echo "cp". It proves the rejection
+      // by naming the connectionId field and ccloud as the sole accepted value
+      // — the narrowed enum enforced at call time, not just advertised in
+      // tools/list.
+      expect(message).toContain("connectionId");
+      expect(message).toContain(CCLOUD_CONNECTION_ID);
+    });
+
+    // --- Assertion 3: discovery tools report both connections correctly ---
+
+    it("should list both connections with flink tools enabled on ccloud only", async () => {
+      const result = await server.client.callTool({
+        name: ToolName.LIST_CONFIGURED_CONNECTIONS,
+        arguments: {},
+      });
+      expect(result.isError, textContent(result)).not.toBe(true);
+
+      const { connections } = result.structuredContent as {
+        connections: Record<string, { enabledTools: string[] }>;
+      };
+      expect(
+        Object.keys(connections).sort((a, b) => a.localeCompare(b)),
+      ).toEqual([CCLOUD_CONNECTION_ID, CP_CONNECTION_ID]);
+
+      const ccloudTools = connections[CCLOUD_CONNECTION_ID]?.enabledTools ?? [];
+      const cpTools = connections[CP_CONNECTION_ID]?.enabledTools ?? [];
+      expect(ccloudTools).toContain(ToolName.LIST_FLINK_STATEMENTS);
+      expect(ccloudTools).toContain(ToolName.LIST_TOPICS);
+      expect(cpTools).toContain(ToolName.LIST_TOPICS);
+      expect(cpTools).not.toContain(ToolName.LIST_FLINK_STATEMENTS);
+    });
+
+    it("should describe each connection's blocks, exposing flink on ccloud only", async () => {
+      const ccloudCard = (
+        await server.client.callTool({
+          name: ToolName.DESCRIBE_CONFIGURED_CONNECTION,
+          arguments: { connectionId: CCLOUD_CONNECTION_ID },
+        })
+      ).structuredContent as {
+        blocks: Record<string, unknown>;
+        enabledTools: string[];
+      };
+      expect(ccloudCard.blocks).toHaveProperty("kafka");
+      expect(ccloudCard.blocks).toHaveProperty("flink");
+      expect(ccloudCard.enabledTools).toContain(ToolName.LIST_FLINK_STATEMENTS);
+
+      const cpCard = (
+        await server.client.callTool({
+          name: ToolName.DESCRIBE_CONFIGURED_CONNECTION,
+          arguments: { connectionId: CP_CONNECTION_ID },
+        })
+      ).structuredContent as {
+        blocks: Record<string, unknown>;
+        enabledTools: string[];
+      };
+      expect(cpCard.blocks).toHaveProperty("kafka");
+      expect(cpCard.blocks).not.toHaveProperty("flink");
+      expect(cpCard.enabledTools).not.toContain(ToolName.LIST_FLINK_STATEMENTS);
+    });
+  });
+});

--- a/src/confluent/tools/multi-connection.integration.test.ts
+++ b/src/confluent/tools/multi-connection.integration.test.ts
@@ -126,7 +126,10 @@ describe("multi-connection routing", { tags: [Tag.MULTI] }, () => {
       name: ToolName,
       args: Record<string, unknown>,
     ): Promise<string> {
-      let result;
+      // Typed (not bare `let result`, which would be implicit any). The expect
+      // stays *outside* the try so a wrongly-successful call fails the test
+      // rather than having its AssertionError caught and returned as a string.
+      let result: Awaited<ReturnType<typeof server.client.callTool>>;
       try {
         result = await server.client.callTool({ name, arguments: args });
       } catch (error) {

--- a/test-fixtures/yaml_configs/integration.multi.yaml
+++ b/test-fixtures/yaml_configs/integration.multi.yaml
@@ -92,8 +92,7 @@ connections:
       extra_properties:
         security.protocol: "SASL_PLAINTEXT"
         sasl.mechanisms: "PLAIN"
-
-    # --- @cp (Schema Registry) ---
-    # The local SR runs unauthenticated; no auth block is needed.
-    schema_registry:
-      endpoint: "http://localhost:8081"
+    # No schema_registry / flink / etc. block: `cp` is deliberately kafka-only,
+    # so it's the non-Flink connection in the routing assertions. (The docker
+    # stack still runs a local SR for the @cp suite; this fixture just doesn't
+    # wire `cp` to it.)

--- a/test-fixtures/yaml_configs/integration.multi.yaml
+++ b/test-fixtures/yaml_configs/integration.multi.yaml
@@ -1,0 +1,99 @@
+# Two-connection integration fixture for the #543 multi-connection suite.
+#
+# Boots one MCP server holding two `direct` connections to two different Kafka
+# clusters, only one of which carries a `flink:` block:
+#
+#   - `ccloud` — the CCloud cluster (mirrors integration.yaml): kafka + flink +
+#     schema_registry + confluent_cloud + telemetry + tableflow. The sole
+#     Flink-capable connection.
+#   - `cp`     — the local Confluent Platform broker (mirrors integration.cp.yaml):
+#     kafka only, SASL_PLAINTEXT. No flink, so Flink tools enable on `ccloud` only.
+#
+# The `cp` connection requires the docker-compose.cp-test.yml stack running:
+#   docker compose -f docker-compose.cp-test.yml up -d
+#
+# Secrets are `${VAR}` interpolation from .env.integration (CCloud secrets via
+# `make setup-test-env`; the static CP creds CP_KAFKA_USERNAME/CP_KAFKA_PASSWORD
+# are documented in .env.integration.example). A missing secret env var throws at
+# YAML load time; tests/harness/multi-runtime.ts catches it and the suite skips.
+server:
+  log_level: error
+
+connections:
+  ccloud:
+    type: direct
+
+    # --- @kafka (admin client + REST proxy) ---
+    kafka:
+      auth:
+        type: api_key
+        key: "${KAFKA_API_KEY}"
+        secret: "${KAFKA_API_SECRET}"
+      bootstrap_servers: "pkc-921jm.us-east-2.aws.confluent.cloud:9092"
+      cluster_id: "lkc-dm5vyd"
+      env_id: "env-rw7g8k"
+      rest_endpoint: "https://pkc-921jm.us-east-2.aws.confluent.cloud:443"
+
+    # --- @schema (Schema Registry) ---
+    schema_registry:
+      auth:
+        type: api_key
+        key: "${SCHEMA_REGISTRY_API_KEY}"
+        secret: "${SCHEMA_REGISTRY_API_SECRET}"
+      endpoint: "https://psrc-4xmdo33.us-east-2.aws.confluent.cloud"
+
+    # --- @clusters / @environments / @connect / @catalog / @search / @billing (CCloud control plane) ---
+    confluent_cloud:
+      auth:
+        type: api_key
+        key: "${CONFLUENT_CLOUD_API_KEY}"
+        secret: "${CONFLUENT_CLOUD_API_SECRET}"
+
+    # --- @metrics (Telemetry API) ---
+    telemetry:
+      auth:
+        type: api_key
+        key: "${TELEMETRY_API_KEY}"
+        secret: "${TELEMETRY_API_SECRET}"
+
+    # --- @flink (Flink SQL + catalog/diagnostics) ---
+    flink:
+      auth:
+        type: api_key
+        key: "${FLINK_API_KEY}"
+        secret: "${FLINK_API_SECRET}"
+      # any future updates to the configured Flink compute pool must ensure the associated cloud
+      # provider/region pair matches the cluster in the `kafka` block
+      compute_pool_id: "lfcp-1gv99z"
+      endpoint: "https://flink.us-east-2.aws.confluent.cloud"
+      environment_id: "env-rw7g8k"
+      organization_id: "683187f4-4132-484a-adf7-0553cea0a5e4"
+
+    # --- @tableflow ---
+    tableflow:
+      auth:
+        type: api_key
+        key: "${TABLEFLOW_API_KEY}"
+        secret: "${TABLEFLOW_API_SECRET}"
+
+  cp:
+    type: direct
+
+    # --- @cp (Kafka) ---
+    # SASL_PLAINTEXT is used instead of SASL_SSL to avoid cert setup.
+    # The extra_properties block overrides the default security.protocol
+    # from SASL_SSL to SASL_PLAINTEXT for the local CP stack.
+    kafka:
+      bootstrap_servers: "localhost:9092"
+      auth:
+        type: api_key
+        key: "${CP_KAFKA_USERNAME}"
+        secret: "${CP_KAFKA_PASSWORD}"
+      extra_properties:
+        security.protocol: "SASL_PLAINTEXT"
+        sasl.mechanisms: "PLAIN"
+
+    # --- @cp (Schema Registry) ---
+    # The local SR runs unauthenticated; no auth block is needed.
+    schema_registry:
+      endpoint: "http://localhost:8081"

--- a/tests/harness/multi-kafka-admin.ts
+++ b/tests/harness/multi-kafka-admin.ts
@@ -1,0 +1,67 @@
+/**
+ * Test-side Kafka admin helper for the #543 multi-connection suite.
+ *
+ * Where kafka-admin.ts and cp-kafka-admin.ts each read their *sole* fixture
+ * connection, this builds an admin client from an explicitly-passed
+ * {@link DirectConnectionConfig}, so one helper serves both clusters the multi
+ * fixture holds. `security.protocol` defaults to `sasl_ssl` (the CCloud shape)
+ * and is overridden by the connection's `extra_properties` (the CP broker sets
+ * `SASL_PLAINTEXT` there), exactly as the production client resolves it.
+ */
+
+import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
+import { type DirectConnectionConfig } from "@src/config/models.js";
+
+/**
+ * Connects a Kafka admin client directly (not via the MCP server) against the
+ * cluster described by `conn`, for test-side topic lifecycle and verification.
+ * Callers must `admin.disconnect()` when done.
+ */
+export async function connectAdminForConnection(
+  conn: DirectConnectionConfig,
+  clientId: string,
+): Promise<KafkaJS.Admin> {
+  const admin = new KafkaJS.Kafka({
+    ...kafkaConfigForConnection(conn, clientId),
+    kafkaJS: { logger: silentKafkaLogger } as KafkaJS.KafkaConfig,
+  }).admin();
+  await admin.connect();
+  return admin;
+}
+
+/**
+ * Builds the librdkafka config for `conn`'s kafka block. Mirrors the protocol
+ * resolution the production client uses: a default of `sasl_ssl` overridden by
+ * whatever `extra_properties` carries (so the CP broker's `SASL_PLAINTEXT` wins),
+ * with `extra_properties` merged last so the test-side client matches exactly
+ * what the server sends to librdkafka.
+ */
+function kafkaConfigForConnection(
+  conn: DirectConnectionConfig,
+  clientId: string,
+): GlobalConfig {
+  if (!conn.kafka?.bootstrap_servers || !conn.kafka.auth) {
+    throw new Error(
+      "test-side multi kafka admin requires kafka.bootstrap_servers + kafka.auth on the connection",
+    );
+  }
+  const extraProps = conn.kafka.extra_properties ?? {};
+  return {
+    "bootstrap.servers": conn.kafka.bootstrap_servers,
+    "client.id": clientId,
+    "security.protocol": "sasl_ssl",
+    "sasl.mechanisms": "PLAIN",
+    "sasl.username": conn.kafka.auth.key,
+    "sasl.password": conn.kafka.auth.secret,
+    ...extraProps,
+  };
+}
+
+const silentKafkaLogger: KafkaJS.Logger = {
+  namespace: () => silentKafkaLogger,
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  setLogLevel: () => {},
+};

--- a/tests/harness/multi-runtime.test.ts
+++ b/tests/harness/multi-runtime.test.ts
@@ -1,5 +1,11 @@
 import { loadConfigFromYaml } from "@src/config/index.js";
-import { isMissingInterpolationVar } from "@tests/harness/multi-runtime.js";
+import { MCPServerConfiguration } from "@src/config/models.js";
+import {
+  assertExpectedConnections,
+  CCLOUD_CONNECTION_ID,
+  CP_CONNECTION_ID,
+  isMissingInterpolationVar,
+} from "@tests/harness/multi-runtime.js";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -62,5 +68,36 @@ describe("isMissingInterpolationVar", () => {
   it("should not classify a non-Error value as skip-eligible", () => {
     expect(isMissingInterpolationVar("some string")).toBe(false);
     expect(isMissingInterpolationVar(undefined)).toBe(false);
+  });
+});
+
+/** Builds a config holding exactly the given connection ids (minimal direct connections). */
+function configWith(ids: string[]): MCPServerConfiguration {
+  return new MCPServerConfiguration({
+    connections: Object.fromEntries(ids.map((id) => [id, { type: "direct" }])),
+  });
+}
+
+describe("assertExpectedConnections", () => {
+  it("should pass when both ccloud and cp are present", () => {
+    expect(() =>
+      assertExpectedConnections(
+        configWith([CCLOUD_CONNECTION_ID, CP_CONNECTION_ID]),
+      ),
+    ).not.toThrow();
+  });
+
+  // A loaded fixture missing an expected id is drift, not a creds-skip: it must
+  // throw loudly rather than green-skip the suite.
+  it("should throw naming the missing cp connection (fixture drift)", () => {
+    expect(() =>
+      assertExpectedConnections(configWith([CCLOUD_CONNECTION_ID])),
+    ).toThrow(/"cp".*drift|drift.*"cp"|missing connection id "cp"/i);
+  });
+
+  it("should throw naming the missing ccloud connection (fixture drift)", () => {
+    expect(() =>
+      assertExpectedConnections(configWith([CP_CONNECTION_ID])),
+    ).toThrow(/ccloud/);
   });
 });

--- a/tests/harness/multi-runtime.test.ts
+++ b/tests/harness/multi-runtime.test.ts
@@ -1,0 +1,66 @@
+import { loadConfigFromYaml } from "@src/config/index.js";
+import { isMissingInterpolationVar } from "@tests/harness/multi-runtime.js";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/** Writes `content` to a throwaway YAML file and returns its path. */
+function tempYaml(content: string): string {
+  const path = join(
+    mkdtempSync(join(tmpdir(), "multi-runtime-test-")),
+    "config.yaml",
+  );
+  writeFileSync(path, content);
+  return path;
+}
+
+/** Runs {@link loadConfigFromYaml} expecting failure, returning the thrown error. */
+function loadError(
+  content: string,
+  env: Record<string, string | undefined> = {},
+): unknown {
+  try {
+    loadConfigFromYaml(tempYaml(content), env);
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected loadConfigFromYaml to throw but it succeeded");
+}
+
+describe("isMissingInterpolationVar", () => {
+  // The skip-eligible case: a required ${VAR} absent from env (creds not
+  // configured) — the only failure the @multi suite should silently skip on.
+  it("should classify a missing ${VAR} as the skip-eligible case", () => {
+    const error = loadError(
+      'connections:\n  c:\n    type: direct\n    kafka:\n      bootstrap_servers: "${UNSET_MULTI_TEST_VAR}"\n',
+      {},
+    );
+    expect((error as Error).message).toContain(
+      "Environment variable not found",
+    );
+    expect(isMissingInterpolationVar(error)).toBe(true);
+  });
+
+  // A malformed fixture is a real regression, not a creds-skip: it must fail
+  // loudly rather than green-skip the suite.
+  it("should not classify a malformed-YAML error as skip-eligible", () => {
+    const error = loadError("connections: [unterminated\n");
+    expect((error as Error).message).toContain("Failed to parse YAML");
+    expect(isMissingInterpolationVar(error)).toBe(false);
+  });
+
+  // A schema-invalid fixture is likewise a real regression that must propagate.
+  it("should not classify a schema-validation error as skip-eligible", () => {
+    const error = loadError("connections:\n  c:\n    type: not-a-real-type\n");
+    expect((error as Error).message).toContain(
+      "Configuration validation failed",
+    );
+    expect(isMissingInterpolationVar(error)).toBe(false);
+  });
+
+  it("should not classify a non-Error value as skip-eligible", () => {
+    expect(isMissingInterpolationVar("some string")).toBe(false);
+    expect(isMissingInterpolationVar(undefined)).toBe(false);
+  });
+});

--- a/tests/harness/multi-runtime.ts
+++ b/tests/harness/multi-runtime.ts
@@ -1,0 +1,121 @@
+/**
+ * Harness helpers for the #543 multi-connection integration suite.
+ *
+ * Mirrors runtime.ts / cp-runtime.ts but targets
+ * test-fixtures/yaml_configs/integration.multi.yaml, which holds two `direct`
+ * connections — `ccloud` (CCloud, the sole Flink-capable connection) and `cp`
+ * (the local Confluent Platform broker, kafka only). The suite uses these to
+ * prove tool calls route to the addressed connection against live infra.
+ */
+
+import { loadConfigFromYaml } from "@src/config/index.js";
+import {
+  type ConnectionConfig,
+  MCPServerConfiguration,
+} from "@src/config/models.js";
+import { TransportType } from "@src/mcp/transports/types.js";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { parse, stringify } from "yaml";
+
+const MULTI_FIXTURE_PATH = resolve(
+  process.cwd(),
+  "test-fixtures/yaml_configs/integration.multi.yaml",
+);
+
+/** The CCloud connection's id — the sole Flink-capable connection in the fixture. */
+export const CCLOUD_CONNECTION_ID = "ccloud";
+
+/** The local Confluent Platform broker connection's id — kafka only, no flink. */
+export const CP_CONNECTION_ID = "cp";
+
+/**
+ * The {@link ConnectionConfig} the spawned MCP server would see for `connId`,
+ * resolved by id from the multi fixture. The two-connection peer of
+ * {@linkcode integrationConnection} in runtime.ts: a single connection is the
+ * right-sized input for a {@linkcode ConnectionPredicate} gate, so a test gates
+ * each connection it needs independently.
+ *
+ * On load failure (a required `${VAR}` missing — creds absent, or the CP broker's
+ * static creds not present) returns an empty `direct` connection so the gate skips
+ * cleanly. A loaded fixture missing `connId` is drift, not a creds-skip, and
+ * {@linkcode MCPServerConfiguration.getConnectionConfig} throws loudly.
+ */
+export function multiIntegrationConnection(connId: string): ConnectionConfig {
+  const config = tryLoadMultiConfig();
+  if (config === undefined) return { type: "direct" };
+  return config.getConnectionConfig(connId);
+}
+
+/**
+ * Whether the multi fixture loaded with **both** the `ccloud` and `cp`
+ * connections present. The suite gates on this so an environment missing either
+ * cluster's creds (no CCloud Vault secrets, or the CP broker creds absent) skips
+ * cleanly rather than spawning a half-configured server.
+ */
+export function multiIntegrationConnectionsLoaded(): boolean {
+  const config = tryLoadMultiConfig();
+  if (config === undefined) return false;
+  const ids = config.getConnectionIds();
+  return ids.includes(CCLOUD_CONNECTION_ID) && ids.includes(CP_CONNECTION_ID);
+}
+
+/**
+ * Loads the multi fixture into an {@link MCPServerConfiguration}, or `undefined`
+ * when the YAML fails to load (a required `${VAR}` missing). The seam both
+ * {@linkcode multiIntegrationConnection} and {@linkcode multiIntegrationConnectionsLoaded}
+ * build on.
+ */
+function tryLoadMultiConfig(): MCPServerConfiguration | undefined {
+  try {
+    return loadConfigFromYaml(MULTI_FIXTURE_PATH, process.env);
+  } catch {
+    return undefined;
+  }
+}
+
+export interface MultiSpawnConfigOptions {
+  transport: TransportType;
+  httpPort?: number;
+  authDisabled?: boolean;
+  apiKey?: string;
+}
+
+/**
+ * Writes a per-spawn multi-connection config to a temp file, exactly like
+ * {@linkcode spawnConfigPath} in runtime.ts but reading the multi fixture.
+ * Returns the path the harness passes via `--config` to the spawned server.
+ */
+export function multiSpawnConfigPath(options: MultiSpawnConfigOptions): string {
+  const parsed = parse(readFileSync(MULTI_FIXTURE_PATH, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+  const server = {
+    ...((parsed.server as Record<string, unknown> | undefined) ?? {}),
+    transports: [options.transport],
+  } as Record<string, unknown>;
+
+  if (options.httpPort !== undefined) {
+    const http = (server.http as Record<string, unknown> | undefined) ?? {};
+    server.http = { ...http, port: options.httpPort };
+  }
+
+  if (options.authDisabled !== undefined || options.apiKey !== undefined) {
+    const auth = (server.auth as Record<string, unknown> | undefined) ?? {};
+    if (options.apiKey !== undefined) {
+      auth.disabled = false;
+      auth.api_key = options.apiKey;
+    } else if (options.authDisabled !== undefined) {
+      auth.disabled = options.authDisabled;
+    }
+    server.auth = auth;
+  }
+
+  parsed.server = server;
+  const dir = mkdtempSync(join(tmpdir(), "mcp-confluent-multi-integration-"));
+  const filePath = join(dir, "config.yaml");
+  writeFileSync(filePath, stringify(parsed));
+  return filePath;
+}

--- a/tests/harness/multi-runtime.ts
+++ b/tests/harness/multi-runtime.ts
@@ -49,16 +49,40 @@ export function multiIntegrationConnection(connId: string): ConnectionConfig {
 }
 
 /**
- * Whether the multi fixture loaded with **both** the `ccloud` and `cp`
- * connections present. The suite gates on this so an environment missing either
- * cluster's creds (no CCloud Vault secrets, or the CP broker creds absent) skips
- * cleanly rather than spawning a half-configured server.
+ * Whether the multi fixture loaded — gating the suite on creds presence. Returns
+ * `false` only when the YAML failed to load (a required `${VAR}` absent — creds
+ * not configured), so a credential-less environment skips cleanly. A fixture
+ * that loads but lacks an expected connection id is drift, not a creds-skip:
+ * {@linkcode assertExpectedConnections} throws loudly rather than letting the
+ * suite green-skip.
  */
 export function multiIntegrationConnectionsLoaded(): boolean {
   const config = tryLoadMultiConfig();
   if (config === undefined) return false;
+  assertExpectedConnections(config);
+  return true;
+}
+
+/**
+ * Asserts the loaded `config` holds both expected connection ids. A missing one
+ * means the fixture drifted (a connection renamed or removed) — a real
+ * regression that must fail loudly, never a silent skip. Split out (mirroring
+ * `hasIntegrationConnection` in runtime.ts) so the drift check is unit-testable
+ * against a directly-constructed config.
+ */
+export function assertExpectedConnections(
+  config: MCPServerConfiguration,
+): void {
   const ids = config.getConnectionIds();
-  return ids.includes(CCLOUD_CONNECTION_ID) && ids.includes(CP_CONNECTION_ID);
+  for (const required of [CCLOUD_CONNECTION_ID, CP_CONNECTION_ID]) {
+    if (!ids.includes(required)) {
+      throw new Error(
+        `Multi-connection fixture loaded but missing connection id "${required}" ` +
+          `(have: ${ids.join(", ") || "none"}). This is fixture drift in ` +
+          `integration.multi.yaml, not a creds-skip.`,
+      );
+    }
+  }
 }
 
 /**

--- a/tests/harness/multi-runtime.ts
+++ b/tests/harness/multi-runtime.ts
@@ -63,16 +63,32 @@ export function multiIntegrationConnectionsLoaded(): boolean {
 
 /**
  * Loads the multi fixture into an {@link MCPServerConfiguration}, or `undefined`
- * when the YAML fails to load (a required `${VAR}` missing). The seam both
- * {@linkcode multiIntegrationConnection} and {@linkcode multiIntegrationConnectionsLoaded}
- * build on.
+ * only when a required `${VAR}` is absent (creds not configured) — the clean
+ * skip case. A malformed or schema-invalid fixture is a real regression and
+ * propagates so CI fails loudly instead of green-skipping the suite. The seam
+ * both {@linkcode multiIntegrationConnection} and
+ * {@linkcode multiIntegrationConnectionsLoaded} build on.
  */
 function tryLoadMultiConfig(): MCPServerConfiguration | undefined {
   try {
     return loadConfigFromYaml(MULTI_FIXTURE_PATH, process.env);
-  } catch {
-    return undefined;
+  } catch (error) {
+    if (isMissingInterpolationVar(error)) return undefined;
+    throw error;
   }
+}
+
+/**
+ * True when `error` is {@linkcode loadConfigFromYaml}'s "a required `${VAR}` is
+ * absent from env" failure — the expected creds-absent case the `@multi` gate
+ * skips on. Every other load failure (malformed YAML, schema-invalid fixture)
+ * is a regression that must propagate. Exported for the colocated unit test.
+ */
+export function isMissingInterpolationVar(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("Environment variable not found")
+  );
 }
 
 export interface MultiSpawnConfigOptions {

--- a/tests/harness/multi-start-server.ts
+++ b/tests/harness/multi-start-server.ts
@@ -1,0 +1,217 @@
+/**
+ * Server-spawn helper for the #543 multi-connection integration suite.
+ *
+ * Mirrors cp-start-server.ts but passes {@linkcode multiSpawnConfigPath}, so the
+ * spawned server reads the two-connection fixture (integration.multi.yaml) and
+ * holds both the `ccloud` and `cp` connections at once.
+ *
+ * The public API — {@linkcode StartedServer} and {@linkcode startMultiServer} —
+ * matches {@linkcode startServer} so test files only import from this module.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { TransportType } from "@src/mcp/transports/types.js";
+import { findFreePort } from "@tests/harness/find-port.js";
+import { multiSpawnConfigPath } from "@tests/harness/multi-runtime.js";
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { resolve } from "node:path";
+
+// Re-export so multi-connection test files have a single import point.
+export type { StartedServer } from "@tests/harness/start-server.js";
+
+import type { StartedServer } from "@tests/harness/start-server.js";
+
+const SERVER_ENTRY = resolve(process.cwd(), "dist/index.js");
+
+export interface StartMultiServerOptions {
+  transport: TransportType;
+  env?: Record<string, string>;
+}
+
+/**
+ * Spawns the MCP server against the multi-connection fixture and connects an SDK
+ * {@link Client} over the requested transport. Mirrors {@linkcode startServer}
+ * but points the server at integration.multi.yaml via
+ * {@linkcode multiSpawnConfigPath}.
+ *
+ * Always call {@linkcode StartedServer.stop} in `afterAll`.
+ */
+export async function startMultiServer(
+  options: StartMultiServerOptions,
+): Promise<StartedServer> {
+  switch (options.transport) {
+    case TransportType.HTTP:
+      return await startMultiHttp(options);
+    case TransportType.SSE:
+      return await startMultiSse(options);
+    case TransportType.STDIO:
+      return await startMultiStdio(options);
+  }
+}
+
+async function startMultiHttp(
+  options: StartMultiServerOptions,
+): Promise<StartedServer> {
+  const port = await findFreePort();
+  const child = await spawnMultiHttpChild(options, port);
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${baseUrl}/mcp`),
+  );
+  const client = newClient();
+  await client.connect(transport);
+
+  return { client, baseUrl, stop: makeHttpStop(client, child) };
+}
+
+async function startMultiSse(
+  options: StartMultiServerOptions,
+): Promise<StartedServer> {
+  const port = await findFreePort();
+  const child = await spawnMultiHttpChild(options, port);
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const transport = new SSEClientTransport(new URL(`${baseUrl}/sse`));
+  const client = newClient();
+  await client.connect(transport);
+
+  return { client, baseUrl, stop: makeHttpStop(client, child) };
+}
+
+async function startMultiStdio(
+  options: StartMultiServerOptions,
+): Promise<StartedServer> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [
+      "--no-deprecation",
+      SERVER_ENTRY,
+      "--config",
+      multiSpawnConfigPath({ transport: options.transport }),
+    ],
+    env: buildEnv(options.env),
+    stderr: "inherit",
+  });
+  const client = newClient();
+  await client.connect(transport);
+
+  const child = (transport as unknown as { _process?: ChildProcess })._process;
+
+  const stop = async () => {
+    await client.close();
+    if (child && child.exitCode === null) {
+      await once(child, "exit").catch(() => {});
+    }
+  };
+
+  return { client, stop };
+}
+
+async function spawnMultiHttpChild(
+  options: StartMultiServerOptions,
+  port: number,
+): Promise<ChildProcess> {
+  const child: ChildProcess = spawn(
+    process.execPath,
+    [
+      "--no-deprecation",
+      SERVER_ENTRY,
+      "--config",
+      multiSpawnConfigPath({
+        transport: options.transport,
+        httpPort: port,
+        authDisabled: true,
+      }),
+    ],
+    {
+      env: buildEnv(options.env),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let outputBuf = "";
+  child.stdout?.on("data", (chunk) => {
+    outputBuf += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    outputBuf += String(chunk);
+  });
+
+  try {
+    await waitForPing(`http://127.0.0.1:${port}/ping`, child, () => outputBuf);
+  } catch (error) {
+    if (child.exitCode === null) {
+      child.kill("SIGTERM");
+      await once(child, "exit").catch(() => {});
+    }
+    throw error;
+  }
+  return child;
+}
+
+async function waitForPing(
+  url: string,
+  child: ChildProcess,
+  getOutput: () => string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `server exited with code ${child.exitCode} before /ping was ready:\n${getOutput()}`,
+      );
+    }
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: "1", method: "ping" }),
+      });
+      if (response.ok) return;
+      lastError = new Error(`ping returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    `server /ping never became ready: ${String(lastError)}\n${getOutput()}`,
+  );
+}
+
+function makeHttpStop(client: Client, child: ChildProcess) {
+  return async () => {
+    await client.close();
+    if (child.exitCode === null) {
+      child.kill("SIGTERM");
+      await once(child, "exit").catch(() => {});
+    }
+  };
+}
+
+function buildEnv(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string") merged[key] = value;
+  }
+  merged.NODE_ENV = "integration";
+  for (const [key, value] of Object.entries(overrides)) {
+    merged[key] = value;
+  }
+  return merged;
+}
+
+function newClient(): Client {
+  return new Client({
+    name: "mcp-confluent-multi-integration",
+    version: "0.0.0-test",
+  });
+}

--- a/tests/tags.ts
+++ b/tests/tags.ts
@@ -14,7 +14,8 @@
  *
  * Cross-cutting tags: {@link Tag.SMOKE} marks transport-layer tests that
  * don't belong to any tool group; {@link Tag.OAUTH} marks tests that exercise
- * the OAuth flow.
+ * the OAuth flow; {@link Tag.MULTI} marks the multi-connection suite that boots
+ * a server holding two connections at once.
  *
  * {@see https://vitest.dev/guide/test-tags}
  */
@@ -23,6 +24,13 @@ export enum Tag {
 
   // Tests that work with an OAuth connection
   OAUTH = "@oauth",
+
+  // Multi-connection suite: one server, two connections (CCloud + local CP
+  // broker), proving per-connection routing against live infra. Cross-cutting
+  // (spans kafka + flink + diagnostics), so it's neither a tool-group nor a
+  // service-config tag. Stood up in CI by its own block, which boots the CP
+  // docker stack (see .semaphore/integration.yml).
+  MULTI = "@multi",
 
   // Tool-group axis: matches handler directories
   BILLING = "@billing",

--- a/tests/tags.ts
+++ b/tests/tags.ts
@@ -29,7 +29,9 @@ export enum Tag {
   // broker), proving per-connection routing against live infra. Cross-cutting
   // (spans kafka + flink + diagnostics), so it's neither a tool-group nor a
   // service-config tag. Stood up in CI by its own block, which boots the CP
-  // docker stack (see .semaphore/integration.yml).
+  // docker stack — currently the per-PR `Integration Tests: multi` block in
+  // .semaphore/semaphore.yml; a follow-up moves it to the scheduled
+  // .semaphore/integration.yml pipeline.
   MULTI = "@multi",
 
   // Tool-group axis: matches handler directories


### PR DESCRIPTION
# Multi-connection integration test(s)

## Multi-connection integration coverage

The multi-connection epic (#532) weaned the codebase off the "at most one connection" assumption; this is the integration suite that proves the result against live infrastructure rather than unit fixtures. It boots one MCP server holding **two `direct` connections to two different Kafka clusters, only one of which carries a `flink:` block**, and asserts that each tool call routes to the connection it addresses.

- **Topology.** A new fixture, `test-fixtures/yaml_configs/integration.multi.yaml`, defines two connections: `ccloud` (the CCloud cluster — kafka + flink + schema_registry + confluent_cloud + telemetry + tableflow, the sole Flink-capable connection) and `cp` (the local Confluent Platform broker from `docker-compose.cp-test.yml` — kafka only, SASL_PLAINTEXT, deliberately Flink-less). Two genuinely distinct clusters, so the two `list-topics` responses are provably different sets.
- **What it proves** (`src/confluent/tools/multi-connection.integration.test.ts`, tagged `@multi`, run across stdio/http/sse):
  - **Kafka routing.** `list-topics` with `connectionId: ccloud` returns ccloud's seeded topic and not cp's; with `connectionId: cp`, the reverse. The injected `connectionId` enum advertises both ids as candidates and is required, so omitting it errors.
  - **Per-tool candidate narrowing.** `list-flink-statements`' injected `connectionId` enum is `["ccloud"]` only; it resolves against `ccloud` and rejects `cp` (no flink block) at call time.
  - **Discovery.** `list-configured-connections` reports both connections with flink tools enabled on `ccloud` only; `describe-configured-connection` shows a `flink` block on `ccloud` but not on `cp`.
- **Harness.** Mirrors the existing `cp-*` parallel-module convention: `tests/harness/multi-runtime.ts` (config load + per-spawn YAML + gating), `tests/harness/multi-start-server.ts` (`startMultiServer`), and `tests/harness/multi-kafka-admin.ts` (a connection-parameterized admin builder that derives SASL_SSL vs SASL_PLAINTEXT from `extra_properties`, serving both clusters from one helper). `Tag.MULTI` was added to `tests/tags.ts`.
- **Fail-loud gating.** The fixture-load helper skips the suite only for the expected creds-absent case (a required `${VAR}` missing); a malformed or schema-invalid fixture propagates instead of green-skipping CI. Pinned by `tests/harness/multi-runtime.test.ts`, which drives `loadConfigFromYaml` against real temp fixtures to assert missing-var → skip, but malformed-YAML and schema-invalid → throw.

### Reframed per #590

The issue body predates #590, which makes a multi-connection server inject a **required** `connectionId` enum into every connection-oriented tool — even one with a single viable candidate (the enum is just narrowed to it). So the issue's original "Flink tool auto-routes with no `connectionId`" no longer holds on a multi-connection server; the suite instead proves the narrowing (Flink's enum is `["ccloud"]`, `cp` is rejected). A comment in the test pins this so a future reader doesn't "fix" it back to the stale expectation.

## CP broker compose fix (prerequisite)

`docker-compose.cp-test.yml` could never start `cp-kafka:7.6.1` on a clean host — two deterministic bugs crash-looped the broker, which is why any CP-backed test saw "Connection refused":

1. **Unset `KAFKA_OPTS`.** cp-kafka's `configure` runs `dub ensure KAFKA_OPTS` whenever SASL appears in the advertised listeners and aborts startup if it's unset. Set to a harmless non-empty JVM flag (the JAAS login is supplied per-listener).
2. **Single-underscore JAAS key.** cp-docker maps env keys `_`→`.` and `__`→`_`. The listener is named `SASL_PLAINTEXT` (literal underscore), so `KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG` produced an ignored `listener.name.sasl.plaintext...` property and Kafka fell back to a missing global JAAS file. The key must double the underscore: `..._SASL__PLAINTEXT_...`.

This fix is the prerequisite that makes any CP-backed integration test runnable. It also unblocks the **pre-existing** `@cp` suite, which could not have passed against this compose on a clean agent — see the follow-up note below.

## CI proof run (temporary per-PR placement)

To prove the suite green on the introducing PR, a per-PR `Integration Tests: multi` block was added to `.semaphore/semaphore.yml`. It stands up the `docker-compose.cp-test.yml` stack (`docker-compose ... up -d` + `dockerize -wait` on the broker port, since the amd64 agents ship docker-compose v1.29.2 with no `--wait`), supplies the static non-secret CP creds, runs `make test-integration TAGS=@multi`, and tears the stack down. It fires on changes to the multi-connection fixture/harness/test or the CP compose file.

A follow-up will move this to the scheduled/manual `integration.yml` pipeline (gated on a `@multi` `SERVICE_CONFIGS` sentinel) and delete the per-PR block, so the docker + two-cluster cost stays off every PR. The green per-PR run on this PR is the evidence that the scheduled block will work.

## Follow-ups

- **Move `@multi` to scheduled-only** (delete the per-PR block, add the `integration.yml` block + `SERVICE_CONFIGS` defaults). Also add the `.claude/rules/integration-tests.md` note for the multi fixture/tag once the CI shape is final.
- **Dormant `@cp` CI gap.** Nothing in CI currently stands up the CP docker stack, so the existing `*.cp.integration.test.ts` suite appears never to have executed on an agent — and with the pre-fix compose it could not have passed anyway. Worth a dedicated issue to give `@cp` real CI coverage now that the broker starts.

## Relationships

- Closes #543.
- Closes #532 (Epic: Multi-connection support), being the last child!
