### PR TITLE
Centralize fetch error handling between list-metrics and query-metrics handlers

### DIFF
--- a/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/list-metrics-handler.ts
@@ -7,6 +7,10 @@ import {
   ToolCategory,
 } from "@src/confluent/tools/base-tools.js";
 import { hasTelemetryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
+import {
+  describeTelemetryError,
+  formatHttpStatusPart,
+} from "@src/confluent/tools/handlers/metrics/telemetry-error.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import type { ServerRuntime } from "@src/server-runtime.js";
@@ -246,10 +250,9 @@ function requireDescriptors<T>(
   result: DescriptorFetchResult<T>,
 ): T[] | undefined {
   if (result.error !== undefined) {
-    const status = result.response?.status;
-    const statusPart = status === undefined ? "" : ` (HTTP ${status})`;
+    const statusPart = formatHttpStatusPart(result.response?.status);
     throw new Error(
-      `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeDescriptorError(result.error)}`,
+      `Telemetry API error fetching ${kind} descriptors${statusPart}: ${describeTelemetryError(result.error)}`,
     );
   }
   return result.data?.data;
@@ -272,33 +275,6 @@ function optionalDescriptors<T>(
     return undefined;
   }
   return result.data?.data;
-}
-
-function describeDescriptorError(error: unknown): string {
-  const envelope = error as { errors?: Array<{ detail?: string }> } | null;
-  const details = envelope?.errors
-    ?.map((e) => e.detail)
-    .filter(Boolean)
-    .join("; ");
-  if (details && details.length > 0) {
-    return details;
-  }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return safeStringify(error);
-}
-
-/**
- * Stringify an arbitrary error payload without ever throwing (e.g. on circular
- * structures) or returning `undefined` (e.g. for values JSON.stringify omits).
- */
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value) ?? String(value);
-  } catch {
-    return String(value);
-  }
 }
 
 function filterMetricsByResourceType(

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.test.ts
@@ -330,6 +330,28 @@ describe("query-metrics-handler.ts", () => {
         });
       });
 
+      it("should surface the HTTP status and error detail when the query endpoint returns an openapi-fetch error instead of throwing", async () => {
+        const clientManager = getMockedClientManager();
+        clientManager
+          .getConfluentCloudTelemetryRestClient()
+          .POST.mockResolvedValue({
+            error: { errors: [{ detail: "authentication failed" }] },
+            response: { status: 403 },
+          } as never);
+
+        const result = await handler.handle(
+          runtimeWith(TELEMETRY_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { metric: KAFKA_SERVER_METRIC },
+        );
+
+        const text = textOf(result);
+        expect(result.isError).toBe(true);
+        expect(text).toContain("Failed to query metrics");
+        expect(text).toContain("HTTP 403");
+        expect(text).toContain("authentication failed");
+        expect(text).not.toContain("No data returned");
+      });
+
       it("should return a flagged error when the telemetry client throws", async () => {
         const clientManager = getMockedClientManager();
         clientManager

--- a/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
+++ b/src/confluent/tools/handlers/metrics/query-metrics-handler.ts
@@ -6,6 +6,10 @@ import {
   ToolCategory,
 } from "@src/confluent/tools/base-tools.js";
 import { hasTelemetryOrOAuth } from "@src/confluent/tools/connection-predicates.js";
+import {
+  describeTelemetryError,
+  formatHttpStatusPart,
+} from "@src/confluent/tools/handlers/metrics/telemetry-error.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
 import { logger } from "@src/logger.js";
 import type { ServerRuntime } from "@src/server-runtime.js";
@@ -124,9 +128,20 @@ export class QueryMetricsHandler extends BaseToolHandler {
           params: { path: { dataset } },
           body,
         } as never,
-      )) as { data?: TelemetryResponse; error?: unknown };
+      )) as {
+        data?: TelemetryResponse;
+        error?: unknown;
+        response?: { status?: number };
+      };
 
-      const data = response.data as TelemetryResponse;
+      if (response.error !== undefined) {
+        const statusPart = formatHttpStatusPart(response.response?.status);
+        throw new Error(
+          `Telemetry API error querying metrics${statusPart}: ${describeTelemetryError(response.error)}`,
+        );
+      }
+
+      const data = response.data;
 
       if (data?.errors && data.errors.length > 0) {
         const errorDetails = data.errors
@@ -164,7 +179,7 @@ export class QueryMetricsHandler extends BaseToolHandler {
         result_count: data.data.length,
       });
     } catch (error) {
-      logger.error({ error }, "Error in QueryMetricsHandler");
+      logger.error({ err: error }, "Error in QueryMetricsHandler");
       return this.createResponse(
         `Failed to query metrics: ${error instanceof Error ? error.message : String(error)}`,
         true,

--- a/src/confluent/tools/handlers/metrics/telemetry-error.test.ts
+++ b/src/confluent/tools/handlers/metrics/telemetry-error.test.ts
@@ -36,6 +36,12 @@ describe("telemetry-error.ts", () => {
       expect(() => describeTelemetryError(circular)).not.toThrow();
     });
 
+    it("should not throw when errors is present but not an array, falling back to stringifying the payload", () => {
+      const payload = { errors: "not an array" };
+      expect(() => describeTelemetryError(payload)).not.toThrow();
+      expect(describeTelemetryError(payload)).toBe(JSON.stringify(payload));
+    });
+
     it("should stringify a plain non-Error value", () => {
       expect(describeTelemetryError("boom")).toBe('"boom"');
     });

--- a/src/confluent/tools/handlers/metrics/telemetry-error.test.ts
+++ b/src/confluent/tools/handlers/metrics/telemetry-error.test.ts
@@ -1,0 +1,43 @@
+import {
+  describeTelemetryError,
+  formatHttpStatusPart,
+} from "@src/confluent/tools/handlers/metrics/telemetry-error.js";
+import { describe, expect, it } from "vitest";
+
+describe("telemetry-error.ts", () => {
+  describe("formatHttpStatusPart()", () => {
+    it("should return an empty string when status is undefined", () => {
+      expect(formatHttpStatusPart(undefined)).toBe("");
+    });
+
+    it("should format a defined status as ' (HTTP <status>)'", () => {
+      expect(formatHttpStatusPart(403)).toBe(" (HTTP 403)");
+    });
+  });
+
+  describe("describeTelemetryError()", () => {
+    it("should join errors[].detail entries with '; '", () => {
+      expect(
+        describeTelemetryError({
+          errors: [{ detail: "bad metric" }, { detail: "wrong dataset" }],
+        }),
+      ).toBe("bad metric; wrong dataset");
+    });
+
+    it("should preserve an Error payload's message rather than JSON-stringifying it to {}", () => {
+      expect(describeTelemetryError(new Error("token expired"))).toBe(
+        "token expired",
+      );
+    });
+
+    it("should not throw when the error payload is a circular structure", () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      expect(() => describeTelemetryError(circular)).not.toThrow();
+    });
+
+    it("should stringify a plain non-Error value", () => {
+      expect(describeTelemetryError("boom")).toBe('"boom"');
+    });
+  });
+});

--- a/src/confluent/tools/handlers/metrics/telemetry-error.ts
+++ b/src/confluent/tools/handlers/metrics/telemetry-error.ts
@@ -10,12 +10,14 @@ export function formatHttpStatusPart(status: number | undefined): string {
 }
 
 export function describeTelemetryError(error: unknown): string {
-  const envelope = error as { errors?: Array<{ detail?: string }> } | null;
-  const details = envelope?.errors
-    ?.map((e) => e.detail)
-    .filter(Boolean)
-    .join("; ");
-  if (details && details.length > 0) {
+  const envelope = error as { errors?: unknown } | null;
+  const details = Array.isArray(envelope?.errors)
+    ? envelope.errors
+        .map((e: { detail?: string }) => e?.detail)
+        .filter(Boolean)
+        .join("; ")
+    : "";
+  if (details.length > 0) {
     return details;
   }
   if (error instanceof Error) {

--- a/src/confluent/tools/handlers/metrics/telemetry-error.ts
+++ b/src/confluent/tools/handlers/metrics/telemetry-error.ts
@@ -1,0 +1,37 @@
+/**
+ * openapi-fetch surfaces a non-2xx Telemetry API response through an `error`
+ * property rather than throwing, so callers must check it explicitly before
+ * trusting `data` — otherwise an HTTP failure reads as an empty success.
+ * Shared by list-metrics-handler.ts and query-metrics-handler.ts.
+ */
+
+export function formatHttpStatusPart(status: number | undefined): string {
+  return status === undefined ? "" : ` (HTTP ${status})`;
+}
+
+export function describeTelemetryError(error: unknown): string {
+  const envelope = error as { errors?: Array<{ detail?: string }> } | null;
+  const details = envelope?.errors
+    ?.map((e) => e.detail)
+    .filter(Boolean)
+    .join("; ");
+  if (details && details.length > 0) {
+    return details;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return safeStringify(error);
+}
+
+/**
+ * Stringify an arbitrary error payload without ever throwing (e.g. on circular
+ * structures) or returning `undefined` (e.g. for values JSON.stringify omits).
+ */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
* Hoist the fetch error handling and general philosophy from list-metrics handler to be shared between it and query-metrics handler.
* query-metrics-handler.ts now checks the openapi-fetch error property before falling through to the "No data returned" message,
* New tests.

Closes #697 