### PR TITLE
Refactor pkce-login.ts to reduce complexity.

### DIFF
--- a/src/confluent/oauth/pkce-login.ts
+++ b/src/confluent/oauth/pkce-login.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 import { nodeHttp, nodeOpen } from "@src/confluent/node-deps.js";
 import {
@@ -90,163 +90,162 @@ function buildAuthorizationUrl(
   return `https://${auth0Config.domain}/authorize?${params.toString()}`;
 }
 
+type CallbackServer = ReturnType<typeof nodeHttp.createServer>;
+
 /**
- * Runs the PKCE flow end-to-end:
- *  - generates verifier / challenge / state
- *  - binds a one-shot HTTP listener on {@link OAUTH_CALLBACK_PORT}
- *  - opens the browser to the Auth0 authorization endpoint
- *  - waits for the redirect carrying the auth code
- *  - exchanges the code for the full Confluent token chain
- *
- * Bounded by {@link PKCE_LOGIN_TIMEOUT_MS}. Throws {@link PkceLoginError} on
- * failure with a structured `reason`. If `signal` aborts before the auth
- * code arrives, throws `PkceLoginError("user_aborted", ...)` and the finally
- * block tears down the timer + HTTP server.
+ * Mutable state shared across the PKCE callback server's request handlers,
+ * threaded explicitly instead of closure capture so those handlers can live
+ * as module-level functions (see the cognitive-complexity note on
+ * {@link runPkceLogin}).
  */
-// eslint-disable-next-line sonarjs/cognitive-complexity -- baselined pre-existing complexity; reduce below 15 (#656)
-export async function runPkceLogin(
-  auth0Config: Auth0Config,
-  signal?: AbortSignal,
-): Promise<TokenChainResult> {
-  // Early abort: skip the bind/open work entirely if the caller has already
-  // signaled cancellation.
-  if (signal?.aborted) {
-    throw new PkceLoginError("user_aborted", "PKCE login aborted");
+interface PkceCallbackState {
+  readonly oauthState: string;
+  readonly streamClients: Set<ServerResponse>;
+  readonly resolveCode: (code: string) => void;
+  readonly rejectFlow: (err: PkceLoginError) => void;
+  successServed: boolean;
+  serverClosed: boolean;
+  bound: boolean;
+  lifetimeTimer?: ReturnType<typeof setTimeout>;
+}
+
+function closeServerOnce(server: CallbackServer, state: PkceCallbackState) {
+  if (state.serverClosed || !state.bound) return;
+  state.serverClosed = true;
+  if (state.lifetimeTimer) {
+    clearTimeout(state.lifetimeTimer);
+    state.lifetimeTimer = undefined;
   }
-  if (!auth0Config.clientId) {
-    throw new PkceLoginError(
-      "configuration",
-      "Auth0 clientId is not configured for the selected environment",
+  for (const client of state.streamClients) client.end();
+  state.streamClients.clear();
+  server.close();
+}
+
+function handleSkillsHintCopiedRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  state: PkceCallbackState,
+): void {
+  // Only reachable once we've served the success page. Anything earlier
+  // would be a stray request on localhost, not a copy of the install hint.
+  if (!state.successServed) {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+  if (req.method !== "POST") {
+    res.writeHead(405, { Allow: "POST" });
+    res.end();
+    return;
+  }
+  try {
+    TelemetryService.getInstance().track(
+      TelemetryEvent.AGENT_SKILLS_HINT_COPIED,
+      {},
     );
+  } catch (err) {
+    logger.warn({ err }, "Failed to track agent-skills hint copied event");
   }
+  res.writeHead(204);
+  res.end();
+}
 
-  const codeVerifier = generateCodeVerifier();
-  const codeChallenge = generateCodeChallenge(codeVerifier);
-  const state = generateOpaqueToken();
-
-  let resolveCode: (code: string) => void = () => undefined;
-  let rejectFlow: (err: PkceLoginError) => void = () => undefined;
-  const codePromise = new Promise<string>((resolve, reject) => {
-    resolveCode = resolve;
-    rejectFlow = reject;
+function handleSkillsHintStreamRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  server: CallbackServer,
+  state: PkceCallbackState,
+): void {
+  // Same gate as the beacon: the stream only makes sense once the success
+  // page has been served. Pre-auth requests get a 404.
+  if (!state.successServed) {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
   });
-
-  // Tracks whether the success page was served. After success, the server's
-  // lifetime is driven by the success page's EventSource: it stays bound while
-  // the tab is open and closes when the stream disconnects (or when the safety
-  // timer fires).
-  let successServed = false;
-  let serverClosed = false;
-  let lifetimeTimer: ReturnType<typeof setTimeout> | undefined;
-  const streamClients = new Set<ServerResponse>();
-
-  const closeServerOnce = (): void => {
-    if (serverClosed || !bound) return;
-    serverClosed = true;
-    if (lifetimeTimer) {
-      clearTimeout(lifetimeTimer);
-      lifetimeTimer = undefined;
+  // Flush headers so the browser considers the EventSource "open".
+  res.write(": connected\n\n");
+  state.streamClients.add(res);
+  req.on("close", () => {
+    state.streamClients.delete(res);
+    // When the last tab closes and auth already succeeded, the listener
+    // has no further reason to exist.
+    if (state.successServed && state.streamClients.size === 0) {
+      closeServerOnce(server, state);
     }
-    for (const client of streamClients) client.end();
-    streamClients.clear();
-    server.close();
-  };
+  });
+}
 
-  const server = nodeHttp.createServer((req, res) => {
-    const reqUrl = req.url ?? "";
-    const parsed = new URL(reqUrl, "http://127.0.0.1");
+function handleOAuthRedirectRequest(
+  res: ServerResponse,
+  parsed: URL,
+  state: PkceCallbackState,
+): void {
+  const receivedState = parsed.searchParams.get("state");
+  if (receivedState !== state.oauthState) {
+    sendHtml(res, 400, renderErrorPage("State mismatch"));
+    return;
+  }
+  const errorParam = parsed.searchParams.get("error");
+  if (errorParam) {
+    sendHtml(res, 400, renderErrorPage(`Authentication failed: ${errorParam}`));
+    state.rejectFlow(
+      new PkceLoginError(
+        "user_aborted",
+        `Auth0 redirect carried error=${errorParam}`,
+      ),
+    );
+    return;
+  }
+  const code = parsed.searchParams.get("code");
+  if (!code) {
+    sendHtml(res, 400, renderErrorPage("Missing authorization code"));
+    return;
+  }
+  sendHtml(
+    res,
+    200,
+    renderSuccessPage({
+      copiedPath: SKILLS_HINT_COPIED_PATH,
+      streamPath: SKILLS_HINT_STREAM_PATH,
+    }),
+  );
+  state.successServed = true;
+  state.resolveCode(code);
+}
+
+function createCallbackRequestListener(
+  server: CallbackServer,
+  state: PkceCallbackState,
+) {
+  return (req: IncomingMessage, res: ServerResponse): void => {
+    const parsed = new URL(req.url ?? "", "http://127.0.0.1");
     if (parsed.pathname === SKILLS_HINT_COPIED_PATH) {
-      // Only reachable once we've served the success page. Anything earlier
-      // would be a stray request on localhost, not a copy of the install hint.
-      if (!successServed) {
-        res.writeHead(404);
-        res.end();
-        return;
-      }
-      if (req.method !== "POST") {
-        res.writeHead(405, { Allow: "POST" });
-        res.end();
-        return;
-      }
-      try {
-        TelemetryService.getInstance().track(
-          TelemetryEvent.AGENT_SKILLS_HINT_COPIED,
-          {},
-        );
-      } catch (err) {
-        logger.warn({ err }, "Failed to track agent-skills hint copied event");
-      }
-      res.writeHead(204);
-      res.end();
+      handleSkillsHintCopiedRequest(req, res, state);
       return;
     }
     if (parsed.pathname === SKILLS_HINT_STREAM_PATH) {
-      // Same gate as the beacon: the stream only makes sense once the success
-      // page has been served. Pre-auth requests get a 404.
-      if (!successServed) {
-        res.writeHead(404);
-        res.end();
-        return;
-      }
-      res.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      });
-      // Flush headers so the browser considers the EventSource "open".
-      res.write(": connected\n\n");
-      streamClients.add(res);
-      req.on("close", () => {
-        streamClients.delete(res);
-        // When the last tab closes and auth already succeeded, the listener
-        // has no further reason to exist.
-        if (successServed && streamClients.size === 0) closeServerOnce();
-      });
+      handleSkillsHintStreamRequest(req, res, server, state);
       return;
     }
     if (parsed.pathname !== OAUTH_CALLBACK_PATH) {
       sendHtml(res, 404, renderErrorPage("Not found"));
       return;
     }
-    const receivedState = parsed.searchParams.get("state");
-    if (receivedState !== state) {
-      sendHtml(res, 400, renderErrorPage("State mismatch"));
-      return;
-    }
-    const errorParam = parsed.searchParams.get("error");
-    if (errorParam) {
-      sendHtml(
-        res,
-        400,
-        renderErrorPage(`Authentication failed: ${errorParam}`),
-      );
-      rejectFlow(
-        new PkceLoginError(
-          "user_aborted",
-          `Auth0 redirect carried error=${errorParam}`,
-        ),
-      );
-      return;
-    }
-    const code = parsed.searchParams.get("code");
-    if (!code) {
-      sendHtml(res, 400, renderErrorPage("Missing authorization code"));
-      return;
-    }
-    sendHtml(
-      res,
-      200,
-      renderSuccessPage({
-        copiedPath: SKILLS_HINT_COPIED_PATH,
-        streamPath: SKILLS_HINT_STREAM_PATH,
-      }),
-    );
-    successServed = true;
-    resolveCode(code);
-  });
+    handleOAuthRedirectRequest(res, parsed, state);
+  };
+}
 
-  let bound = false;
-  const bindResult = new Promise<void>((resolve, reject) => {
+function bindCallbackServer(
+  server: CallbackServer,
+  state: PkceCallbackState,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
     const onBindError = (err: NodeJS.ErrnoException) => {
       if (err.code === "EADDRINUSE") {
         reject(
@@ -266,14 +265,14 @@ export async function runPkceLogin(
     };
     server.on("error", onBindError);
     server.listen(OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_HOST, () => {
-      bound = true;
+      state.bound = true;
       server.off("error", onBindError);
       // Post-bind socket errors must reject the in-flight flow, not just warn: if the listener
       // dies mid-callback (EMFILE, broken TLS upgrade, etc.) the user would otherwise hang on
       // `codePromise` until `PKCE_LOGIN_TIMEOUT_MS` (minutes) instead of failing fast.
       server.on("error", (err) => {
         logger.warn({ err }, "PKCE callback server post-bind error");
-        rejectFlow(
+        state.rejectFlow(
           new PkceLoginError(
             "callback_server_error",
             `PKCE callback listener errored after bind: ${err.message}`,
@@ -283,6 +282,120 @@ export async function runPkceLogin(
       resolve();
     });
   });
+}
+
+async function openBrowserOrThrow(
+  authUrl: string,
+  abortPromise: Promise<never>,
+): Promise<void> {
+  try {
+    await Promise.race([nodeOpen.open(authUrl), abortPromise]);
+  } catch (err) {
+    // Preserve user_aborted from the race; wrap any other open() failure.
+    if (err instanceof PkceLoginError) throw err;
+    throw new PkceLoginError(
+      "configuration",
+      `Failed to open browser: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function teardownCallbackServer(
+  server: CallbackServer,
+  state: PkceCallbackState,
+): void {
+  if (!state.bound) return;
+  if (state.successServed) {
+    // The success page's EventSource keeps the listener alive while the
+    // browser tab is open; stream-disconnect calls closeServerOnce. The
+    // timer + unref'd server are the "tab left open" backstop so this
+    // listener can never keep the process alive on its own.
+    server.unref?.();
+    state.lifetimeTimer = setTimeout(
+      () => closeServerOnce(server, state),
+      SUCCESS_PAGE_MAX_LIFETIME_MS,
+    );
+    state.lifetimeTimer.unref?.();
+  } else {
+    closeServerOnce(server, state);
+  }
+}
+
+async function exchangeTokensOrThrow(
+  auth0Config: Auth0Config,
+  authCode: string,
+  codeVerifier: string,
+): Promise<TokenChainResult> {
+  try {
+    return await executeFullTokenChain(auth0Config, authCode, codeVerifier);
+  } catch (err) {
+    throw new PkceLoginError(
+      "auth0_unreachable",
+      `Token chain failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Runs the PKCE flow end-to-end:
+ *  - generates verifier / challenge / state
+ *  - binds a one-shot HTTP listener on {@link OAUTH_CALLBACK_PORT}
+ *  - opens the browser to the Auth0 authorization endpoint
+ *  - waits for the redirect carrying the auth code
+ *  - exchanges the code for the full Confluent token chain
+ *
+ * Bounded by {@link PKCE_LOGIN_TIMEOUT_MS}. Throws {@link PkceLoginError} on
+ * failure with a structured `reason`. If `signal` aborts before the auth
+ * code arrives, throws `PkceLoginError("user_aborted", ...)` and the finally
+ * block tears down the timer + HTTP server.
+ */
+export async function runPkceLogin(
+  auth0Config: Auth0Config,
+  signal?: AbortSignal,
+): Promise<TokenChainResult> {
+  // Early abort: skip the bind/open work entirely if the caller has already
+  // signaled cancellation.
+  if (signal?.aborted) {
+    throw new PkceLoginError("user_aborted", "PKCE login aborted");
+  }
+  if (!auth0Config.clientId) {
+    throw new PkceLoginError(
+      "configuration",
+      "Auth0 clientId is not configured for the selected environment",
+    );
+  }
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const oauthState = generateOpaqueToken();
+
+  let resolveCode: (code: string) => void = () => undefined;
+  let rejectFlow: (err: PkceLoginError) => void = () => undefined;
+  const codePromise = new Promise<string>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectFlow = reject;
+  });
+
+  // Tracks whether the success page was served. After success, the server's
+  // lifetime is driven by the success page's EventSource: it stays bound while
+  // the tab is open and closes when the stream disconnects (or when the safety
+  // timer fires).
+  const state: PkceCallbackState = {
+    oauthState,
+    streamClients: new Set<ServerResponse>(),
+    resolveCode,
+    rejectFlow,
+    successServed: false,
+    serverClosed: false,
+    bound: false,
+  };
+
+  // `server` is referenced inside its own request listener (to close itself
+  // once the success-page stream disconnects); the listener closure only
+  // runs once a request arrives, well after this `const` is initialized.
+  const server: CallbackServer = nodeHttp.createServer((req, res) =>
+    createCallbackRequestListener(server, state)(req, res),
+  );
 
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -307,22 +420,17 @@ export async function runPkceLogin(
 
   let authCode: string;
   try {
-    await Promise.race([bindResult, abortPromise]);
-    const authUrl = buildAuthorizationUrl(auth0Config, codeChallenge, state);
+    await Promise.race([bindCallbackServer(server, state), abortPromise]);
+    const authUrl = buildAuthorizationUrl(
+      auth0Config,
+      codeChallenge,
+      oauthState,
+    );
     // log the URL so users whose default browser misbehaves can open it manually. safe to log:
     // the URL carries only the one-time PKCE code_challenge + state, both bound to this single
     // login attempt and discarded once the callback resolves.
     logger.info({ authUrl }, "Opening Auth0 authorization URL");
-    try {
-      await Promise.race([nodeOpen.open(authUrl), abortPromise]);
-    } catch (err) {
-      // Preserve user_aborted from the race; wrap any other open() failure.
-      if (err instanceof PkceLoginError) throw err;
-      throw new PkceLoginError(
-        "configuration",
-        `Failed to open browser: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    await openBrowserOrThrow(authUrl, abortPromise);
     authCode = await Promise.race([codePromise, timeoutPromise, abortPromise]);
   } finally {
     // Remove the abort listener if the race resolved via something other
@@ -331,31 +439,9 @@ export async function runPkceLogin(
       signal.removeEventListener("abort", abortListener);
     }
     clearTimeout(timer);
-    if (bound) {
-      if (successServed) {
-        // The success page's EventSource keeps the listener alive while the
-        // browser tab is open; stream-disconnect calls closeServerOnce. The
-        // timer + unref'd server are the "tab left open" backstop so this
-        // listener can never keep the process alive on its own.
-        server.unref?.();
-        lifetimeTimer = setTimeout(
-          closeServerOnce,
-          SUCCESS_PAGE_MAX_LIFETIME_MS,
-        );
-        lifetimeTimer.unref?.();
-      } else {
-        closeServerOnce();
-      }
-    }
+    teardownCallbackServer(server, state);
   }
 
   logger.info("PKCE auth code received; exchanging for token chain");
-  try {
-    return await executeFullTokenChain(auth0Config, authCode, codeVerifier);
-  } catch (err) {
-    throw new PkceLoginError(
-      "auth0_unreachable",
-      `Token chain failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  return exchangeTokensOrThrow(auth0Config, authCode, codeVerifier);
 }


### PR DESCRIPTION
## Reduce cognitive complexity in src/confluent/oauth/pkce-login.ts

- `runPkceLogin` defined its HTTP callback-server request listener, bind-error handler, and `closeServerOnce` as closures nested inside itself. Sonar's cognitive complexity rolls a nested closure's branching into the _enclosing_ function's score (only genuinely top-level functions are scored independently), which is why the function sat at complexity 16 despite each individual branch reading simply on its own.
- Hoisted every nested closure to module scope, threading the state they used to close over through an explicit `PkceCallbackState` struct and a `server` parameter instead of capture: `closeServerOnce()`, `handleSkillsHintCopiedRequest()`, `handleSkillsHintStreamRequest()`, `handleOAuthRedirectRequest()`, `createCallbackRequestListener()`, `bindCallbackServer()`, `openBrowserOrThrow()`, `teardownCallbackServer()`, and `exchangeTokensOrThrow()`. `runPkceLogin` is now an orchestrator — guards, setup, a handful of awaits — at complexity ~4.
- Removed the `// eslint-disable-next-line sonarjs/cognitive-complexity` suppression now that the function is under the gate.
- The test double `mockHttpServer` (in `tests/stubs/node-deps.ts`) only captures a listener passed directly as `createServer`'s constructor argument, not via `.on("request", ...)`. That ruled out the simplest ordering fix for the `server`/listener chicken-and-egg (the listener needs `server` to close itself on stream disconnect); landed on a `const server: CallbackServer = nodeHttp.createServer((req, res) => createCallbackRequestListener(server, state)(req, res))` trampoline instead — legal because the closure only runs once a request arrives, well after the `const` initializes.
- Pure refactor: all 18 existing cases in `pkce-login.test.ts` pass unchanged, proving no observable behavior change. Coverage on the file is unchanged in substance too — the same two pre-existing gaps (the stream-path pre-success 404 branch, and the post-bind server error handler) persist at their relocated line numbers; nothing new went uncovered.

## Relationships

Closes #656
