### PR TITLE
Remove complexity lint-skip in`flink-sql-helper.ts`

### DIFF
--- a/src/confluent/tools/handlers/flink/flink-sql-helper.ts
+++ b/src/confluent/tools/handlers/flink/flink-sql-helper.ts
@@ -231,7 +231,6 @@ async function deleteCompletedStatement(
  * For bounded queries (like INFORMATION_SCHEMA), waits for statement to complete,
  * then fetches all results and deletes the spent statement.
  */
-// eslint-disable-next-line sonarjs/cognitive-complexity -- baselined pre-existing complexity; reduce below 15 (#663)
 export async function executeFlinkSql(
   clientManager: BaseClientManager,
   sql: string,


### PR DESCRIPTION
Prior PR #653 for issue #647 performed the refactoring asked for in #663. It just forgot to remove the `// eslint-disable-next-line` marker.

Closes #663