### PR TITLE
fix(CI): unblock the pnpm audit pipeline and scope its PRs to the lockfile

### DIFF
--- a/.semaphore/npm-audit.yml
+++ b/.semaphore/npm-audit.yml
@@ -39,40 +39,69 @@ blocks:
         - name: "Run audit and create/update PR"
           commands:
             - pnpm install --frozen-lockfile
-            # `pnpm audit --fix` writes `overrides` entries (to pnpm-workspace.yaml
-            # under pnpm 10+) pinning vulnerable transitive deps to fixed versions;
-            # a follow-up install applies those overrides to pnpm-lock.yaml. Unlike
-            # `npm audit fix`, it does not bump the dependency tree directly, so
-            # review the generated overrides.
-            # ( || true to avoid exiting non-zero on unfixable advisories that
-            # require manual, possibly-breaking changes to package.json)
-            - pnpm audit --fix || true
-            - pnpm install --no-frozen-lockfile
+            # the fix method has to be explicit; bare `--fix` errors under pnpm 11.
+            # https://pnpm.io/cli/audit
+            #
+            # `|| true` because audit exits non-zero whenever advisories remain. the grep is
+            # what separates that from audit failing outright, which the exit code does not.
             - |
-              if git diff --quiet -- package.json pnpm-workspace.yaml pnpm-lock.yaml; then
-                echo "No changes after pnpm audit --fix; nothing to do."
-                exit 0
+              # pipefail scoped to the subshell so the pipe reports audit's status, not tee's.
+              (set -o pipefail; pnpm audit --fix=update 2>&1 | tee /tmp/pnpm-audit.log) || true
+              if grep -q "ERR_PNPM_" /tmp/pnpm-audit.log; then
+                echo "pnpm audit could not run; see the ERR_PNPM_ error above." >&2
+                exit 1
               fi
-            # parameterize the head branch by TARGET_BRANCH so a single
-            # long-lived PR accumulates audit updates per base branch.
-            # running against v1.2.x auto-gets chore/pnpm-audit-fix-v1.2.x.
+            # `--fix=update` also rewrites package.json ranges; log and drop them to keep the PR
+            # lockfile-scoped. emptying node_modules is load-bearing: if it is still current,
+            # the install short-circuits instead of re-resolving against the restored ranges.
             - |
               set -e
-              TARGET_BRANCH="${TARGET_BRANCH:-main}"
-              BRANCH="chore/pnpm-audit-fix-${TARGET_BRANCH}"
-              TITLE="[${TARGET_BRANCH}] chore(deps): pnpm audit fix"
-
-              git checkout -b "$BRANCH"
-              git add package.json pnpm-workspace.yaml pnpm-lock.yaml
-              git commit -m "$TITLE"
-              git push --force -u origin "$BRANCH"
-
-              if [ -n "$(gh pr list --head "$BRANCH" --state open --json number -q '.[].number')" ]; then
-                echo "PR already open for $BRANCH; the force-push updated it in place."
+              git --no-pager diff -- package.json
+              git checkout -- package.json
+              rm -rf node_modules
+              pnpm install --no-frozen-lockfile
+            # one block, no early exit: every command in a job shares one shell, so an `exit` on
+            # a success path kills it and fails the job anyway. the paths nest instead.
+            # https://docs.semaphore.io/using-semaphore/jobs
+            #
+            # the head branch is parameterized by TARGET_BRANCH so a single long-lived PR
+            # accumulates audit updates per base branch: v1.2.x auto-gets
+            # chore/pnpm-audit-fix-v1.2.x.
+            - |
+              set -e
+              if git diff --quiet -- pnpm-workspace.yaml pnpm-lock.yaml; then
+                echo "No changes after pnpm audit --fix=update; nothing to do."
               else
-                gh pr create \
-                  --base "$TARGET_BRANCH" \
-                  --head "$BRANCH" \
-                  --title "$TITLE" \
-                  --body "Automated security update produced by \`pnpm audit --fix\` on \`${TARGET_BRANCH}\`. Please review the generated \`overrides\` in \`pnpm-workspace.yaml\` and the \`pnpm-lock.yaml\` changes before merging. Note: \`pnpm audit --fix\` pins vulnerable transitive deps via overrides rather than bumping the dependency tree, so each override should be re-evaluated as upstream fixes land. This PR is created/updated via the [\`scheduled-npm-audit\`](https://github.com/confluentinc/mcp-confluent/blob/${TARGET_BRANCH}/.semaphore/npm-audit.yml) Semaphore task."
+                TARGET_BRANCH="${TARGET_BRANCH:-main}"
+                BRANCH="chore/pnpm-audit-fix-${TARGET_BRANCH}"
+                TITLE="[${TARGET_BRANCH}] chore(deps): pnpm audit fix"
+
+                git checkout -b "$BRANCH"
+                git add pnpm-workspace.yaml pnpm-lock.yaml
+                git commit -m "$TITLE"
+                git push --force -u origin "$BRANCH"
+
+                if [ -n "$(gh pr list --head "$BRANCH" --state open --json number -q '.[].number')" ]; then
+                  echo "PR already open for $BRANCH; the force-push updated it in place."
+                else
+                  # body must sit at the block's base indentation or the markdown renders indented
+                  BODY=$(cat <<EOF
+              Automated security update produced by \`pnpm audit --fix=update\` on \`${TARGET_BRANCH}\`.
+
+              What to review:
+
+              - \`pnpm-lock.yaml\` - vulnerable dependencies moved to fixed versions within the ranges package.json already declares.
+              - \`pnpm-workspace.yaml\` - each new \`minimumReleaseAgeExclude\` entry waives pnpm's minimum release age so a just-published patch can install. Drop any whose version is already old enough, or is no longer in \`pnpm-lock.yaml\`.
+
+              \`package.json\` is left untouched, so this PR has no dependency-range changes. Fixes needing a wider range, and advisories with no published fix, are excluded and take a manual bump.
+
+              Created and updated by the [\`scheduled-npm-audit\`](https://github.com/confluentinc/mcp-confluent/blob/${TARGET_BRANCH}/.semaphore/npm-audit.yml) Semaphore task.
+              EOF
+              )
+                  gh pr create \
+                    --base "$TARGET_BRANCH" \
+                    --head "$BRANCH" \
+                    --title "$TITLE" \
+                    --body "$BODY"
+                fi
               fi


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The `[p]npm audit` pipeline has been failing lately, which has been causing a pileup of [vulnerabilities](https://github.com/confluentinc/mcp-confluent/security/dependabot):
<img width="561" height="248" alt="image" src="https://github.com/user-attachments/assets/d22be39b-2cc3-47a1-b642-17f299908c73" />

Docs: https://pnpm.io/cli/audit#--fix

Three problems, none of which surfaced clearly:

- **Bare `--fix` errors under pnpm 11** (`ERR_PNPM_INVALID_FIX_OPTION`), and the `|| true` hid it, so the job fixed nothing.
  Now passes `--fix=update` explicitly, and fails the job when pnpm reports an `ERR_PNPM_` error, since the exit code alone can't separate "advisories remain" (the normal steady state) from "audit never ran".
- **`--fix=update` also rewrites `package.json` range floors**, which desynced the lockfile from our unqualified `zod` override and broke the generated PR's own CI with `ERR_PNPM_OUTDATED_LOCKFILE` (#715).
  Those rewrites are discarded now, so audit PRs contain only `pnpm-lock.yaml` and `pnpm-workspace.yaml`, the same shape `npm audit fix` produces on our npm repos.
- **`exit 0` on the success paths** killed the shell Semaphore shares across a job's commands, so a run that did all of its work correctly still got marked failed.

Renaming the pipeline and its `service.yml` task to `pnpm-audit` is stacked on top in #716.
Keeping it separate leaves this diff readable in place and means this PR needs no ServiceBot re-sync to merge.

### Manual testing instructions

<!-- Include any special instructions to help reviewers verify your changes: which tool(s) to invoke, required env vars, transport(s) exercised (stdio/http/sse), and sample inputs/outputs. For quick iteration, `pnpm run inspector` launches the MCP Inspector. Delete this section if not applicable (e.g., docs-only or CI changes) -->

1. In the Semaphore UI, run the `scheduled-npm-audit` task against this branch (`djs/fix-pnpm-audit`), leaving `TARGET_BRANCH` at `main`.
2. Confirm the job is green, and that its log shows the discarded `package.json` diff followed by `rm -rf node_modules` and a re-resolving install.
3. Confirm the PR it creates or updates (#715) touches only `pnpm-lock.yaml` and `pnpm-workspace.yaml`, and that its own CI gets past `pnpm install --frozen-lockfile`.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- Already exercised end to end: a run of the task against this branch regenerated #715, which is green (18/18) and no longer touches `package.json`.
  That PR takes `main` from 1 critical / 22 high / 31 moderate / 1 low advisories down to 2 high / 3 moderate.
- Discarding audit's `package.json` rewrites costs no fixes.
  Measured against pnpm 11.9.0: the advisory posture is identical with and without them, because every fix here lands on a transitive package that `package.json` never names.
- `--fix=override` was considered and rejected.
  It produces the same two-file PR shape, but leaves 3 more advisories standing (including a high) and adds ~40 permanent override pins per run.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
