### PR TITLE
Deflake the oauth integration tests.

### DIFF
--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -448,13 +448,19 @@ describe("<handler>", { tags: [Tag.<GROUP>] }, () => {
       return;
     }
 
-    describe.each(activeTransports)("via %s transport", (transport) => {
+    describe.each(activeOAuthTransports)("via %s transport", (transport) => {
       // oauth-only beforeAll (startOAuthServer + 180_000 timeout) / afterAll (stopOAuthServer)
       // tool calls dispatch via callToolWithOAuthFlow(server, credentials, ...)
     });
   });
 });
 ```
+
+**Every OAuth describe iterates `activeOAuthTransports` (stdio only), not `activeTransports`** — the direct describe keeps `activeTransports` (all three).
+The Auth0/PKCE sign-in is transport-agnostic, so running it on every transport adds no coverage the direct describes and the smoke suite don't already provide; it only multiplies work.
+And that work is serialized: every OAuth describe blocks on a single hard-coded callback port (`acquireOAuthPortLock`), so ×3 transports triples the serialized lock-holds — enough, in the OAuth-heavy `@kafka` job, to push queued `beforeAll`s past their 180s hook timeout.
+The OAuth-flow smoke test (`ccloud-oauth.integration.test.ts`) is stdio-only for the same reason.
+CI additionally runs the OAuth lane sequentially; see the CI Matrix section.
 
 Tags are **additive down the describe tree**: the outer describe carries the group tag (`Tag.<GROUP>`), the inner `oauth` describe adds `Tag.OAUTH`, the inner `direct` describe adds nothing.
 A test inside `direct` therefore runs under `[Tag.<GROUP>]`; a test inside `oauth` runs under `[Tag.<GROUP>, Tag.OAUTH]`.
@@ -523,6 +529,9 @@ The CI surface has two shapes; they share the harness and the Makefile but diffe
 One block per tool group (12 of them) plus a smoke block, each gated by `run.when: change_in('/src/confluent/tools/handlers/<dir>/', { default_branch: 'main' })`.
 Only the blocks whose handler dirs the PR touched actually run; everything else stays gray.
 Within a block, a single job exercises both connection types sequentially via the harness's `activeConnectionTypes` default; transport (stdio/http/sse) and connection type (direct/oauth) are deliberately NOT Semaphore axes, since splitting them would multiply agent count without unique coverage.
+The **kafka block is the exception**: it splits into two jobs, `@kafka direct` (forwards `INTEGRATION_TEST_CONNECTION_TYPE=direct`, runs parallel) and `@kafka oauth` (forwards `=oauth`, runs sequentially via the Makefile's `--no-file-parallelism`).
+Kafka has 11 OAuth describes — enough that running them across parallel forks piled them into the callback-port lock queue and overran the 180s `beforeAll` hook timeout; isolating the OAuth lane onto its own sequential agent removes the contention while the direct lane keeps its parallelism.
+Other tool groups have few enough OAuth describes that the single-job default doesn't pile up, so they stay unsplit.
 The smoke block fires on any change under `src/` (excluding `*.test.ts`) so transport-layer regressions (auth middleware, multi-client wiring, OAuth flow) trigger regardless of which handler dir the PR touched.
 
 ### Scheduled / manual full (`.semaphore/integration.yml`)

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -175,6 +175,15 @@ blocks:
             - pnpm run test:harness
             - make test-integration TAGS=@flink
 
+  # Kafka splits direct and oauth into two parallel jobs (separate agents) so the
+  # oauth lane can run sequentially without slowing the direct lane. The oauth
+  # describes serialize on a single hard-coded callback port; running them across
+  # parallel forks piled them into a lock queue that overran the 180s beforeAll
+  # hook timeout (flaky "Hook timed out … startOAuthServer"). The oauth job's
+  # `INTEGRATION_TEST_CONNECTION_TYPE=oauth` makes the Makefile add
+  # `--no-file-parallelism`, so each oauth file acquires the free lock instantly;
+  # the direct job stays fully parallel. Separate agents also mean each lane
+  # publishes its own TEST-integration.xml.
   - name: "Integration Tests: kafka"
     dependencies: ["Build & Test"]
     run:
@@ -183,10 +192,14 @@ blocks:
       prologue: *integration-prologue
       epilogue: *integration-epilogue
       jobs:
-        - name: "@kafka"
+        - name: "@kafka direct"
           commands:
             - pnpm run test:harness
-            - make test-integration TAGS=@kafka
+            - INTEGRATION_TEST_CONNECTION_TYPE=direct make test-integration TAGS=@kafka
+        - name: "@kafka oauth"
+          commands:
+            - pnpm run test:harness
+            - INTEGRATION_TEST_CONNECTION_TYPE=oauth make test-integration TAGS=@kafka
 
   - name: "Integration Tests: metrics"
     dependencies: ["Build & Test"]

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,15 @@ remove-test-env:
 #    skips every direct-only test and only exercises the PKCE-flow paths.
 # Unset (local dev) skips the clause entirely; vitest collects everything.
 #
+# The `oauth` lane also appends `--no-file-parallelism`: every oauth describe
+# self-serializes on the single hard-coded OAuth callback port (see
+# tests/harness/oauth-port-lock.ts), so running oauth files across parallel
+# forks only piles them into a lock queue whose wait can exceed the 180s
+# `beforeAll` hook timeout. Running the oauth lane sequentially removes the
+# queue entirely — each file acquires the free lock immediately. Wall clock is
+# unaffected: the lock already serialized this work; the direct lane (a
+# separate, parallel invocation) keeps its parallelism.
+#
 # The `!= "SERVICE_CONFIG"` / `!= "TOOL_GROUP"` / `!= "TRANSPORT"` guards
 # catch a Semaphore misconfiguration where a matrix env-var name leaks
 # through uninterpolated (e.g. `make test-integration TAGS=TOOL_GROUP` if
@@ -132,6 +141,9 @@ test-integration:
 		if [ -d "src/confluent/tools/handlers/$$TAG_SUFFIX" ]; then \
 			set -- "$$@" "src/confluent/tools/handlers/$$TAG_SUFFIX"; \
 		fi; \
+	fi; \
+	if [ "$$INTEGRATION_TEST_CONNECTION_TYPE" = "oauth" ]; then \
+		set -- "$$@" "--no-file-parallelism"; \
 	fi; \
 	if [ ! -f dist/index.js ]; then pnpm run build; fi && \
 	INTEGRATION_TEST_TRANSPORT="$$TRANSPORT_VAL" pnpm exec vitest run \

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.integration.test.ts
@@ -21,7 +21,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -110,37 +113,40 @@ describe(
           return;
         }
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-billing-costs in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            expect(
-              tools.find((t) => t.name === ToolName.LIST_BILLING_COSTS),
-            ).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return billing costs for a 1-day window", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_BILLING_COSTS,
-              arguments: { startDate, endDate },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(result.isError).not.toBe(true);
-            expect(textContent(result)).toMatch(
-              /^Successfully retrieved billing costs:/,
-            );
-          });
-        });
+            it("should expose list-billing-costs in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              expect(
+                tools.find((t) => t.name === ToolName.LIST_BILLING_COSTS),
+              ).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return billing costs for a 1-day window", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_BILLING_COSTS,
+                arguments: { startDate, endDate },
+              });
+
+              expect(result.isError).not.toBe(true);
+              expect(textContent(result)).toMatch(
+                /^Successfully retrieved billing costs:/,
+              );
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.integration.test.ts
@@ -23,7 +23,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -114,36 +117,39 @@ describe(
         // env id is read from the direct YAML; the OAuth-mode handler itself talks to CCloud via OAuth
         const environmentId = getTestEnvironmentId();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-clusters in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            expect(
-              tools.find((t) => t.name === ToolName.LIST_CLUSTERS),
-            ).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return clusters for the resolved environment id", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_CLUSTERS,
-              arguments: { environmentId },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(textContent(result)).toMatch(
-              /^Successfully retrieved [1-9]\d* clusters:/,
-            );
-          });
-        });
+            it("should expose list-clusters in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              expect(
+                tools.find((t) => t.name === ToolName.LIST_CLUSTERS),
+              ).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return clusters for the resolved environment id", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_CLUSTERS,
+                arguments: { environmentId },
+              });
+
+              expect(textContent(result)).toMatch(
+                /^Successfully retrieved [1-9]\d* clusters:/,
+              );
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/environments/list-environments-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.integration.test.ts
@@ -21,7 +21,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -97,36 +100,39 @@ describe(
           return;
         }
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-environments in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            expect(
-              tools.find((t) => t.name === ToolName.LIST_ENVIRONMENTS),
-            ).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return at least one environment from CCloud", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_ENVIRONMENTS,
-              arguments: {},
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
-            // handler's success line starts with "Successfully retrieved N environments:"
-            expect(textContent(result)).toMatch(
-              /^Successfully retrieved \d+ environments:/,
-            );
-          });
-        });
+
+            it("should expose list-environments in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              expect(
+                tools.find((t) => t.name === ToolName.LIST_ENVIRONMENTS),
+              ).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return at least one environment from CCloud", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_ENVIRONMENTS,
+                arguments: {},
+              });
+              // handler's success line starts with "Successfully retrieved N environments:"
+              expect(textContent(result)).toMatch(
+                /^Successfully retrieved \d+ environments:/,
+              );
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/environments/read-environment-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.integration.test.ts
@@ -23,7 +23,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -112,34 +115,37 @@ describe(
         // env id is read from the direct YAML; the OAuth-mode handler itself talks to CCloud via OAuth
         const environmentId = getTestEnvironmentId();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose read-environment in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            expect(
-              tools.find((t) => t.name === ToolName.READ_ENVIRONMENT),
-            ).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return details for the resolved environment id", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.READ_ENVIRONMENT,
-              arguments: { environmentId },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(textContent(result)).toContain(`ID: ${environmentId}`);
-          });
-        });
+            it("should expose read-environment in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              expect(
+                tools.find((t) => t.name === ToolName.READ_ENVIRONMENT),
+              ).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return details for the resolved environment id", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.READ_ENVIRONMENT,
+                arguments: { environmentId },
+              });
+
+              expect(textContent(result)).toContain(`ID: ${environmentId}`);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -136,47 +139,50 @@ describe(
         // seed via the api-key-authed admin client; ALTER_TOPIC_CONFIG goes via OAuth
         const { admin, createdTopics } = withSharedAdminClient();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should alter retention.ms on the test topic via the REST proxy", async () => {
-            const topic = uniqueName(`alter-oauth-${transport}`);
-            createdTopics.push(topic);
-            await admin().createTopics({
-              topics: [{ topic, numPartitions: 1 }],
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.ALTER_TOPIC_CONFIG,
-              arguments: {
-                clusterId,
-                environmentId,
-                topicName: topic,
-                topicConfigs: [
-                  {
-                    name: "retention.ms",
-                    value: "3600000",
-                    operation: "SET",
-                  },
-                ],
-                validateOnly: false,
-              },
-            });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should alter retention.ms on the test topic via the REST proxy", async () => {
+              const topic = uniqueName(`alter-oauth-${transport}`);
+              createdTopics.push(topic);
+              await admin().createTopics({
+                topics: [{ topic, numPartitions: 1 }],
+              });
 
-            expect(textContent(result)).toMatch(
-              /Successfully altered topic config/,
-            );
-          });
-        });
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.ALTER_TOPIC_CONFIG,
+                arguments: {
+                  clusterId,
+                  environmentId,
+                  topicName: topic,
+                  topicConfigs: [
+                    {
+                      name: "retention.ms",
+                      value: "3600000",
+                      operation: "SET",
+                    },
+                  ],
+                  validateOnly: false,
+                },
+              });
+
+              expect(textContent(result)).toMatch(
+                /Successfully altered topic config/,
+              );
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -29,7 +29,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -482,38 +485,41 @@ describe(
           });
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should consume the seeded messages from the topic", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.CONSUME_MESSAGES,
-              arguments: {
-                topics: [{ name: topic, start: "earliest" }],
-                maxMessages: seededValues.length,
-                timeoutMs: 15_000,
-                valueFormat: { disableSchemaRegistry: true },
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            const text = textContent(result);
-            expect(text).toMatch(/^Consumed \d+ messages/);
-            for (const value of seededValues) {
-              expect(text).toContain(value);
-            }
-          });
-        });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should consume the seeded messages from the topic", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.CONSUME_MESSAGES,
+                arguments: {
+                  topics: [{ name: topic, start: "earliest" }],
+                  maxMessages: seededValues.length,
+                  timeoutMs: 15_000,
+                  valueFormat: { disableSchemaRegistry: true },
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              const text = textContent(result);
+              expect(text).toMatch(/^Consumed \d+ messages/);
+              for (const value of seededValues) {
+                expect(text).toContain(value);
+              }
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -157,41 +160,44 @@ describe(
         // actually mutated the cluster
         const { admin, createdTopics } = withSharedAdminClient();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should create the requested Kafka topic", async () => {
-            const topic = uniqueName(`create-oauth-${transport}`);
-            createdTopics.push(topic);
-
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.CREATE_TOPICS,
-              arguments: {
-                topics: [{ topic, numPartitions: 1 }],
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(result.isError, textContent(result)).not.toBe(true);
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should create the requested Kafka topic", async () => {
+              const topic = uniqueName(`create-oauth-${transport}`);
+              createdTopics.push(topic);
 
-            await expect
-              .poll(() => admin().listTopics(), {
-                timeout: 15_000,
-                interval: 500,
-              })
-              .toContain(topic);
-          });
-        });
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.CREATE_TOPICS,
+                arguments: {
+                  topics: [{ topic, numPartitions: 1 }],
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(result.isError, textContent(result)).not.toBe(true);
+
+              await expect
+                .poll(() => admin().listTopics(), {
+                  timeout: 15_000,
+                  interval: 500,
+                })
+                .toContain(topic);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -136,50 +139,53 @@ describe(
         // seed + verify via the api-key-authed admin client; only the DELETE_TOPICS call goes via OAuth
         const { admin, createdTopics } = withSharedAdminClient();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should delete the requested Kafka topic", async () => {
-            const topic = uniqueName(`delete-oauth-${transport}`);
-            createdTopics.push(topic);
-            await admin().createTopics({
-              topics: [{ topic, numPartitions: 1 }],
-            });
-            await expect
-              .poll(() => admin().listTopics(), {
-                timeout: 15_000,
-                interval: 500,
-              })
-              .toContain(topic);
-
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.DELETE_TOPICS,
-              arguments: {
-                topicNames: [topic],
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(result.isError, textContent(result)).not.toBe(true);
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should delete the requested Kafka topic", async () => {
+              const topic = uniqueName(`delete-oauth-${transport}`);
+              createdTopics.push(topic);
+              await admin().createTopics({
+                topics: [{ topic, numPartitions: 1 }],
+              });
+              await expect
+                .poll(() => admin().listTopics(), {
+                  timeout: 15_000,
+                  interval: 500,
+                })
+                .toContain(topic);
 
-            await expect
-              .poll(() => admin().listTopics(), {
-                timeout: 15_000,
-                interval: 500,
-              })
-              .not.toContain(topic);
-          });
-        });
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.DELETE_TOPICS,
+                arguments: {
+                  topicNames: [topic],
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(result.isError, textContent(result)).not.toBe(true);
+
+              await expect
+                .poll(() => admin().listTopics(), {
+                  timeout: 15_000,
+                  interval: 500,
+                })
+                .not.toContain(topic);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.integration.test.ts
@@ -30,7 +30,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -210,33 +213,36 @@ describe(
           });
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should describe the seeded consumer group end-to-end", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.DESCRIBE_CONSUMER_GROUP,
-              arguments: {
-                groupId,
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            const text = textContent(result);
-            const expectedPrefix = `Consumer group "${groupId}" is `;
-            expect(text.startsWith(expectedPrefix), text).toBe(true);
-          });
-        });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should describe the seeded consumer group end-to-end", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.DESCRIBE_CONSUMER_GROUP,
+                arguments: {
+                  groupId,
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              const text = textContent(result);
+              const expectedPrefix = `Consumer group "${groupId}" is `;
+              expect(text.startsWith(expectedPrefix), text).toBe(true);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.integration.test.ts
@@ -33,7 +33,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -330,35 +333,38 @@ describe(
           });
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return the deterministic lag for the seeded group on the seeded topic", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.GET_CONSUMER_GROUP_LAG,
-              arguments: {
-                groupId,
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(result.isError, textContent(result)).not.toBe(true);
-            const payload =
-              result.structuredContent as GetConsumerGroupLagResponse;
-            expect(payload.groupId).toBe(groupId);
-            expect(payload.totalLag).toBe(EXPECTED_LAG);
-          });
-        });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return the deterministic lag for the seeded group on the seeded topic", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.GET_CONSUMER_GROUP_LAG,
+                arguments: {
+                  groupId,
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(result.isError, textContent(result)).not.toBe(true);
+              const payload =
+                result.structuredContent as GetConsumerGroupLagResponse;
+              expect(payload.groupId).toBe(groupId);
+              expect(payload.totalLag).toBe(EXPECTED_LAG);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.integration.test.ts
@@ -32,7 +32,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -248,40 +251,43 @@ describe(
           });
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return every partition with messageCount totaling the seeded writes", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.GET_PARTITION_OFFSETS,
-              arguments: {
-                topicName: topic,
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(result.isError, textContent(result)).not.toBe(true);
-            const payload =
-              result.structuredContent as GetPartitionOffsetsResponse;
-            expect(payload.topicName).toBe(topic);
-            expect(payload.partitions).toHaveLength(NUM_PARTITIONS);
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return every partition with messageCount totaling the seeded writes", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.GET_PARTITION_OFFSETS,
+                arguments: {
+                  topicName: topic,
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
 
-            const partition0 = payload.partitions.find(
-              (p) => p.partition === 0,
-            );
-            expect(partition0?.messageCount).toBe(SEEDED_VALUES.length);
-          });
-        });
+              expect(result.isError, textContent(result)).not.toBe(true);
+              const payload =
+                result.structuredContent as GetPartitionOffsetsResponse;
+              expect(payload.topicName).toBe(topic);
+              expect(payload.partitions).toHaveLength(NUM_PARTITIONS);
+
+              const partition0 = payload.partitions.find(
+                (p) => p.partition === 0,
+              );
+              expect(partition0?.messageCount).toBe(SEEDED_VALUES.length);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -130,40 +133,43 @@ describe(
         // seed via the api-key-authed admin client; GET_TOPIC_CONFIG goes via OAuth
         const { admin, createdTopics } = withSharedAdminClient();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return the topic configuration for an existing topic", async () => {
-            const topic = uniqueName(`get-config-oauth-${transport}`);
-            createdTopics.push(topic);
-            await admin().createTopics({
-              topics: [{ topic, numPartitions: 1 }],
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.GET_TOPIC_CONFIG,
-              arguments: {
-                clusterId,
-                environmentId,
-                topicName: topic,
-              },
-            });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return the topic configuration for an existing topic", async () => {
+              const topic = uniqueName(`get-config-oauth-${transport}`);
+              createdTopics.push(topic);
+              await admin().createTopics({
+                topics: [{ topic, numPartitions: 1 }],
+              });
 
-            const text = textContent(result);
-            expect(text).toContain(`Topic configuration for '${topic}'`);
-            expect(text).toContain("topicDetails");
-            expect(text).toContain("topicConfig");
-          });
-        });
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.GET_TOPIC_CONFIG,
+                arguments: {
+                  clusterId,
+                  environmentId,
+                  topicName: topic,
+                },
+              });
+
+              const text = textContent(result);
+              expect(text).toContain(`Topic configuration for '${topic}'`);
+              expect(text).toContain("topicDetails");
+              expect(text).toContain("topicConfig");
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.integration.test.ts
@@ -24,7 +24,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -119,38 +122,41 @@ describe(
         const clusterId = getTestClusterId();
         const environmentId = getTestEnvironmentId();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-consumer-groups in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            const listConsumerGroups = tools.find(
-              (t) => t.name === ToolName.LIST_CONSUMER_GROUPS,
-            );
-            expect(listConsumerGroups).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return the consumer groups from the configured Kafka cluster", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_CONSUMER_GROUPS,
-              arguments: {
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(textContent(result)).toMatch(/^Found \d+ consumer group/);
-          });
-        });
+            it("should expose list-consumer-groups in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              const listConsumerGroups = tools.find(
+                (t) => t.name === ToolName.LIST_CONSUMER_GROUPS,
+              );
+              expect(listConsumerGroups).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return the consumer groups from the configured Kafka cluster", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_CONSUMER_GROUPS,
+                arguments: {
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(textContent(result)).toMatch(/^Found \d+ consumer group/);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.integration.test.ts
@@ -24,7 +24,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -117,38 +120,41 @@ describe(
         const clusterId = getTestClusterId();
         const environmentId = getTestEnvironmentId();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-topics in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            const listTopics = tools.find(
-              (t) => t.name === ToolName.LIST_TOPICS,
-            );
-            expect(listTopics).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return the topics from the configured Kafka cluster", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_TOPICS,
-              arguments: {
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(textContent(result)).toMatch(/^Kafka topics:/);
-          });
-        });
+            it("should expose list-topics in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              const listTopics = tools.find(
+                (t) => t.name === ToolName.LIST_TOPICS,
+              );
+              expect(listTopics).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return the topics from the configured Kafka cluster", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_TOPICS,
+                arguments: {
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(textContent(result)).toMatch(/^Kafka topics:/);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -31,7 +31,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -162,34 +165,39 @@ describe(
           await admin.disconnect();
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should produce a raw-string message and return a partition+offset delivery report", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.PRODUCE_MESSAGE,
-              arguments: {
-                topicName: topic,
-                value: { message: `hello from oauth ${transport}` },
-                cluster_id: clusterId,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            const text = textContent(result);
-            expect(text).toMatch(/Message produced successfully to \[Topic: /);
-            expect(text).toContain(topic);
-          });
-        });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should produce a raw-string message and return a partition+offset delivery report", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.PRODUCE_MESSAGE,
+                arguments: {
+                  topicName: topic,
+                  value: { message: `hello from oauth ${transport}` },
+                  cluster_id: clusterId,
+                  environment_id: environmentId,
+                },
+              });
+
+              const text = textContent(result);
+              expect(text).toMatch(
+                /Message produced successfully to \[Topic: /,
+              );
+              expect(text).toContain(topic);
+            });
+          },
+        );
       },
     );
 

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.integration.test.ts
@@ -21,7 +21,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -94,35 +97,38 @@ describe(
           return;
         }
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-organizations in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            expect(
-              tools.find((t) => t.name === ToolName.LIST_ORGANIZATIONS),
-            ).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return at least one organization from CCloud", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_ORGANIZATIONS,
-              arguments: {},
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
-            expect(textContent(result)).toMatch(
-              /^Retrieved \d+ organizations?:/,
-            );
-          });
-        });
+
+            it("should expose list-organizations in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              expect(
+                tools.find((t) => t.name === ToolName.LIST_ORGANIZATIONS),
+              ).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return at least one organization from CCloud", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_ORGANIZATIONS,
+                arguments: {},
+              });
+              expect(textContent(result)).toMatch(
+                /^Retrieved \d+ organizations?:/,
+              );
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/schema/create-schema-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/create-schema-handler.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -133,43 +136,46 @@ describe(
         // the api-key SR client verifies (and cleans up) what the server-side OAuth path created
         const { client, createdSubjects } = withSharedSrClient();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should register a new subject via the tool", async () => {
-            const subject = uniqueName(`create-oauth-${transport}`);
-            createdSubjects.push(subject);
-
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.CREATE_SCHEMA,
-              arguments: {
-                subject,
-                schema: TEST_AVRO_SCHEMA,
-                schemaType: "AVRO",
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(textContent(result)).toContain(
-              `Successfully registered schema for subject "${subject}"`,
-            );
-            await expect
-              .poll(() => client().getAllSubjects(), {
-                timeout: 15_000,
-                interval: 500,
-              })
-              .toContain(subject);
-          });
-        });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should register a new subject via the tool", async () => {
+              const subject = uniqueName(`create-oauth-${transport}`);
+              createdSubjects.push(subject);
+
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.CREATE_SCHEMA,
+                arguments: {
+                  subject,
+                  schema: TEST_AVRO_SCHEMA,
+                  schemaType: "AVRO",
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(textContent(result)).toContain(
+                `Successfully registered schema for subject "${subject}"`,
+              );
+              await expect
+                .poll(() => client().getAllSubjects(), {
+                  timeout: 15_000,
+                  interval: 500,
+                })
+                .toContain(subject);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -139,45 +142,48 @@ describe(
         // we're exercising via the DELETE_SCHEMA call below
         const { client, createdSubjects } = withSharedSrClient();
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should soft-delete a registered subject", async () => {
-            const subject = uniqueName(`delete-oauth-${transport}`);
-            createdSubjects.push(subject);
-            await client().register(subject, { schema: TEST_AVRO_SCHEMA });
-            await expect
-              .poll(() => client().getAllSubjects(), {
-                timeout: 15_000,
-                interval: 500,
-              })
-              .toContain(subject);
-
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.DELETE_SCHEMA,
-              arguments: { subject, environment_id: environmentId },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(textContent(result)).toContain(
-              `Successfully deleted subject "${subject}"`,
-            );
-            await expect
-              .poll(() => client().getAllSubjects(), {
-                timeout: 15_000,
-                interval: 500,
-              })
-              .not.toContain(subject);
-          });
-        });
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should soft-delete a registered subject", async () => {
+              const subject = uniqueName(`delete-oauth-${transport}`);
+              createdSubjects.push(subject);
+              await client().register(subject, { schema: TEST_AVRO_SCHEMA });
+              await expect
+                .poll(() => client().getAllSubjects(), {
+                  timeout: 15_000,
+                  interval: 500,
+                })
+                .toContain(subject);
+
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.DELETE_SCHEMA,
+                arguments: { subject, environment_id: environmentId },
+              });
+
+              expect(textContent(result)).toContain(
+                `Successfully deleted subject "${subject}"`,
+              );
+              await expect
+                .poll(() => client().getAllSubjects(), {
+                  timeout: 15_000,
+                  interval: 500,
+                })
+                .not.toContain(subject);
+            });
+          },
+        );
       },
     );
   },

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.integration.test.ts
@@ -27,7 +27,10 @@ import {
   type StartedServer,
 } from "@tests/harness/start-server.js";
 import { textContent } from "@tests/harness/tool-results.js";
-import { activeTransports } from "@tests/harness/transports.js";
+import {
+  activeOAuthTransports,
+  activeTransports,
+} from "@tests/harness/transports.js";
 import { uniqueName } from "@tests/harness/unique-name.js";
 import { Tag } from "@tests/tags.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -161,40 +164,43 @@ describe(
           createdSubjects.push(subject);
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
-          let server: StartedServer;
+        describe.each(activeOAuthTransports)(
+          "via %s transport",
+          (transport) => {
+            let server: StartedServer;
 
-          beforeAll(async () => {
-            server = await startOAuthServer({ transport });
-          }, 180_000);
+            beforeAll(async () => {
+              server = await startOAuthServer({ transport });
+            }, 180_000);
 
-          afterAll(async () => {
-            await stopOAuthServer(server);
-          });
-
-          it("should expose list-schemas in tools/list", async () => {
-            const { tools } = await server.client.listTools();
-            const listSchemas = tools.find(
-              (t) => t.name === ToolName.LIST_SCHEMAS,
-            );
-            expect(listSchemas).toBeDefined();
-          });
-
-          // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
-          it("should return a subject map that includes the seeded subject", async () => {
-            const result = await callToolWithOAuthFlow(server, credentials, {
-              name: ToolName.LIST_SCHEMAS,
-              arguments: {
-                subjectPrefix: subject,
-                environment_id: environmentId,
-              },
+            afterAll(async () => {
+              await stopOAuthServer(server);
             });
 
-            expect(result.isError, textContent(result)).not.toBe(true);
-            const parsed = JSON.parse(textContent(result));
-            expect(parsed).toHaveProperty(subject);
-          });
-        });
+            it("should expose list-schemas in tools/list", async () => {
+              const { tools } = await server.client.listTools();
+              const listSchemas = tools.find(
+                (t) => t.name === ToolName.LIST_SCHEMAS,
+              );
+              expect(listSchemas).toBeDefined();
+            });
+
+            // first auth-required call starts the CCloud OAuth flow; cached tokens reuse for later tests
+            it("should return a subject map that includes the seeded subject", async () => {
+              const result = await callToolWithOAuthFlow(server, credentials, {
+                name: ToolName.LIST_SCHEMAS,
+                arguments: {
+                  subjectPrefix: subject,
+                  environment_id: environmentId,
+                },
+              });
+
+              expect(result.isError, textContent(result)).not.toBe(true);
+              const parsed = JSON.parse(textContent(result));
+              expect(parsed).toHaveProperty(subject);
+            });
+          },
+        );
       },
     );
   },

--- a/tests/harness/oauth-port-lock.ts
+++ b/tests/harness/oauth-port-lock.ts
@@ -29,8 +29,15 @@ const POLL_INTERVAL_MS = 500;
 /**
  * Block until OAUTH_CALLBACK_PORT is free, then claim it by writing `process.pid` into the lock
  * file. Stale locks (holder PID no longer alive) are reclaimed automatically.
+ *
+ * The default timeout is deliberately **below** the OAuth `beforeAll` hook timeout (180_000ms in
+ * the dual-mode tests): if a holder genuinely wedges, this throws a descriptive
+ * "lock not released within … (holder PID=…)" before vitest kills the hook with an opaque
+ * "Hook timed out in 180000ms" — so the failure names the culprit. With the OAuth lane now running
+ * sequentially (`--no-file-parallelism`), acquisition is normally uncontended and instant; a real
+ * wait here means a stuck/crashed holder, which the shorter window surfaces faster.
  */
-export async function acquireOAuthPortLock(timeoutMs = 300_000): Promise<void> {
+export async function acquireOAuthPortLock(timeoutMs = 150_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (tryAcquire()) return;

--- a/tests/harness/transports.ts
+++ b/tests/harness/transports.ts
@@ -32,3 +32,26 @@ function resolveActiveTransports(): TransportType[] {
 }
 
 export const activeTransports: TransportType[] = resolveActiveTransports();
+
+/**
+ * Transports an OAuth describe should iterate: {@linkcode activeTransports}
+ * narrowed to stdio only.
+ *
+ * The CCloud OAuth sign-in is transport-agnostic — the Auth0/PKCE flow drives a
+ * browser regardless of MCP transport, and the resulting bearer token then rides
+ * whatever transport the tool call uses. The stdio/http/sse transport layer is
+ * already covered by the (parallel, fast) direct describes and the smoke suite,
+ * so running the OAuth flow on all three transports just re-pays the
+ * Auth0-round-trip tax thrice. Worse, every OAuth describe serializes on the
+ * single hard-coded callback port (see {@linkcode acquireOAuthPortLock}), so
+ * ×3 transports triples the serialized lock-holds and is what pushed the @kafka
+ * job's queued `beforeAll`s past their 180s hook timeout. Pinning OAuth to one
+ * transport cuts that contention ~3× at no real coverage loss.
+ *
+ * Honors `INTEGRATION_TEST_TRANSPORT`: when an operator forces a non-stdio
+ * transport this is empty, so OAuth describes register nothing (consistent with
+ * "OAuth is stdio-only" rather than silently running on the forced transport).
+ */
+export const activeOAuthTransports: TransportType[] = activeTransports.filter(
+  (transport) => transport === TransportType.STDIO,
+);


### PR DESCRIPTION
# Deflake the kafka + OAuth integration suite

## The flake

The `@kafka` CI job intermittently failed with `Hook timed out in 180000ms` in an OAuth describe's `beforeAll` at `startOAuthServer` — a different test each run (`delete-topics` oauth/stdio one run, `create-topics` oauth/http the next). Root cause: every OAuth describe must bind a single hard-coded Auth0 callback port (26640), so they all serialize through one filesystem lock (`acquireOAuthPortLock`), acquired _inside_ the `beforeAll`. With 11 kafka files each running an OAuth describe across 3 transports (~33 serialized lock-holds, each spanning a real Playwright→Auth0 sign-in), and `pool: "forks"` starting ~8 files at once, the forks queued on the lock. A `beforeAll`'s 180s timeout includes the time blocked waiting for the lock, so a fork stuck behind enough holders died before doing any work. The lock's own 300s timeout never fired because the shorter hook timeout killed the hook first — yielding the opaque message instead of naming the holder.

## The fixes

Three changes, smallest-blast-radius first:

- **OAuth describes run on stdio only.** New `activeOAuthTransports` (stdio-filtered `activeTransports`) in `tests/harness/transports.ts`; **all 19 OAuth describes** across the suite now iterate it instead of `activeTransports` (direct describes keep all three; the OAuth-flow smoke test was already stdio-only). The Auth0/PKCE sign-in is transport-agnostic — the browser flow is identical regardless of MCP transport, and the transport layer is already covered by the parallel direct describes and the smoke suite. This alone cuts each OAuth job's serialized lock-holds ~3× (kafka: 33 → 11). The `.claude/rules/integration-tests.md` dual-mode pattern now documents `activeOAuthTransports` as the rule for OAuth describes.
- **Lock timeout below the hook timeout.** `acquireOAuthPortLock` default dropped from 300s to 150s (< the 180s OAuth `beforeAll`). If a holder ever genuinely wedges, the failure now reads `lock not released within … (holder PID=…)` and names the culprit, rather than the opaque `Hook timed out`.
- **OAuth lane runs sequentially.** The Makefile appends `--no-file-parallelism` when `INTEGRATION_TEST_CONNECTION_TYPE=oauth`, and the per-PR `@kafka` block is split into two parallel jobs (separate agents): `@kafka direct` (parallel) and `@kafka oauth` (sequential). With the OAuth lane on its own sequential agent, the callback-port lock is never contended — each file acquires it instantly — so no `beforeAll` ever sits in a queue. The direct lane keeps full parallelism, and each lane publishes its own `TEST-integration.xml`.

## Wall clock

Unaffected-to-better. The OAuth work was _already_ serialized by the lock, so forcing the OAuth lane sequential doesn't slow it — it just stops the other forks from busy-waiting and tripping the 180s timeout. The direct lane stays parallel (separate job). And stdio-only OAuth actually cuts OAuth wall time ~3×. Net: faster, and no more timeout-driven retries.

## Note: scheduled full run

This fixes the per-PR path (where the flake was observed). The scheduled `integration.yml` run with `CONNECTION_TYPE=all` still executes kafka direct+oauth in one combined, parallel invocation; stdio-only OAuth makes a pile-up ~3× less likely there, but it isn't split. Running that pipeline with `CONNECTION_TYPE=oauth` already serializes via the Makefile knob. Splitting the scheduled kafka cell too is a small follow-up if the daily run proves flaky.


## References
A sample doomed CICD is over at https://semaphore.ci.confluent.io/branches/f20ded17-2c09-416b-9b22-eca8f226dc30