### PR TITLE
Refactor formatMetricsResponse to greatly reduce complexity.

### DIFF
--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -402,15 +402,21 @@ describe("query-metrics-handler.ts", () => {
 
         const text = textOf(result);
         expect(result.isError).toBe(false);
-        expect(text).toContain("Metrics Query Results");
-        expect(text).toContain(`Metric: ${KAFKA_SERVER_METRIC}`);
-        expect(text).toContain(
-          'Filter: {"resource.kafka.id":"lkc-from-config"}',
+        expect(text).toBe(
+          [
+            "Metrics Query Results",
+            `  Metric: ${KAFKA_SERVER_METRIC}`,
+            "  Aggregation: SUM",
+            "  Granularity: PT1M",
+            "  Interval: 2024-06-01T11:00:00Z/2024-06-01T12:00:00Z",
+            '  Filter: {"resource.kafka.id":"lkc-from-config"}',
+            "",
+            "Data Points: 3",
+            `  2024-06-01T12:00:00.000Z: ${(1234567).toLocaleString()}`,
+            "  2024-06-01T12:01:00.000Z: 0.1235",
+            "  2024-06-01T12:02:00.000Z: N/A",
+          ].join("\n"),
         );
-        expect(text).toContain("Data Points: 3");
-        expect(text).toContain((1234567).toLocaleString());
-        expect(text).toContain("0.1235");
-        expect(text).toContain("2024-06-01T12:02:00.000Z: N/A");
         expect(result._meta).toEqual({
           metric: KAFKA_SERVER_METRIC,
           dataset: "cloud",
@@ -453,13 +459,25 @@ describe("query-metrics-handler.ts", () => {
         );
 
         const text = textOf(result);
-        expect(text).toContain("Group by: metric.topic");
-        expect(text).toContain("Groups: 2");
-        expect(text).toContain("Group: metric.topic=orders");
-        expect(text).toContain("42");
-        expect(text).toContain("2024-06-01T12:01:00.000Z: N/A");
-        expect(text).toContain("Group: metric.topic=shipments");
-        expect(text).toContain("(no data points)");
+        expect(text).toBe(
+          [
+            "Metrics Query Results",
+            `  Metric: ${KAFKA_SERVER_METRIC}`,
+            "  Aggregation: SUM",
+            "  Granularity: PT1M",
+            "  Interval: 2024-06-01T11:00:00Z/2024-06-01T12:00:00Z",
+            "  Group by: metric.topic",
+            "",
+            "Groups: 2",
+            "",
+            "Group: metric.topic=orders",
+            "  2024-06-01T12:00:00.000Z: 42",
+            "  2024-06-01T12:01:00.000Z: N/A",
+            "",
+            "Group: metric.topic=shipments",
+            "  (no data points)",
+          ].join("\n"),
+        );
       });
     });
 

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -386,7 +386,7 @@ function formatPoint(timestamp: unknown, value: unknown): string {
   const ts = timestamp
     ? new Date(timestamp as string).toISOString()
     : "unknown";
-  const val = value !== undefined ? formatValue(value as number) : "N/A";
+  const val = value === undefined ? "N/A" : formatValue(value as number);
   return `  ${ts}: ${val}`;
 }
 

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -282,7 +282,6 @@ export function buildRequestBody(
  * vs. grouped format by inspecting whether the first element has a top-level
  * `timestamp` field (flat) or a nested `points` array (grouped).
  */
-// eslint-disable-next-line sonarjs/cognitive-complexity -- baselined pre-existing complexity; reduce below 15 (#666)
 function formatMetricsResponse(
   data: Array<Record<string, unknown>>,
   metric: string,
@@ -292,13 +291,37 @@ function formatMetricsResponse(
   filter?: Record<string, string>,
   groupBy?: string[],
 ): string {
-  const lines: string[] = [];
+  const lines = [
+    ...formatQueryHeader(
+      metric,
+      aggregation,
+      granularity,
+      interval,
+      filter,
+      groupBy,
+    ),
+    ...(isFlatResponse(data)
+      ? formatFlatPoints(data)
+      : formatGroupedPoints(data)),
+  ];
+  return lines.join("\n").trimEnd();
+}
 
-  lines.push(`Metrics Query Results`);
-  lines.push(`  Metric: ${metric}`);
-  lines.push(`  Aggregation: ${aggregation}`);
-  lines.push(`  Granularity: ${granularity}`);
-  lines.push(`  Interval: ${interval}`);
+function formatQueryHeader(
+  metric: string,
+  aggregation: string,
+  granularity: string,
+  interval: string,
+  filter?: Record<string, string>,
+  groupBy?: string[],
+): string[] {
+  const lines = [
+    "Metrics Query Results",
+    `  Metric: ${metric}`,
+    `  Aggregation: ${aggregation}`,
+    `  Granularity: ${granularity}`,
+    `  Interval: ${interval}`,
+  ];
   if (filter && Object.keys(filter).length > 0) {
     lines.push(`  Filter: ${JSON.stringify(filter)}`);
   }
@@ -306,61 +329,65 @@ function formatMetricsResponse(
     lines.push(`  Group by: ${groupBy.join(", ")}`);
   }
   lines.push("");
+  return lines;
+}
 
-  // Detect format: flat responses have timestamp/value at top level,
-  // grouped responses have a points array
+/**
+ * Flat responses carry `timestamp`/`value` at the top level of each element;
+ * grouped responses instead nest a `points` array under group labels.
+ */
+function isFlatResponse(data: Array<Record<string, unknown>>): boolean {
   const firstItem = data[0];
-  const isFlat =
-    firstItem !== undefined && "timestamp" in firstItem && "value" in firstItem;
+  return (
+    firstItem !== undefined && "timestamp" in firstItem && "value" in firstItem
+  );
+}
 
-  if (isFlat) {
-    lines.push(`Data Points: ${data.length}`);
-    for (const point of data) {
-      const ts = point.timestamp
-        ? new Date(point.timestamp as string).toISOString()
-        : "unknown";
-      const val =
-        point.value !== undefined ? formatValue(point.value as number) : "N/A";
-      lines.push(`  ${ts}: ${val}`);
-    }
-  } else {
-    lines.push(`Groups: ${data.length}`);
-    lines.push("");
-    for (const group of data) {
-      const labels: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(group)) {
-        if (key !== "points") {
-          labels[key] = value;
-        }
-      }
+function formatFlatPoints(data: Array<Record<string, unknown>>): string[] {
+  return [
+    `Data Points: ${data.length}`,
+    ...data.map((point) => formatPoint(point.timestamp, point.value)),
+  ];
+}
 
-      if (Object.keys(labels).length > 0) {
-        const labelStr = Object.entries(labels)
-          .map(([k, v]) => `${k}=${v}`)
-          .join(", ");
-        lines.push(`Group: ${labelStr}`);
-      }
+function formatGroupedPoints(data: Array<Record<string, unknown>>): string[] {
+  return [
+    `Groups: ${data.length}`,
+    "",
+    ...data.flatMap((group) => formatGroup(group)),
+  ];
+}
 
-      const points = group.points as
-        | Array<{ timestamp?: string; value?: number }>
-        | undefined;
-      if (points && points.length > 0) {
-        for (const point of points) {
-          const ts = point.timestamp
-            ? new Date(point.timestamp).toISOString()
-            : "unknown";
-          const val =
-            point.value !== undefined ? formatValue(point.value) : "N/A";
-          lines.push(`  ${ts}: ${val}`);
-        }
-      } else {
-        lines.push("  (no data points)");
-      }
-      lines.push("");
-    }
-  }
+function formatGroup(group: Record<string, unknown>): string[] {
+  const labelStr = formatGroupLabels(group);
+  const header = labelStr ? [`Group: ${labelStr}`] : [];
+  const points = group.points as
+    | Array<{ timestamp?: string; value?: number }>
+    | undefined;
+  const pointLines =
+    points && points.length > 0
+      ? points.map((point) => formatPoint(point.timestamp, point.value))
+      : ["  (no data points)"];
+  return [...header, ...pointLines, ""];
+}
 
-  return lines.join("\n").trimEnd();
+/**
+ * Renders a group's non-`points` label entries as `key=value` pairs, or an
+ * empty string when the group carries no labels.
+ */
+function formatGroupLabels(group: Record<string, unknown>): string {
+  return Object.entries(group)
+    .filter(([key]) => key !== "points")
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+}
+
+function formatPoint(timestamp: unknown, value: unknown): string {
+  const ts = timestamp
+    ? new Date(timestamp as string).toISOString()
+    : "unknown";
+  const val = value !== undefined ? formatValue(value as number) : "N/A";
+  return `  ${ts}: ${val}`;
 }
 
 /**


### PR DESCRIPTION
## Reduce cognitive complexity of `formatMetricsResponse`

- `formatMetricsResponse` in `query-metrics-handler.ts` carried a cognitive complexity of 46 (threshold 15), baselined behind an `eslint-disable-next-line sonarjs/cognitive-complexity`. It rendered the query header, detected flat-vs-grouped response shape, and rendered data points in two places with duplicated timestamp/value logic — all in one function.
- Decomposed it into focused peer helpers so the orchestrator reads like a table of contents: `formatQueryHeader` (the metric/aggregation/interval/filter/group-by block), `isFlatResponse` (shape detection), `formatFlatPoints` and `formatGroupedPoints` (the two top-level branches), `formatGroup` + `formatGroupLabels` (one group's labels and points), and `formatPoint` (the timestamp/value line shared by both flat and grouped rendering — the duplication that most inflated the score). Each returns `string[]`, spread into the orchestrator's `lines`.
- Removed the suppression; `pnpm run lint` passes with it gone, confirming every resulting function is at or below the threshold.
- Helpers are declared after the handler class, matching the epic's convention.

### Proof of behaviour preservation

- Before refactoring, tightened the two existing rendering tests (flat and grouped) from `toContain` substring checks to exact full-output `toBe` assertions — pinning line order, blank-line placement, and whitespace that substring checks would have let drift. Integer values are asserted via `toLocaleString()` so the pin stays locale-portable.
- Both exact-output tests were confirmed green against the pre-refactor code (characterization), then stayed green after the refactor. Full suite: 25/25.

## Relationships

Closes #666.

Note: the `openapi-fetch` error-laundering bug in this same handler (the `POST` result's `error` field is captured but unchecked) is tracked separately as #697 and is intentionally out of scope here.
