### PR TITLE
MINOR fix(Docker): add `--ignore-scripts` to prune in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ RUN pnpm run build
 # remove dev dependencies, keeping compiled native modules intact. pnpm uses
 # relative symlinks with the .pnpm store nested under node_modules, so the
 # pruned node_modules copies cleanly into the production stage below.
-RUN pnpm prune --prod
+# --ignore-scripts skips the `prepare` lifecycle (husky), which pnpm runs after
+# pruning; husky is a devDependency that prune just removed, so without this the
+# step dies on `sh: husky: not found`
+RUN pnpm prune --prod --ignore-scripts
 
 # Production stage
 FROM ${NODE_IMAGE}


### PR DESCRIPTION
The daily Docker scan job in CI has been failing after the migration from npm to pnpm: https://semaphore.ci.confluent.io/jobs/1bdba342-ef13-4878-a78f-87afb9ab8e95#L373
```
#13 [builder 9/9] RUN pnpm prune --prod
#13 1.331 Lockfile is up to date, resolution step is skipped
#13 1.386 Packages: -218
#13 1.386 --------------------------------------------------------------------------------
#13 5.208 
#13 5.208 devDependencies:
#13 5.208 - @eslint/js 9.39.4
#13 5.208 - @types/content-type 1.1.9
#13 5.208 - @types/eslint__js 8.42.3
#13 5.208 - @types/node 24.12.2
#13 5.208 - @types/turndown 5.0.6
#13 5.208 - @types/ws 8.18.1
#13 5.208 - @typescript-eslint/eslint-plugin 8.58.1
#13 5.208 - @typescript-eslint/parser 8.58.1
#13 5.208 - @vitest/coverage-v8 4.1.4
#13 5.208 - concurrently 9.2.1
#13 5.208 - eslint 9.39.4
#13 5.208 - eslint-config-prettier 10.1.8
#13 5.208 - eslint-plugin-prettier 5.5.5
#13 5.208 - eslint-plugin-unused-imports 4.4.1
#13 5.208 - globals 16.5.0
#13 5.208 - husky 9.1.7
#13 5.208 - openapi-typescript 7.13.0
#13 5.208 - playwright-core 1.60.0
#13 5.208 - prettier 3.6.1
#13 5.208 - prettier-plugin-organize-imports 4.3.0
#13 5.208 - tsc-alias 1.8.16
#13 5.208 - typescript 5.9.3
#13 5.208 - typescript-eslint 8.58.1
#13 5.208 - vitest 4.1.4
#13 5.208 
#13 5.216 . prepare$ husky
#13 5.225 . prepare: sh: husky: not found
#13 5.240  ELIFECYCLE  Command failed.
#13 ERROR: process "/bin/sh -c pnpm prune --prod" did not complete successfully: exit code: 1
```

The main issue here is `pnpm prune` removes dev dependencies but still tries using the `prepare` script, which calls `husky` (a dev dependency).

The fix is to use the [`ignoreScripts` setting](https://pnpm.io/settings#ignorescripts) as a flag in the prune command -- (similar to [`pnpm install`](https://pnpm.io/cli/install#--ignore-scripts), but not documented for [`pnpm prune`](https://pnpm.io/cli/prune)) -- which skips `prepare` entirely and allows building the Docker image.

✅ Clean image scan workflow now: https://semaphore.ci.confluent.io/jobs/18c8343b-c8ed-4666-9ff7-a17b818f7e31