### PR TITLE
Reduce complexity in list-schemas-handler.

### DIFF
--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -454,6 +454,38 @@ describe("list-schemas-handler.ts", () => {
           orders: { error: "[object Object]" },
         });
       });
+
+      // JSON.stringify returns the value undefined (not a string) for bare
+      // undefined, functions, and symbols without throwing, so the try/catch
+      // never fires. Left unguarded, describeError would return undefined, the
+      // per-subject entry would collapse to {} (the error key silently dropped),
+      // and describeError would violate its string return contract.
+      it.each([
+        { label: "bare undefined", value: undefined, expected: "undefined" },
+        { label: "a symbol", value: Symbol("boom"), expected: "Symbol(boom)" },
+      ])(
+        "should fall back to String() when a per-subject rejection serializes to undefined via JSON.stringify ($label)",
+        async ({ value, expected }) => {
+          sr.getAllSubjects.mockResolvedValue(["orders"]);
+          sr.getLatestSchemaMetadata.mockRejectedValue(value);
+
+          const result = await assertHandleCase({
+            handler,
+            runtime: runtimeWithDecoy(
+              SR_CONN,
+              DEFAULT_CONNECTION_ID,
+              clientManager,
+            ),
+            args: {},
+            outcome: { resolves: '"orders":', isError: false },
+            clientManager,
+          });
+
+          expect(JSON.parse(textOf(result!))).toEqual({
+            orders: { error: expected },
+          });
+        },
+      );
     });
 
     describe("getToolConfig()", () => {

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -298,12 +298,34 @@ describe("list-schemas-handler.ts", () => {
         });
       });
 
-      // The handler narrows every rejection with `err instanceof Error ? err.message : ...`.
-      // The SR SDK can reject with a non-Error value, so the four cases below pin the
-      // fallback arm of each catch block (String(err) inside the loops, JSON.stringify at
-      // the top level) rather than letting it rot as untested defensive code.
+      // Every rejection flows through describeError(): a string passes through
+      // verbatim, an Error surrenders its message, and any other value is
+      // JSON.stringify'd (falling back to String() only if stringification itself
+      // throws). The SR SDK can reject with any of these, so the cases below pin
+      // each arm at every seam that catches — the top-level catch plus the three
+      // per-subject / per-version loops — rather than letting them rot as
+      // untested defensive code.
 
-      it("should JSON.stringify a non-Error rejection from getAllSubjects in the top-level catch", async () => {
+      it("should pass a string rejection from getAllSubjects through verbatim in the top-level catch", async () => {
+        sr.getAllSubjects.mockRejectedValue("registry unreachable");
+
+        await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: {
+            resolves: "Failed to list schemas: registry unreachable",
+            isError: true,
+          },
+          clientManager,
+        });
+      });
+
+      it("should JSON.stringify a non-Error object rejection from getAllSubjects in the top-level catch", async () => {
         sr.getAllSubjects.mockRejectedValue({ code: 503 });
 
         await assertHandleCase({
@@ -322,7 +344,7 @@ describe("list-schemas-handler.ts", () => {
         });
       });
 
-      it("should String()-coerce a non-Error rejection from getLatestSchemaMetadata into the per-subject error entry", async () => {
+      it("should pass a string rejection from getLatestSchemaMetadata through verbatim in the per-subject error entry", async () => {
         sr.getAllSubjects.mockResolvedValue(["orders"]);
         sr.getLatestSchemaMetadata.mockRejectedValue("registry exploded");
 
@@ -343,10 +365,34 @@ describe("list-schemas-handler.ts", () => {
         });
       });
 
-      it("should String()-coerce a non-Error rejection from getSchemaMetadata into the per-version error entry", async () => {
+      it("should JSON.stringify a non-Error object rejection from getLatestSchemaMetadata into the per-subject error entry", async () => {
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getLatestSchemaMetadata.mockRejectedValue({
+          code: 404,
+          detail: "no schema",
+        });
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: { resolves: '"orders":{"error":', isError: false },
+          clientManager,
+        });
+
+        expect(JSON.parse(textOf(result!))).toEqual({
+          orders: { error: '{"code":404,"detail":"no schema"}' },
+        });
+      });
+
+      it("should JSON.stringify a non-Error object rejection from getSchemaMetadata into the per-version error entry", async () => {
         sr.getAllSubjects.mockResolvedValue(["orders"]);
         sr.getAllVersions.mockResolvedValue([1]);
-        sr.getSchemaMetadata.mockRejectedValue("version exploded");
+        sr.getSchemaMetadata.mockRejectedValue({ status: "GONE" });
 
         const result = await assertHandleCase({
           handler,
@@ -356,18 +402,18 @@ describe("list-schemas-handler.ts", () => {
             clientManager,
           ),
           args: { latestOnly: false },
-          outcome: { resolves: "version exploded", isError: false },
+          outcome: { resolves: '"version":1', isError: false },
           clientManager,
         });
 
         expect(JSON.parse(textOf(result!))).toEqual({
-          orders: [{ version: 1, error: "version exploded" }],
+          orders: [{ version: 1, error: '{"status":"GONE"}' }],
         });
       });
 
-      it("should String()-coerce a non-Error rejection from getAllVersions into the per-subject error entry", async () => {
+      it("should JSON.stringify a non-Error object rejection from getAllVersions into the per-subject error entry", async () => {
         sr.getAllSubjects.mockResolvedValue(["orders"]);
-        sr.getAllVersions.mockRejectedValue("versions exploded");
+        sr.getAllVersions.mockRejectedValue({ status: 500 });
 
         const result = await assertHandleCase({
           handler,
@@ -382,7 +428,30 @@ describe("list-schemas-handler.ts", () => {
         });
 
         expect(JSON.parse(textOf(result!))).toEqual({
-          orders: { error: "versions exploded" },
+          orders: { error: '{"status":500}' },
+        });
+      });
+
+      it("should fall back to String() when a rejection cannot be JSON.stringify'd (circular reference)", async () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        sr.getAllSubjects.mockResolvedValue(["orders"]);
+        sr.getLatestSchemaMetadata.mockRejectedValue(circular);
+
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            SR_CONN,
+            DEFAULT_CONNECTION_ID,
+            clientManager,
+          ),
+          args: {},
+          outcome: { resolves: '"orders":{"error":', isError: false },
+          clientManager,
+        });
+
+        expect(JSON.parse(textOf(result!))).toEqual({
+          orders: { error: "[object Object]" },
         });
       });
     });

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -71,16 +71,9 @@ export class ListSchemasHandler extends BaseToolHandler {
       );
       return this.createResponse(JSON.stringify(result));
     } catch (error) {
-      logger.error(
-        {
-          error: error instanceof Error ? error.message : JSON.stringify(error),
-        },
-        "Failed to list schemas",
-      );
-      return this.createResponse(
-        `Failed to list schemas: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
-        true,
-      );
+      const message = describeError(error);
+      logger.error({ error: message }, "Failed to list schemas");
+      return this.createResponse(`Failed to list schemas: ${message}`, true);
     }
   }
 
@@ -98,10 +91,23 @@ export class ListSchemasHandler extends BaseToolHandler {
 
 /**
  * Narrow an unknown thrown value to a message, tolerating the SR SDK's habit of
- * rejecting with non-Error values.
+ * rejecting with non-Error values: a string passes through verbatim, an Error
+ * yields its message, and any other value is JSON-serialized so objects keep
+ * their detail instead of collapsing to "[object Object]". String() is the last
+ * resort for values JSON.stringify refuses (circular references, BigInt).
  */
 function describeError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (typeof err === "string") {
+    return err;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
 }
 
 /**

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -1,4 +1,4 @@
-import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { CallToolResult } from "@src/confluent/schema.js";
 import {
   BaseToolHandler,
@@ -36,7 +36,6 @@ const listSchemasArguments = z.object({
 });
 
 export class ListSchemasHandler extends BaseToolHandler {
-  // eslint-disable-next-line sonarjs/cognitive-complexity -- baselined pre-existing complexity; reduce below 15 (#667)
   async handle(
     runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
@@ -59,94 +58,12 @@ export class ListSchemasHandler extends BaseToolHandler {
       await clientManager.getSchemaRegistrySdkClient(environment_id);
 
     try {
-      let subjects: string[] = await registry.getAllSubjects();
-      logger.debug(
-        { subjectsCount: subjects.length },
-        "Fetched all subjects from registry",
-      );
-      if (subjectPrefix) {
-        subjects = subjects.filter((s) => s.startsWith(subjectPrefix));
-        logger.debug(
-          { filteredSubjectsCount: subjects.length, subjectPrefix },
-          "Filtered subjects by prefix",
-        );
-      }
-
+      const subjects = await fetchSubjects(registry, subjectPrefix);
       const result: Record<string, unknown> = {};
       for (const subject of subjects) {
-        if (latestOnly) {
-          try {
-            const latest = await registry.getLatestSchemaMetadata(subject);
-            logger.debug({ subject, latest }, "Fetched latest schema metadata");
-            result[subject] = {
-              version: latest.version,
-              id: latest.id,
-              schemaType: latest.schemaType,
-              schema: latest.schema,
-            };
-          } catch (err) {
-            logger.warn(
-              {
-                subject,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              "Failed to fetch latest schema metadata",
-            );
-            result[subject] = {
-              error: err instanceof Error ? err.message : String(err),
-            };
-          }
-        } else {
-          try {
-            const versions: number[] = await registry.getAllVersions(subject);
-            logger.debug({ subject, versions }, "Fetched all schema versions");
-            result[subject] = [];
-            const versionPromises = versions.map(async (version) => {
-              try {
-                const schema = await registry.getSchemaMetadata(
-                  subject,
-                  version,
-                  deleted,
-                );
-                logger.debug(
-                  { subject, version, schema },
-                  "Fetched schema metadata for version",
-                );
-                (result[subject] as unknown[]).push({
-                  version: schema.version,
-                  id: schema.id,
-                  schemaType: schema.schemaType,
-                  schema: schema.schema,
-                });
-              } catch (err) {
-                logger.warn(
-                  {
-                    subject,
-                    version,
-                    error: err instanceof Error ? err.message : String(err),
-                  },
-                  "Failed to fetch schema metadata for version",
-                );
-                (result[subject] as unknown[]).push({
-                  version,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-              }
-            });
-            await Promise.all(versionPromises);
-          } catch (err) {
-            logger.warn(
-              {
-                subject,
-                error: err instanceof Error ? err.message : String(err),
-              },
-              "Failed to fetch all versions for subject",
-            );
-            result[subject] = {
-              error: err instanceof Error ? err.message : String(err),
-            };
-          }
-        }
+        result[subject] = latestOnly
+          ? await fetchLatestSchema(registry, subject)
+          : await fetchAllVersions(registry, subject, deleted);
       }
       logger.info(
         { subjects: Object.keys(result).length },
@@ -177,4 +94,119 @@ export class ListSchemasHandler extends BaseToolHandler {
   }
   readonly category = ToolCategory.SchemaRegistry;
   readonly predicate = hasSchemaRegistryOrOAuth;
+}
+
+/**
+ * Narrow an unknown thrown value to a message, tolerating the SR SDK's habit of
+ * rejecting with non-Error values.
+ */
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Fetch every subject from the registry, narrowed to an optional prefix.
+ * Prefix matching is client-side because the SR list endpoint takes no prefix.
+ */
+async function fetchSubjects(
+  registry: SchemaRegistryClient,
+  subjectPrefix: string | undefined,
+): Promise<string[]> {
+  let subjects: string[] = await registry.getAllSubjects();
+  logger.debug(
+    { subjectsCount: subjects.length },
+    "Fetched all subjects from registry",
+  );
+  if (subjectPrefix) {
+    subjects = subjects.filter((s) => s.startsWith(subjectPrefix));
+    logger.debug(
+      { filteredSubjectsCount: subjects.length, subjectPrefix },
+      "Filtered subjects by prefix",
+    );
+  }
+  return subjects;
+}
+
+/**
+ * Resolve one subject's latest schema metadata, degrading to an `{ error }`
+ * placeholder so a single bad subject doesn't abort the whole listing.
+ */
+async function fetchLatestSchema(
+  registry: SchemaRegistryClient,
+  subject: string,
+): Promise<unknown> {
+  try {
+    const latest = await registry.getLatestSchemaMetadata(subject);
+    logger.debug({ subject, latest }, "Fetched latest schema metadata");
+    return {
+      version: latest.version,
+      id: latest.id,
+      schemaType: latest.schemaType,
+      schema: latest.schema,
+    };
+  } catch (err) {
+    logger.warn(
+      { subject, error: describeError(err) },
+      "Failed to fetch latest schema metadata",
+    );
+    return { error: describeError(err) };
+  }
+}
+
+/**
+ * Resolve every version of one subject in parallel, degrading to an `{ error }`
+ * placeholder for the whole subject if its version list can't be fetched.
+ */
+async function fetchAllVersions(
+  registry: SchemaRegistryClient,
+  subject: string,
+  deleted: boolean | undefined,
+): Promise<unknown> {
+  let versions: number[];
+  try {
+    versions = await registry.getAllVersions(subject);
+  } catch (err) {
+    logger.warn(
+      { subject, error: describeError(err) },
+      "Failed to fetch all versions for subject",
+    );
+    return { error: describeError(err) };
+  }
+  logger.debug({ subject, versions }, "Fetched all schema versions");
+  return Promise.all(
+    versions.map((version) =>
+      fetchVersion(registry, subject, version, deleted),
+    ),
+  );
+}
+
+/**
+ * Resolve one (subject, version) pair, degrading to a `{ version, error }`
+ * entry so one hard-deleted or missing version doesn't drop its siblings.
+ */
+async function fetchVersion(
+  registry: SchemaRegistryClient,
+  subject: string,
+  version: number,
+  deleted: boolean | undefined,
+): Promise<unknown> {
+  try {
+    const schema = await registry.getSchemaMetadata(subject, version, deleted);
+    logger.debug(
+      { subject, version, schema },
+      "Fetched schema metadata for version",
+    );
+    return {
+      version: schema.version,
+      id: schema.id,
+      schemaType: schema.schemaType,
+      schema: schema.schema,
+    };
+  } catch (err) {
+    logger.warn(
+      { subject, version, error: describeError(err) },
+      "Failed to fetch schema metadata for version",
+    );
+    return { version, error: describeError(err) };
+  }
 }

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -72,7 +72,7 @@ export class ListSchemasHandler extends BaseToolHandler {
       return this.createResponse(JSON.stringify(result));
     } catch (error) {
       const message = describeError(error);
-      logger.error({ error: message }, "Failed to list schemas");
+      logger.error({ err: error, message }, "Failed to list schemas");
       return this.createResponse(`Failed to list schemas: ${message}`, true);
     }
   }
@@ -94,7 +94,10 @@ export class ListSchemasHandler extends BaseToolHandler {
  * rejecting with non-Error values: a string passes through verbatim, an Error
  * yields its message, and any other value is JSON-serialized so objects keep
  * their detail instead of collapsing to "[object Object]". String() is the last
- * resort for values JSON.stringify refuses (circular references, BigInt).
+ * resort for the two cases JSON.stringify won't hand back a string: values it
+ * throws on (circular references, BigInt) and values it returns `undefined` for
+ * without throwing (bare undefined, functions, symbols). Either way the return
+ * is always a string.
  */
 function describeError(err: unknown): string {
   if (typeof err === "string") {
@@ -104,7 +107,7 @@ function describeError(err: unknown): string {
     return err.message;
   }
   try {
-    return JSON.stringify(err);
+    return JSON.stringify(err) ?? String(err);
   } catch {
     return String(err);
   }
@@ -152,7 +155,7 @@ async function fetchLatestSchema(
     };
   } catch (err) {
     logger.warn(
-      { subject, error: describeError(err) },
+      { subject, err, message: describeError(err) },
       "Failed to fetch latest schema metadata",
     );
     return { error: describeError(err) };
@@ -173,7 +176,7 @@ async function fetchAllVersions(
     versions = await registry.getAllVersions(subject);
   } catch (err) {
     logger.warn(
-      { subject, error: describeError(err) },
+      { subject, err, message: describeError(err) },
       "Failed to fetch all versions for subject",
     );
     return { error: describeError(err) };
@@ -210,7 +213,7 @@ async function fetchVersion(
     };
   } catch (err) {
     logger.warn(
-      { subject, version, error: describeError(err) },
+      { subject, version, err, message: describeError(err) },
       "Failed to fetch schema metadata for version",
     );
     return { version, error: describeError(err) };


### PR DESCRIPTION
Refactor to reduce complexity in ist-schemas-handler.

While here, improve error handling / logging throughout `handle()`.

Closes #667