### PR TITLE
Enforce importing types as types.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,19 @@ export default [
       ],
     },
   },
+  // Require `import type { … }` for symbols referenced only in type position.
+  // `fixStyle: "separate-type-imports"` keeps the codebase's existing separate-line
+  // `import type { … } from "…"` style, and `eslint --fix` (pre-commit hook) auto-corrects
+  // future drift.
+  {
+    files: ["**/*.ts"],
+    rules: {
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { fixStyle: "separate-type-imports" },
+      ],
+    },
+  },
   // Mirror SonarQube's cognitive-complexity quality gate (rule
   // typescript:S3776, default threshold 15) locally, so `pnpm run lint` and the
   // pre-push hook flag an over-complex function before it reaches the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,8 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import { TransportType } from "@src/mcp/transports/types.js";
 
-import { getProperties, KeyValuePairObject } from "properties-file";
+import type { KeyValuePairObject } from "properties-file";
+import { getProperties } from "properties-file";
 import pkg from "../package.json" with { type: "json" };
 
 /**

--- a/src/confluent/base-client-manager.ts
+++ b/src/confluent/base-client-manager.ts
@@ -13,12 +13,12 @@ import {
   type ConfluentRestClient,
   type SchemaRegistryClientHandler,
 } from "@src/confluent/client-manager.js";
-import {
+import type {
   ConfluentAuth,
   ConfluentEndpoints,
-  createAuthMiddleware,
 } from "@src/confluent/middleware.js";
-import { paths } from "@src/confluent/openapi-schema.js";
+import { createAuthMiddleware } from "@src/confluent/middleware.js";
+import type { paths } from "@src/confluent/openapi-schema.js";
 import { Lazy } from "@src/lazy.js";
 import { logger } from "@src/logger.js";
 import createClient from "openapi-fetch";

--- a/src/confluent/client-manager.ts
+++ b/src/confluent/client-manager.ts
@@ -5,7 +5,7 @@
  * for api-key auth + native Kafka, plus the OAuth variant) alongside it.
  */
 
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import type { paths } from "@src/confluent/openapi-schema.js";
 import type { Client } from "openapi-fetch";

--- a/src/confluent/direct-client-manager.ts
+++ b/src/confluent/direct-client-manager.ts
@@ -3,7 +3,7 @@
  * REST/Schema-Registry surfaces inherited from {@link BaseClientManager}.
  */
 
-import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
+import type { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
 import {
   CONFLUENT_CLOUD_DEFAULT_ENDPOINT,
   type DirectConnectionConfig,

--- a/src/confluent/middleware.ts
+++ b/src/confluent/middleware.ts
@@ -1,5 +1,5 @@
 import { logger } from "@src/logger.js";
-import { Middleware } from "openapi-fetch";
+import type { Middleware } from "openapi-fetch";
 import pkg from "../../package.json" with { type: "json" };
 
 /**

--- a/src/confluent/oauth-client-manager.ts
+++ b/src/confluent/oauth-client-manager.ts
@@ -43,7 +43,7 @@ import {
   getFlinkRestUrlForRegion,
   getTelemetryRestUrlForEnv,
 } from "@src/confluent/oauth/auth0-config.js";
-import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
+import type { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
 import type { Auth0Environment } from "@src/confluent/oauth/types.js";
 import type { paths } from "@src/confluent/openapi-schema.js";
 import { kafkaLogger } from "@src/logger.js";

--- a/src/confluent/oauth/auth-context.test.ts
+++ b/src/confluent/oauth/auth-context.test.ts
@@ -7,9 +7,9 @@ import {
   REFRESH_TOKEN_IDLE_LIFETIME_MS,
 } from "@src/confluent/oauth/token-lifetimes.js";
 import type { ConfluentTokenSet } from "@src/confluent/oauth/types.js";
+import type { MockedFetch } from "@tests/stubs/index.js";
 import {
   jsonResponse,
-  MockedFetch,
   mockFetch,
   stubAuth0Ok,
   stubCpOk,

--- a/src/confluent/schema-registry-helper.test.ts
+++ b/src/confluent/schema-registry-helper.test.ts
@@ -1,5 +1,5 @@
-import { MutableRegistry } from "@bufbuild/protobuf";
-import { IHeaders } from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import type { MutableRegistry } from "@bufbuild/protobuf";
+import type { IHeaders } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import {
   KEY_SCHEMA_ID_HEADER,
   SchemaId,

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -4,34 +4,36 @@
  * using various schema formats (AVRO, JSON, PROTOBUF).
  */
 
+import type { MutableRegistry } from "@bufbuild/protobuf";
 import {
   createFileRegistry,
   createMutableRegistry,
   fromBinary,
   fromJson,
-  MutableRegistry,
 } from "@bufbuild/protobuf";
 import {
   FileDescriptorProtoSchema,
   FileDescriptorSetSchema,
 } from "@bufbuild/protobuf/wkt";
-import { IHeaders } from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import type { IHeaders } from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import type {
+  Deserializer,
+  DeserializerConfig,
+  ProtobufSerializerConfig,
+  SchemaRegistryClient,
+  Serializer,
+  SerializerConfig,
+} from "@confluentinc/schemaregistry";
 import {
   AvroDeserializer,
   AvroSerializer,
-  Deserializer,
-  DeserializerConfig,
   HeaderSchemaIdSerializer,
   JsonDeserializer,
   JsonSerializer,
   ProtobufDeserializer,
   ProtobufSerializer,
-  ProtobufSerializerConfig,
   SchemaId,
-  SchemaRegistryClient,
   SerdeType,
-  Serializer,
-  SerializerConfig,
 } from "@confluentinc/schemaregistry";
 import { logger } from "@src/logger.js";
 import protobuf from "protobufjs";

--- a/src/confluent/schema.ts
+++ b/src/confluent/schema.ts
@@ -1,4 +1,4 @@
-import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
+import type { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { z } from "zod";
 
 export type CallToolResult = z.infer<typeof CallToolResultSchema>;

--- a/src/confluent/tools/base-tools.ts
+++ b/src/confluent/tools/base-tools.ts
@@ -4,18 +4,21 @@ import type {
   DirectConnectionConfig,
 } from "@src/config/models.js";
 import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type {
+  ConnectionPredicate,
+  PredicateResult,
+} from "@src/confluent/tools/connection-predicates.js";
 import {
   alwaysEnabled,
-  ConnectionPredicate,
   ENABLED,
-  PredicateResult,
   ToolDisabledReason,
 } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { quoteJoinIds } from "@src/utils/quote-join-ids.js";
-import { z, ZodRawShape } from "zod";
+import type { ZodRawShape } from "zod";
+import { z } from "zod";
 
 /**
  * Standard MCP tool annotations.

--- a/src/confluent/tools/cluster-arg-resolvers.ts
+++ b/src/confluent/tools/cluster-arg-resolvers.ts
@@ -12,9 +12,9 @@
  */
 
 import { KafkaJS } from "@confluentinc/kafka-javascript";
-import { ConnectionConfig } from "@src/config/models.js";
+import type { ConnectionConfig } from "@src/config/models.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 
 /**
  * Resolves a required string from an explicit arg, falling back to a

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -1,9 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
@@ -12,7 +12,7 @@ import {
 } from "@src/confluent/tools/pagination.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
+++ b/src/confluent/tools/handlers/catalog/add-tags-to-topic.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/catalog/create-topic-tags.ts
+++ b/src/confluent/tools/handlers/catalog/create-topic-tags.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/catalog/delete-tag.ts
+++ b/src/confluent/tools/handlers/catalog/delete-tag.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   DESTRUCTIVE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/catalog/list-tags.ts
+++ b/src/confluent/tools/handlers/catalog/list-tags.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
+++ b/src/confluent/tools/handlers/catalog/remove-tag-from-entity.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   DESTRUCTIVE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.test.ts
@@ -1,11 +1,11 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ListClustersHandler } from "@src/confluent/tools/handlers/clusters/list-clusters-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   ccloudOAuthRuntime,
   DEFAULT_CONNECTION_ID,
-  HandleCaseWithConn,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
+++ b/src/confluent/tools/handlers/clusters/list-clusters-handler.ts
@@ -1,15 +1,15 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveEnvArg } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/connect/connect-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/connect-tool-handler.test.ts
@@ -1,6 +1,7 @@
 import type { OAuthConnectionConfig } from "@src/config/models.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ConnectToolHandler } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { directConnectionOf } from "@tests/factories/config.js";

--- a/src/confluent/tools/handlers/connect/connect-tool-handler.ts
+++ b/src/confluent/tools/handlers/connect/connect-tool-handler.ts
@@ -1,4 +1,4 @@
-import { ConnectionConfig } from "@src/config/models.js";
+import type { ConnectionConfig } from "@src/config/models.js";
 import {
   BaseToolHandler,
   ToolCategory,

--- a/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.test.ts
@@ -1,8 +1,8 @@
 import { CreateConnectorHandler } from "@src/confluent/tools/handlers/connect/create-connector-handler.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN_WITH_AUTH,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/create-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/create-connector-handler.ts
@@ -1,9 +1,10 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { canCreateDirectConnector } from "@src/confluent/tools/connection-predicates.js";
 import { ConnectToolHandler } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.test.ts
@@ -1,8 +1,8 @@
 import { DeleteConnectorHandler } from "@src/confluent/tools/handlers/connect/delete-connector-handler.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/delete-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/delete-connector-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { DESTRUCTIVE } from "@src/confluent/tools/base-tools.js";
 import { ConnectToolHandler } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/connect/get-connector-config-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-config-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { GetConnectorConfigHandler } from "@src/confluent/tools/handlers/connect/get-connector-config-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/get-connector-config-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-config-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class GetConnectorConfigHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/get-connector-error-recommendations-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-recommendations-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 interface RecommendationsProjection {

--- a/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 const HEALTHY_TASK_STATES = new Set(["RUNNING", "PROVISIONING", "UNASSIGNED"]);

--- a/src/confluent/tools/handlers/connect/get-connector-logs-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-logs-handler.ts
@@ -1,15 +1,16 @@
-import { ConnectionConfig } from "@src/config/models.js";
-import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import type { ConnectionConfig } from "@src/config/models.js";
+import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { nodeFetch } from "@src/confluent/node-deps.js";
-import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/connect/get-connector-offsets-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-offsets-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { GetConnectorOffsetsHandler } from "@src/confluent/tools/handlers/connect/get-connector-offsets-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/get-connector-offsets-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-offsets-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class GetConnectorOffsetsHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/get-connector-status-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-status-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { GetConnectorStatusHandler } from "@src/confluent/tools/handlers/connect/get-connector-status-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/get-connector-status-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-status-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class GetConnectorStatusHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/get-connector-tasks-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-tasks-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { GetConnectorTasksHandler } from "@src/confluent/tools/handlers/connect/get-connector-tasks-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/get-connector-tasks-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-tasks-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class GetConnectorTasksHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.test.ts
@@ -1,8 +1,8 @@
 import { ListConnectorsHandler } from "@src/confluent/tools/handlers/connect/list-connectors-handler.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/list-connectors-handler.ts
+++ b/src/confluent/tools/handlers/connect/list-connectors-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ConnectToolHandler } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/connect/pause-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/pause-connector-handler.test.ts
@@ -1,10 +1,10 @@
 import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { PauseConnectorHandler } from "@src/confluent/tools/handlers/connect/pause-connector-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/pause-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/pause-connector-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class PauseConnectorHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/restart-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/restart-connector-handler.test.ts
@@ -1,10 +1,10 @@
 import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { RestartConnectorHandler } from "@src/confluent/tools/handlers/connect/restart-connector-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/restart-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/restart-connector-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class RestartConnectorHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/resume-connector-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/resume-connector-handler.test.ts
@@ -1,10 +1,10 @@
 import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { ResumeConnectorHandler } from "@src/confluent/tools/handlers/connect/resume-connector-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/resume-connector-handler.ts
+++ b/src/confluent/tools/handlers/connect/resume-connector-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export class ResumeConnectorHandler extends ConnectToolHandler {

--- a/src/confluent/tools/handlers/connect/update-connector-config-handler.test.ts
+++ b/src/confluent/tools/handlers/connect/update-connector-config-handler.test.ts
@@ -1,10 +1,10 @@
 import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { UpdateConnectorConfigHandler } from "@src/confluent/tools/handlers/connect/update-connector-config-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ConnectHandleCase } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   CONNECT_CONN,
-  ConnectHandleCase,
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/connect/update-connector-config-handler.ts
+++ b/src/confluent/tools/handlers/connect/update-connector-config-handler.ts
@@ -1,11 +1,12 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import {
   ConnectToolHandler,
   connectorByNameArguments,
 } from "@src/confluent/tools/handlers/connect/connect-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/diagnostics/config-help-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/config-help-handler.test.ts
@@ -1,13 +1,10 @@
-import { DirectConnectionConfig } from "@src/config/models.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  CREATE_UPDATE,
-  READ_ONLY,
-  ToolHandler,
-} from "@src/confluent/tools/base-tools.js";
+import type { DirectConnectionConfig } from "@src/config/models.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE, READ_ONLY } from "@src/confluent/tools/base-tools.js";
+import type { ConnectionPredicate } from "@src/confluent/tools/connection-predicates.js";
 import {
   alwaysEnabled,
-  ConnectionPredicate,
   hasCCloudCatalogSupport,
   hasConfluentCloud,
   hasFlink,

--- a/src/confluent/tools/handlers/diagnostics/config-help-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/config-help-handler.ts
@@ -1,17 +1,16 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  READ_ONLY,
-  ToolCategory,
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type {
   ToolConfig,
   ToolHandler,
 } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY, ToolCategory } from "@src/confluent/tools/base-tools.js";
 import {
   alwaysEnabled,
   ToolDisabledReason,
 } from "@src/confluent/tools/connection-predicates.js";
 import { ToolMetadataHandler } from "@src/confluent/tools/tool-metadata-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const configHelpArguments = z.object({

--- a/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.test.ts
@@ -1,10 +1,7 @@
 import { MCPServerConfiguration } from "@src/config/models.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  CREATE_UPDATE,
-  READ_ONLY,
-  ToolHandler,
-} from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE, READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   alwaysEnabled,
   hasFlink,

--- a/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/describe-configured-connection-handler.ts
@@ -1,9 +1,6 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  READ_ONLY,
-  ToolCategory,
-  ToolConfig,
-} from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY, ToolCategory } from "@src/confluent/tools/base-tools.js";
 import {
   alwaysEnabled,
   ToolDisabledReason,
@@ -11,7 +8,7 @@ import {
 import { buildConnectionCard } from "@src/confluent/tools/handlers/diagnostics/describe-fields.js";
 import { ToolMetadataHandler } from "@src/confluent/tools/tool-metadata-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { quoteJoinIds } from "@src/utils/quote-join-ids.js";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
 import { READ_ONLY, ToolCategory } from "@src/confluent/tools/base-tools.js";
 import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
 import { ExplainDisabledToolsHandler } from "@src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.js";

--- a/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/explain-disabled-tools-handler.ts
@@ -1,9 +1,6 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  READ_ONLY,
-  ToolCategory,
-  ToolConfig,
-} from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY, ToolCategory } from "@src/confluent/tools/base-tools.js";
 import {
   alwaysEnabled,
   ToolDisabledReason,
@@ -17,7 +14,7 @@ import {
 } from "@src/confluent/tools/tool-availability.js";
 import { ToolMetadataHandler } from "@src/confluent/tools/tool-metadata-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const explainDisabledToolsArguments = z.object({

--- a/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.test.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.test.ts
@@ -1,9 +1,6 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  CREATE_UPDATE,
-  READ_ONLY,
-  ToolHandler,
-} from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE, READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   alwaysEnabled,
   hasKafka,

--- a/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.ts
+++ b/src/confluent/tools/handlers/diagnostics/list-configured-connections-handler.ts
@@ -1,13 +1,10 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import {
-  READ_ONLY,
-  ToolCategory,
-  ToolConfig,
-} from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY, ToolCategory } from "@src/confluent/tools/base-tools.js";
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolMetadataHandler } from "@src/confluent/tools/tool-metadata-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listConfiguredConnectionsArguments = z.object({});

--- a/src/confluent/tools/handlers/docs/get-product-doc-page-handler.test.ts
+++ b/src/confluent/tools/handlers/docs/get-product-doc-page-handler.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
 import { GetProductDocPageHandler } from "@src/confluent/tools/handlers/docs/get-product-doc-page-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { bareRuntime } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/docs/get-product-doc-page-handler.ts
+++ b/src/confluent/tools/handlers/docs/get-product-doc-page-handler.ts
@@ -1,15 +1,15 @@
 import { nodeFetch } from "@src/confluent/node-deps.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import * as cheerio from "cheerio";
 import TurndownService from "turndown";
 import { z } from "zod";

--- a/src/confluent/tools/handlers/docs/search-product-docs-handler.test.ts
+++ b/src/confluent/tools/handlers/docs/search-product-docs-handler.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
 import { SearchProductDocsHandler } from "@src/confluent/tools/handlers/docs/search-product-docs-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { bareRuntime } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/docs/search-product-docs-handler.ts
+++ b/src/confluent/tools/handlers/docs/search-product-docs-handler.ts
@@ -1,15 +1,15 @@
 import { nodeFetch } from "@src/confluent/node-deps.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { alwaysEnabled } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 // Public search-only key from docs.confluent.io frontend; safe to hardcode.

--- a/src/confluent/tools/handlers/environments/list-environments-handler.ts
+++ b/src/confluent/tools/handlers/environments/list-environments-handler.ts
@@ -1,9 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import {
@@ -12,7 +12,7 @@ import {
 } from "@src/confluent/tools/pagination.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/environments/read-environment-handler.ts
+++ b/src/confluent/tools/handlers/environments/read-environment-handler.ts
@@ -1,18 +1,16 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
-import {
-  Environment,
-  environmentSchema,
-} from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
+import type { Environment } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
+import { environmentSchema } from "@src/confluent/tools/handlers/environments/list-environments-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/catalog/catalog-resolver.ts
+++ b/src/confluent/tools/handlers/flink/catalog/catalog-resolver.ts
@@ -1,5 +1,5 @@
 import type { DirectConnectionConfig } from "@src/config/index.js";
-import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { executeFlinkSql } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 
 /**

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.test.ts
@@ -1,9 +1,9 @@
 import { DescribeTableHandler } from "@src/confluent/tools/handlers/flink/catalog/describe-table-handler.js";
 import { textOf } from "@tests/call-tool-result.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  HandleCaseWithConn,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/describe-table-handler.ts
@@ -1,5 +1,6 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   getSchemaMapping,
   resolveDatabaseName,
@@ -11,7 +12,7 @@ import {
   type FlinkStatementMeta,
 } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const describeTableArguments = z.object({

--- a/src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.test.ts
@@ -1,5 +1,6 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { describe, expect, it } from "vitest";

--- a/src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
 import { resolveCatalogName } from "@src/confluent/tools/handlers/flink/catalog/catalog-resolver.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.test.ts
@@ -1,9 +1,9 @@
 import { GetTableInfoHandler } from "@src/confluent/tools/handlers/flink/catalog/get-table-info-handler.js";
 import { textOf } from "@tests/call-tool-result.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  HandleCaseWithConn,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/get-table-info-handler.ts
@@ -1,5 +1,6 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   getSchemaMapping,
   resolveDatabaseName,
@@ -11,7 +12,7 @@ import {
   type FlinkStatementMeta,
 } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const getTableInfoArguments = z.object({

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.test.ts
@@ -1,9 +1,9 @@
 import { ListCatalogsHandler } from "@src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.js";
 import { textOf } from "@tests/call-tool-result.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  HandleCaseWithConn,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-catalogs-handler.ts
@@ -1,12 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
 import {
   executeFlinkSql,
   type FlinkStatementMeta,
 } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listCatalogsArguments = z.object({

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.test.ts
@@ -1,9 +1,9 @@
 import { ListDatabasesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-databases-handler.js";
 import { textOf } from "@tests/call-tool-result.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  HandleCaseWithConn,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-databases-handler.ts
@@ -1,12 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
 import {
   executeFlinkSql,
   type FlinkStatementMeta,
 } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listDatabasesArguments = z.object({

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.test.ts
@@ -1,9 +1,9 @@
 import { ListTablesHandler } from "@src/confluent/tools/handlers/flink/catalog/list-tables-handler.js";
 import { textOf } from "@tests/call-tool-result.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  HandleCaseWithConn,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
+++ b/src/confluent/tools/handlers/flink/catalog/list-tables-handler.ts
@@ -1,12 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkCatalogToolHandler } from "@src/confluent/tools/handlers/flink/catalog/flink-catalog-tool-handler.js";
 import {
   executeFlinkSql,
   type FlinkStatementMeta,
 } from "@src/confluent/tools/handlers/flink/flink-sql-helper.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listTablesArguments = z.object({

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.test.ts
@@ -1,8 +1,8 @@
 import { CreateFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/create-flink-statement-handler.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   FLINK_CONN as BASE_FLINK_CONN,
   DEFAULT_CONNECTION_ID,
-  HandleCaseWithConn,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/create-flink-statement-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.test.ts
@@ -1,8 +1,8 @@
 import { DeleteFlinkStatementHandler } from "@src/confluent/tools/handlers/flink/delete-flink-statement-handler.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  HandleCaseWithConn,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
+++ b/src/confluent/tools/handlers/flink/delete-flink-statement-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { DESTRUCTIVE } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { CheckHealthHandler } from "@src/confluent/tools/handlers/flink/diagnostics/check-health-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { FlinkGetCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  FlinkGetCase,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/check-health-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { DetectIssuesHandler } from "@src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { FlinkGetCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  FlinkGetCase,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/detect-issues-handler.ts
@@ -1,13 +1,14 @@
 import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   analyzeMetrics,
   getStatementMetrics,
 } from "@src/confluent/tools/handlers/flink/diagnostics/metrics-helper.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/diagnostics/metrics-helper.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/metrics-helper.ts
@@ -1,4 +1,4 @@
-import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 
 /**
  * Flink statement metrics from the Confluent Cloud Telemetry API.

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
@@ -1,10 +1,10 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { QueryProfilerHandler } from "@src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { FlinkGetCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_TELEMETRY_CONN,
-  FlinkGetCase,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -1,9 +1,10 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { flinkWithTelemetryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/flink-sql-helper.ts
+++ b/src/confluent/tools/handlers/flink/flink-sql-helper.ts
@@ -1,7 +1,8 @@
-import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import type { components, paths } from "@src/confluent/openapi-schema.js";
 import { logger } from "@src/logger.js";
-import { PathBasedClient, wrapAsPathBasedClient } from "openapi-fetch";
+import type { PathBasedClient } from "openapi-fetch";
+import { wrapAsPathBasedClient } from "openapi-fetch";
 
 export interface FlinkSqlResult {
   success: boolean;

--- a/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.test.ts
@@ -1,14 +1,13 @@
-import {
+import type {
   DirectConnectionConfig,
   FlinkDirectConfig,
   OAuthConnectionConfig,
 } from "@src/config/models.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
-import {
-  FlinkRoutingArgs,
-  FlinkToolHandler,
-} from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
+import type { FlinkRoutingArgs } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
+import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { FLINK_CONN } from "@tests/factories/runtime.js";
 import { describe, expect, it } from "vitest";

--- a/src/confluent/tools/handlers/flink/flink-tool-handler.ts
+++ b/src/confluent/tools/handlers/flink/flink-tool-handler.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ConnectionConfig,
   DirectConnectionConfig,
   FlinkDirectConfig,

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.test.ts
@@ -1,8 +1,8 @@
 import { GetFlinkExceptionsHandler } from "@src/confluent/tools/handlers/flink/get-flink-exceptions-handler.js";
+import type { FlinkGetCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  FlinkGetCase,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-exceptions-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/get-flink-statement-results-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-statement-results-handler.test.ts
@@ -1,8 +1,8 @@
 import { GetFlinkStatementResultsHandler } from "@src/confluent/tools/handlers/flink/get-flink-statement-results-handler.js";
+import type { FlinkGetCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  FlinkGetCase,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/get-flink-statement-results-handler.ts
+++ b/src/confluent/tools/handlers/flink/get-flink-statement-results-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/list-compute-pools-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/list-compute-pools-handler.test.ts
@@ -1,11 +1,11 @@
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ListComputePoolsHandler } from "@src/confluent/tools/handlers/flink/list-compute-pools-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   CCLOUD_CONN,
   ccloudOAuthRuntime,
   DEFAULT_CONNECTION_ID,
-  HandleCaseWithConn,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";
 import {

--- a/src/confluent/tools/handlers/flink/list-compute-pools-handler.ts
+++ b/src/confluent/tools/handlers/flink/list-compute-pools-handler.ts
@@ -1,15 +1,15 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveEnvArg } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.test.ts
@@ -1,8 +1,8 @@
 import { ListFlinkStatementsHandler } from "@src/confluent/tools/handlers/flink/list-flink-statements-handler.js";
+import type { FlinkGetCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   FLINK_CONN,
-  FlinkGetCase,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
+++ b/src/confluent/tools/handlers/flink/list-flink-statements-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { FlinkToolHandler } from "@src/confluent/tools/handlers/flink/flink-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.test.ts
@@ -1,7 +1,7 @@
 import { AlterTopicConfigHandler } from "@src/confluent/tools/handlers/kafka/alter-topic-config.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
-  HandleCaseWithConn,
   KAFKA_CONN,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/kafka/alter-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/alter-topic-config.ts
@@ -1,14 +1,14 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveKafkaRestArgs } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { kafkaRestWithAuthOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.cp.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.cp.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { ConsumeKafkaMessagesHandler } from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { ConsumeKafkaMessagesHandler } from "@src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { getTestEnvironmentId } from "@tests/harness/confluent-cloud.js";

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.test.ts
@@ -1,12 +1,12 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import type {
   EachMessagePayload,
   KafkaMessage,
 } from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import {
   KEY_SCHEMA_ID_HEADER,
   SchemaId,
-  SchemaRegistryClient,
   SerdeType,
   VALUE_SCHEMA_ID_HEADER,
 } from "@confluentinc/schemaregistry";

--- a/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
+++ b/src/confluent/tools/handlers/kafka/consume-kafka-messages-handler.ts
@@ -1,19 +1,19 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import type { KafkaMessage } from "@confluentinc/kafka-javascript/types/kafkajs.js";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import {
   KEY_SCHEMA_ID_HEADER,
-  SchemaRegistryClient,
   SerdeType,
   VALUE_SCHEMA_ID_HEADER,
 } from "@confluentinc/schemaregistry";
 import { nodeCrypto } from "@src/confluent/node-deps.js";
 import * as schemaRegistryHelper from "@src/confluent/schema-registry-helper.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -30,7 +30,7 @@ import {
 } from "@src/confluent/tools/handlers/kafka/partition-watermarks.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const schemaRegistryOptions = z

--- a/src/confluent/tools/handlers/kafka/create-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/create-topics-handler.ts
@@ -1,9 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -12,7 +12,7 @@ import {
 } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const createTopicArgs = z.object({

--- a/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/delete-topics-handler.ts
@@ -1,9 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   DESTRUCTIVE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -11,7 +11,7 @@ import {
 } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const deleteKafkaTopicsArguments = z.object({

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { DescribeConsumerGroupHandler } from "@src/confluent/tools/handlers/kafka/describe-consumer-group-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { getTestEnvironmentId } from "@tests/harness/confluent-cloud.js";

--- a/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.ts
+++ b/src/confluent/tools/handlers/kafka/describe-consumer-group-handler.ts
@@ -3,12 +3,12 @@ import type {
   GroupDescription,
   MemberDescription,
 } from "@confluentinc/kafka-javascript/types/rdkafka.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -24,7 +24,7 @@ import {
   notFoundGroupMessage,
 } from "@src/confluent/tools/handlers/kafka/consumer-group-helpers.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 export const describeConsumerGroupArgs = z.object({

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import {
   GetConsumerGroupLagHandler,
   type GetConsumerGroupLagResponse,

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.test.ts
@@ -4,10 +4,10 @@ import type {
   GroupDescription,
   LibrdKafkaError,
 } from "@confluentinc/kafka-javascript/types/rdkafka.js";
+import type { GetConsumerGroupLagResponse } from "@src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.js";
 import {
   getConsumerGroupLagArgs,
   GetConsumerGroupLagHandler,
-  GetConsumerGroupLagResponse,
 } from "@src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";

--- a/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.ts
+++ b/src/confluent/tools/handlers/kafka/get-consumer-group-lag-handler.ts
@@ -1,11 +1,11 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
 import type { FetchOffsetsPartition } from "@confluentinc/kafka-javascript/types/kafkajs.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -25,7 +25,7 @@ import {
 } from "@src/confluent/tools/handlers/kafka/partition-watermarks.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 export const getConsumerGroupLagArgs = z.object({

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import {
   GetPartitionOffsetsHandler,
   type GetPartitionOffsetsResponse,

--- a/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.ts
+++ b/src/confluent/tools/handlers/kafka/get-partition-offsets-handler.ts
@@ -1,10 +1,10 @@
 import { KafkaJS } from "@confluentinc/kafka-javascript";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -19,7 +19,7 @@ import {
 } from "@src/confluent/tools/handlers/kafka/partition-watermarks.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 export const getPartitionOffsetsArgs = z.object({

--- a/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.test.ts
@@ -1,7 +1,7 @@
 import { GetTopicConfigHandler } from "@src/confluent/tools/handlers/kafka/get-topic-config.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
-  HandleCaseWithConn,
   KAFKA_CONN,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/kafka/get-topic-config.ts
+++ b/src/confluent/tools/handlers/kafka/get-topic-config.ts
@@ -1,14 +1,14 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { resolveKafkaRestArgs } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { kafkaRestWithAuthOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-consumer-groups-handler.ts
@@ -1,10 +1,10 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -20,7 +20,7 @@ import {
   typeName,
 } from "@src/confluent/tools/handlers/kafka/consumer-group-enums.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 export const listConsumerGroupsArgs = z.object({

--- a/src/confluent/tools/handlers/kafka/list-topics-handler.ts
+++ b/src/confluent/tools/handlers/kafka/list-topics-handler.ts
@@ -1,9 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -11,7 +11,7 @@ import {
 } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listTopicArgs = z.object({

--- a/src/confluent/tools/handlers/kafka/partition-watermarks.ts
+++ b/src/confluent/tools/handlers/kafka/partition-watermarks.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { logger } from "@src/logger.js";
 
 /**

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.cp.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.cp.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import {

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { VALUE_SCHEMA_ID_HEADER } from "@confluentinc/schemaregistry";
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.ts
@@ -1,21 +1,24 @@
-import {
+import type {
   IHeaders,
   Message,
   RecordMetadata,
 } from "@confluentinc/kafka-javascript/types/kafkajs.js";
-import { SchemaRegistryClient, SerdeType } from "@confluentinc/schemaregistry";
-import {
-  checkSchemaNeeded,
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import { SerdeType } from "@confluentinc/schemaregistry";
+import type {
   MessageOptions,
   SchemaCheckResult,
+} from "@src/confluent/schema-registry-helper.js";
+import {
+  checkSchemaNeeded,
   serializeMessage,
 } from "@src/confluent/schema-registry-helper.js";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import {
   disposeIfOAuth,
@@ -24,7 +27,7 @@ import {
 } from "@src/confluent/tools/cluster-arg-resolvers.js";
 import { kafkaBootstrapOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const messageOptions = z.object({

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.test.ts
@@ -1,4 +1,4 @@
-import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
+import type { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ListMetricsHandler } from "@src/confluent/tools/handlers/metrics/list-metrics-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";

--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -1,14 +1,14 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasTelemetryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listMetricsArguments = z.object({

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -1,4 +1,4 @@
-import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
+import type { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import {
   buildEffectiveFilter,
@@ -8,10 +8,10 @@ import {
 } from "@src/confluent/tools/handlers/metrics/query-metrics-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { textOf } from "@tests/call-tool-result.js";
+import type { HandleCaseWithConn } from "@tests/factories/runtime.js";
 import {
   ccloudOAuthRuntime,
   DEFAULT_CONNECTION_ID,
-  HandleCaseWithConn,
   runtimeWith,
   runtimeWithDecoy,
 } from "@tests/factories/runtime.js";

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -1,14 +1,14 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasTelemetryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const queryMetricsArguments = z.object({

--- a/src/confluent/tools/handlers/organizations/list-organizations-handler.ts
+++ b/src/confluent/tools/handlers/organizations/list-organizations-handler.ts
@@ -1,14 +1,14 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasConfluentCloudOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/schema/create-schema-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/create-schema-handler.test.ts
@@ -1,4 +1,4 @@
-import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { CreateSchemaHandler } from "@src/confluent/tools/handlers/schema/create-schema-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";

--- a/src/confluent/tools/handlers/schema/create-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/create-schema-handler.ts
@@ -1,15 +1,15 @@
-import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   CREATE_UPDATE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasSchemaRegistryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const createSchemaArguments = z.object({

--- a/src/confluent/tools/handlers/schema/delete-schema-handler.ts
+++ b/src/confluent/tools/handlers/schema/delete-schema-handler.ts
@@ -1,14 +1,14 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   DESTRUCTIVE,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasSchemaRegistryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.test.ts
@@ -1,4 +1,4 @@
-import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { ListSchemasHandler } from "@src/confluent/tools/handlers/schema/list-schemas-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";

--- a/src/confluent/tools/handlers/schema/list-schemas-handler.ts
+++ b/src/confluent/tools/handlers/schema/list-schemas-handler.ts
@@ -1,15 +1,15 @@
-import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { SchemaRegistryClient } from "@confluentinc/schemaregistry";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasSchemaRegistryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { z } from "zod";
 
 const listSchemasArguments = z.object({

--- a/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topic-by-tag-handler.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
+++ b/src/confluent/tools/handlers/search/search-topics-by-name-handler.ts
@@ -1,13 +1,13 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
 import {
   BaseToolHandler,
   READ_ONLY,
   ToolCategory,
-  ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
 import { hasCCloudCatalogOrOAuth } from "@src/confluent/tools/connection-predicates.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.test.ts
@@ -1,9 +1,9 @@
 import { CreateTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/create-tableflow-catalog-integration-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.test.ts
@@ -1,9 +1,9 @@
 import { DeleteTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/delete-tableflow-catalog-integration-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { DESTRUCTIVE } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.test.ts
@@ -1,9 +1,9 @@
 import { ListTableFlowCatalogIntegrationsHandler } from "@src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/list-tableflow-catalog-integrations-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.test.ts
@@ -1,9 +1,9 @@
 import { ReadTableFlowCatalogIntegrationHandler } from "@src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/read-tableflow-catalog-integration-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/catalog/update-tableflow-catalog-integration-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/list-tableflow-regions-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.test.ts
@@ -1,7 +1,8 @@
 import type { DirectConnectionConfig } from "@src/config/index.js";
 import type { OAuthConnectionConfig } from "@src/config/models.js";
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { describe, expect, it } from "vitest";

--- a/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/tableflow-tool-handler.ts
@@ -1,4 +1,4 @@
-import { ConnectionConfig } from "@src/config/models.js";
+import type { ConnectionConfig } from "@src/config/models.js";
 import {
   BaseToolHandler,
   ToolCategory,

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.test.ts
@@ -1,9 +1,9 @@
 import { CreateTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/create-tableflow-topic-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.test.ts
@@ -1,9 +1,9 @@
 import { DeleteTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/delete-tableflow-topic-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { DESTRUCTIVE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { DESTRUCTIVE } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.test.ts
@@ -1,9 +1,9 @@
 import { ListTableFlowTopicsHandler } from "@src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/list-tableflow-topics-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.test.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.test.ts
@@ -1,9 +1,9 @@
 import { ReadTableFlowTopicHandler } from "@src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.js";
+import type { TableflowHandleCase } from "@tests/factories/runtime.js";
 import {
   DEFAULT_CONNECTION_ID,
   runtimeWithDecoy,
   TABLEFLOW_CONN,
-  TableflowHandleCase,
 } from "@tests/factories/runtime.js";
 import {
   assertHandleCase,

--- a/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/read-tableflow-topic-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { READ_ONLY, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { READ_ONLY } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
+++ b/src/confluent/tools/handlers/tableflow/topic/update-tableflow-topic-handler.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@src/confluent/schema.js";
-import { CREATE_UPDATE, ToolConfig } from "@src/confluent/tools/base-tools.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
+import type { ToolConfig } from "@src/confluent/tools/base-tools.js";
+import { CREATE_UPDATE } from "@src/confluent/tools/base-tools.js";
 import { TableflowToolHandler } from "@src/confluent/tools/handlers/tableflow/tableflow-tool-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import { wrapAsPathBasedClient } from "openapi-fetch";
 import { z } from "zod";
 

--- a/src/confluent/tools/multi-connection.integration.test.ts
+++ b/src/confluent/tools/multi-connection.integration.test.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import {
   type ConnectionConfig,
   type DirectConnectionConfig,

--- a/src/confluent/tools/tool-availability.test.ts
+++ b/src/confluent/tools/tool-availability.test.ts
@@ -1,10 +1,10 @@
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import {
   CREATE_UPDATE,
   ToolCategory,
-  ToolHandler,
 } from "@src/confluent/tools/base-tools.js";
+import type { ConnectionPredicate } from "@src/confluent/tools/connection-predicates.js";
 import {
-  ConnectionPredicate,
   ToolDisabledReason,
   alwaysEnabled,
   hasKafka,

--- a/src/confluent/tools/tool-availability.ts
+++ b/src/confluent/tools/tool-availability.ts
@@ -1,7 +1,10 @@
-import { ToolCategory, ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type {
+  ToolCategory,
+  ToolHandler,
+} from "@src/confluent/tools/base-tools.js";
+import type { ToolDisabledReason } from "@src/confluent/tools/connection-predicates.js";
+import type { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 
 /**
  * One bucket of disabled tools sharing a single bucket key. The key field

--- a/src/confluent/tools/tool-metadata-handler.ts
+++ b/src/confluent/tools/tool-metadata-handler.ts
@@ -1,8 +1,6 @@
-import {
-  BaseToolHandler,
-  ToolHandler,
-} from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import { BaseToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { ToolName } from "@src/confluent/tools/tool-name.js";
 import type { ServerRuntime } from "@src/server-runtime.js";
 
 /**

--- a/src/confluent/tools/tool-registry.ts
+++ b/src/confluent/tools/tool-registry.ts
@@ -1,4 +1,4 @@
-import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ListBillingCostsHandler } from "@src/confluent/tools/handlers/billing/list-billing-costs-handler.js";
 import { AddTagToTopicHandler } from "@src/confluent/tools/handlers/catalog/add-tags-to-topic.js";
 import { CreateTopicTagsHandler } from "@src/confluent/tools/handlers/catalog/create-topic-tags.js";

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,6 @@
 import { combinedSchema } from "@src/env-schema.js";
 import { logger } from "@src/logger.js";
-import { z } from "zod";
+import type { z } from "zod";
 
 export type Environment = z.infer<typeof combinedSchema>;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import pino from "pino";
 
 const logLevel = process.env.LOG_LEVEL || "info";

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,7 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
-import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import {
   hasKafka,
   kafkaBootstrapOrOAuth,
@@ -10,14 +10,15 @@ import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
 import { createMcpServer, type ToolCallProps } from "@src/mcp/server.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import {
   ccloudOAuthRuntime,
   localPlusOAuthRuntime,
   runtimeWith,
   runtimeWithConnections,
 } from "@tests/factories/runtime.js";
-import { createTestServer, TestServerContext } from "@tests/server.js";
+import type { TestServerContext } from "@tests/server.js";
+import { createTestServer } from "@tests/server.js";
 import { createMockInstance, StubHandler } from "@tests/stubs/index.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 
 /** Properties recorded for each tool invocation. */
 export interface ToolCallProps {

--- a/src/mcp/transports/auth.test.ts
+++ b/src/mcp/transports/auth.test.ts
@@ -1,6 +1,6 @@
 import * as nodeDeps from "@src/confluent/node-deps.js";
+import type { AuthConfig } from "@src/mcp/transports/auth.js";
 import {
-  AuthConfig,
   CFLT_MCP_API_KEY_HEADER,
   createAuthHook,
   generateApiKey,

--- a/src/mcp/transports/auth.ts
+++ b/src/mcp/transports/auth.ts
@@ -1,7 +1,7 @@
 import { nodeCrypto } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
 import { timingSafeEqual } from "crypto";
-import { FastifyReply, FastifyRequest } from "fastify";
+import type { FastifyReply, FastifyRequest } from "fastify";
 
 /**
  * HTTP header name carrying the MCP API key. Confluent custom-header

--- a/src/mcp/transports/http.test.ts
+++ b/src/mcp/transports/http.test.ts
@@ -1,16 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import { HttpTransport } from "@src/mcp/transports/http.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
-import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
+import type { SessionRegistry } from "@src/mcp/transports/session-registry.js";
 import {
   createMockHttpServerTransport,
   createMockInstance,
   createMockSessionRegistry,
   MOCK_SESSION_ID,
 } from "@tests/stubs/index.js";
-import Fastify, { FastifyInstance } from "fastify";
+import type { FastifyInstance } from "fastify";
+import Fastify from "fastify";
 import {
   afterEach,
   beforeEach,

--- a/src/mcp/transports/http.ts
+++ b/src/mcp/transports/http.ts
@@ -1,13 +1,13 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { sdkTransports } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
-import { HttpServer } from "@src/mcp/transports/server.js";
+import type { HttpServer } from "@src/mcp/transports/server.js";
 import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
-import { Transport } from "@src/mcp/transports/types.js";
+import type { Transport } from "@src/mcp/transports/types.js";
 import { randomUUID } from "crypto";
-import { FastifyReply, FastifyRequest } from "fastify";
+import type { FastifyReply, FastifyRequest } from "fastify";
 
 interface McpRequestHeaders {
   "mcp-session-id"?: string;

--- a/src/mcp/transports/manager.test.ts
+++ b/src/mcp/transports/manager.test.ts
@@ -1,15 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ToolHandler } from "@src/confluent/tools/base-tools.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
-import { CreateMcpServerOptions } from "@src/mcp/server.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { CreateMcpServerOptions } from "@src/mcp/server.js";
 import { HttpTransport } from "@src/mcp/transports/http.js";
-import {
-  HttpStartOptions,
-  TransportManager,
-} from "@src/mcp/transports/manager.js";
-import { HttpServer } from "@src/mcp/transports/server.js";
+import type { HttpStartOptions } from "@src/mcp/transports/manager.js";
+import { TransportManager } from "@src/mcp/transports/manager.js";
+import type { HttpServer } from "@src/mcp/transports/server.js";
 import { SseTransport } from "@src/mcp/transports/sse.js";
-import { Transport, TransportType } from "@src/mcp/transports/types.js";
+import type { Transport } from "@src/mcp/transports/types.js";
+import { TransportType } from "@src/mcp/transports/types.js";
 import { runtimeWith } from "@tests/factories/runtime.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/mcp/transports/manager.ts
+++ b/src/mcp/transports/manager.ts
@@ -1,12 +1,14 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logger } from "@src/logger.js";
-import { createMcpServer, CreateMcpServerOptions } from "@src/mcp/server.js";
-import { AuthConfig } from "@src/mcp/transports/auth.js";
+import type { CreateMcpServerOptions } from "@src/mcp/server.js";
+import { createMcpServer } from "@src/mcp/server.js";
+import type { AuthConfig } from "@src/mcp/transports/auth.js";
 import { HttpTransport } from "@src/mcp/transports/http.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
 import { SseTransport } from "@src/mcp/transports/sse.js";
 import { StdioTransport } from "@src/mcp/transports/stdio.js";
-import { Transport, TransportType } from "@src/mcp/transports/types.js";
+import type { Transport } from "@src/mcp/transports/types.js";
+import { TransportType } from "@src/mcp/transports/types.js";
 
 /**
  * Configuration for the transport manager

--- a/src/mcp/transports/ping.ts
+++ b/src/mcp/transports/ping.ts
@@ -1,4 +1,4 @@
-import { FastifyReply, FastifyRequest } from "fastify";
+import type { FastifyReply, FastifyRequest } from "fastify";
 
 export const pingRequestSchema = {
   type: "object",

--- a/src/mcp/transports/server.test.ts
+++ b/src/mcp/transports/server.test.ts
@@ -1,4 +1,4 @@
-import { AuthConfig } from "@src/mcp/transports/auth.js";
+import type { AuthConfig } from "@src/mcp/transports/auth.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/src/mcp/transports/server.ts
+++ b/src/mcp/transports/server.ts
@@ -13,7 +13,7 @@ import {
 } from "@src/mcp/transports/ping.js";
 import type { ServerConfig } from "@src/mcp/transports/types.js";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
-import { default as Fastify } from "fastify";
+import Fastify from "fastify";
 
 /**
  * Configuration for the HTTP server

--- a/src/mcp/transports/server.ts
+++ b/src/mcp/transports/server.ts
@@ -1,8 +1,8 @@
 import fastifySwagger from "@fastify/swagger";
 import fastifySwaggerUi from "@fastify/swagger-ui";
 import { logger } from "@src/logger.js";
+import type { AuthConfig } from "@src/mcp/transports/auth.js";
 import {
-  AuthConfig,
   CFLT_MCP_API_KEY_HEADER,
   createAuthHook,
 } from "@src/mcp/transports/auth.js";
@@ -11,12 +11,9 @@ import {
   pingRequestSchema,
   pingResponseSchema,
 } from "@src/mcp/transports/ping.js";
-import { ServerConfig } from "@src/mcp/transports/types.js";
-import {
-  default as Fastify,
-  FastifyBaseLogger,
-  FastifyInstance,
-} from "fastify";
+import type { ServerConfig } from "@src/mcp/transports/types.js";
+import type { FastifyBaseLogger, FastifyInstance } from "fastify";
+import { default as Fastify } from "fastify";
 
 /**
  * Configuration for the HTTP server

--- a/src/mcp/transports/sse.test.ts
+++ b/src/mcp/transports/sse.test.ts
@@ -1,8 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import type { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import * as nodeDeps from "@src/confluent/node-deps.js";
 import { HttpServer } from "@src/mcp/transports/server.js";
-import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
+import type { SessionRegistry } from "@src/mcp/transports/session-registry.js";
 import { SseTransport } from "@src/mcp/transports/sse.js";
 import {
   createMockInstance,
@@ -10,8 +10,9 @@ import {
   createMockSseServerTransport,
   MOCK_SESSION_ID,
 } from "@tests/stubs/index.js";
-import Fastify, { FastifyInstance } from "fastify";
-import { ServerResponse } from "node:http";
+import type { FastifyInstance } from "fastify";
+import Fastify from "fastify";
+import type { ServerResponse } from "node:http";
 import {
   afterEach,
   beforeEach,

--- a/src/mcp/transports/sse.ts
+++ b/src/mcp/transports/sse.ts
@@ -1,12 +1,12 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { sdkTransports } from "@src/confluent/node-deps.js";
 import { logger } from "@src/logger.js";
-import { HttpServer } from "@src/mcp/transports/server.js";
+import type { HttpServer } from "@src/mcp/transports/server.js";
 import { SessionRegistry } from "@src/mcp/transports/session-registry.js";
-import { Transport } from "@src/mcp/transports/types.js";
-import { FastifyReply, FastifyRequest } from "fastify";
-import { ServerResponse } from "node:http";
+import type { Transport } from "@src/mcp/transports/types.js";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { ServerResponse } from "node:http";
 
 interface SseMessageRequest {
   Querystring: {

--- a/src/mcp/transports/stdio.ts
+++ b/src/mcp/transports/stdio.ts
@@ -1,7 +1,7 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { logger } from "@src/logger.js";
-import { Transport } from "@src/mcp/transports/types.js";
+import type { Transport } from "@src/mcp/transports/types.js";
 
 export class StdioTransport implements Transport {
   constructor(private server: McpServer) {}

--- a/src/server-main.test.ts
+++ b/src/server-main.test.ts
@@ -23,7 +23,7 @@ import {
   resolveAllowedToolNames,
   resolveTelemetryWriteKey,
 } from "@src/server-main.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 import {
   ccloudOAuthRuntime,
   runtimeWith,

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
+import type { CLIOptions } from "@src/cli.js";
 import {
-  CLIOptions,
   DisplayedCommandLineUsageError,
   getFilteredToolNames,
   getPackageVersion,
@@ -16,13 +16,16 @@ import {
 import { buildConfigTelemetry } from "@src/confluent/config-telemetry.js";
 import { buildConfig, fs, path } from "@src/confluent/node-deps.js";
 import { TelemetryEvent, TelemetryService } from "@src/confluent/telemetry.js";
-import { ToolCategory, ToolHandler } from "@src/confluent/tools/base-tools.js";
+import type {
+  ToolCategory,
+  ToolHandler,
+} from "@src/confluent/tools/base-tools.js";
 import { groupDisabledToolsByReason } from "@src/confluent/tools/tool-availability.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
 import { logger, setLogLevel } from "@src/logger.js";
-import { CreateMcpServerOptions } from "@src/mcp/server.js";
+import type { CreateMcpServerOptions } from "@src/mcp/server.js";
 import { generateApiKey, TransportManager } from "@src/mcp/transports/index.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,12 +1,10 @@
-import {
-  type OAuthConnectionConfig,
-  MCPServerConfiguration,
-} from "@src/config/index.js";
-import { BaseClientManager } from "@src/confluent/base-client-manager.js";
+import type { MCPServerConfiguration } from "@src/config/index.js";
+import { type OAuthConnectionConfig } from "@src/config/index.js";
+import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { constructDirectClientManager } from "@src/confluent/direct-client-manager.js";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";
 import { OAuthHolder } from "@src/confluent/oauth/oauth-holder.js";
-import { ToolName } from "@src/confluent/tools/tool-name.js";
+import type { ToolName } from "@src/confluent/tools/tool-name.js";
 
 /**
  * Aggregate of all runtime state threaded through the server.

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,5 +1,7 @@
-import type { MCPServerConfiguration } from "@src/config/index.js";
-import { type OAuthConnectionConfig } from "@src/config/index.js";
+import type {
+  MCPServerConfiguration,
+  OAuthConnectionConfig,
+} from "@src/config/index.js";
 import type { BaseClientManager } from "@src/confluent/base-client-manager.js";
 import { constructDirectClientManager } from "@src/confluent/direct-client-manager.js";
 import { OAuthClientManager } from "@src/confluent/oauth-client-manager.js";

--- a/tests/call-tool-result.ts
+++ b/tests/call-tool-result.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@src/confluent/schema.js";
+import type { CallToolResult } from "@src/confluent/schema.js";
 
 /**
  * Flatten the text segments of a {@link CallToolResult} into a single string.

--- a/tests/factories/config.ts
+++ b/tests/factories/config.ts
@@ -1,7 +1,5 @@
-import {
-  type DirectConnectionConfig,
-  MCPServerConfiguration,
-} from "@src/config/models.js";
+import type { MCPServerConfiguration } from "@src/config/models.js";
+import { type DirectConnectionConfig } from "@src/config/models.js";
 import { DEFAULT_CONNECTION_ID } from "@tests/factories/runtime.js";
 
 /**

--- a/tests/harness/cp-kafka-admin.ts
+++ b/tests/harness/cp-kafka-admin.ts
@@ -7,7 +7,8 @@
  * (integration.cp.yaml) via {@linkcode cpIntegrationRuntime}.
  */
 
-import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
+import type { GlobalConfig } from "@confluentinc/kafka-javascript";
+import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { cpIntegrationRuntime } from "@tests/harness/cp-runtime.js";
 import { afterAll, beforeAll } from "vitest";
 

--- a/tests/harness/cp-runtime.ts
+++ b/tests/harness/cp-runtime.ts
@@ -11,7 +11,7 @@ import {
   type ConnectionConfig,
   MCPServerConfiguration,
 } from "@src/config/models.js";
-import { TransportType } from "@src/mcp/transports/types.js";
+import type { TransportType } from "@src/mcp/transports/types.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/harness/kafka-admin.ts
+++ b/tests/harness/kafka-admin.ts
@@ -1,4 +1,5 @@
-import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
+import type { GlobalConfig } from "@confluentinc/kafka-javascript";
+import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { integrationDirectConnection } from "@tests/harness/runtime.js";
 import { afterAll, beforeAll } from "vitest";
 

--- a/tests/harness/multi-kafka-admin.ts
+++ b/tests/harness/multi-kafka-admin.ts
@@ -9,7 +9,8 @@
  * `SASL_PLAINTEXT` there), exactly as the production client resolves it.
  */
 
-import { GlobalConfig, KafkaJS } from "@confluentinc/kafka-javascript";
+import type { GlobalConfig } from "@confluentinc/kafka-javascript";
+import { KafkaJS } from "@confluentinc/kafka-javascript";
 import { type DirectConnectionConfig } from "@src/config/models.js";
 
 /**

--- a/tests/harness/multi-runtime.ts
+++ b/tests/harness/multi-runtime.ts
@@ -9,11 +9,9 @@
  */
 
 import { loadConfigFromYaml } from "@src/config/index.js";
-import {
-  type ConnectionConfig,
-  MCPServerConfiguration,
-} from "@src/config/models.js";
-import { TransportType } from "@src/mcp/transports/types.js";
+import type { MCPServerConfiguration } from "@src/config/models.js";
+import { type ConnectionConfig } from "@src/config/models.js";
+import type { TransportType } from "@src/mcp/transports/types.js";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";

--- a/tests/harness/runtime.ts
+++ b/tests/harness/runtime.ts
@@ -4,7 +4,7 @@ import {
   type DirectConnectionConfig,
   MCPServerConfiguration,
 } from "@src/config/models.js";
-import { TransportType } from "@src/mcp/transports/types.js";
+import type { TransportType } from "@src/mcp/transports/types.js";
 import { ServerRuntime } from "@src/server-runtime.js";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -1,12 +1,12 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ToolHandler } from "@src/confluent/tools/base-tools.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolHandler } from "@src/confluent/tools/base-tools.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { ToolHandlerRegistry } from "@src/confluent/tools/tool-registry.js";
 import { initEnv } from "@src/env.js";
 import { createMcpServer } from "@src/mcp/server.js";
-import { ServerRuntime } from "@src/server-runtime.js";
+import type { ServerRuntime } from "@src/server-runtime.js";
 
 export interface TestServerContext {
   server: McpServer;

--- a/tests/stubs/admin.ts
+++ b/tests/stubs/admin.ts
@@ -1,4 +1,4 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { type Mock, vi } from "vitest";
 
 /** {@link KafkaJS.Admin} with all methods replaced by {@link Mock mocks}. */

--- a/tests/stubs/clients.ts
+++ b/tests/stubs/clients.ts
@@ -1,9 +1,9 @@
-import { KafkaJS } from "@confluentinc/kafka-javascript";
+import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { SchemaRegistryClient } from "@confluentinc/schemaregistry";
 import type { ConsumerBuildOptions } from "@src/confluent/base-client-manager.js";
 import { DirectClientManager } from "@src/confluent/direct-client-manager.js";
 import { kafkaDeps } from "@src/confluent/node-deps.js";
-import { paths } from "@src/confluent/openapi-schema.js";
+import type { paths } from "@src/confluent/openapi-schema.js";
 import type { Client } from "openapi-fetch";
 import { type Mock, type MockInstance, type Mocked, vi } from "vitest";
 import { createMockInstance } from "./mock-instance.js";

--- a/tests/stubs/stub-handler.ts
+++ b/tests/stubs/stub-handler.ts
@@ -6,8 +6,8 @@ import {
   ToolCategory,
   type ToolConfig,
 } from "@src/confluent/tools/base-tools.js";
+import type { ConnectionPredicate } from "@src/confluent/tools/connection-predicates.js";
 import {
-  ConnectionPredicate,
   ToolDisabledReason,
   alwaysEnabled,
 } from "@src/confluent/tools/connection-predicates.js";


### PR DESCRIPTION
Add linter rule to enforce that types must be imported as types, so as to ultimately prevent Copilot reviews from possibly complaining about it.

The actual material change is in file `eslint.config.mjs`. No actual code / functionality changes, just respellings of import statements where needed (a lot of places ;-().

Ran `npm run lint:fix` to respell the plethora of existing offenders.

The single SonarCube complaint is "'SSEServerTransport' is deprecated" based on rewriting its import. That's an issue above and beyond the scope of this mechanical branch.


Closes #693