### PR TITLE
[tests]: add applyJsonNAmes

### DIFF
--- a/src/confluent/schema-registry-helper.test.ts
+++ b/src/confluent/schema-registry-helper.test.ts
@@ -296,6 +296,55 @@ describe("schema-registry-helper.ts", () => {
       });
     });
 
+    it("accepts camelCase payload keys on the use-latest path (proto json_name)", async () => {
+      const registry = newRegistry();
+      const topic = "proto-latest-camelcase";
+      // Seed the subject the same way: the first produce supplies the schema,
+      // registering it as a base64 FileDescriptorProto in Schema Registry.
+      await serializeMessage(
+        topic,
+        {
+          message: { user_id: "USR-000", name: "Seed" },
+          useSchemaRegistry: true,
+          schemaType: "PROTOBUF",
+          schema: PROTO_USER,
+          messageName: "com.example.User",
+        },
+        SerdeType.VALUE,
+        registry,
+      );
+
+      // Use-latest produce with a camelCase payload key: protobufRegistryFromSerialized
+      // decodes the stored FileDescriptorProto and must populate jsonName itself,
+      // the same way protobufRegistryFromProto does for the from-.proto-text path.
+      const bytes = await serializeMessage(
+        topic,
+        {
+          message: { userId: "USR-010", name: "Carol" },
+          useSchemaRegistry: true,
+          schemaType: "PROTOBUF",
+          messageName: "com.example.User",
+        },
+        SerdeType.VALUE,
+        registry,
+      );
+
+      const decoded = await deserializeMessage(
+        topic,
+        bytes as Buffer,
+        "PROTOBUF",
+        registry,
+        SerdeType.VALUE,
+      );
+      expect(decoded).toEqual({
+        $typeName: "com.example.User",
+        userId: "USR-010",
+        name: "Carol",
+        email: "",
+        age: 0,
+      });
+    });
+
     it("throws an actionable error when the registered schema is not PROTOBUF (use-latest path)", async () => {
       const registry = newRegistry();
       const topic = "proto-mismatch";

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -35,7 +35,10 @@ import {
 } from "@confluentinc/schemaregistry";
 import { logger } from "@src/logger.js";
 import protobuf from "protobufjs";
-import descriptor from "protobufjs/ext/descriptor/index.js";
+import descriptor, {
+  IDescriptorProto,
+  IFileDescriptorSet,
+} from "protobufjs/ext/descriptor/index.js";
 
 /**
  * Where the Schema Registry schema ID rides on the wire. "payload" embeds it as
@@ -273,6 +276,29 @@ export async function getLatestSchemaOfTypeOrThrow(
 }
 
 /**
+ * Sets each field's `jsonName` to the standard lowerCamelCase form of its
+ * (possibly snake_case) name, recursing into nested message types.
+ *
+ * protobufjs's `Field#toDescriptor` never populates `jsonName` (see its
+ * "Not supported" doc comment), so a descriptor built from `.proto` text always
+ * has it unset. `@bufbuild/protobuf` takes `jsonName` as authoritative — it
+ * does not fall back to deriving it from `name` — so without this, `fromJson`
+ * only accepts the literal proto field name and rejects the camelCase JSON
+ * name a real protoc-generated descriptor would also accept.
+ */
+function applyJsonNames(messageTypes: IDescriptorProto[] | undefined): void {
+  for (const messageType of messageTypes ?? []) {
+    for (const field of messageType.field ?? []) {
+      // protobufjs's reflection Message getter returns "" (the proto3 string
+      // default) rather than undefined for an unset jsonName, so `||=` (not
+      // `??=`) is required to detect "not set".
+      field.jsonName ||= protobuf.util.camelCase(field.name ?? "");
+    }
+    applyJsonNames(messageType.nestedType);
+  }
+}
+
+/**
  * Builds a `@bufbuild/protobuf` descriptor registry from raw `.proto` schema text.
  *
  * The `@confluentinc/schemaregistry` ProtobufSerializer encodes locally against
@@ -295,18 +321,19 @@ export function protobufRegistryFromProto(protoText: string): MutableRegistry {
     const FileDescriptorSet = (
       descriptor as unknown as {
         FileDescriptorSet: {
-          encode(message: object): { finish(): Uint8Array };
+          encode(message: IFileDescriptorSet): { finish(): Uint8Array };
         };
       }
     ).FileDescriptorSet;
     const toDescriptor = (
       root as unknown as {
-        toDescriptor(
-          syntax?: string,
-        ): Parameters<typeof FileDescriptorSet.encode>[0];
+        toDescriptor(syntax?: string): IFileDescriptorSet;
       }
     ).toDescriptor;
     const fileDescriptorSet = toDescriptor.call(root, "proto3");
+    for (const file of fileDescriptorSet.file) {
+      applyJsonNames(file.messageType);
+    }
     const bytes = FileDescriptorSet.encode(fileDescriptorSet).finish();
     return createMutableRegistry(
       createFileRegistry(fromBinary(FileDescriptorSetSchema, bytes)),

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -35,10 +35,7 @@ import {
 } from "@confluentinc/schemaregistry";
 import { logger } from "@src/logger.js";
 import protobuf from "protobufjs";
-import descriptor, {
-  IDescriptorProto,
-  IFileDescriptorSet,
-} from "protobufjs/ext/descriptor/index.js";
+import descriptor, { IFileDescriptorSet } from "protobufjs/ext/descriptor.js";
 
 /**
  * Where the Schema Registry schema ID rides on the wire. "payload" embeds it as
@@ -276,17 +273,34 @@ export async function getLatestSchemaOfTypeOrThrow(
 }
 
 /**
+ * Structural subset of both protobufjs's `IDescriptorProto` and
+ * `@bufbuild/protobuf`'s generated `DescriptorProto` — {@link applyJsonNames}
+ * runs against descriptors from either source (a freshly parsed `.proto` via
+ * protobufjs, or one decoded from Schema Registry's stored `FileDescriptorProto`
+ * bytes via `@bufbuild/protobuf`), and only needs `field`/`nestedType`.
+ */
+interface DescriptorWithFields {
+  field?: { name?: string; jsonName?: string }[];
+  nestedType?: DescriptorWithFields[];
+}
+
+/**
  * Sets each field's `jsonName` to the standard lowerCamelCase form of its
  * (possibly snake_case) name, recursing into nested message types.
  *
  * protobufjs's `Field#toDescriptor` never populates `jsonName` (see its
  * "Not supported" doc comment), so a descriptor built from `.proto` text always
- * has it unset. `@bufbuild/protobuf` takes `jsonName` as authoritative — it
- * does not fall back to deriving it from `name` — so without this, `fromJson`
- * only accepts the literal proto field name and rejects the camelCase JSON
- * name a real protoc-generated descriptor would also accept.
+ * has it unset. A descriptor previously stored by this same gap (registered
+ * before this fix, or decoded from Schema Registry on the use-latest produce
+ * path) is missing it too. `@bufbuild/protobuf` takes `jsonName` as
+ * authoritative — it does not fall back to deriving it from `name` — so
+ * without this, `fromJson` only accepts the literal proto field name and
+ * rejects the camelCase JSON name a real protoc-generated descriptor would
+ * also accept.
  */
-function applyJsonNames(messageTypes: IDescriptorProto[] | undefined): void {
+function applyJsonNames(
+  messageTypes: DescriptorWithFields[] | undefined,
+): void {
   for (const messageType of messageTypes ?? []) {
     for (const field of messageType.field ?? []) {
       // protobufjs's reflection Message getter returns "" (the proto3 string
@@ -435,6 +449,10 @@ export function protobufRegistryFromSerialized(
       FileDescriptorProtoSchema,
       Buffer.from(serializedSchema, "base64"),
     );
+    // Schemas registered before jsonName population landed (or by other
+    // producers) may still lack it; normalize the same way as the
+    // from-.proto-text path so use-latest produces accept camelCase keys too.
+    applyJsonNames(fileDescriptorProto.messageType);
     // Single self-contained file: no external dependencies to resolve.
     return createMutableRegistry(
       createFileRegistry(fileDescriptorProto, () => undefined),


### PR DESCRIPTION
## Summary of Changes

There was a test failing on main. 
<img width="422" height="346" alt="Screenshot 2026-06-30 at 1 32 18 PM" src="https://github.com/user-attachments/assets/17027a01-72ed-494c-98f8-e1289fdf31fc" />


Turns out we had a sneaky casing issue in the schema registry helper itself, see the comment:

```
/**
 * Sets each field's `jsonName` to the standard lowerCamelCase form of its
 * (possibly snake_case) name, recursing into nested message types.
 *
 * protobufjs's `Field#toDescriptor` never populates `jsonName` (see its
 * "Not supported" doc comment), so a descriptor built from `.proto` text always
 * has it unset. `@bufbuild/protobuf` takes `jsonName` as authoritative — it
 * does not fall back to deriving it from `name` — so without this, `fromJson`
 * only accepts the literal proto field name and rejects the camelCase JSON
 * name a real protoc-generated descriptor would also accept.
 */
```

### Manual testing instructions
N/A, can run tests locally to confirm 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing-- technically, since this casing change fixes the test. 
- [ ] Deleted existing