### PR TITLE
Pin env-omitted Flink OAuth case and fold Flink arg-validation tests

### DIFF
--- a/src/confluent/oauth-client-manager.test.ts
+++ b/src/confluent/oauth-client-manager.test.ts
@@ -401,19 +401,18 @@ describe("oauth-client-manager.ts", () => {
     });
 
     describe("getFlinkRestClient()", () => {
-      it("should reject when computePoolId is omitted under OAuth", async () => {
-        const manager = buildManager();
-        await expect(
-          manager.getFlinkRestClient(undefined, "env-1"),
-        ).rejects.toThrow("required under OAuth for Flink access");
-      });
-
-      it("should reject when environmentId is omitted under OAuth", async () => {
-        const manager = buildManager();
-        await expect(
-          manager.getFlinkRestClient("lfcp-1", undefined),
-        ).rejects.toThrow("required under OAuth for Flink access");
-      });
+      it.each([
+        { omitted: "computePoolId", computePoolId: undefined, envId: "env-1" },
+        { omitted: "environmentId", computePoolId: "lfcp-1", envId: undefined },
+      ])(
+        "should reject when $omitted is omitted under OAuth",
+        async ({ computePoolId, envId }) => {
+          const manager = buildManager();
+          await expect(
+            manager.getFlinkRestClient(computePoolId, envId),
+          ).rejects.toThrow("required under OAuth for Flink access");
+        },
+      );
 
       it("should build a fresh REST client per call against the resolved regional Flink host", async () => {
         vi.spyOn(resolvers, "resolveFlinkComputePoolRegion").mockResolvedValue({

--- a/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
@@ -5,7 +5,10 @@ import {
 } from "@src/config/models.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
-import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
+import {
+  FlinkRoutingArgs,
+  FlinkToolHandler,
+} from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { FLINK_CONN } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";
@@ -123,23 +126,35 @@ describe("flink-tool-handler.ts", () => {
         });
       });
 
-      it("should throw a discovery hint under OAuth when computePoolId is omitted", () => {
-        expect(() =>
-          handler["resolveFlinkRouting"](oauthConn, {
-            organizationId: "org-arg",
-            environmentId: "env-arg",
-          }),
-        ).toThrow("required under OAuth connection type");
-      });
+      // Each row drops exactly one of the three required ids so every conjunct
+      // of the OAuth guard (!organization_id || !environment_id ||
+      // !compute_pool_id) is pinned independently.
+      const oauthMissingCases: Array<{
+        omitted: string;
+        args: FlinkRoutingArgs;
+      }> = [
+        {
+          omitted: "organizationId",
+          args: { environmentId: "env-arg", computePoolId: "lfcp-arg" },
+        },
+        {
+          omitted: "environmentId",
+          args: { organizationId: "org-arg", computePoolId: "lfcp-arg" },
+        },
+        {
+          omitted: "computePoolId",
+          args: { organizationId: "org-arg", environmentId: "env-arg" },
+        },
+      ];
 
-      it("should throw a discovery hint under OAuth when organizationId is omitted", () => {
-        expect(() =>
-          handler["resolveFlinkRouting"](oauthConn, {
-            environmentId: "env-arg",
-            computePoolId: "lfcp-arg",
-          }),
-        ).toThrow("required under OAuth connection type");
-      });
+      it.each(oauthMissingCases)(
+        "should throw a discovery hint under OAuth when $omitted is omitted",
+        ({ args }) => {
+          expect(() => handler["resolveFlinkRouting"](oauthConn, args)).toThrow(
+            "required under OAuth connection type",
+          );
+        },
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary of Changes

Test-only follow-up to #644

- Pin the `environmentId`-omitted OAuth case. `resolveFlinkRouting`'s OAuth guard is `!organization_id || !environment_id || !compute_pool_id`, but `flink-tool-handler.test.ts` only covered the org- and compute-pool-omitted failures. A refactor dropping `!environment_id` would have gone uncaught; the missing case is now pinned.
- Fold the repetitive arg-validation cases into `it.each`. The three OAuth-missing cases in `flink-tool-handler.test.ts` (now a clean 3-row table) and the two `getFlinkRestClient` rejection cases in `oauth-client-manager.test.ts` varied only by which id was nulled — converted to `it.each`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)? — no, test-only.
