### PR TITLE
Refactor ListMetricsHandler.

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,47 @@
+---
+paths:
+  - src/**/*.ts
+---
+
+# Logging with Pino: errors go under the `err` key, context goes in fields
+
+The project logs through Pino (`@src/logger.js`).
+Pino registers a **serializer for the `err` key by default** — pass an error there and it extracts `message`, `type`, and the full `stack`.
+That serializer keys off the property name: an error logged under any other key (`error`, `e`, `cause`) is serialized as a plain object, so its stack is lost.
+
+## The rule
+
+When a log call reports a failure, pass the caught value under `err`, and put every other identifier (ids, status codes, names, URLs) in its own field on the same context object.
+The message string is a static human label, not a place to interpolate the error.
+
+```typescript
+// Good: err captures the stack; status/kind are filterable fields.
+logger.warn(
+  { err, status: result.response?.status, kind },
+  "Telemetry API descriptors request failed; omitting best-effort section",
+);
+logger.error({ err }, "Error in ListMetricsHandler");
+```
+
+```typescript
+// Bad: no stack (wrong key), and the error is welded into the message so it
+// can't be filtered or parsed downstream.
+logger.warn(`Telemetry API error (HTTP ${status}): ${describeError(err)}`);
+logger.error({ error }, "Error in ListMetricsHandler"); // `error` ≠ `err`
+```
+
+`err` may hold a value typed `unknown` (a `catch` binding, an `openapi-fetch` `error` payload).
+Pino serializes a non-`Error` under `err` fine — it just has no stack to add — so there is no need to narrow to `Error` before logging.
+Reference calls that already follow this: `src/confluent/oauth/pkce-login.ts` and `src/confluent/tools/cluster-arg-resolvers.ts`.
+
+## Don't test the log
+
+Logging is a side effect, not observable behaviour — do not stub the logger or assert on log shape.
+This mirrors the standing guidance in `.claude/rules/unit-tests.md` ("Do not test or stub side effects like logging").
+Get the `err`-key convention right by reading, not by pinning it in a test.
+
+## Migration note
+
+Some historical call sites still log under `error` (e.g. a few in `src/confluent/tools/handlers/docs/`).
+They pre-date this rule and are harmless but lose the stack.
+Convert them to `err` opportunistically when you're already editing the surrounding code, not as a standalone sweep.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ below affect source-code edits too, so they're called out here:
   `vi.fn()`.
 - **Test-only helpers belong in test files.** Functions that exist solely to support tests (builders, factories, convenience wrappers around production code) must live in `*.test.ts` files or under `tests/`. Do not export them from production source files — they bloat the public API surface and obscure what the module actually provides to callers.
 
+## Logging Conventions
+
+Log through Pino (`@src/logger.js`) with the error under the `err` key (Pino's default serializer captures the stack only for that key) and other identifiers as their own fields — never string-interpolate an error into the message. Full rule at `.claude/rules/logging.md` (auto-loads when editing `src/**/*.ts`).
+
 ## Integration Test Conventions
 
 Integration tests spawn the real MCP server as a child process and exercise it against a real Confluent Cloud account over both stdio and streamable HTTP transports. Full rule at `.claude/rules/integration-tests.md` (auto-loads when editing `*.integration.test.ts` or `tests/harness/**`).

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
@@ -239,6 +239,34 @@ describe("list-metrics-handler.ts", () => {
         expect(text).not.toContain("No metrics descriptors available");
       });
 
+      it("should still list metrics when only the resources descriptors call fails (resources are best-effort)", async () => {
+        telemetryRest.GET.mockImplementation(((path: string) => {
+          if (path.includes("/descriptors/metrics")) {
+            return Promise.resolve({
+              data: { data: [FLINK_METRIC_DESCRIPTOR] },
+            });
+          }
+          if (path.includes("/descriptors/resources")) {
+            return Promise.resolve({
+              error: { errors: [{ detail: "forbidden" }] },
+              response: { status: 403 },
+            });
+          }
+          throw new Error(`unexpected path ${path}`);
+        }) as MockedRestClient["GET"]);
+
+        const result = await handler.handle(
+          runtimeWith(TELEMETRY_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { resource_type: "flink_statement" },
+        );
+
+        const text = textOf(result);
+        expect(result.isError).toBe(false);
+        expect(text).toContain("io.confluent.flink/num_records_in");
+        expect(text).not.toContain("Resource Types and Filter Fields:");
+        expect(text).not.toContain("Failed to list metrics");
+      });
+
       it("should preserve an Error payload's message rather than JSON-stringifying it to {}", async () => {
         telemetryRest.GET.mockResolvedValue({
           error: new Error("token expired"),

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
@@ -239,6 +239,42 @@ describe("list-metrics-handler.ts", () => {
         expect(text).not.toContain("No metrics descriptors available");
       });
 
+      it("should preserve an Error payload's message rather than JSON-stringifying it to {}", async () => {
+        telemetryRest.GET.mockResolvedValue({
+          error: new Error("token expired"),
+          response: { status: 500 },
+        } as never);
+
+        const result = await handler.handle(
+          runtimeWith(TELEMETRY_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+
+        const text = textOf(result);
+        expect(result.isError).toBe(true);
+        expect(text).toContain("HTTP 500");
+        expect(text).toContain("token expired");
+        expect(text).not.toContain("{}");
+      });
+
+      it("should not throw when the descriptor error payload is a circular structure", async () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        telemetryRest.GET.mockResolvedValue({
+          error: circular,
+          response: { status: 500 },
+        } as never);
+
+        const result = await handler.handle(
+          runtimeWith(TELEMETRY_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toContain("Failed to list metrics");
+        expect(textOf(result)).toContain("HTTP 500");
+      });
+
       it("should stringify non-Error thrown values in the failure message", async () => {
         telemetryRest.GET.mockRejectedValue("string failure");
 

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
@@ -220,6 +220,25 @@ describe("list-metrics-handler.ts", () => {
         });
       });
 
+      it("should surface the HTTP status and error detail when the descriptors endpoint returns an openapi-fetch error instead of throwing", async () => {
+        telemetryRest.GET.mockResolvedValue({
+          error: { errors: [{ detail: "authentication failed" }] },
+          response: { status: 403 },
+        } as never);
+
+        const result = await handler.handle(
+          runtimeWith(TELEMETRY_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          {},
+        );
+
+        const text = textOf(result);
+        expect(result.isError).toBe(true);
+        expect(text).toContain("Failed to list metrics");
+        expect(text).toContain("HTTP 403");
+        expect(text).toContain("authentication failed");
+        expect(text).not.toContain("No metrics descriptors available");
+      });
+
       it("should stringify non-Error thrown values in the failure message", async () => {
         telemetryRest.GET.mockRejectedValue("string failure");
 

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -1,3 +1,4 @@
+import type { ConfluentRestClient } from "@src/confluent/client-manager.js";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -141,7 +142,6 @@ const KAFKA_SERVER_METRICS = [
 ];
 
 export class ListMetricsHandler extends BaseToolHandler {
-  // eslint-disable-next-line sonarjs/cognitive-complexity -- baselined pre-existing complexity; reduce below 15 (#665)
   async handle(
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
@@ -150,27 +150,9 @@ export class ListMetricsHandler extends BaseToolHandler {
     const { clientManager } = this.resolveConnection(runtime, toolArguments);
 
     try {
-      const telemetryClient =
-        clientManager.getConfluentCloudTelemetryRestClient();
-
-      // Fetch both metrics and resources descriptors
-      const [metricsResponse, resourcesResponse] = await Promise.all([
-        telemetryClient.GET(
-          "/v2/metrics/{dataset}/descriptors/metrics" as never,
-          { params: { path: { dataset: "cloud" } } } as never,
-        ) as Promise<{ data?: DescriptorResponse }>,
-        telemetryClient.GET(
-          "/v2/metrics/{dataset}/descriptors/resources" as never,
-          { params: { path: { dataset: "cloud" } } } as never,
-        ) as Promise<{ data?: DescriptorResponse }>,
-      ]);
-
-      const metrics = (metricsResponse.data as DescriptorResponse)?.data as
-        | MetricDescriptor[]
-        | undefined;
-      const resources = (resourcesResponse.data as DescriptorResponse)?.data as
-        | ResourceDescriptor[]
-        | undefined;
+      const { metrics, resources } = await fetchDescriptors(
+        clientManager.getConfluentCloudTelemetryRestClient(),
+      );
 
       if (!metrics || metrics.length === 0) {
         return this.createResponse(
@@ -179,70 +161,15 @@ export class ListMetricsHandler extends BaseToolHandler {
         );
       }
 
-      // Filter by resource type if specified
-      let filteredMetrics = resource_type
-        ? metrics.filter((m) => m.resources.includes(resource_type))
-        : metrics;
-
-      // The descriptors endpoint may not list Kafka server metrics depending
-      // on API key permissions, but they still work when queried directly.
-      // Include well-known Kafka server metrics as a fallback.
-      if (
-        (!resource_type || resource_type === "kafka") &&
-        !filteredMetrics.some((m) =>
-          m.name.startsWith("io.confluent.kafka.server/"),
-        )
-      ) {
-        const kafkaServerMetrics: MetricDescriptor[] = KAFKA_SERVER_METRICS.map(
-          (m) => ({
-            ...m,
-            type: "GAUGE_DOUBLE",
-            unit: m.unit,
-            lifecycle_stage: "GENERAL_AVAILABILITY",
-            resources: ["kafka"],
-          }),
-        );
-        filteredMetrics = [...kafkaServerMetrics, ...filteredMetrics];
-      }
-
-      // Format resources section
-      const lines: string[] = [];
-
-      if (resources && resources.length > 0) {
-        const relevantResources = resource_type
-          ? resources.filter((r) => r.type === resource_type)
-          : resources;
-
-        if (relevantResources.length > 0) {
-          lines.push("Resource Types and Filter Fields:");
-          for (const r of relevantResources) {
-            lines.push(`  ${r.type}: ${r.description}`);
-            for (const label of r.labels) {
-              lines.push(`    resource.${label.key} — ${label.description}`);
-            }
-          }
-          lines.push("");
-        }
-      }
-
-      // Format metrics
-      lines.push(
-        `Available Metrics${resource_type ? ` (${resource_type})` : ""}: ${filteredMetrics.length}`,
+      const filteredMetrics = withKafkaServerFallback(
+        filterMetricsByResourceType(metrics, resource_type),
+        resource_type,
       );
-      lines.push("");
 
-      for (const m of filteredMetrics) {
-        lines.push(`${m.name}`);
-        lines.push(`  ${m.description}`);
-        lines.push(
-          `  Type: ${m.type} | Unit: ${m.unit} | Resources: ${m.resources.join(", ")}`,
-        );
-        if (m.labels.length > 0) {
-          const labelKeys = m.labels.map((l) => `metric.${l.key}`).join(", ");
-          lines.push(`  Filter/group_by labels: ${labelKeys}`);
-        }
-        lines.push("");
-      }
+      const lines = [
+        ...formatResourcesSection(resources, resource_type),
+        ...formatMetricsSection(filteredMetrics, resource_type),
+      ];
 
       return this.createResponse(lines.join("\n").trimEnd());
     } catch (error) {
@@ -265,4 +192,121 @@ export class ListMetricsHandler extends BaseToolHandler {
   }
   readonly category = ToolCategory.Metrics;
   readonly predicate = hasTelemetryOrOAuth;
+}
+
+type ResourceType = z.infer<typeof listMetricsArguments>["resource_type"];
+
+/**
+ * Fetch the metrics and resources descriptor lists from the Telemetry API in
+ * parallel, unwrapping each response's nested `data.data` payload.
+ */
+async function fetchDescriptors(telemetryClient: ConfluentRestClient): Promise<{
+  metrics?: MetricDescriptor[];
+  resources?: ResourceDescriptor[];
+}> {
+  const [metricsResponse, resourcesResponse] = await Promise.all([
+    telemetryClient.GET(
+      "/v2/metrics/{dataset}/descriptors/metrics" as never,
+      {
+        params: { path: { dataset: "cloud" } },
+      } as never,
+    ) as Promise<{ data?: DescriptorResponse }>,
+    telemetryClient.GET(
+      "/v2/metrics/{dataset}/descriptors/resources" as never,
+      { params: { path: { dataset: "cloud" } } } as never,
+    ) as Promise<{ data?: DescriptorResponse }>,
+  ]);
+
+  return {
+    metrics: (metricsResponse.data as DescriptorResponse)?.data as
+      | MetricDescriptor[]
+      | undefined,
+    resources: (resourcesResponse.data as DescriptorResponse)?.data as
+      | ResourceDescriptor[]
+      | undefined,
+  };
+}
+
+function filterMetricsByResourceType(
+  metrics: MetricDescriptor[],
+  resourceType: ResourceType,
+): MetricDescriptor[] {
+  return resourceType
+    ? metrics.filter((m) => m.resources.includes(resourceType))
+    : metrics;
+}
+
+/**
+ * Prepend well-known Kafka server metrics when the filtered set covers Kafka
+ * yet lacks them. The descriptors endpoint may omit these depending on API key
+ * permissions, but they remain queryable directly, so we surface them anyway.
+ */
+function withKafkaServerFallback(
+  filteredMetrics: MetricDescriptor[],
+  resourceType: ResourceType,
+): MetricDescriptor[] {
+  const kafkaInScope = !resourceType || resourceType === "kafka";
+  const alreadyPresent = filteredMetrics.some((m) =>
+    m.name.startsWith("io.confluent.kafka.server/"),
+  );
+  if (!kafkaInScope || alreadyPresent) {
+    return filteredMetrics;
+  }
+
+  const kafkaServerMetrics: MetricDescriptor[] = KAFKA_SERVER_METRICS.map(
+    (m) => ({
+      ...m,
+      type: "GAUGE_DOUBLE",
+      unit: m.unit,
+      lifecycle_stage: "GENERAL_AVAILABILITY",
+      resources: ["kafka"],
+    }),
+  );
+  return [...kafkaServerMetrics, ...filteredMetrics];
+}
+
+function formatResourcesSection(
+  resources: ResourceDescriptor[] | undefined,
+  resourceType: ResourceType,
+): string[] {
+  const relevantResources = (resources ?? []).filter(
+    (r) => !resourceType || r.type === resourceType,
+  );
+  if (relevantResources.length === 0) {
+    return [];
+  }
+
+  const lines = ["Resource Types and Filter Fields:"];
+  for (const r of relevantResources) {
+    lines.push(`  ${r.type}: ${r.description}`);
+    for (const label of r.labels) {
+      lines.push(`    resource.${label.key} — ${label.description}`);
+    }
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatMetricsSection(
+  filteredMetrics: MetricDescriptor[],
+  resourceType: ResourceType,
+): string[] {
+  const lines = [
+    `Available Metrics${resourceType ? ` (${resourceType})` : ""}: ${filteredMetrics.length}`,
+    "",
+  ];
+
+  for (const m of filteredMetrics) {
+    lines.push(`${m.name}`);
+    lines.push(`  ${m.description}`);
+    lines.push(
+      `  Type: ${m.type} | Unit: ${m.unit} | Resources: ${m.resources.join(", ")}`,
+    );
+    if (m.labels.length > 0) {
+      const labelKeys = m.labels.map((l) => `metric.${l.key}`).join(", ");
+      lines.push(`  Filter/group_by labels: ${labelKeys}`);
+    }
+    lines.push("");
+  }
+  return lines;
 }

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -244,7 +244,7 @@ function unwrapDescriptors<T>(
 ): T[] | undefined {
   if (result.error !== undefined) {
     const status = result.response?.status;
-    const statusPart = status !== undefined ? ` (HTTP ${status})` : "";
+    const statusPart = status === undefined ? "" : ` (HTTP ${status})`;
     throw new Error(
       `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`,
     );
@@ -258,7 +258,25 @@ function describeDescriptorError(error: unknown): string {
     ?.map((e) => e.detail)
     .filter(Boolean)
     .join("; ");
-  return details && details.length > 0 ? details : JSON.stringify(error);
+  if (details && details.length > 0) {
+    return details;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return safeStringify(error);
+}
+
+/**
+ * Stringify an arbitrary error payload without ever throwing (e.g. on circular
+ * structures) or returning `undefined` (e.g. for values JSON.stringify omits).
+ */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function filterMetricsByResourceType(

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -44,8 +44,8 @@ interface ResourceDescriptor {
   labels: Array<{ key: string; description: string }>;
 }
 
-interface DescriptorResponse {
-  data?: MetricDescriptor[] | ResourceDescriptor[];
+interface DescriptorResponse<T> {
+  data?: T[];
   errors?: Array<{ detail?: string }>;
 }
 
@@ -210,20 +210,16 @@ async function fetchDescriptors(telemetryClient: ConfluentRestClient): Promise<{
       {
         params: { path: { dataset: "cloud" } },
       } as never,
-    ) as Promise<{ data?: DescriptorResponse }>,
+    ) as Promise<{ data?: DescriptorResponse<MetricDescriptor> }>,
     telemetryClient.GET(
       "/v2/metrics/{dataset}/descriptors/resources" as never,
       { params: { path: { dataset: "cloud" } } } as never,
-    ) as Promise<{ data?: DescriptorResponse }>,
+    ) as Promise<{ data?: DescriptorResponse<ResourceDescriptor> }>,
   ]);
 
   return {
-    metrics: (metricsResponse.data as DescriptorResponse)?.data as
-      | MetricDescriptor[]
-      | undefined,
-    resources: (resourcesResponse.data as DescriptorResponse)?.data as
-      | ResourceDescriptor[]
-      | undefined,
+    metrics: metricsResponse.data?.data,
+    resources: resourcesResponse.data?.data,
   };
 }
 
@@ -291,22 +287,15 @@ function formatMetricsSection(
   filteredMetrics: MetricDescriptor[],
   resourceType: ResourceType,
 ): string[] {
-  const lines = [
-    `Available Metrics${resourceType ? ` (${resourceType})` : ""}: ${filteredMetrics.length}`,
-    "",
-  ];
+  const scope = resourceType ? ` (${resourceType})` : "";
+  const lines = [`Available Metrics${scope}: ${filteredMetrics.length}`, ""];
 
   for (const m of filteredMetrics) {
-    lines.push(`${m.name}`);
-    lines.push(`  ${m.description}`);
-    lines.push(
-      `  Type: ${m.type} | Unit: ${m.unit} | Resources: ${m.resources.join(", ")}`,
-    );
-    if (m.labels.length > 0) {
-      const labelKeys = m.labels.map((l) => `metric.${l.key}`).join(", ");
-      lines.push(`  Filter/group_by labels: ${labelKeys}`);
-    }
-    lines.push("");
+    const detail = `  Type: ${m.type} | Unit: ${m.unit} | Resources: ${m.resources.join(", ")}`;
+    const labelKeys = m.labels.map((l) => `metric.${l.key}`).join(", ");
+    const labelLine =
+      m.labels.length > 0 ? [`  Filter/group_by labels: ${labelKeys}`] : [];
+    lines.push(`${m.name}`, `  ${m.description}`, detail, ...labelLine, "");
   }
   return lines;
 }

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -173,7 +173,7 @@ export class ListMetricsHandler extends BaseToolHandler {
 
       return this.createResponse(lines.join("\n").trimEnd());
     } catch (error) {
-      logger.error({ error }, "Error in ListMetricsHandler");
+      logger.error({ err: error }, "Error in ListMetricsHandler");
       return this.createResponse(
         `Failed to list metrics: ${error instanceof Error ? error.message : String(error)}`,
         true,
@@ -246,7 +246,11 @@ function requireDescriptors<T>(
   result: DescriptorFetchResult<T>,
 ): T[] | undefined {
   if (result.error !== undefined) {
-    throw new Error(descriptorErrorMessage(kind, result));
+    const status = result.response?.status;
+    const statusPart = status === undefined ? "" : ` (HTTP ${status})`;
+    throw new Error(
+      `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`,
+    );
   }
   return result.data?.data;
 }
@@ -261,19 +265,13 @@ function optionalDescriptors<T>(
   result: DescriptorFetchResult<T>,
 ): T[] | undefined {
   if (result.error !== undefined) {
-    logger.warn(descriptorErrorMessage(kind, result));
+    logger.warn(
+      { err: result.error, status: result.response?.status, kind },
+      "Telemetry API descriptors request failed; omitting best-effort section",
+    );
     return undefined;
   }
   return result.data?.data;
-}
-
-function descriptorErrorMessage<T>(
-  kind: string,
-  result: DescriptorFetchResult<T>,
-): string {
-  const status = result.response?.status;
-  const statusPart = status === undefined ? "" : ` (HTTP ${status})`;
-  return `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`;
 }
 
 function describeDescriptorError(error: unknown): string {

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -197,6 +197,16 @@ export class ListMetricsHandler extends BaseToolHandler {
 type ResourceType = z.infer<typeof listMetricsArguments>["resource_type"];
 
 /**
+ * openapi-fetch surfaces a non-2xx response through `error` rather than
+ * throwing, so an unchecked call treats an HTTP failure as an empty body.
+ */
+interface DescriptorFetchResult<T> {
+  data?: DescriptorResponse<T>;
+  error?: unknown;
+  response?: { status?: number };
+}
+
+/**
  * Fetch the metrics and resources descriptor lists from the Telemetry API in
  * parallel, unwrapping each response's nested `data.data` payload.
  */
@@ -204,23 +214,51 @@ async function fetchDescriptors(telemetryClient: ConfluentRestClient): Promise<{
   metrics?: MetricDescriptor[];
   resources?: ResourceDescriptor[];
 }> {
-  const [metricsResponse, resourcesResponse] = await Promise.all([
+  const [metricsResult, resourcesResult] = await Promise.all([
     telemetryClient.GET(
       "/v2/metrics/{dataset}/descriptors/metrics" as never,
       {
         params: { path: { dataset: "cloud" } },
       } as never,
-    ) as Promise<{ data?: DescriptorResponse<MetricDescriptor> }>,
+    ) as Promise<DescriptorFetchResult<MetricDescriptor>>,
     telemetryClient.GET(
       "/v2/metrics/{dataset}/descriptors/resources" as never,
       { params: { path: { dataset: "cloud" } } } as never,
-    ) as Promise<{ data?: DescriptorResponse<ResourceDescriptor> }>,
+    ) as Promise<DescriptorFetchResult<ResourceDescriptor>>,
   ]);
 
   return {
-    metrics: metricsResponse.data?.data,
-    resources: resourcesResponse.data?.data,
+    metrics: unwrapDescriptors("metrics", metricsResult),
+    resources: unwrapDescriptors("resources", resourcesResult),
   };
+}
+
+/**
+ * Return the descriptor payload, throwing an actionable error when the
+ * Telemetry API reported an HTTP-level failure so `handle()` surfaces the real
+ * cause instead of a misleading "no descriptors available" message.
+ */
+function unwrapDescriptors<T>(
+  kind: string,
+  result: DescriptorFetchResult<T>,
+): T[] | undefined {
+  if (result.error !== undefined) {
+    const status = result.response?.status;
+    const statusPart = status !== undefined ? ` (HTTP ${status})` : "";
+    throw new Error(
+      `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`,
+    );
+  }
+  return result.data?.data;
+}
+
+function describeDescriptorError(error: unknown): string {
+  const envelope = error as { errors?: Array<{ detail?: string }> } | null;
+  const details = envelope?.errors
+    ?.map((e) => e.detail)
+    .filter(Boolean)
+    .join("; ");
+  return details && details.length > 0 ? details : JSON.stringify(error);
 }
 
 function filterMetricsByResourceType(

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -208,7 +208,10 @@ interface DescriptorFetchResult<T> {
 
 /**
  * Fetch the metrics and resources descriptor lists from the Telemetry API in
- * parallel, unwrapping each response's nested `data.data` payload.
+ * parallel. Metrics descriptors are essential — an HTTP failure there throws so
+ * `handle()` surfaces the real cause. Resources descriptors are best-effort:
+ * they only feed the optional "Resource Types" section, so a failure there is
+ * logged and the section is omitted rather than failing the whole call.
  */
 async function fetchDescriptors(telemetryClient: ConfluentRestClient): Promise<{
   metrics?: MetricDescriptor[];
@@ -228,8 +231,8 @@ async function fetchDescriptors(telemetryClient: ConfluentRestClient): Promise<{
   ]);
 
   return {
-    metrics: unwrapDescriptors("metrics", metricsResult),
-    resources: unwrapDescriptors("resources", resourcesResult),
+    metrics: requireDescriptors("metrics", metricsResult),
+    resources: optionalDescriptors("resources", resourcesResult),
   };
 }
 
@@ -238,18 +241,39 @@ async function fetchDescriptors(telemetryClient: ConfluentRestClient): Promise<{
  * Telemetry API reported an HTTP-level failure so `handle()` surfaces the real
  * cause instead of a misleading "no descriptors available" message.
  */
-function unwrapDescriptors<T>(
+function requireDescriptors<T>(
   kind: string,
   result: DescriptorFetchResult<T>,
 ): T[] | undefined {
   if (result.error !== undefined) {
-    const status = result.response?.status;
-    const statusPart = status === undefined ? "" : ` (HTTP ${status})`;
-    throw new Error(
-      `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`,
-    );
+    throw new Error(descriptorErrorMessage(kind, result));
   }
   return result.data?.data;
+}
+
+/**
+ * Return the descriptor payload, or `undefined` (with a logged warning) when
+ * the Telemetry API reported an HTTP-level failure — for best-effort sections
+ * that should degrade gracefully rather than fail the whole call.
+ */
+function optionalDescriptors<T>(
+  kind: string,
+  result: DescriptorFetchResult<T>,
+): T[] | undefined {
+  if (result.error !== undefined) {
+    logger.warn(descriptorErrorMessage(kind, result));
+    return undefined;
+  }
+  return result.data?.data;
+}
+
+function descriptorErrorMessage<T>(
+  kind: string,
+  result: DescriptorFetchResult<T>,
+): string {
+  const status = result.response?.status;
+  const statusPart = status === undefined ? "" : ` (HTTP ${status})`;
+  return `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`;
 }
 
 function describeDescriptorError(error: unknown): string {


### PR DESCRIPTION
Refactor ListMetricsHandler to reduce complexity and to improve error handling.

Introduces new Claude guidance over `pino` error log formatting / handling, something that we were ding'd on multiple times during the development of this PR.

Closes #665