### PR TITLE
Enable linting for `reportUnusedDisableDirectives: "error"`  to flag uneeded eslint escapes.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,8 @@ import tseslint from "typescript-eslint";
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
+  // Any `eslint-disable*` comment that no longer suppresses a finding fails the build
+  { linterOptions: { reportUnusedDisableDirectives: "error" } },
   { languageOptions: { globals: globals.browser } },
   {
     ignores: [


### PR DESCRIPTION
Enable linting for unused/unneeded eslint disable directives so that any now-unneeded directive will fail the build. Keeps such comments/directives truthy!

Closes #696 