### PR TITLE
[Prototype for evaluation] Replace `turndown` with a small `cheerio`-based converter in `get-product-doc-page`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/content-type": "^1.1.9",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^24.0.4",
-    "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",
@@ -96,7 +95,6 @@
     "pino-pretty": "^13.1.3",
     "properties-file": "^3.5.12",
     "protobufjs": "^8.6.3",
-    "turndown": "^7.2.4",
     "yaml": "^2.8.3",
     "zod": "^4.0"
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@typescript-eslint/parser": "^8.35.0",
     "@vitest/coverage-v8": "^4.1.0",
     "concurrently": "^9.2.0",
+    "domhandler": "5.0.3",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,16 +33,16 @@ importers:
         version: 1.10.0
       '@confluentinc/schemaregistry':
         specifier: ^1.9.1
-        version: 1.9.1(@azure/core-client@1.10.1)
+        version: 1.9.1(@azure/core-client@1.10.1)(supports-color@10.2.2)
       '@fastify/swagger':
         specifier: ^9.5.1
-        version: 9.7.0
+        version: 9.7.0(supports-color@10.2.2)
       '@fastify/swagger-ui':
         specifier: ^5.2.3
         version: 5.2.5
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
-        version: 1.29.0(zod@4.3.6)
+        version: 1.29.0(supports-color@10.2.2)(zod@4.3.6)
       '@segment/analytics-node':
         specifier: ^3.0.0
         version: 3.0.0
@@ -76,9 +76,6 @@ importers:
       protobufjs:
         specifier: ^8.6.3
         version: 8.6.3
-      turndown:
-        specifier: ^7.2.4
-        version: 7.2.4
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -98,18 +95,15 @@ importers:
       '@types/node':
         specifier: ^24.0.4
         version: 24.12.2
-      '@types/turndown':
-        specifier: ^5.0.6
-        version: 5.0.6
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.35.0
-        version: 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.35.0
-        version: 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.4(vitest@4.1.4)
@@ -118,19 +112,19 @@ importers:
         version: 9.2.1
       eslint:
         specifier: ^9.29.0
-        version: 9.39.4
+        version: 9.39.4(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: ^10.1.5
-        version: 10.1.8(eslint@9.39.4)
+        version: 10.1.8(eslint@9.39.4(supports-color@10.2.2))
       eslint-plugin-prettier:
         specifier: ^5.5.1
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.6.1)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(supports-color@10.2.2)))(eslint@9.39.4(supports-color@10.2.2))(prettier@3.6.1)
       eslint-plugin-sonarjs:
         specifier: ^4.1.0
-        version: 4.1.0(eslint@9.39.4)
+        version: 4.1.0(eslint@9.39.4(supports-color@10.2.2))
       eslint-plugin-unused-imports:
         specifier: ^4.4.1
-        version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))
       globals:
         specifier: ^16.2.0
         version: 16.5.0
@@ -157,7 +151,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.35.0
-        version: 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
         version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.2)(yaml@2.8.3))
@@ -600,9 +594,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@mixmark-io/domino@2.2.0':
-    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
-
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -979,9 +970,6 @@ packages:
 
   '@types/simple-oauth2@5.0.8':
     resolution: {integrity: sha512-TehQqoOGdy3/rmFsCEGgnt1f4JhUCA0joWemGGCTbVYvoZvfBjkRsBFYmz8k0V/sn2XQZHe33L4lWxqMhIO3tQ==}
-
-  '@types/turndown@5.0.6':
-    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -2886,10 +2874,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turndown@7.2.4:
-    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
-    engines: {node: '>=18', npm: '>=9'}
-
   tv4@1.3.0:
     resolution: {integrity: sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==}
     engines: {node: '>= 0.8.0'}
@@ -3726,7 +3710,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@confluentinc/schemaregistry@1.9.1(@azure/core-client@1.10.1)':
+  '@confluentinc/schemaregistry@1.9.1(@azure/core-client@1.10.1)(supports-color@10.2.2)':
     dependencies:
       '@aws-sdk/client-kms': 3.1028.0
       '@aws-sdk/credential-providers': 3.1028.0
@@ -3745,13 +3729,13 @@ snapshots:
       ajv: 8.18.0
       async-mutex: 0.5.0
       avsc: 5.7.9
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       axios-retry: 4.5.0(axios@1.16.0)
       json-stringify-deterministic: 1.0.12
       jsonata: 2.2.1
       lru-cache: 10.4.3
-      node-vault: 0.10.10
-      simple-oauth2: 5.1.0
+      node-vault: 0.10.10(supports-color@10.2.2)
+      simple-oauth2: 5.1.0(supports-color@10.2.2)
       uuid: 11.1.1
       validator: 13.15.35
     transitivePeerDependencies:
@@ -3794,12 +3778,12 @@ snapshots:
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@10.2.2)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@10.2.2)
@@ -3815,7 +3799,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@10.2.2)':
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3(supports-color@10.2.2)
@@ -3888,10 +3872,10 @@ snapshots:
       rfdc: 1.4.1
       yaml: 2.8.3
 
-  '@fastify/swagger@9.7.0':
+  '@fastify/swagger@9.7.0(supports-color@10.2.2)':
     dependencies:
       fastify-plugin: 5.1.0
-      json-schema-resolver: 3.0.0
+      json-schema-resolver: 3.0.0(supports-color@10.2.2)
       openapi-types: 12.1.3
       rfdc: 1.4.1
       yaml: 2.8.3
@@ -3998,9 +3982,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mixmark-io/domino@2.2.0': {}
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.25)
       ajv: 8.18.0
@@ -4010,8 +3992,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.5.1(express@5.2.1)
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.5.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.25
       jose: 6.2.2
       json-schema-typed: 8.0.2
@@ -4463,23 +4445,21 @@ snapshots:
 
   '@types/simple-oauth2@5.0.8': {}
 
-  '@types/turndown@5.0.6': {}
-
   '@types/validator@13.15.10': {}
 
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.12.2
 
-  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.1
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -4487,14 +4467,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4517,13 +4497,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4552,7 +4532,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4706,12 +4686,12 @@ snapshots:
 
   axios-retry@4.5.0(axios@1.16.0):
     dependencies:
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       is-retry-allowed: 2.2.0
 
-  axios@1.16.0(debug@4.4.3):
+  axios@1.16.0(debug@4.4.3(supports-color@10.2.2)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -4731,7 +4711,7 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -5033,26 +5013,26 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(supports-color@10.2.2)):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.6.1):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(supports-color@10.2.2)))(eslint@9.39.4(supports-color@10.2.2))(prettier@3.6.1):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       prettier: 3.6.1
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.4)
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(supports-color@10.2.2))
 
-  eslint-plugin-sonarjs@4.1.0(eslint@9.39.4):
+  eslint-plugin-sonarjs@4.1.0(eslint@9.39.4(supports-color@10.2.2)):
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       builtin-modules: 3.3.0
       bytes: 3.1.2
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       functional-red-black-tree: 1.0.1
       globals: 17.7.0
       jsx-ast-utils-x: 0.1.0
@@ -5064,11 +5044,11 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.9.0
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2)):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -5081,14 +5061,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4:
+  eslint@9.39.4(supports-color@10.2.2):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@10.2.2)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@10.2.2)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -5152,15 +5132,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.1(express@5.2.1):
+  express-rate-limit@8.5.1(express@5.2.1(supports-color@10.2.2)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -5170,7 +5150,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -5181,8 +5161,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -5284,7 +5264,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
@@ -5313,7 +5293,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
     optionalDependencies:
       debug: 4.4.3(supports-color@10.2.2)
 
@@ -5617,7 +5597,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  json-schema-resolver@3.0.0:
+  json-schema-resolver@3.0.0(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       fast-uri: 3.1.2
@@ -5855,9 +5835,9 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-vault@0.10.10:
+  node-vault@0.10.10(supports-color@10.2.2):
     dependencies:
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       debug: 4.4.3(supports-color@10.2.2)
       mustache: 4.2.0
       tv4: 1.3.0
@@ -6177,7 +6157,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
-  router@2.2.0:
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
@@ -6219,7 +6199,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
@@ -6240,7 +6220,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6288,7 +6268,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-oauth2@5.1.0:
+  simple-oauth2@5.1.0(supports-color@10.2.2):
     dependencies:
       '@hapi/hoek': 11.0.7
       '@hapi/wreck': 18.1.2
@@ -6438,10 +6418,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  turndown@7.2.4:
-    dependencies:
-      '@mixmark-io/domino': 2.2.0
-
   tv4@1.3.0: {}
 
   type-check@0.4.0:
@@ -6456,13 +6432,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.58.1(eslint@9.39.4)(typescript@5.9.3):
+  typescript-eslint@8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
-      eslint: 9.39.4
+      eslint: 9.39.4(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,16 +100,19 @@ importers:
         version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.35.0
-        version: 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
+        version: 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.35.0
-        version: 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
+        version: 8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.4(vitest@4.1.4)
       concurrently:
         specifier: ^9.2.0
         version: 9.2.1
+      domhandler:
+        specifier: 5.0.3
+        version: 5.0.3
       eslint:
         specifier: ^9.29.0
         version: 9.39.4(supports-color@10.2.2)
@@ -124,7 +127,7 @@ importers:
         version: 4.1.0(eslint@9.39.4(supports-color@10.2.2))
       eslint-plugin-unused-imports:
         specifier: ^4.4.1
-        version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))
       globals:
         specifier: ^16.2.0
         version: 16.5.0
@@ -3776,7 +3779,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(supports-color@10.2.2))':
     dependencies:
       eslint: 9.39.4(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
@@ -4451,13 +4454,13 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.1
       eslint: 9.39.4(supports-color@10.2.2)
       ignore: 7.0.5
@@ -4467,7 +4470,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
@@ -4497,11 +4500,11 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3)
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -4526,9 +4529,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(supports-color@10.2.2))
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
@@ -5044,11 +5047,11 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.9.0
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2)):
     dependencies:
       eslint: 9.39.4(supports-color@10.2.2)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -5063,7 +5066,7 @@ snapshots:
 
   eslint@9.39.4(supports-color@10.2.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(supports-color@10.2.2))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2(supports-color@10.2.2)
       '@eslint/config-helpers': 0.4.2
@@ -6434,10 +6437,10 @@ snapshots:
 
   typescript-eslint@8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4)(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(supports-color@10.2.2))(typescript@5.9.3)
       eslint: 9.39.4(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/src/confluent/tools/handlers/docs/get-product-doc-page-handler.ts
+++ b/src/confluent/tools/handlers/docs/get-product-doc-page-handler.ts
@@ -7,11 +7,11 @@ import {
   ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
+import { htmlToMarkdown } from "@src/confluent/tools/handlers/docs/html-to-markdown.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import * as cheerio from "cheerio";
-import TurndownService from "turndown";
 import { z } from "zod";
 
 type Source =
@@ -37,12 +37,6 @@ const getProductDocPageArguments = z.object({
 });
 
 export class GetProductDocPageHandler extends BaseToolHandler {
-  private readonly turndown = new TurndownService({
-    headingStyle: "atx",
-    codeBlockStyle: "fenced",
-    bulletListMarker: "-",
-  });
-
   async handle(
     _runtime: ServerRuntime,
     toolArguments: Record<string, unknown>,
@@ -258,7 +252,7 @@ export class GetProductDocPageHandler extends BaseToolHandler {
   }
 
   private toMarkdown(html: string | null): string {
-    return this.turndown.turndown(html ?? "").trim();
+    return htmlToMarkdown(html);
   }
 
   private formatResponse(

--- a/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
@@ -17,6 +17,11 @@ describe("html-to-markdown.ts", () => {
       expect(htmlToMarkdown("<h3>Sub-heading</h3>")).toBe("### Sub-heading");
     });
 
+    it("should drop empty headings instead of emitting a bare ###", () => {
+      const html = '<h3 id="spacer"> </h3><p>Body.</p>';
+      expect(htmlToMarkdown(html)).toBe("Body.");
+    });
+
     it("should render bold, italic, and inline code", () => {
       const html =
         "<p>Some <b>bold</b>, <i>italic</i>, and <code>inline.code</code> text.</p>";

--- a/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
@@ -1,0 +1,139 @@
+import { htmlToMarkdown } from "@src/confluent/tools/handlers/docs/html-to-markdown.js";
+import { describe, expect, it } from "vitest";
+
+describe("html-to-markdown.ts", () => {
+  describe("htmlToMarkdown()", () => {
+    it("should return an empty string for null or empty input", () => {
+      expect(htmlToMarkdown(null)).toBe("");
+      expect(htmlToMarkdown("")).toBe("");
+    });
+
+    it("should render a heading followed by a paragraph", () => {
+      const html = "<h1>Title</h1><p>Some body text.</p>";
+      expect(htmlToMarkdown(html)).toBe("# Title\n\nSome body text.");
+    });
+
+    it("should render nested heading levels", () => {
+      expect(htmlToMarkdown("<h3>Sub-heading</h3>")).toBe("### Sub-heading");
+    });
+
+    it("should render bold, italic, and inline code", () => {
+      const html =
+        "<p>Some <b>bold</b>, <i>italic</i>, and <code>inline.code</code> text.</p>";
+      expect(htmlToMarkdown(html)).toBe(
+        "Some **bold**, _italic_, and `inline.code` text.",
+      );
+    });
+
+    it("should render a link", () => {
+      const html = '<p>See <a href="https://example.com">the docs</a>.</p>';
+      expect(htmlToMarkdown(html)).toBe("See [the docs](https://example.com).");
+    });
+
+    it("should render an image", () => {
+      const html = '<img src="/img/arch.png" alt="architecture diagram">';
+      expect(htmlToMarkdown(html)).toBe(
+        "![architecture diagram](/img/arch.png)",
+      );
+    });
+
+    it("should render a fenced code block, preserving internal whitespace", () => {
+      const html =
+        "<pre><code>kafka-topics --create --topic foo\n  --partitions 3</code></pre>";
+      expect(htmlToMarkdown(html)).toBe(
+        "```\nkafka-topics --create --topic foo\n  --partitions 3\n```",
+      );
+    });
+
+    it("should render an unordered list", () => {
+      const html = "<ul><li>Item one</li><li>Item two</li></ul>";
+      expect(htmlToMarkdown(html)).toBe("- Item one\n- Item two");
+    });
+
+    it("should render an ordered list", () => {
+      const html = "<ol><li>First</li><li>Second</li></ol>";
+      expect(htmlToMarkdown(html)).toBe("1. First\n2. Second");
+    });
+
+    it("should indent a nested list under its parent item", () => {
+      const html =
+        "<ul><li>Parent<ul><li>Child one</li><li>Child two</li></ul></li></ul>";
+      expect(htmlToMarkdown(html)).toBe(
+        "- Parent\n  - Child one\n  - Child two",
+      );
+    });
+
+    it("should render a blockquote", () => {
+      expect(htmlToMarkdown("<blockquote><p>Note this.</p></blockquote>")).toBe(
+        "> Note this.",
+      );
+    });
+
+    it("should render a table with an explicit thead/tbody", () => {
+      const html =
+        "<table><thead><tr><th>Config</th><th>Default</th></tr></thead>" +
+        "<tbody><tr><td>retention.ms</td><td>604800000</td></tr></tbody></table>";
+      expect(htmlToMarkdown(html)).toBe(
+        "| Config | Default |\n| --- | --- |\n| retention.ms | 604800000 |",
+      );
+    });
+
+    it("should render a table with a <th> header row but no <thead> wrapper", () => {
+      const html =
+        "<table><tr><th>Config</th><th>Default</th></tr>" +
+        "<tr><td>retention.ms</td><td>604800000</td></tr></table>";
+      expect(htmlToMarkdown(html)).toBe(
+        "| Config | Default |\n| --- | --- |\n| retention.ms | 604800000 |",
+      );
+    });
+
+    it("should render a plain <td>-only table (e.g. Zendesk-authored HTML)", () => {
+      const html =
+        "<table><tr><td>Config</td><td>Default</td></tr>" +
+        "<tr><td>retention.ms</td><td>604800000</td></tr></table>";
+      expect(htmlToMarkdown(html)).toBe(
+        "| Config | Default |\n| --- | --- |\n| retention.ms | 604800000 |",
+      );
+    });
+
+    it("should flatten wrapping containers like div and section", () => {
+      const html =
+        '<div class="wrapper"><section><h2>Heading</h2><p>Body.</p></section></div>';
+      expect(htmlToMarkdown(html)).toBe("## Heading\n\nBody.");
+    });
+
+    it("should keep the link when loose inline content sits directly in a div without a <p>", () => {
+      const html =
+        '<div style="text-align: right">See <a href="/tutorial/">this tutorial</a>.</div>';
+      expect(htmlToMarkdown(html)).toBe("See [this tutorial](/tutorial/).");
+    });
+
+    it("should drop empty-text anchors instead of emitting a bare [](url)", () => {
+      const html = '<h2>Heading<a href="#heading"><span></span></a></h2>';
+      expect(htmlToMarkdown(html)).toBe("## Heading");
+    });
+
+    it("should drop script and style tags", () => {
+      const html =
+        "<p>Visible.</p><script>console.log('x')</script><style>.a{}</style>";
+      expect(htmlToMarkdown(html)).toBe("Visible.");
+    });
+
+    it("should collapse HTML source whitespace to single spaces", () => {
+      const html = "<p>\n  Line one\n  Line two  \n</p>";
+      expect(htmlToMarkdown(html)).toBe("Line one Line two");
+    });
+
+    it("should escape literal Markdown-significant characters in plain text", () => {
+      expect(
+        htmlToMarkdown("<p>Use __consumer_offsets and *not* this.</p>"),
+      ).toBe("Use \\_\\_consumer\\_offsets and \\*not\\* this.");
+    });
+
+    it("should not escape characters inside inline code", () => {
+      expect(htmlToMarkdown("<p><code>__consumer_offsets</code></p>")).toBe(
+        "`__consumer_offsets`",
+      );
+    });
+  });
+});

--- a/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
@@ -30,6 +30,12 @@ describe("html-to-markdown.ts", () => {
       );
     });
 
+    it("should drop empty bold, italic, and code tags instead of emitting bare delimiters", () => {
+      const html =
+        '<p>Scroll<i class="scroll-indicator"></i> down<b></b> for <code></code>more.</p>';
+      expect(htmlToMarkdown(html)).toBe("Scroll down for more.");
+    });
+
     it("should render a link", () => {
       const html = '<p>See <a href="https://example.com">the docs</a>.</p>';
       expect(htmlToMarkdown(html)).toBe("See [the docs](https://example.com).");

--- a/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.test.ts
@@ -56,6 +56,27 @@ describe("html-to-markdown.ts", () => {
       );
     });
 
+    it("should widen the fence when the code block itself contains a ``` run", () => {
+      const html = "<pre><code>```js\nconsole.log(1)\n```</code></pre>";
+      expect(htmlToMarkdown(html)).toBe(
+        "````\n```js\nconsole.log(1)\n```\n````",
+      );
+    });
+
+    it("should widen the inline code delimiter when the content contains a backtick", () => {
+      expect(htmlToMarkdown("<p><code>a`b</code></p>")).toBe("``a`b``");
+    });
+
+    it("should pad the inline code delimiter when content starts or ends with a backtick", () => {
+      expect(htmlToMarkdown("<p><code>`code`</code></p>")).toBe("`` `code` ``");
+    });
+
+    it("should render <br> as a CommonMark hard break, not a soft break", () => {
+      expect(htmlToMarkdown("<p>Line one<br>Line two</p>")).toBe(
+        "Line one  \nLine two",
+      );
+    });
+
     it("should render an unordered list", () => {
       const html = "<ul><li>Item one</li><li>Item two</li></ul>";
       expect(htmlToMarkdown(html)).toBe("- Item one\n- Item two");
@@ -104,6 +125,20 @@ describe("html-to-markdown.ts", () => {
         "<tr><td>retention.ms</td><td>604800000</td></tr></table>";
       expect(htmlToMarkdown(html)).toBe(
         "| Config | Default |\n| --- | --- |\n| retention.ms | 604800000 |",
+      );
+    });
+
+    it("should not let a nested table's rows/cells leak into the outer table", () => {
+      const html =
+        "<table><tr><th>Outer1</th><th>Outer2</th></tr>" +
+        "<tr><td>Cell</td><td><table><tr><th>Inner1</th></tr>" +
+        "<tr><td>InnerVal</td></tr></table></td></tr></table>";
+      // The outer table keeps exactly one header + one body row (not three,
+      // which is what find("tr") would produce without scoping); the nested
+      // table's own content isn't rendered as proper Markdown, that's an
+      // accepted limitation, but it must not corrupt the outer table's shape.
+      expect(htmlToMarkdown(html)).toBe(
+        "| Outer1 | Outer2 |\n| --- | --- |\n| Cell | Inner1InnerVal |",
       );
     });
 

--- a/src/confluent/tools/handlers/docs/html-to-markdown.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.ts
@@ -220,12 +220,12 @@ function renderInlineNode($: cheerio.CheerioAPI, node: AnyNode): string {
   switch (tag) {
     case "strong":
     case "b":
-      return `**${renderInlineChildren($, node).trim()}**`;
+      return wrapInline(renderInlineChildren($, node).trim(), "**");
     case "em":
     case "i":
-      return `_${renderInlineChildren($, node).trim()}_`;
+      return wrapInline(renderInlineChildren($, node).trim(), "_");
     case "code":
-      return `\`${$(node).text()}\``;
+      return wrapInline($(node).text(), "`");
     case "a":
       return renderLink($, node);
     case "img":
@@ -239,6 +239,13 @@ function renderInlineNode($: cheerio.CheerioAPI, node: AnyNode): string {
     default:
       return renderInlineChildren($, node);
   }
+}
+
+// Drops empty inline elements (e.g. decorative CSS-only icons like
+// `<i class="scroll-indicator"></i>`) instead of emitting bare delimiters
+// such as `__` or `` `` ``.
+function wrapInline(text: string, delimiter: string): string {
+  return text ? `${delimiter}${text}${delimiter}` : "";
 }
 
 function renderLink($: cheerio.CheerioAPI, el: AnyNode): string {

--- a/src/confluent/tools/handlers/docs/html-to-markdown.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.ts
@@ -146,7 +146,16 @@ function renderCodeBlock($: cheerio.CheerioAPI, el: AnyNode): string {
     /\n+$/,
     "",
   );
-  return "```\n" + text + "\n```";
+  const fence = backtickFence(text, 3);
+  return `${fence}\n${text}\n${fence}`;
+}
+
+// A fence longer than any backtick run in the content, so a ``` inside the
+// code itself can't be misread as the closing fence.
+function backtickFence(text: string, minLength: number): string {
+  const runs = text.match(/`+/g) ?? [];
+  const longestRun = Math.max(0, ...runs.map((run) => run.length));
+  return "`".repeat(Math.max(minLength, longestRun + 1));
 }
 
 function renderList(
@@ -187,13 +196,20 @@ function renderTable($: cheerio.CheerioAPI, el: AnyNode): string {
   // Real-world tables vary: proper <thead>/<th>, <th> rows with no <thead>
   // wrapper, and Zendesk's plain <td>-only markup. All three are just "first
   // row is the header, the rest is body", so there's no need to special-case <thead>.
+  // find() over-matches into nested tables, so rows/cells are filtered back
+  // down to the ones whose nearest table/row is this element.
+  const directRows = $(el)
+    .find("tr")
+    .toArray()
+    .filter((tr) => $(tr).closest("table").get(0) === el);
   const rowCells = (tr: AnyNode) =>
     $(tr)
       .find("th, td")
       .toArray()
+      .filter((cell) => $(cell).closest("tr").get(0) === tr)
       .map((cell) => renderInlineChildren($, cell).trim());
 
-  const [headerRow, ...bodyRows] = $(el).find("tr").toArray();
+  const [headerRow, ...bodyRows] = directRows;
   if (!headerRow) return "";
   const header = rowCells(headerRow);
   if (header.length === 0) return "";
@@ -225,13 +241,15 @@ function renderInlineNode($: cheerio.CheerioAPI, node: AnyNode): string {
     case "i":
       return wrapInline(renderInlineChildren($, node).trim(), "_");
     case "code":
-      return wrapInline($(node).text(), "`");
+      return wrapCode($(node).text());
     case "a":
       return renderLink($, node);
     case "img":
       return `![${$(node).attr("alt") ?? ""}](${$(node).attr("src") ?? ""})`;
     case "br":
-      return "\n";
+      // CommonMark hard break: a bare "\n" is a soft break (usually
+      // rendered as a space), losing the explicit <br> line break.
+      return "  \n";
     case "script":
     case "style":
     case "noscript":
@@ -246,6 +264,16 @@ function renderInlineNode($: cheerio.CheerioAPI, node: AnyNode): string {
 // such as `__` or `` `` ``.
 function wrapInline(text: string, delimiter: string): string {
   return text ? `${delimiter}${text}${delimiter}` : "";
+}
+
+// Inline code needs its own delimiter length (per CommonMark, longer than
+// any backtick run in the content) plus a padding space when the content
+// itself starts or ends with a backtick, so the delimiter reads unambiguously.
+function wrapCode(text: string): string {
+  if (!text) return "";
+  const fence = backtickFence(text, 1);
+  const needsPadding = text.startsWith("`") || text.endsWith("`");
+  return needsPadding ? `${fence} ${text} ${fence}` : `${fence}${text}${fence}`;
 }
 
 function renderLink($: cheerio.CheerioAPI, el: AnyNode): string {

--- a/src/confluent/tools/handlers/docs/html-to-markdown.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.ts
@@ -1,0 +1,253 @@
+import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
+
+// Confluent doc pages only ever exercise a small, known set of tags (headings,
+// paragraphs, lists, links, code, tables, images), per the real-page samples
+// pulled via search-product-docs during evaluation. This covers that set
+// directly with cheerio instead of pulling in a general-purpose HTML-to-
+// Markdown library and its own bundled HTML parser dependency.
+
+const INDENT = "  ";
+
+// Tags that always start a new block. Anything else encountered directly
+// inside a container (bare text, <a>, <img>, <strong>, ...) is a loose
+// inline run, e.g. `<div>See <a href="...">this</a></div>`, and gets
+// grouped into one paragraph rather than losing its markup.
+const BLOCK_TAGS = new Set([
+  "p",
+  "div",
+  "section",
+  "article",
+  "aside",
+  "main",
+  "header",
+  "footer",
+  "figure",
+  "blockquote",
+  "pre",
+  "ul",
+  "ol",
+  "li",
+  "table",
+  "hr",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+]);
+
+export function htmlToMarkdown(html: string | null): string {
+  if (!html) return "";
+  const $ = cheerio.load(html);
+  const body = $("body").get(0);
+  if (!body) return "";
+  return renderBlockChildren($, body)
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function renderBlockChildren(
+  $: cheerio.CheerioAPI,
+  el: AnyNode,
+  depth = 0,
+): string {
+  const blocks: string[] = [];
+  let inlineRun: AnyNode[] = [];
+
+  const flushInlineRun = () => {
+    const text = inlineRun.map((node) => renderInlineNode($, node)).join("");
+    const trimmed = text.trim();
+    if (trimmed) blocks.push(trimmed);
+    inlineRun = [];
+  };
+
+  $(el)
+    .contents()
+    .each((_, node) => {
+      if (node.type === "tag" && BLOCK_TAGS.has(node.tagName.toLowerCase())) {
+        flushInlineRun();
+        const rendered = renderBlockNode($, node, depth).trim();
+        if (rendered) blocks.push(rendered);
+      } else {
+        inlineRun.push(node);
+      }
+    });
+  flushInlineRun();
+
+  return blocks.join("\n\n");
+}
+
+function renderBlockNode(
+  $: cheerio.CheerioAPI,
+  node: AnyNode,
+  depth: number,
+): string {
+  if (node.type !== "tag") return "";
+
+  const tag = node.tagName.toLowerCase();
+  switch (tag) {
+    case "h1":
+    case "h2":
+    case "h3":
+    case "h4":
+    case "h5":
+    case "h6":
+      return renderHeading($, node, tag);
+    case "p":
+      return renderInlineChildren($, node).trim();
+    case "blockquote":
+      return renderBlockquote($, node, depth);
+    case "pre":
+      return renderCodeBlock($, node);
+    case "ul":
+    case "ol":
+      return renderList($, node, tag, depth);
+    case "table":
+      return renderTable($, node);
+    case "hr":
+      return "---";
+    default:
+      // Wrapping containers (div, section, article, aside, ...) aren't
+      // structural on their own, so flatten to the blocks they contain.
+      return renderBlockChildren($, node, depth);
+  }
+}
+
+function renderHeading(
+  $: cheerio.CheerioAPI,
+  el: AnyNode,
+  tag: string,
+): string {
+  const level = Number(tag[1]);
+  return `${"#".repeat(level)} ${renderInlineChildren($, el).trim()}`;
+}
+
+function renderBlockquote(
+  $: cheerio.CheerioAPI,
+  el: AnyNode,
+  depth: number,
+): string {
+  const inner = renderBlockChildren($, el, depth);
+  return inner
+    .split("\n")
+    .map((line) => (line ? `> ${line}` : ">"))
+    .join("\n");
+}
+
+function renderCodeBlock($: cheerio.CheerioAPI, el: AnyNode): string {
+  const code = $(el).find("code").first();
+  const text = (code.length > 0 ? code.text() : $(el).text()).replace(
+    /\n+$/,
+    "",
+  );
+  return "```\n" + text + "\n```";
+}
+
+function renderList(
+  $: cheerio.CheerioAPI,
+  el: AnyNode,
+  tag: string,
+  depth: number,
+): string {
+  const ordered = tag === "ol";
+  return $(el)
+    .children("li")
+    .toArray()
+    .map((li, index) => renderListItem($, li, ordered, index, depth))
+    .join("\n");
+}
+
+function renderListItem(
+  $: cheerio.CheerioAPI,
+  li: AnyNode,
+  ordered: boolean,
+  index: number,
+  depth: number,
+): string {
+  const marker = ordered ? `${index + 1}.` : "-";
+  const nested = $(li).children("ul, ol");
+  const ownContent = $(li).clone();
+  ownContent.children("ul, ol").remove();
+  const text = renderInlineChildren($, ownContent.get(0)!).trim();
+
+  const lines = [`${INDENT.repeat(depth)}${marker} ${text}`];
+  nested.each((_, nestedList) => {
+    lines.push(renderList($, nestedList, nestedList.tagName, depth + 1));
+  });
+  return lines.join("\n");
+}
+
+function renderTable($: cheerio.CheerioAPI, el: AnyNode): string {
+  // Real-world tables vary: proper <thead>/<th>, <th> rows with no <thead>
+  // wrapper, and Zendesk's plain <td>-only markup. All three are just "first
+  // row is the header, the rest is body", so there's no need to special-case <thead>.
+  const rowCells = (tr: AnyNode) =>
+    $(tr)
+      .find("th, td")
+      .toArray()
+      .map((cell) => renderInlineChildren($, cell).trim());
+
+  const [headerRow, ...bodyRows] = $(el).find("tr").toArray();
+  if (!headerRow) return "";
+  const header = rowCells(headerRow);
+  if (header.length === 0) return "";
+
+  const headerLine = `| ${header.join(" | ")} |`;
+  const separatorLine = `| ${header.map(() => "---").join(" | ")} |`;
+  const bodyLines = bodyRows.map((tr) => `| ${rowCells(tr).join(" | ")} |`);
+  return [headerLine, separatorLine, ...bodyLines].join("\n");
+}
+
+function renderInlineChildren($: cheerio.CheerioAPI, el: AnyNode): string {
+  return $(el)
+    .contents()
+    .toArray()
+    .map((node) => renderInlineNode($, node))
+    .join("");
+}
+
+function renderInlineNode($: cheerio.CheerioAPI, node: AnyNode): string {
+  if (node.type === "text") return escapeText(node.data ?? "");
+  if (node.type !== "tag") return "";
+
+  const tag = node.tagName.toLowerCase();
+  switch (tag) {
+    case "strong":
+    case "b":
+      return `**${renderInlineChildren($, node).trim()}**`;
+    case "em":
+    case "i":
+      return `_${renderInlineChildren($, node).trim()}_`;
+    case "code":
+      return `\`${$(node).text()}\``;
+    case "a":
+      return renderLink($, node);
+    case "img":
+      return `![${$(node).attr("alt") ?? ""}](${$(node).attr("src") ?? ""})`;
+    case "br":
+      return "\n";
+    case "script":
+    case "style":
+    case "noscript":
+      return "";
+    default:
+      return renderInlineChildren($, node);
+  }
+}
+
+function renderLink($: cheerio.CheerioAPI, el: AnyNode): string {
+  const href = $(el).attr("href");
+  const text = renderInlineChildren($, el).trim();
+  // Drop empty-text anchors (e.g. heading permalink icons) rather than
+  // emitting a bare, meaningless `[](url)`.
+  if (!text) return "";
+  return href ? `[${text}](${href})` : text;
+}
+
+// Collapses HTML source whitespace/newlines to single spaces and escapes the
+// handful of characters that would otherwise be misread as Markdown syntax.
+function escapeText(text: string): string {
+  return text.replace(/\s+/g, " ").replace(/[*_`\\]/g, "\\$&");
+}

--- a/src/confluent/tools/handlers/docs/html-to-markdown.ts
+++ b/src/confluent/tools/handlers/docs/html-to-markdown.ts
@@ -120,8 +120,12 @@ function renderHeading(
   el: AnyNode,
   tag: string,
 ): string {
+  const text = renderInlineChildren($, el).trim();
+  // Drop empty headings (e.g. Zendesk spacer elements like `<h3> </h3>`)
+  // instead of emitting a bare, meaningless `###`.
+  if (!text) return "";
   const level = Number(tag[1]);
-  return `${"#".repeat(level)} ${renderInlineChildren($, el).trim()}`;
+  return `${"#".repeat(level)} ${text}`;
 }
 
 function renderBlockquote(


### PR DESCRIPTION
## Summary of Changes

- `turndown` depends on `@mixmark-io/domino` as its Node.js HTML parser. Some
  enterprise Artifactory/security scanners quarantine `@mixmark-io/domino`,
  which breaks `npm install -g @confluentinc/mcp-confluent` for customers on
  locked-down networks. ([thread](https://confluent.slack.com/archives/C0AJUENFYDC/p1784236880201669))
- This PR writes a small converter (`html-to-markdown.ts`, ~185 lines) using
  `cheerio`, which is already a direct dependency of this project. No new
  package is introduced at all, so this removes the whole class of
  "third-party HTML parser gets flagged" risk rather than trading one
  flagged dependency for a different, less-scrutinized one.
- Covers the specific tag set Confluent doc pages actually use (headings,
  paragraphs, bold/italic, links, images, inline/fenced code, ordered/
  unordered lists incl. nesting, blockquotes, tables), based on real-page
  samples pulled via `search-product-docs` during evaluation. Unknown tags
  fall back to plain text.
- Bonus: renders real Markdown tables. `turndown` (without the GFM plugin,
  which this project doesn't use) has no table support at all, it dumps
  each cell's text on its own line with no row/column structure.
- Known limitations (not hit on any real page tested): nested tables aren't
  handled correctly, and a backtick inside inline `<code>` text isn't escaped.
- No call-site changes outside `get-product-doc-page-handler.ts`; `turndown`
  was only used there.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm run build` — passes
- [x] `pnpm run test:unit` — 2429/2429 passes
- [x] `grep -c "turndown\|node-html-markdown\|@mixmark-io/domino" pnpm-lock.yaml` → `0`
- [x] Manually verified against real pages on all three hosts
      (`docs.confluent.io`, `developer.confluent.io`, `support.confluent.io`)

### Manual Testing Instructions

refer to https://github.com/confluentinc/mcp-confluent/pull/354

Additionally worth checking against this PR specifically:
1. `https://developer.confluent.io/what-is-apache-kafka/`
   → link text/hrefs are preserved even where the source HTML has an
     `<a>` sitting directly inside a `<div>` with no wrapping `<p>`
   → no stray `[]()` artifacts from heading permalink icons
2. Any support.confluent.io article containing a table (e.g. a release-notes
   article) → renders as a proper `| a | b |` Markdown table, not flattened
   cell-by-cell text

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?
