### PR TITLE
More tests for direct-client-manager.ts 

### DIFF
--- a/src/confluent/direct-client-manager.test.ts
+++ b/src/confluent/direct-client-manager.test.ts
@@ -1,4 +1,9 @@
 import {
+  CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
+  type DirectConnectionConfig,
+} from "@src/config/models.js";
+import {
+  constructDirectClientManager,
   DirectClientManager,
   type DirectClientManagerConfig,
 } from "@src/confluent/direct-client-manager.js";
@@ -6,7 +11,12 @@ import type {
   ConfluentAuth,
   ConfluentEndpoints,
 } from "@src/confluent/middleware.js";
-import { getMockedConsumer, mockKafkaConstructor } from "@tests/stubs/index.js";
+import {
+  getMockedAdmin,
+  getMockedConsumer,
+  getMockedProducer,
+  mockKafkaConstructor,
+} from "@tests/stubs/index.js";
 import { describe, expect, it, vi } from "vitest";
 
 const apiKeyAuth: ConfluentAuth = { apiKey: "k", apiSecret: "s" };
@@ -39,6 +49,168 @@ describe("direct-client-manager.ts", () => {
       it("should resolve without error on a fresh instance", async () => {
         const cm = new DirectClientManager(buildConfig());
         await expect(cm.disconnect()).resolves.toBeUndefined();
+      });
+
+      it("should disconnect admin and producer after both are initialized", async () => {
+        const fakeAdmin = getMockedAdmin();
+        fakeAdmin.connect.mockResolvedValue(undefined);
+        fakeAdmin.disconnect.mockResolvedValue(undefined);
+        const fakeProducer = getMockedProducer();
+        fakeProducer.connect.mockResolvedValue(undefined);
+        fakeProducer.disconnect.mockResolvedValue(undefined);
+        mockKafkaConstructor({
+          admin: vi.fn().mockReturnValue(fakeAdmin),
+          producer: vi.fn().mockReturnValue(fakeProducer),
+        });
+
+        const cm = new DirectClientManager(buildConfig());
+        await cm.getAdminClient();
+        await cm.getProducer();
+        await cm.disconnect();
+
+        expect(fakeAdmin.disconnect).toHaveBeenCalledOnce();
+        expect(fakeProducer.disconnect).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("getKafkaClient()", () => {
+      it("should return the Kafka instance and cache it across calls", () => {
+        const fakeKafka = {
+          admin: vi.fn(),
+          producer: vi.fn(),
+          consumer: vi.fn(),
+        };
+        mockKafkaConstructor(fakeKafka);
+
+        const cm = new DirectClientManager(buildConfig());
+        const first = cm.getKafkaClient();
+        const second = cm.getKafkaClient();
+
+        expect(first).toBe(fakeKafka);
+        expect(second).toBe(fakeKafka);
+      });
+    });
+
+    describe("getAdminClient()", () => {
+      it("should connect and return the admin client", async () => {
+        const fakeAdmin = getMockedAdmin();
+        fakeAdmin.connect.mockResolvedValue(undefined);
+        mockKafkaConstructor({ admin: vi.fn().mockReturnValue(fakeAdmin) });
+
+        const cm = new DirectClientManager(buildConfig());
+        const admin = await cm.getAdminClient();
+
+        expect(admin).toBe(fakeAdmin);
+        expect(fakeAdmin.connect).toHaveBeenCalledOnce();
+      });
+
+      it("should return the same admin instance on subsequent calls without reconnecting", async () => {
+        const fakeAdmin = getMockedAdmin();
+        fakeAdmin.connect.mockResolvedValue(undefined);
+        const adminFn = vi.fn().mockReturnValue(fakeAdmin);
+        mockKafkaConstructor({ admin: adminFn });
+
+        const cm = new DirectClientManager(buildConfig());
+        const first = await cm.getAdminClient();
+        const second = await cm.getAdminClient();
+
+        expect(first).toBe(second);
+        expect(adminFn).toHaveBeenCalledOnce();
+        expect(fakeAdmin.connect).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("getProducer()", () => {
+      it("should connect and return the producer", async () => {
+        const fakeProducer = getMockedProducer();
+        fakeProducer.connect.mockResolvedValue(undefined);
+        mockKafkaConstructor({
+          producer: vi.fn().mockReturnValue(fakeProducer),
+        });
+
+        const cm = new DirectClientManager(buildConfig());
+        const producer = await cm.getProducer();
+
+        expect(producer).toBe(fakeProducer);
+        expect(fakeProducer.connect).toHaveBeenCalledOnce();
+      });
+
+      it("should return the same producer instance on subsequent calls without reconnecting", async () => {
+        const fakeProducer = getMockedProducer();
+        fakeProducer.connect.mockResolvedValue(undefined);
+        const producerFn = vi.fn().mockReturnValue(fakeProducer);
+        mockKafkaConstructor({ producer: producerFn });
+
+        const cm = new DirectClientManager(buildConfig());
+        const first = await cm.getProducer();
+        const second = await cm.getProducer();
+
+        expect(first).toBe(second);
+        expect(producerFn).toHaveBeenCalledOnce();
+        expect(fakeProducer.connect).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("getKafkaAdminClient()", () => {
+      it("should delegate to getAdminClient() ignoring clusterId and envId", async () => {
+        const fakeAdmin = getMockedAdmin();
+        fakeAdmin.connect.mockResolvedValue(undefined);
+        mockKafkaConstructor({ admin: vi.fn().mockReturnValue(fakeAdmin) });
+
+        const cm = new DirectClientManager(buildConfig());
+        const admin = await cm.getKafkaAdminClient(
+          "lkc-ignored",
+          "env-ignored",
+        );
+
+        expect(admin).toBe(fakeAdmin);
+      });
+    });
+
+    describe("getKafkaProducer()", () => {
+      it("should delegate to getProducer() ignoring clusterId and envId", async () => {
+        const fakeProducer = getMockedProducer();
+        fakeProducer.connect.mockResolvedValue(undefined);
+        mockKafkaConstructor({
+          producer: vi.fn().mockReturnValue(fakeProducer),
+        });
+
+        const cm = new DirectClientManager(buildConfig());
+        const producer = await cm.getKafkaProducer(
+          "lkc-ignored",
+          "env-ignored",
+        );
+
+        expect(producer).toBe(fakeProducer);
+      });
+    });
+
+    describe("getConsumer()", () => {
+      it("should build a consumer with groupId set to the sessionId suffix", async () => {
+        const fakeConsumer = getMockedConsumer();
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({ consumer: consumerFn });
+
+        const cm = new DirectClientManager(buildConfig());
+        const consumer = await cm.getConsumer("my-session");
+
+        expect(consumer).toBe(fakeConsumer);
+        expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+          "group.id": "mcp-confluent-my-session",
+        });
+      });
+
+      it("should use the base group id when sessionId is omitted", async () => {
+        const fakeConsumer = getMockedConsumer();
+        const consumerFn = vi.fn().mockReturnValue(fakeConsumer);
+        mockKafkaConstructor({ consumer: consumerFn });
+
+        const cm = new DirectClientManager(buildConfig());
+        await cm.getConsumer();
+
+        expect(consumerFn.mock.calls[0]![0]).toMatchObject({
+          "group.id": "mcp-confluent",
+        });
       });
     });
 
@@ -87,6 +259,106 @@ describe("direct-client-manager.ts", () => {
           "group.id": "mcp-confluent-session-42",
         });
       });
+    });
+  });
+
+  describe("constructDirectClientManager()", () => {
+    it("should build full SASL config when kafka.auth and bootstrap_servers are present", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        kafka: {
+          bootstrap_servers: "broker:9092",
+          auth: { type: "api_key", key: "k1", secret: "s1" },
+        },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["kafkaConfig"]).toEqual({
+        "client.id": "mcp-confluent",
+        "bootstrap.servers": "broker:9092",
+        "security.protocol": "sasl_ssl",
+        "sasl.mechanisms": "PLAIN",
+        "sasl.username": "k1",
+        "sasl.password": "s1",
+      });
+    });
+
+    it("should omit SASL fields when kafka.auth is absent", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        kafka: { bootstrap_servers: "broker:9092" },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["kafkaConfig"]).toEqual({
+        "client.id": "mcp-confluent",
+        "bootstrap.servers": "broker:9092",
+      });
+    });
+
+    it("should omit bootstrap.servers when kafka.bootstrap_servers is absent", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        kafka: { auth: { type: "api_key", key: "k1", secret: "s1" } },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["kafkaConfig"]).toEqual({
+        "client.id": "mcp-confluent",
+        "security.protocol": "sasl_ssl",
+        "sasl.mechanisms": "PLAIN",
+        "sasl.username": "k1",
+        "sasl.password": "s1",
+      });
+    });
+
+    it("should spread kafka.extra_properties into the kafka config", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        kafka: {
+          extra_properties: {
+            "socket.timeout.ms": "30000",
+            debug: "broker",
+          },
+        },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["kafkaConfig"]).toEqual({
+        "client.id": "mcp-confluent",
+        "socket.timeout.ms": "30000",
+        debug: "broker",
+      });
+    });
+
+    it("should use confluent_cloud.endpoint when provided", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        confluent_cloud: {
+          endpoint: "https://my.custom.confluent.cloud",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["confluentCloudBaseUrl"]).toBe(
+        "https://my.custom.confluent.cloud",
+      );
+    });
+
+    it("should fall back to CONFLUENT_CLOUD_DEFAULT_ENDPOINT when confluent_cloud is absent", () => {
+      const conn: DirectConnectionConfig = { type: "direct" };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["confluentCloudBaseUrl"]).toBe(
+        CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
+      );
     });
   });
 });

--- a/src/confluent/direct-client-manager.test.ts
+++ b/src/confluent/direct-client-manager.test.ts
@@ -360,5 +360,54 @@ describe("direct-client-manager.ts", () => {
         CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
       );
     });
+
+    it("should return a DirectClientManager instance", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        kafka: { bootstrap_servers: "broker:9092" },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm).toBeInstanceOf(DirectClientManager);
+    });
+
+    it("should omit all kafka properties when there is no kafka block", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        confluent_cloud: {
+          endpoint: "https://api.confluent.cloud",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["kafkaConfig"]).toEqual({ "client.id": "mcp-confluent" });
+    });
+
+    it("should set confluentCloudTelemetryBaseUrl from the telemetry block", () => {
+      const conn: DirectConnectionConfig = {
+        type: "direct",
+        telemetry: {
+          endpoint: "https://my.telemetry.api",
+          auth: { type: "api_key", key: "k", secret: "s" },
+        },
+      };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["confluentCloudTelemetryBaseUrl"]).toBe(
+        "https://my.telemetry.api",
+      );
+    });
+
+    it("should leave confluentCloudTelemetryBaseUrl undefined when there is no telemetry block", () => {
+      const conn: DirectConnectionConfig = { type: "direct" };
+
+      const cm = constructDirectClientManager(conn);
+
+      expect(cm["confluentCloudTelemetryBaseUrl"]).toBeUndefined();
+    });
   });
 });

--- a/src/server-runtime.test.ts
+++ b/src/server-runtime.test.ts
@@ -1,10 +1,7 @@
 import { DEFAULT_CONNECTION_ID } from "@src/config/env-config.js";
 import { type DirectConnectionConfig } from "@src/config/index.js";
 import { MCPServerConfiguration } from "@src/config/models.js";
-import {
-  constructDirectClientManager,
-  DirectClientManager,
-} from "@src/confluent/direct-client-manager.js";
+import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
@@ -17,130 +14,6 @@ function connWith(
 ): DirectConnectionConfig {
   return { type: "direct", ...fields };
 }
-
-describe("constructDirectClientManager()", () => {
-  it("should return a DirectClientManager instance", () => {
-    const manager = constructDirectClientManager(
-      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-    );
-    expect(manager).toBeInstanceOf(DirectClientManager);
-  });
-
-  it("should always set client.id to mcp-confluent", () => {
-    const manager = constructDirectClientManager(
-      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-    );
-    expect(manager["kafkaConfig"]["client.id"]).toBe("mcp-confluent");
-  });
-
-  it("should set bootstrap.servers from the kafka block", () => {
-    const manager = constructDirectClientManager(
-      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-    );
-    expect(manager["kafkaConfig"]["bootstrap.servers"]).toBe("broker:9092");
-  });
-
-  it("should include SASL config when the kafka block has auth", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        kafka: {
-          bootstrap_servers: "broker:9092",
-          auth: { type: "api_key", key: "the-key", secret: "the-secret" },
-        },
-      }),
-    );
-    expect(manager["kafkaConfig"]["security.protocol"]).toBe("sasl_ssl");
-    expect(manager["kafkaConfig"]["sasl.username"]).toBe("the-key");
-    expect(manager["kafkaConfig"]["sasl.password"]).toBe("the-secret");
-  });
-
-  it("should omit SASL config when the kafka block has no auth", () => {
-    const manager = constructDirectClientManager(
-      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-    );
-    expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
-  });
-
-  it("should omit SASL config when there is no kafka block", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        confluent_cloud: {
-          endpoint: "https://api.confluent.cloud",
-          auth: { type: "api_key", key: "k", secret: "s" },
-        },
-      }),
-    );
-    expect(manager["kafkaConfig"]["security.protocol"]).toBeUndefined();
-  });
-
-  it("should spread kafka extra_properties into the GlobalConfig", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        kafka: {
-          bootstrap_servers: "broker:9092",
-          extra_properties: { "socket.timeout.ms": "5000" },
-        },
-      }),
-    );
-    expect(manager["kafkaConfig"]["socket.timeout.ms"]).toBe("5000");
-  });
-
-  it("should set confluentCloudBaseUrl from the confluent_cloud block endpoint", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        confluent_cloud: {
-          endpoint: "https://my.cloud.api",
-          auth: { type: "api_key", key: "k", secret: "s" },
-        },
-      }),
-    );
-    expect(manager["confluentCloudBaseUrl"]).toBe("https://my.cloud.api");
-  });
-
-  it("should set confluentCloudBaseUrl to https://api.confluent.cloud when the block uses the default endpoint", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        confluent_cloud: {
-          endpoint: "https://api.confluent.cloud",
-          auth: { type: "api_key", key: "k", secret: "s" },
-        },
-      }),
-    );
-    expect(manager["confluentCloudBaseUrl"]).toBe(
-      "https://api.confluent.cloud",
-    );
-  });
-
-  it("should default confluentCloudBaseUrl to https://api.confluent.cloud when there is no confluent_cloud block", () => {
-    const manager = constructDirectClientManager(
-      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-    );
-    expect(manager["confluentCloudBaseUrl"]).toBe(
-      "https://api.confluent.cloud",
-    );
-  });
-
-  it("should set confluentCloudTelemetryBaseUrl from the telemetry block", () => {
-    const manager = constructDirectClientManager(
-      connWith({
-        telemetry: {
-          endpoint: "https://my.telemetry.api",
-          auth: { type: "api_key", key: "k", secret: "s" },
-        },
-      }),
-    );
-    expect(manager["confluentCloudTelemetryBaseUrl"]).toBe(
-      "https://my.telemetry.api",
-    );
-  });
-
-  it("should leave confluentCloudTelemetryBaseUrl undefined when there is no telemetry block", () => {
-    const manager = constructDirectClientManager(
-      connWith({ kafka: { bootstrap_servers: "broker:9092" } }),
-    );
-    expect(manager["confluentCloudTelemetryBaseUrl"]).toBeUndefined();
-  });
-});
 
 describe("ServerRuntime", () => {
   const config = new MCPServerConfiguration({


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Bring direct-client-manager.ts from 50% to 100% LOC coverage.
- Consolidate tests over some of this code over in `src/server-runtime.test.ts` into `src/confluent/direct-client-manager.test.ts`
