### PR TITLE
Refactor list environments handler to reduce complexity.

### DIFF
--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -201,6 +201,27 @@ describe("list-billing-costs-handler.ts", () => {
         });
       });
 
+      it("should render a Total Items line of 0 when total_size is zero", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({
+          data: {
+            api_version: "v1",
+            kind: "CostList",
+            metadata: { total_size: 0 },
+            data: [],
+          },
+        });
+
+        const result = await handler.handle(
+          runtimeWith(CCLOUD_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          VALID_ARGS,
+        );
+
+        expect(result.isError).toBe(false);
+        expect(textOf(result)).toContain("Total Items: 0");
+        expect((result._meta as { total: unknown }).total).toBe(0);
+      });
+
       it("should omit the pagination section and leave _meta.pagination undefined when metadata is absent", async () => {
         const clientManager = getMockedClientManager();
         clientManager.getConfluentCloudRestClient().GET.mockResolvedValue({

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -6,6 +6,10 @@ import {
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
+import {
+  renderPaginationSection,
+  toPaginationMeta,
+} from "@src/confluent/tools/pagination.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -125,7 +129,6 @@ const billingCostsSchema = z.object({
 });
 
 type BillingCostsList = z.infer<typeof billingCostsSchema>;
-type BillingCostsMetadata = BillingCostsList["metadata"];
 
 export class ListBillingCostsHandler extends BaseToolHandler {
   async handle(
@@ -204,7 +207,7 @@ Cost Summary (${startDate} to ${endDate}):
 `;
       const productBreakdown = formatProductBreakdown(productCosts);
       const metadata = validatedResponse.metadata;
-      const paginationInfo = formatPaginationSection(metadata);
+      const paginationInfo = renderPaginationSection(metadata, "Total Items");
 
       return this.createResponse(
         `Successfully retrieved billing costs:\n${costSummary}${productBreakdown}${paginationInfo}`,
@@ -223,14 +226,7 @@ Cost Summary (${startDate} to ${endDate}):
           },
           product_breakdown: Object.fromEntries(productCosts),
           total: metadata?.total_size,
-          pagination: metadata
-            ? {
-                first: metadata.first,
-                last: metadata.last,
-                prev: metadata.prev,
-                next: metadata.next,
-              }
-            : undefined,
+          pagination: toPaginationMeta(metadata),
         },
       );
     } catch (validationError) {
@@ -311,29 +307,5 @@ function formatProductBreakdown(productCosts: Map<string, number>): string {
   return `
 Product Breakdown:
 ${lines}
-`;
-}
-
-/**
- * Render the pagination section, omitting individual rows whose value is absent.
- * Empty string when the response carried no metadata block at all.
- */
-function formatPaginationSection(metadata: BillingCostsMetadata): string {
-  if (!metadata) {
-    return "";
-  }
-  const rows: ReadonlyArray<[string, string | number | undefined]> = [
-    ["Total Items", metadata.total_size],
-    ["First Page", metadata.first],
-    ["Last Page", metadata.last],
-    ["Previous Page", metadata.prev],
-    ["Next Page", metadata.next],
-  ];
-  const body = rows
-    .filter(([, value]) => Boolean(value))
-    .map(([label, value]) => `\n  ${label}: ${value}`)
-    .join("");
-  return `
-Pagination:${body}
 `;
 }

--- a/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.test.ts
@@ -204,6 +204,32 @@ describe("list-environments-handler.ts", () => {
         });
       });
 
+      it("should render a Total Environments line of 0 when total_size is zero", async () => {
+        const clientManager = getMockedClientManager();
+        configureGet(clientManager, {
+          data: {
+            api_version: "org/v2",
+            kind: "EnvironmentList",
+            metadata: { total_size: 0 },
+            data: [],
+          },
+        });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            CCLOUD_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          outcome: { resolves: "Total Environments: 0", isError: false },
+          clientManager,
+        });
+
+        expect(textOf(result!)).toContain("Total Environments: 0");
+        expect(result!._meta).toMatchObject({ total: 0 });
+      });
+
       it("should render deleted-at, stream-governance, and every pagination link for a fully-populated response", async () => {
         const clientManager = getMockedClientManager();
         configureGet(clientManager, {

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -60,7 +60,6 @@ export type Environment = z.infer<typeof environmentSchema>;
 export type EnvironmentList = z.infer<typeof environmentListSchema>;
 
 export class ListEnvironmentsHandler extends BaseToolHandler {
-  // eslint-disable-next-line sonarjs/cognitive-complexity -- baselined pre-existing complexity; reduce below 15 (#659)
   async handle(
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
@@ -92,75 +91,49 @@ export class ListEnvironmentsHandler extends BaseToolHandler {
         );
       }
 
-      try {
-        const validatedResponse = environmentListSchema.parse(
-          response,
-        ) as EnvironmentList;
-        const environments = validatedResponse.data.map((env) => ({
-          id: env.id,
-          name: env.display_name,
-          created_at: env.metadata.created_at,
-          updated_at: env.metadata.updated_at,
-          deleted_at: env.metadata.deleted_at,
-          resource_name: env.metadata.resource_name,
-          stream_governance: env.stream_governance_config?.package,
-        }));
-
-        // Format environment details for display
-        const environmentDetails = environments
-          .map(
-            (env) => `
-Environment: ${env.name}
-  ID: ${env.id}
-  Resource Name: ${env.resource_name}
-  Created At: ${env.created_at}
-  Updated At: ${env.updated_at}${env.deleted_at ? `\n  Deleted At: ${env.deleted_at}` : ""}${env.stream_governance ? `\n  Stream Governance Package: ${env.stream_governance}` : ""}
-`,
-          )
-          .join("\n");
-
-        const metadata = validatedResponse.metadata;
-        const paginationInfo = metadata
-          ? `
-Pagination:${metadata.total_size ? `\n  Total Environments: ${metadata.total_size}` : ""}${metadata.first ? `\n  First Page: ${metadata.first}` : ""}${metadata.last ? `\n  Last Page: ${metadata.last}` : ""}${metadata.prev ? `\n  Previous Page: ${metadata.prev}` : ""}${metadata.next ? `\n  Next Page: ${metadata.next}` : ""}
-`
-          : "";
-
-        return this.createResponse(
-          `Successfully retrieved ${environments.length} environments:\n${environmentDetails}\n${paginationInfo}`,
-          false,
-          {
-            environments,
-            total: metadata?.total_size,
-            pagination: metadata
-              ? {
-                  first: metadata.first,
-                  last: metadata.last,
-                  prev: metadata.prev,
-                  next: metadata.next,
-                }
-              : undefined,
-          },
-        );
-      } catch (validationError) {
-        logger.error(
-          { error: validationError },
-          "Environment list validation error",
-        );
-        return this.createResponse(
-          `Invalid environment list data: ${validationError instanceof Error ? validationError.message : String(validationError)}`,
-          true,
-          { error: validationError },
-        );
-      }
+      return this.buildEnvironmentListResponse(response);
     } catch (error) {
       logger.error({ error }, "Error in ListEnvironmentsHandler");
       return this.createResponse(
-        `Failed to fetch environments: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to fetch environments: ${errorMessage(error)}`,
         true,
-        { error: error instanceof Error ? error.message : String(error) },
+        { error: errorMessage(error) },
       );
     }
+  }
+
+  /**
+   * Validates the raw environment-list payload and renders the success response,
+   * returning a validation-error response when the payload doesn't match the schema.
+   */
+  private buildEnvironmentListResponse(response: unknown): CallToolResult {
+    let validatedResponse: EnvironmentList;
+    try {
+      validatedResponse = environmentListSchema.parse(response);
+    } catch (validationError) {
+      logger.error(
+        { error: validationError },
+        "Environment list validation error",
+      );
+      return this.createResponse(
+        `Invalid environment list data: ${errorMessage(validationError)}`,
+        true,
+        { error: validationError },
+      );
+    }
+
+    const environments = validatedResponse.data.map(toEnvironmentSummary);
+    const metadata = validatedResponse.metadata;
+
+    return this.createResponse(
+      `Successfully retrieved ${environments.length} environments:\n${renderEnvironmentDetails(environments)}\n${renderPaginationInfo(metadata)}`,
+      false,
+      {
+        environments,
+        total: metadata?.total_size,
+        pagination: toPaginationMeta(metadata),
+      },
+    );
   }
 
   getToolConfig(): ToolConfig {
@@ -174,4 +147,103 @@ Pagination:${metadata.total_size ? `\n  Total Environments: ${metadata.total_siz
   }
   readonly category = ToolCategory.ConfluentCloud;
   readonly predicate = hasConfluentCloudOrOAuth;
+}
+
+type EnvironmentListMetadata = EnvironmentList["metadata"];
+
+/**
+ * Flattened view of an environment for both the rendered text and the _meta payload.
+ */
+type EnvironmentSummary = {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | undefined;
+  resource_name: string;
+  stream_governance: string | undefined;
+};
+
+/**
+ * Extracts a message from an unknown throw/error value without assuming it is an Error.
+ */
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/**
+ * Projects a validated environment onto the flat summary shape callers see.
+ */
+function toEnvironmentSummary(env: Environment): EnvironmentSummary {
+  return {
+    id: env.id,
+    name: env.display_name,
+    created_at: env.metadata.created_at,
+    updated_at: env.metadata.updated_at,
+    deleted_at: env.metadata.deleted_at,
+    resource_name: env.metadata.resource_name,
+    stream_governance: env.stream_governance_config?.package,
+  };
+}
+
+/**
+ * Renders the per-environment text block; deleted-at and stream-governance lines
+ * appear only when populated.
+ */
+function renderEnvironmentDetails(environments: EnvironmentSummary[]): string {
+  return environments
+    .map((env) => {
+      const deletedLine = env.deleted_at
+        ? `\n  Deleted At: ${env.deleted_at}`
+        : "";
+      const governanceLine = env.stream_governance
+        ? `\n  Stream Governance Package: ${env.stream_governance}`
+        : "";
+      return `
+Environment: ${env.name}
+  ID: ${env.id}
+  Resource Name: ${env.resource_name}
+  Created At: ${env.created_at}
+  Updated At: ${env.updated_at}${deletedLine}${governanceLine}
+`;
+    })
+    .join("\n");
+}
+
+/**
+ * Renders the pagination text block. A present-but-empty metadata object still
+ * emits the header; absent metadata emits nothing.
+ */
+function renderPaginationInfo(metadata: EnvironmentListMetadata): string {
+  if (!metadata) {
+    return "";
+  }
+  const links: Array<[string, string | number | undefined]> = [
+    ["Total Environments", metadata.total_size],
+    ["First Page", metadata.first],
+    ["Last Page", metadata.last],
+    ["Previous Page", metadata.prev],
+    ["Next Page", metadata.next],
+  ];
+  const lines = links
+    .filter(([, value]) => value)
+    .map(([label, value]) => `\n  ${label}: ${value}`)
+    .join("");
+  return `
+Pagination:${lines}
+`;
+}
+
+/**
+ * Builds the _meta pagination object, or undefined when no metadata was returned.
+ */
+function toPaginationMeta(metadata: EnvironmentListMetadata) {
+  return metadata
+    ? {
+        first: metadata.first,
+        last: metadata.last,
+        prev: metadata.prev,
+        next: metadata.next,
+      }
+    : undefined;
 }

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -226,7 +226,7 @@ function renderPaginationInfo(metadata: EnvironmentListMetadata): string {
     ["Next Page", metadata.next],
   ];
   const lines = links
-    .filter(([, value]) => value)
+    .filter(([, value]) => value !== undefined)
     .map(([label, value]) => `\n  ${label}: ${value}`)
     .join("");
   return `

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -6,6 +6,10 @@ import {
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
+import {
+  renderPaginationSection,
+  toPaginationMeta,
+} from "@src/confluent/tools/pagination.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
@@ -126,7 +130,7 @@ export class ListEnvironmentsHandler extends BaseToolHandler {
     const metadata = validatedResponse.metadata;
 
     return this.createResponse(
-      `Successfully retrieved ${environments.length} environments:\n${renderEnvironmentDetails(environments)}\n${renderPaginationInfo(metadata)}`,
+      `Successfully retrieved ${environments.length} environments:\n${renderEnvironmentDetails(environments)}\n${renderPaginationSection(metadata, "Total Environments")}`,
       false,
       {
         environments,
@@ -148,8 +152,6 @@ export class ListEnvironmentsHandler extends BaseToolHandler {
   readonly category = ToolCategory.ConfluentCloud;
   readonly predicate = hasConfluentCloudOrOAuth;
 }
-
-type EnvironmentListMetadata = EnvironmentList["metadata"];
 
 /**
  * Flattened view of an environment for both the rendered text and the _meta payload.
@@ -208,42 +210,4 @@ Environment: ${env.name}
 `;
     })
     .join("\n");
-}
-
-/**
- * Renders the pagination text block. A present-but-empty metadata object still
- * emits the header; absent metadata emits nothing.
- */
-function renderPaginationInfo(metadata: EnvironmentListMetadata): string {
-  if (!metadata) {
-    return "";
-  }
-  const links: Array<[string, string | number | undefined]> = [
-    ["Total Environments", metadata.total_size],
-    ["First Page", metadata.first],
-    ["Last Page", metadata.last],
-    ["Previous Page", metadata.prev],
-    ["Next Page", metadata.next],
-  ];
-  const lines = links
-    .filter(([, value]) => value !== undefined)
-    .map(([label, value]) => `\n  ${label}: ${value}`)
-    .join("");
-  return `
-Pagination:${lines}
-`;
-}
-
-/**
- * Builds the _meta pagination object, or undefined when no metadata was returned.
- */
-function toPaginationMeta(metadata: EnvironmentListMetadata) {
-  return metadata
-    ? {
-        first: metadata.first,
-        last: metadata.last,
-        prev: metadata.prev,
-        next: metadata.next,
-      }
-    : undefined;
 }

--- a/src/confluent/tools/pagination.test.ts
+++ b/src/confluent/tools/pagination.test.ts
@@ -1,0 +1,76 @@
+import {
+  renderPaginationSection,
+  toPaginationMeta,
+} from "@src/confluent/tools/pagination.js";
+import { describe, expect, it } from "vitest";
+
+describe("pagination.ts", () => {
+  describe("renderPaginationSection", () => {
+    it("should return an empty string when metadata is undefined", () => {
+      expect(renderPaginationSection(undefined, "Total Items")).toBe("");
+    });
+
+    it("should render the header but no link lines when metadata is present but empty", () => {
+      const rendered = renderPaginationSection({}, "Total Items");
+      expect(rendered).toContain("Pagination:");
+      expect(rendered).not.toContain("Total Items:");
+      expect(rendered).not.toContain("First Page:");
+      expect(rendered).not.toContain("Last Page:");
+      expect(rendered).not.toContain("Previous Page:");
+      expect(rendered).not.toContain("Next Page:");
+    });
+
+    it("should render a total line of 0 when total_size is zero", () => {
+      // Regression guard: a truthiness filter drops 0, omitting a legitimate
+      // total. The filter must be undefined-based so a real zero still renders.
+      expect(
+        renderPaginationSection({ total_size: 0 }, "Total Environments"),
+      ).toContain("Total Environments: 0");
+    });
+
+    it("should render every populated link line under the caller's total label", () => {
+      const rendered = renderPaginationSection(
+        {
+          total_size: 7,
+          first: "url-first",
+          last: "url-last",
+          prev: "url-prev",
+          next: "url-next",
+        },
+        "Total Items",
+      );
+      expect(rendered).toContain("Total Items: 7");
+      expect(rendered).toContain("First Page: url-first");
+      expect(rendered).toContain("Last Page: url-last");
+      expect(rendered).toContain("Previous Page: url-prev");
+      expect(rendered).toContain("Next Page: url-next");
+    });
+  });
+
+  describe("toPaginationMeta", () => {
+    it("should return undefined when metadata is undefined", () => {
+      expect(toPaginationMeta(undefined)).toBeUndefined();
+    });
+
+    it("should project only the four link fields, dropping total_size", () => {
+      expect(
+        toPaginationMeta({
+          total_size: 7,
+          first: "f",
+          last: "l",
+          prev: "p",
+          next: "n",
+        }),
+      ).toEqual({ first: "f", last: "l", prev: "p", next: "n" });
+    });
+
+    it("should carry undefined link fields through when metadata is empty", () => {
+      expect(toPaginationMeta({})).toEqual({
+        first: undefined,
+        last: undefined,
+        prev: undefined,
+        next: undefined,
+      });
+    });
+  });
+});

--- a/src/confluent/tools/pagination.ts
+++ b/src/confluent/tools/pagination.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared rendering for the pagination `metadata` block that Confluent Cloud
+ * list endpoints return. Individual endpoints type the link fields as either a
+ * plain string or a validated URL; both narrow to `string`, so the per-handler
+ * metadata types are assignable to this common shape.
+ */
+export type PaginationMetadata = {
+  first?: string;
+  last?: string;
+  prev?: string;
+  next?: string;
+  total_size?: number;
+};
+
+/**
+ * Renders the pagination text block. A present-but-empty metadata object still
+ * emits the header; absent metadata emits nothing. Rows whose value is absent
+ * are omitted — the filter tests for `undefined`, not truthiness, so a
+ * legitimate `total_size: 0` still renders.
+ */
+export function renderPaginationSection(
+  metadata: PaginationMetadata | undefined,
+  totalLabel: string,
+): string {
+  if (!metadata) {
+    return "";
+  }
+  const rows: ReadonlyArray<[string, string | number | undefined]> = [
+    [totalLabel, metadata.total_size],
+    ["First Page", metadata.first],
+    ["Last Page", metadata.last],
+    ["Previous Page", metadata.prev],
+    ["Next Page", metadata.next],
+  ];
+  const body = rows
+    .filter(([, value]) => value !== undefined)
+    .map(([label, value]) => `\n  ${label}: ${value}`)
+    .join("");
+  return `
+Pagination:${body}
+`;
+}
+
+/**
+ * Builds the `_meta` pagination object (the four navigation links, without
+ * total_size), or undefined when no metadata was returned.
+ */
+export function toPaginationMeta(metadata: PaginationMetadata | undefined) {
+  return metadata
+    ? {
+        first: metadata.first,
+        last: metadata.last,
+        prev: metadata.prev,
+        next: metadata.next,
+      }
+    : undefined;
+}


### PR DESCRIPTION
Refactor list environments handler to reduce complexity.

Centralizes code handling pagination common to both `list-billing-costs-handler` and `list-environments-handler` into new  `tools/pagination.ts` (improving an edge case path in `list-billing-costs-handler`).

Closes #659