### PR TITLE
(main) Fix PROTOBUF produce fails on .proto-text-registered subjects (#720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this MCP server will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- **`produce-message` (PROTOBUF, use-latest).** Producing to a PROTOBUF subject registered as `.proto` text via the standard Schema Registry REST API no longer fails with "Failed to decode registered Protobuf schema".
+
 ## 1.5.0
 
 ### Added
@@ -35,7 +39,6 @@ All notable changes to this MCP server will be documented in this file.
 #### Observability
 
 - **Error reporting (Sentry):** runtime errors are reported to [Sentry](https://sentry.io) (credentials redacted), on by default and disabled by the same `DO_NOT_TRACK` switch as usage analytics. See [telemetry.md](telemetry.md).
-
 
 ### Changed
 

--- a/src/confluent/schema-registry-helper.test.ts
+++ b/src/confluent/schema-registry-helper.test.ts
@@ -1,4 +1,5 @@
 import type { MutableRegistry } from "@bufbuild/protobuf";
+import { fromBinary } from "@bufbuild/protobuf";
 import type { IHeaders } from "@confluentinc/kafka-javascript/types/kafkajs.js";
 import {
   KEY_SCHEMA_ID_HEADER,
@@ -18,6 +19,7 @@ import {
   protobufMessageFrom,
   protobufRegistryFromProto,
   protobufRegistryFromSerialized,
+  protobufRegistryFromStoredSchema,
   serializeMessage,
 } from "@src/confluent/schema-registry-helper.js";
 import { getMockedSchemaRegistry } from "@tests/stubs/index.js";
@@ -247,6 +249,52 @@ describe("schema-registry-helper.ts", () => {
         email: "alice@example.com",
         age: 30,
       });
+    });
+
+    it("uses the latest registered schema when it was registered as .proto text via the REST API (issue #720)", async () => {
+      // Seed the subject directly via registry.register() with literal .proto
+      // text, bypassing the ProtobufSerializer entirely — this is what the
+      // standard Schema Registry REST API stores, as opposed to the base64
+      // FileDescriptorProto the SDK's own serializer writes. A use-latest
+      // produce against such a subject previously failed because the
+      // use-latest path always assumed the serialized format.
+      const registry = newRegistry();
+      const topic = "proto-text-latest";
+      const subject = `${topic}-value`;
+      await registry.register(subject, {
+        schema: PROTO_USER,
+        schemaType: "PROTOBUF",
+      });
+
+      const bytes = await serializeMessage(
+        topic,
+        {
+          message: { user_id: "USR-009", name: "Bob" },
+          useSchemaRegistry: true,
+          schemaType: "PROTOBUF",
+          messageName: "com.example.User",
+        },
+        SerdeType.VALUE,
+        registry,
+      );
+      expect(Buffer.isBuffer(bytes)).toBe(true);
+
+      // The real Confluent Cloud Schema Registry transparently converts a
+      // stored .proto-text schema to the serialized FileDescriptorProto format
+      // on request (the `format` query param), which is what lets
+      // ProtobufDeserializer — which unconditionally base64-decodes whatever
+      // it's handed — read it back. The mock:// client doesn't implement that
+      // conversion, so decode manually here against the same descriptor
+      // instead, to prove the produced bytes are valid Protobuf for the schema.
+      const schemaId = new SchemaId("PROTOBUF");
+      const bytesRead = schemaId.fromBytes(bytes as Buffer);
+      const messageDesc =
+        protobufRegistryFromProto(PROTO_USER).getMessage("com.example.User")!;
+      const decoded = fromBinary(
+        messageDesc,
+        (bytes as Buffer).subarray(bytesRead),
+      );
+      expect(decoded).toMatchObject({ userId: "USR-009", name: "Bob" });
     });
 
     it("uses the latest registered schema when no schema is supplied", async () => {
@@ -483,6 +531,47 @@ describe("schema-registry-helper.ts", () => {
       expect(() =>
         protobufRegistryFromSerialized("not-valid-base64$$"),
       ).toThrow(/Failed to decode registered Protobuf schema/);
+    });
+  });
+
+  describe("protobufRegistryFromStoredSchema()", () => {
+    it("parses a serialized (base64 FileDescriptorProto) stored schema, as written by this SDK's own serializer", async () => {
+      const registry = SchemaRegistryClient.newClient({
+        baseURLs: ["mock://"],
+      }) as SchemaRegistryClient;
+      // Registering with a schema present drives the same serialized-format
+      // write path the ProtobufSerializer uses on a normal produce.
+      await serializeMessage(
+        "proto-stored-schema",
+        {
+          message: { user_id: "USR-000", name: "Seed" },
+          useSchemaRegistry: true,
+          schemaType: "PROTOBUF",
+          schema: PROTO_USER,
+          messageName: "com.example.User",
+        },
+        SerdeType.VALUE,
+        registry,
+      );
+      const latest = await registry.getLatestSchemaMetadata(
+        "proto-stored-schema-value",
+      );
+
+      const stored = protobufRegistryFromStoredSchema(latest.schema!);
+      expect(stored.getMessage("com.example.User")).not.toBeUndefined();
+    });
+
+    it("falls back to .proto text parsing when the stored schema is literal .proto text (REST-API-registered subject)", () => {
+      const registry = protobufRegistryFromStoredSchema(PROTO_USER);
+      expect(registry.getMessage("com.example.User")).not.toBeUndefined();
+    });
+
+    it("throws a combined error when the stored schema matches neither format", () => {
+      expect(() =>
+        protobufRegistryFromStoredSchema("not-valid-base64$$"),
+      ).toThrow(
+        /Failed to parse registered Protobuf schema as either a serialized FileDescriptorProto .* or \.proto text/,
+      );
     });
   });
 

--- a/src/confluent/schema-registry-helper.ts
+++ b/src/confluent/schema-registry-helper.ts
@@ -422,6 +422,39 @@ export function protobufRegistryFromSerialized(
 }
 
 /**
+ * Builds a descriptor registry from a Protobuf schema as stored in Schema
+ * Registry, regardless of which client registered it. Two formats are in the
+ * wild for the same subject: this SDK's own serializer stores a base64
+ * `FileDescriptorProto` (see {@link protobufRegistryFromSerialized}), while the
+ * standard Schema Registry REST API (and other clients) store literal `.proto`
+ * source text (see {@link protobufRegistryFromProto}). The stored schema
+ * carries no explicit tag for which one it is, so this tries the serialized
+ * form first and falls back to `.proto` text parsing on failure.
+ *
+ * @param storedSchema - The schema string as returned by the registry for the
+ *   subject (either base64 `FileDescriptorProto` or `.proto` text)
+ * @returns A mutable descriptor registry the serializer can consume
+ * @throws Error if the stored schema matches neither format
+ */
+export function protobufRegistryFromStoredSchema(
+  storedSchema: string,
+): MutableRegistry {
+  try {
+    return protobufRegistryFromSerialized(storedSchema);
+  } catch (serializedErr) {
+    try {
+      return protobufRegistryFromProto(storedSchema);
+    } catch (protoErr) {
+      throw new Error(
+        "Failed to parse registered Protobuf schema as either a serialized " +
+          `FileDescriptorProto (${serializedErr instanceof Error ? serializedErr.message : String(serializedErr)}) ` +
+          `or .proto text (${protoErr instanceof Error ? protoErr.message : String(protoErr)}).`,
+      );
+    }
+  }
+}
+
+/**
  * Converts a plain JS payload into a typed `@bufbuild/protobuf` message (carrying
  * the `$typeName` the ProtobufSerializer requires) using a descriptor registry.
  *
@@ -562,8 +595,10 @@ export async function serializeMessage(
  * format the SDK's deserializer can read back.
  *
  * - When no schema is supplied (use-latest), the previously-registered schema is
- *   fetched, its descriptor rebuilt from the stored serialized form, and the
- *   serializer uses the latest version.
+ *   fetched, its descriptor rebuilt from the stored form (serialized
+ *   `FileDescriptorProto` or `.proto` text, whichever it turns out to be — see
+ *   {@link protobufRegistryFromStoredSchema}), and the serializer uses the
+ *   latest version.
  *
  * The payload is always converted into a typed `@bufbuild/protobuf` message
  * (carrying `$typeName`) before serialization.
@@ -614,13 +649,15 @@ async function serializeProtobufMessage(
       subjectNameStrategy: () => subject,
     };
   } else {
-    // Use-latest path: rebuild the descriptor from the stored serialized schema.
+    // Use-latest path: rebuild the descriptor from the stored schema, which may
+    // be either this SDK's serialized format or literal .proto text registered
+    // via the REST API (issue #720).
     const latest = await getLatestSchemaOfTypeOrThrow(
       registry,
       subject,
       "PROTOBUF",
     );
-    protobufRegistry = protobufRegistryFromSerialized(latest.schema);
+    protobufRegistry = protobufRegistryFromStoredSchema(latest.schema);
     serializerConfig = {
       useLatestVersion: true,
       subjectNameStrategy: () => subject,

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -551,5 +551,112 @@ describe(
         });
       },
     );
+
+    describe(
+      "with a Protobuf subject registered as .proto text via the REST API (issue #720)",
+      { tags: [Tag.REQUIRES_SCHEMA_REGISTRY_CONFIG] },
+      () => {
+        if (!activeConnectionTypes.includes(ConnectionType.DIRECT)) {
+          it.skip(CONNECTION_TYPE_DIRECT_FILTERED_REASON, () => {});
+          return;
+        }
+        if (skipIfDisabled(handler, integrationConnection())) {
+          return;
+        }
+        const connection = integrationConnection();
+        if (connection.type !== "direct" || !connection.schema_registry) {
+          it.skip("requires schema_registry config", () => {});
+          return;
+        }
+
+        // The standard Schema Registry REST API stores a Protobuf schema as
+        // literal .proto source text, distinct from the base64
+        // FileDescriptorProto this SDK's own ProtobufSerializer writes on a
+        // caller-supplied-schema produce. Registering directly via the SR
+        // client (rather than through PRODUCE_MESSAGE) reproduces that shape
+        // for the use-latest produce path under test.
+        const PROTO_USER = `syntax = "proto3";
+package com.example;
+
+message User {
+  string user_id = 1;
+  string name = 2;
+}`;
+
+        let admin: KafkaJS.Admin;
+        const topic = uniqueName("produce-proto-text");
+        const subject = `${topic}-value`;
+        const { client, createdSubjects } = withSharedSrClient();
+
+        beforeAll(async () => {
+          admin = await connectTestAdmin();
+          await admin.createTopics({ topics: [{ topic, numPartitions: 1 }] });
+          createdSubjects.push(subject);
+          await client().register(subject, {
+            schema: PROTO_USER,
+            schemaType: "PROTOBUF",
+          });
+        });
+
+        afterAll(async () => {
+          await admin.deleteTopics({ topics: [topic] }).catch(() => {
+            // teardown-only; a cleanup failure shouldn't fail an already-asserted test
+          });
+          await admin.disconnect();
+        });
+
+        describe.each(activeTransports)("via %s transport", (transport) => {
+          let server: StartedServer;
+
+          beforeAll(async () => {
+            server = await startServer({ transport });
+          });
+
+          afterAll(async () => {
+            await server?.stop();
+          });
+
+          it("should produce via the use-latest path and decode back through consume-messages", async () => {
+            // unique per transport so this iteration's decoded record is
+            // unambiguous even though the topic (and its earlier messages)
+            // is shared across the describe.each transports
+            const userId = `USR-${transport}`;
+
+            const produceResult = await server.client.callTool({
+              name: ToolName.PRODUCE_MESSAGE,
+              arguments: {
+                topicName: topic,
+                value: {
+                  message: { user_id: userId, name: "Bob" },
+                  useSchemaRegistry: true,
+                  schemaType: "PROTOBUF",
+                  messageName: "com.example.User",
+                },
+              },
+            });
+            const produceText = textContent(produceResult);
+            expect(produceText).toMatch(
+              /Message produced successfully to \[Topic: /,
+            );
+
+            // consume-messages auto-decodes via Schema Registry; asserting the
+            // rendered JSON field values (rather than mere byte-string
+            // containment) proves a real decode happened rather than the
+            // handler's silent raw-string fallback on a deserialize failure.
+            const consumeResult = await server.client.callTool({
+              name: ToolName.CONSUME_MESSAGES,
+              arguments: {
+                topics: [{ name: topic, start: "earliest" }],
+                maxMessages: 10,
+                timeoutMs: 15_000,
+              },
+            });
+            const consumeText = textContent(consumeResult);
+            expect(consumeText).toContain(`"userId": "${userId}"`);
+            expect(consumeText).toContain('"name": "Bob"');
+          });
+        });
+      },
+    );
   },
 );

--- a/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
+++ b/src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts
@@ -2,6 +2,7 @@ import type { KafkaJS } from "@confluentinc/kafka-javascript";
 import { VALUE_SCHEMA_ID_HEADER } from "@confluentinc/schemaregistry";
 import { ProduceKafkaMessageHandler } from "@src/confluent/tools/handlers/kafka/produce-kafka-message-handler.js";
 import { ToolName } from "@src/confluent/tools/tool-name.js";
+import { TransportType } from "@src/mcp/transports/types.js";
 import { getTestEnvironmentId } from "@tests/harness/confluent-cloud.js";
 import {
   activeConnectionTypes,
@@ -605,7 +606,16 @@ message User {
           await admin.disconnect();
         });
 
-        describe.each(activeTransports)("via %s transport", (transport) => {
+        // Stdio-only: this fix lives in schema/serialization logic shared by
+        // every transport, so exercising it on all three would just re-pay
+        // the CCloud round-trip tax without adding coverage. Filtering (vs.
+        // hard-coding TransportType.STDIO) still honors a forced
+        // INTEGRATION_TEST_TRANSPORT=http|sse by skipping cleanly.
+        describe.each(
+          activeTransports.filter(
+            (transport) => transport === TransportType.STDIO,
+          ),
+        )("via %s transport", (transport) => {
           let server: StartedServer;
 
           beforeAll(async () => {
@@ -617,10 +627,7 @@ message User {
           });
 
           it("should produce via the use-latest path and decode back through consume-messages", async () => {
-            // unique per transport so this iteration's decoded record is
-            // unambiguous even though the topic (and its earlier messages)
-            // is shared across the describe.each transports
-            const userId = `USR-${transport}`;
+            const userId = "USR-001";
 
             const produceResult = await server.client.callTool({
               name: ToolName.PRODUCE_MESSAGE,


### PR DESCRIPTION
## Summary of Changes

Fix for #720 against main:

- **`produce-message` (PROTOBUF, use-latest).** Producing to a PROTOBUF subject registered as `.proto` text via the standard Schema Registry REST API no longer fails with "Failed to decode registered Protobuf schema".


New integration test passes:

 ✓  integration  src/confluent/tools/handlers/kafka/produce-kafka-message-handler.integration.test.ts > produce-kafka-message-handler > with a Protobuf subject registered as .proto text via the REST API (issue #720) > via stdio transport > should produce via the use-latest path and decode back through consume-messages 17074ms

Closes #720
