### PR TITLE
chore(CI): rename the audit pipeline and task to pnpm-audit

### DIFF
--- a/.semaphore/pnpm-audit.yml
+++ b/.semaphore/pnpm-audit.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: npm-audit
+name: pnpm-audit
 agent:
   machine:
     type: s1-prod-ubuntu24-04-amd64-1
@@ -95,7 +95,7 @@ blocks:
 
               \`package.json\` is left untouched, so this PR has no dependency-range changes. Fixes needing a wider range, and advisories with no published fix, are excluded and take a manual bump.
 
-              Created and updated by the [\`scheduled-npm-audit\`](https://github.com/confluentinc/mcp-confluent/blob/${TARGET_BRANCH}/.semaphore/npm-audit.yml) Semaphore task.
+              Created and updated by the [\`scheduled-pnpm-audit\`](https://github.com/confluentinc/mcp-confluent/blob/${TARGET_BRANCH}/.semaphore/pnpm-audit.yml) Semaphore task.
               EOF
               )
                   gh pr create \

--- a/service.yml
+++ b/service.yml
@@ -81,9 +81,9 @@ semaphore:
             - "direct"
             - "oauth"
           description: 'Connection type to exercise. all (default) runs both direct and oauth sequentially in each job; direct or oauth limits the run to that single mode.'
-    - name: scheduled-npm-audit
+    - name: scheduled-pnpm-audit
       branch: main
-      pipeline_file: .semaphore/npm-audit.yml
+      pipeline_file: .semaphore/pnpm-audit.yml
       scheduled: true
       at: '0 6 * * *' # Daily at 06:00 UTC
       parameters:


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to #714.
The project has been pnpm-only since #583, so `npm-audit` is a stale name.

Pure rename, no behavior change:

- `.semaphore/npm-audit.yml` → `.semaphore/pnpm-audit.yml`, at 96% similarity so GitHub renders it as a rename rather than a delete plus a create
- the pipeline's `name:`, the `service.yml` task (`scheduled-npm-audit` → `scheduled-pnpm-audit`), and its `pipeline_file`
- the self-referencing task URL in the PR body the job generates

Stacked on #714 and merges after it.
GitHub re-targets this PR to `main` once #714 lands.

<!-- Manual testing instructions omitted: this cannot be exercised before merge. The deployed scheduler entry still reads `scheduled-npm-audit` with `pipeline_file: .semaphore/npm-audit.yml`, so pointing it at this branch would fail to resolve a file that has been renamed here. The renamed task only exists once ServiceBot re-syncs after merge. -->

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, screenshots of client output, follow-on work that should be expected, links to discussions or issues, etc -->

- **After merge, trigger `run-service-bot`** rather than waiting for the nightly sync.
  Until ServiceBot re-syncs, the deployed scheduler still points at `.semaphore/npm-audit.yml`, which will no longer exist on `main`, and a 06:00 UTC fire in that window fails on a missing file.
- Renaming a scheduled task creates a new scheduler entry rather than moving the old one, so the previous run history stays attached to `scheduled-npm-audit`.
- The pipeline's behavior is verified by #714; this PR changes only names and paths.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

<!-- Internal Contributors

 Please inform `#mcp-confluent` before proposing new development to avoid conflicting with or duplicating work in progress.
 -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/mcp-confluent/blob/main/CHANGELOG.md)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
