### PR TITLE
minor: move protobuf bug fix to Unreleased changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this MCP server will be documented in this file.
 
 - `produce-message` can now produce primitive key and value payloads (numbers, booleans, strings) against top-level primitive Schema Registry schemas such as Avro `long`; previously the serializer rejected anything but an object.
 - `explain-disabled-tools` now accounts for tools the operator excluded via `--allow-tools` / `--block-tools`; previously (since v1.3.0) such tools were ignored by the diagnostic, which either counted them as enabled — contradicting `tools/list` — or blamed a missing config block. They now appear in a dedicated server-wide block.
+- Introduced new optional tool argument `messageName` to `produce-message` tool to fix producing messages using PROTOBUF as format ([#127](https://github.com/confluentinc/mcp-confluent/issues/127))
 
 ### Changed
 
@@ -71,10 +72,6 @@ All notable changes to this MCP server will be documented in this file.
 ### Removed
 
 - **`read-connector` tool.** Its content is now covered by `get-connector-config` (config map) and `get-connector-tasks` (per-task configs and connector type).
-
-### Fixed
-
-- Introduced new optional tool argument `messageName` to`produce-message` tool to fix producing messages using PROTOBUF as format ([#127](https://github.com/confluentinc/mcp-confluent/issues/127))
 
 ## 1.3.0
 


### PR DESCRIPTION
## Summary of Changes

- This PR moved the PROTOBUF `produce-message` fix under `Unreleased`.
- Addressed this [comment](https://github.com/confluentinc/mcp-confluent/pull/529/changes/BASE..48570a7a4c18981277e4bb6e4ec80eaca53a59f2#r3476437230).

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `pnpm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
