### PR TITLE
Enforce no-negated-condition lint rule, fix + test handful of offenders.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,12 +105,18 @@ export default [
   // `recommended` set) to avoid a flood of unrelated findings on existing code.
   // Scoped to non-test src to match `sonar.exclusions` (tests and generated
   // `.d.ts` are excluded from SonarQube analysis).
+  //
+  // `no-negated-condition` mirrors SonarQube's "Unexpected negated condition"
+  // check (delegates to this same core ESLint rule, no new plugin needed) —
+  // added after PR #694 pushed a negated ternary that SonarCloud caught only
+  // after the round-trip through CI (#698).
   {
     files: ["src/**/*.ts"],
     ignores: ["**/*.test.ts", "**/*.d.ts"],
     plugins: { sonarjs },
     rules: {
       "sonarjs/cognitive-complexity": ["error", 15],
+      "no-negated-condition": "error",
     },
   },
 ];

--- a/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.ts
+++ b/src/confluent/tools/handlers/connect/get-connector-error-summary-handler.ts
@@ -126,7 +126,7 @@ function projectErrorSummary(
     (payload.override_message?.trim() ? payload.override_message.trim() : "") ||
     (payload.error_summary?.trim() ? payload.error_summary.trim() : "");
   const connectorTraceHead =
-    state !== "RUNNING" ? truncateTrace(payload.connector?.trace) : undefined;
+    state === "RUNNING" ? undefined : truncateTrace(payload.connector?.trace);
 
   const projection: ErrorSummaryProjection = {
     connectorName,

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
@@ -202,6 +202,34 @@ describe("query-profiler-handler.ts", () => {
         });
       });
 
+      it("should format busyPercent and idlePercent as percentages when telemetry reports them", async () => {
+        const cm = getMockedClientManager();
+        cm.getConfluentCloudFlinkRestClient().GET.mockResolvedValue({
+          data: { Graph: JSON.stringify(TASK_GRAPH) },
+        });
+        // task/busy_time_ms_per_second at 456 ms/s → 45.6%;
+        // task/idle_time_ms_per_second at 123 ms/s → 12.3%
+        wireFlinkTelemetry(cm, {
+          "task/busy_time": [{ value: 456, taskId: "task-1" }],
+          "task/idle_time": [{ value: 123, taskId: "task-1" }],
+        });
+        const result = await assertHandleCase({
+          handler,
+          runtime: runtimeWithDecoy(
+            FLINK_TELEMETRY_CONN,
+            DEFAULT_CONNECTION_ID,
+            cm,
+          ),
+          args: { statementName: STATEMENT_NAME },
+          outcome: { resolves: '"busyPercent": "45.6%"' },
+          clientManager: cm,
+        });
+        const text = result?.content
+          .map((c) => ("text" in c ? c.text : ""))
+          .join("");
+        expect(text).toContain('"idlePercent": "12.3%"');
+      });
+
       it("should detect high consumer lag from summary pendingRecords", async () => {
         const cm = getMockedClientManager();
         cm.getConfluentCloudFlinkRestClient().GET.mockResolvedValue({

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.test.ts
@@ -184,9 +184,11 @@ describe("query-profiler-handler.ts", () => {
         cm.getConfluentCloudFlinkRestClient().GET.mockResolvedValue({
           data: { Graph: JSON.stringify(TASK_GRAPH) },
         });
-        // task/backpressure_time at 600 ms/s → 60% → medium severity
+        // task/backpressure_time_ms_per_second at 600 ms/s → 60% → medium severity
         wireFlinkTelemetry(cm, {
-          "task/backpressure_time": [{ value: 600, taskId: "task-1" }],
+          "task/backpressure_time_ms_per_second": [
+            { value: 600, taskId: "task-1" },
+          ],
         });
         await assertHandleCase({
           handler,
@@ -208,7 +210,9 @@ describe("query-profiler-handler.ts", () => {
         });
         // 900 ms/s → 90% → "high"
         wireFlinkTelemetry(cm, {
-          "task/backpressure_time": [{ value: 900, taskId: "task-1" }],
+          "task/backpressure_time_ms_per_second": [
+            { value: 900, taskId: "task-1" },
+          ],
         });
         await assertHandleCase({
           handler,
@@ -231,8 +235,8 @@ describe("query-profiler-handler.ts", () => {
         // task/busy_time_ms_per_second at 456 ms/s → 45.6%;
         // task/idle_time_ms_per_second at 123 ms/s → 12.3%
         wireFlinkTelemetry(cm, {
-          "task/busy_time": [{ value: 456, taskId: "task-1" }],
-          "task/idle_time": [{ value: 123, taskId: "task-1" }],
+          "task/busy_time_ms_per_second": [{ value: 456, taskId: "task-1" }],
+          "task/idle_time_ms_per_second": [{ value: 123, taskId: "task-1" }],
         });
         const result = await assertHandleCase({
           handler,

--- a/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
+++ b/src/confluent/tools/handlers/flink/diagnostics/query-profiler-handler.ts
@@ -393,17 +393,17 @@ export class QueryProfilerHandler extends FlinkToolHandler {
         recordsOut: task.recordsOut,
         stateBytes: task.stateBytes,
         busyPercent:
-          task.busyPercent !== undefined
-            ? `${task.busyPercent.toFixed(1)}%`
-            : undefined,
+          task.busyPercent === undefined
+            ? undefined
+            : `${task.busyPercent.toFixed(1)}%`,
         idlePercent:
-          task.idlePercent !== undefined
-            ? `${task.idlePercent.toFixed(1)}%`
-            : undefined,
+          task.idlePercent === undefined
+            ? undefined
+            : `${task.idlePercent.toFixed(1)}%`,
         backpressurePercent:
-          task.backpressurePercent !== undefined
-            ? `${task.backpressurePercent.toFixed(1)}%`
-            : undefined,
+          task.backpressurePercent === undefined
+            ? undefined
+            : `${task.backpressurePercent.toFixed(1)}%`,
         inputWatermark: task.inputWatermarkMs
           ? new Date(task.inputWatermarkMs).toISOString()
           : undefined,


### PR DESCRIPTION
Enable the `no-negated-condition` lint rule, preventing it from becoming a SonarCube complaint on future PRs. Fix and ensure test coverage over the handful of existing offenders.

Closes #698