### PR TITLE
Upgrade pnpm from 10.33.4 to 11.9.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,11 +20,11 @@ global_job_config:
     commands:
       - sem-version node 22.22.1
       - checkout
-      # Install any recent pnpm after checkout so the repo's `.npmrc` governs the
-      # install; pnpm reads package.json's `packageManager` field and self-switches
-      # to the pinned version, keeping that field the single source of truth shared
-      # with local dev (no version pin or Corepack needed).
-      - npm install --global pnpm
+      # Install the exact pnpm version pinned in package.json's `packageManager`
+      # field, fetched from the public registry so the internal mirror's lag never
+      # blocks a pnpm upgrade. Installing the exact version means pnpm's self-update
+      # step is a no-op; package.json remains the single source of truth.
+      - npm install --global "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")" --registry https://registry.npmjs.org
       - pnpm config set store-dir ~/.pnpm-store
       # Fuzzy-match restore: an exact key hit (lockfile unchanged) skips all
       # downloads; the bare `pnpm-store-` prefix lets a changed lockfile still

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "config.oauth.example.yaml",
     "assets/oauth-templates"
   ],
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "engines": {
     "node": ">=22.19.0"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+allowBuilds:
+  "@confluentinc/kafka-javascript": true
 onlyBuiltDependencies:
   - "@confluentinc/kafka-javascript"
   - fsevents
@@ -8,13 +10,13 @@ onlyBuiltDependencies:
 # See https://pnpm.io/settings.
 overrides:
   form-data@>=4.0.0 <4.0.6: ">=4.0.6"
-  hono@<4.12.25: '>=4.12.25'
+  hono@<4.12.25: ">=4.12.25"
   js-yaml@<=4.1.1: ">=4.2.0"
   protobufjs@<=7.6.0: ">=7.6.1"
   protobufjs@<=7.6.2: ">=7.6.3"
   shell-quote@>=1.1.0 <=1.8.3: ">=1.8.4"
   tar@<=7.5.15: ">=7.5.16"
-  undici@>=7.0.0 <7.28.0: '>=7.28.0'
-  undici@>=7.23.0 <7.28.0: '>=7.28.0'
+  undici@>=7.0.0 <7.28.0: ">=7.28.0"
+  undici@>=7.23.0 <7.28.0: ">=7.28.0"
   vite@>=8.0.0 <=8.0.15: ">=8.0.16"
   zod: ^4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,14 @@
+# pnpm 11 reads project settings (`allowBuilds`, `overrides`) from this file, not
+# the `pnpm` field in package.json. Recent pnpm versions ignore that field (and warn
+# that it "is no longer read"), so keep these settings here. See https://pnpm.io/settings.
+#
+# `allowBuilds` is pnpm 11's explicit trust gate for lifecycle scripts. The older
+# `onlyBuiltDependencies` list is vestigial in pnpm 11 (no code reads it) and has
+# been removed in favour of this map.
 allowBuilds:
   "@confluentinc/kafka-javascript": true
-onlyBuiltDependencies:
-  - "@confluentinc/kafka-javascript"
-  - fsevents
-  - protobufjs
-# pnpm reads project settings like `overrides` and `onlyBuiltDependencies` from
-# this file, not the `pnpm` field in package.json. Recent pnpm versions ignore
-# that field (and warn that it "is no longer read"), so keep these settings here.
-# See https://pnpm.io/settings.
+  fsevents: true
+  protobufjs: true
 overrides:
   form-data@>=4.0.0 <4.0.6: ">=4.0.6"
   hono@<4.12.25: ">=4.12.25"


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Upgrade to the [latest pnpm release](https://pnpm.io/blog/releases/11.9).
- Mark allowing builds of @confluentinc/kafka-javascript, fsevents, and protobufjs using the new syntax `allowBuilds` [introduced later in v10 series.](https://pnpm.io/settings#allowbuilds)
- Work around pnpm not being present in internal mirror for cicd builds better and more flexibly.

After pulling (or after this gets merged): upgrade your local pnpm to v11 before running pnpm install.
  - With Corepack (recommended): `corepack enable && pnpm install` — Corepack picks up the packageManager pin automatically.
  - Without Corepack: `npm install -g pnpm@11 && pnpm install`