### PR TITLE
Fix billing date validation for invalid calendar dates

### DIFF
--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -346,14 +346,6 @@ describe("list-billing-costs-handler.ts", () => {
           label: "endDate is before startDate",
           args: { startDate: "2026-02-01", endDate: "2026-01-01" },
         },
-        {
-          label: "startDate matches the format but is not a real calendar date",
-          args: { startDate: "2026-02-30", endDate: "2026-02-28" },
-        },
-        {
-          label: "endDate matches the format but is not a real calendar date",
-          args: { startDate: "2026-01-01", endDate: "2026-13-01" },
-        },
       ])(
         "should throw a ZodError and not call the API when $label",
         async ({ args }) => {
@@ -370,6 +362,64 @@ describe("list-billing-costs-handler.ts", () => {
           expect(restClient.GET).not.toHaveBeenCalled();
         },
       );
+
+      it.each([
+        {
+          label: "an impossible start date",
+          args: { startDate: "2026-02-30", endDate: "2026-03-02" },
+          errorMessage:
+            "Date must be a valid calendar date (got startDate=2026-02-30).",
+        },
+        {
+          label: "an impossible end date",
+          args: { startDate: "2026-04-01", endDate: "2026-04-31" },
+          errorMessage:
+            "Date must be a valid calendar date (got endDate=2026-04-31).",
+        },
+        {
+          label: "an invalid month",
+          args: { startDate: "2026-01-01", endDate: "2026-13-01" },
+          errorMessage:
+            "Date must be a valid calendar date (got endDate=2026-13-01).",
+        },
+        {
+          label: "February 29 in a non-leap year",
+          args: { startDate: "2026-02-29", endDate: "2026-03-01" },
+          errorMessage:
+            "Date must be a valid calendar date (got startDate=2026-02-29).",
+        },
+      ])(
+        "should reject $label with a calendar-date error",
+        async ({ args, errorMessage }) => {
+          const clientManager = getMockedClientManager();
+          const restClient = clientManager.getConfluentCloudRestClient();
+
+          await expect(
+            handler.handle(
+              runtimeWith(CCLOUD_CONN, DEFAULT_CONNECTION_ID, clientManager),
+              args,
+            ),
+          ).rejects.toThrowError(errorMessage);
+
+          expect(restClient.GET).not.toHaveBeenCalled();
+        },
+      );
+
+      it("should accept February 29 in a leap year", async () => {
+        const clientManager = getMockedClientManager();
+        const restClient = clientManager.getConfluentCloudRestClient();
+        restClient.GET.mockResolvedValue({
+          data: { api_version: "v1", kind: "CostList", data: [] },
+        });
+
+        const result = await handler.handle(
+          runtimeWith(CCLOUD_CONN, DEFAULT_CONNECTION_ID, clientManager),
+          { startDate: "2024-02-29", endDate: "2024-02-29" },
+        );
+
+        expect(result.isError).toBe(false);
+        expect(restClient.GET).toHaveBeenCalledOnce();
+      });
 
       it("should name the 31-day cap and the actual span in the ZodError message", async () => {
         const clientManager = getMockedClientManager();

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.test.ts
@@ -366,40 +366,59 @@ describe("list-billing-costs-handler.ts", () => {
       it.each([
         {
           label: "an impossible start date",
-          args: { startDate: "2026-02-30", endDate: "2026-03-02" },
-          errorMessage:
-            "Date must be a valid calendar date (got startDate=2026-02-30).",
+          args: { startDate: "2026-02-30", endDate: "2026-02-28" },
+          expectedIssue: {
+            code: "custom",
+            path: ["startDate"],
+            message:
+              "Date must be a valid calendar date (got startDate=2026-02-30).",
+          },
         },
         {
           label: "an impossible end date",
           args: { startDate: "2026-04-01", endDate: "2026-04-31" },
-          errorMessage:
-            "Date must be a valid calendar date (got endDate=2026-04-31).",
+          expectedIssue: {
+            code: "custom",
+            path: ["endDate"],
+            message:
+              "Date must be a valid calendar date (got endDate=2026-04-31).",
+          },
         },
         {
           label: "an invalid month",
           args: { startDate: "2026-01-01", endDate: "2026-13-01" },
-          errorMessage:
-            "Date must be a valid calendar date (got endDate=2026-13-01).",
+          expectedIssue: {
+            code: "custom",
+            path: ["endDate"],
+            message:
+              "Date must be a valid calendar date (got endDate=2026-13-01).",
+          },
         },
         {
           label: "February 29 in a non-leap year",
-          args: { startDate: "2026-02-29", endDate: "2026-03-01" },
-          errorMessage:
-            "Date must be a valid calendar date (got startDate=2026-02-29).",
+          args: { startDate: "2026-02-29", endDate: "2026-02-28" },
+          expectedIssue: {
+            code: "custom",
+            path: ["startDate"],
+            message:
+              "Date must be a valid calendar date (got startDate=2026-02-29).",
+          },
         },
       ])(
-        "should reject $label with a calendar-date error",
-        async ({ args, errorMessage }) => {
+        "should reject $label with only a calendar-date error",
+        async ({ args, expectedIssue }) => {
           const clientManager = getMockedClientManager();
           const restClient = clientManager.getConfluentCloudRestClient();
 
-          await expect(
-            handler.handle(
+          const thrown = await handler
+            .handle(
               runtimeWith(CCLOUD_CONN, DEFAULT_CONNECTION_ID, clientManager),
               args,
-            ),
-          ).rejects.toThrowError(errorMessage);
+            )
+            .catch((error: unknown) => error);
+
+          expect(thrown).toBeInstanceOf(ZodError);
+          expect((thrown as ZodError).issues).toEqual([expectedIssue]);
 
           expect(restClient.GET).not.toHaveBeenCalled();
         },

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -50,23 +50,30 @@ const listBillingCostsObject = z.object({
 });
 
 const listBillingCostsArguments = listBillingCostsObject
-  .refine(
-    ({ startDate, endDate }) =>
-      isValidCalendarDate(startDate) && isValidCalendarDate(endDate),
-    {
-      error: (issue) => {
-        const { startDate, endDate } = issue.input as {
-          startDate: string;
-          endDate: string;
-        };
-        const invalid = isValidCalendarDate(startDate)
-          ? `endDate=${endDate}`
-          : `startDate=${startDate}`;
-        return `Date must be a valid calendar date (got ${invalid}).`;
-      },
-      path: ["endDate"],
-    },
-  )
+  .check((payload) => {
+    const { startDate, endDate } = payload.value;
+
+    if (!isValidCalendarDate(startDate)) {
+      payload.issues.push({
+        code: "custom",
+        message: `Date must be a valid calendar date (got startDate=${startDate}).`,
+        path: ["startDate"],
+        input: startDate,
+        continue: false,
+      });
+      return;
+    }
+
+    if (!isValidCalendarDate(endDate)) {
+      payload.issues.push({
+        code: "custom",
+        message: `Date must be a valid calendar date (got endDate=${endDate}).`,
+        path: ["endDate"],
+        input: endDate,
+        continue: false,
+      });
+    }
+  })
   .refine(
     ({ startDate, endDate }) => Date.parse(endDate) >= Date.parse(startDate),
     {

--- a/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
+++ b/src/confluent/tools/handlers/billing/list-billing-costs-handler.ts
@@ -19,6 +19,14 @@ import { z } from "zod";
 const BILLING_RANGE_MAX_DAYS = 31;
 const MS_PER_DAY = 86_400_000;
 
+function isValidCalendarDate(date: string): boolean {
+  const timestamp = Date.parse(date);
+  return (
+    Number.isFinite(timestamp) &&
+    new Date(timestamp).toISOString().slice(0, 10) === date
+  );
+}
+
 const listBillingCostsObject = z.object({
   startDate: z
     .string()
@@ -44,15 +52,14 @@ const listBillingCostsObject = z.object({
 const listBillingCostsArguments = listBillingCostsObject
   .refine(
     ({ startDate, endDate }) =>
-      Number.isFinite(Date.parse(startDate)) &&
-      Number.isFinite(Date.parse(endDate)),
+      isValidCalendarDate(startDate) && isValidCalendarDate(endDate),
     {
       error: (issue) => {
         const { startDate, endDate } = issue.input as {
           startDate: string;
           endDate: string;
         };
-        const invalid = Number.isFinite(Date.parse(startDate))
+        const invalid = isValidCalendarDate(startDate)
           ? `endDate=${endDate}`
           : `startDate=${startDate}`;
         return `Date must be a valid calendar date (got ${invalid}).`;


### PR DESCRIPTION
## What changed

`Date.parse()` normalizes some impossible dates, so the billing tool could accept values like `2026-04-31`.

- Round-trip parsed dates through UTC `YYYY-MM-DD` before accepting them.
- Keep valid leap days working.
- Add coverage for impossible dates, invalid months, non-leap-year February 29, and a valid leap day.
- Assert the calendar-date error so the ordering check cannot hide the bug.

## Testing

- `pnpm run test:unit`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`